### PR TITLE
chore(lint): add personal-data leak scan (constitution P6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ __pycache__/
 .env.*
 !.env.example
 .router-token
+# Private personal-data blacklist for scripts/lint.sh leak-scan (Check 4).
+# Holds the maintainer's own identifying literals (real name, employer, home
+# city, target-company names) so the leak-scan can refuse to commit them. It is
+# private by definition and MUST NEVER be committed — see SECURITY note in
+# scripts/lint.sh. lint.sh hard-fails if this file is ever git-tracked.
+scripts/.leak-blacklist
 .DS_Store
 sessions/
 sessions.bak-*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ edit `frontend/*.html|js|css`, hard-refresh the browser.
 
 - [ ] `uv run pytest tests/` passes
 - [ ] `uv run ruff check backend/ tests/` passes (CI blocks merge on lint failures)
-- [ ] `bash scripts/lint.sh` passes (catches encoding / BOM / class-collision issues)
+- [ ] `bash scripts/lint.sh` passes (encoding / class-collision + personal-data leak scan)
 - [ ] Backend changes: added or updated a test in `tests/`
 - [ ] Frontend visual changes: described in the PR with a before/after note
       (visual regression tests are not yet in place)
@@ -58,6 +58,20 @@ edit `frontend/*.html|js|css`, hard-refresh the browser.
   browsers understand. Match the semicolon style of neighbouring code.
 - CSS: per-component sections with a comment header (see `frontend/styles.css`).
   Use CSS variables (`--c-*`, `--sp-*`) for theming; do not hardcode colors.
+
+## Keeping personal data out (leak scan)
+
+`scripts/lint.sh` runs a personal-data leak scan over tracked files
+(constitution P6 — no real personal data in shipped artifacts):
+
+- **Generic PII** (phone / national-ID patterns) — always on, runs in CI.
+- **Maintainer identity** — your OS login and home-dir name are derived at
+  runtime (nothing private is stored in the script), so a stray `/home/<you>/`
+  path or username is caught automatically.
+- **Optional private blacklist** — for names a regex can't know (real name,
+  employer, target companies), create `scripts/.leak-blacklist` (gitignored,
+  one literal per line) or point `MUSELAB_LEAK_BLACKLIST` at a file outside the
+  repo. The scan hard-fails if that blacklist ever becomes git-tracked.
 
 ## Filing an issue
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,6 +5,9 @@
 # Checks:
 #   1. Python read_text / write_text without encoding=
 #   2. .thinking class collision (mascot vs message bubble)
+#   3. Personal-data / PII leak — generic patterns (constitution P6 / §6)
+#   4. Maintainer-identity leak — runtime-derived ($USER, $HOME) + optional
+#      private blacklist file. NO private literal is ever stored in this script.
 set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -48,6 +51,97 @@ if [[ -n "$violations" ]]; then
   fail=1
 else
   green "OK — no .thinking class collisions detected."
+fi
+echo
+
+# Tracked text files only — this is exactly the "shipped artifacts" surface
+# that constitution P6 governs. `git ls-files` naturally excludes .env /
+# sessions/ (gitignored) and anything not committed. Skip vendored libs,
+# lockfiles and the third-party license dump (legit external names there).
+_tracked_text_files() {
+  git ls-files -- \
+    ':!frontend/vendor/**' ':!*.lock' ':!uv.lock' \
+    ':!THIRD_PARTY_LICENSES.md' ':!frontend/assets/**' \
+    ':!*.png' ':!*.jpg' ':!*.jpeg' ':!*.gif' ':!*.ico' ':!*.webp' \
+    ':!*.woff' ':!*.woff2' ':!*.ttf' 2>/dev/null
+}
+
+echo "== Check 3: personal-data / PII leak (generic patterns) =="
+# Generic, ship-safe patterns verified clean against the current tree. These
+# carry NO private literal, so the check is identical on every machine + CI.
+#   - CN mobile (1[3-9] + 9 digits)   - 18-digit national ID (17 + [0-9Xx])
+pii_hits=""
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  m=$(grep -nE '\b1[3-9][0-9]{9}\b|\b[0-9]{17}[0-9Xx]\b' "$f" 2>/dev/null) || true
+  [[ -n "$m" ]] && pii_hits+="$(echo "$m" | sed "s|^|$f:|")"$'\n'
+done < <(_tracked_text_files)
+if [[ -n "${pii_hits// /}" ]]; then
+  red "FAIL — possible phone number / national ID in a tracked file:"
+  echo "$pii_hits" | sed '/^$/d;s/^/  /'
+  echo "  → Remove it, or if it is a deliberate fake example use an obvious"
+  echo "    hyphenated placeholder (e.g. 138-XXXX-XXXX) so it cannot match a real number."
+  fail=1
+else
+  green "OK — no phone / ID patterns in tracked files."
+fi
+echo
+
+echo "== Check 4: maintainer-identity leak (runtime-derived + private blacklist) =="
+# Guard: the private blacklist MUST stay untracked. If it ever gets committed,
+# that itself is the leak — hard fail before scanning anything.
+if git ls-files --error-unmatch scripts/.leak-blacklist >/dev/null 2>&1; then
+  red "FAIL — scripts/.leak-blacklist is git-tracked. It holds private literals"
+  red "        and MUST be gitignored. Run: git rm --cached scripts/.leak-blacklist"
+  fail=1
+fi
+
+# Build the forbidden-literal list WITHOUT writing any private value into this
+# script. Runtime-derived identities (your OS login + home dir basename) catch
+# the historical `/home/<login>` class automatically, for every contributor.
+declare -a forbidden=()
+# Common CI / system / container account names that are NOT personal — skip so
+# CI (runs as `runner`) and Docker (`muse`) don't self-trip.
+_generic_account=" runner root user ubuntu admin muse you me alice bob test ci "
+for id in "$(whoami 2>/dev/null)" "$(basename "${HOME:-}" 2>/dev/null)"; do
+  [[ -z "$id" || ${#id} -lt 3 ]] && continue
+  [[ "$_generic_account" == *" ${id} "* ]] && continue
+  forbidden+=("$id")
+done
+# Optional private blacklist: env override, else gitignored file. One literal
+# per line; blank lines and #-comments ignored. Lives only on your machine.
+_bl="${MUSELAB_LEAK_BLACKLIST:-scripts/.leak-blacklist}"
+if [[ -f "$_bl" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"; line="${line#"${line%%[![:space:]]*}"}"; line="${line%"${line##*[![:space:]]}"}"
+    [[ -n "$line" ]] && forbidden+=("$line")
+  done < "$_bl"
+fi
+
+if (( ${#forbidden[@]} == 0 )); then
+  yellow "SKIP — no identity literals to check (generic account + no blacklist file)."
+elif [[ ! -t 1 && -z "${MUSELAB_LEAK_BLACKLIST:-}" && ! -f scripts/.leak-blacklist ]]; then
+  yellow "NOTE — only runtime-derived identities checked (no blacklist on this host)."
+fi
+
+id_hits=""
+if (( ${#forbidden[@]} > 0 )); then
+  # Build one alternation; grep -F-style literal match, case-insensitive.
+  pat=$(printf '%s\n' "${forbidden[@]}" | sed 's/[][\.*^$/]/\\&/g' | paste -sd'|' -)
+  while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    m=$(grep -niE "$pat" "$f" 2>/dev/null) || true
+    [[ -n "$m" ]] && id_hits+="$(echo "$m" | sed "s|^|$f:|")"$'\n'
+  done < <(_tracked_text_files)
+fi
+if [[ -n "${id_hits// /}" ]]; then
+  red "FAIL — maintainer-identity literal found in a tracked (shippable) file:"
+  echo "$id_hits" | sed '/^$/d;s/^/  /'
+  echo "  → constitution P6: no real personal data in shipped artifacts."
+  echo "    Replace with a neutral placeholder (you / alice / \$HOME)."
+  fail=1
+else
+  green "OK — no maintainer-identity literals in tracked files."
 fi
 echo
 


### PR DESCRIPTION
## Summary
- Adds two new checks to `scripts/lint.sh` enforcing constitution **P6** (no real personal data in shipped artifacts):
  - **Check 3** — generic PII scan: CN mobile (`1[3-9]\d{9}`) / ID-card (`\d{17}[0-9Xx]`) patterns across git-tracked text files.
  - **Check 4** — identity leak scan: derives forbidden literals at runtime from `whoami` + `basename $HOME` (skipping generic account names), plus an optional `$MUSELAB_LEAK_BLACKLIST` / `scripts/.leak-blacklist` file. **No private literal is hardcoded in the script itself.**
- `.gitignore`: ignore `scripts/.leak-blacklist` (holds private identifying seeds, must never be committed).
- `CONTRIBUTING.md`: documents the leak scan under a new "Keeping personal data out" section.

## Why
The repo historically shipped artifacts containing the maintainer's real username/name. This guard catches that class of leak in CI before merge — and is designed so the guard itself can't become a leak (identity is derived at runtime, never baked into the tracked script).

## Test plan
- [x] `bash scripts/lint.sh` exits 0 on a clean tree (all 4 checks pass)
- [x] Injection test: seeding `chenxiaosen` / `潇森` into a tracked file makes Check 4 fail as expected
- [x] `uv run pytest tests/` — 408 passed, 1 skipped
- [x] `uv run ruff check backend/ tests/` — clean
- [x] CI wiring: lint job already runs `bash scripts/lint.sh`, no workflow change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)