### PR TITLE
fix(frontend): streaming avatar animation only on latest turn

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1919,6 +1919,22 @@ function portal() {
     // identity layer (single-user, token-auth), so we just stamp "我" / "U"
     // by language. Cheap, requires no extra SVG asset.
     userAvatarText() { return this.lang === "zh" ? "我" : "U"; },
+    // 是否给第 i 条消息的头像加流式动效。
+    // 之前的内联条件 `streaming && (i===0 || messages[i-1].role==='user')`
+    // 命中的是「每一个 assistant 轮次的首条」——历史里每个轮次都满足，
+    // 于是流式时所有轮次的头像一起动。正确语义是「仅当前（最新）轮」：
+    // 既是轮首（前一条是 user 或开头），又是最后一轮（自此往后不再有 user）。
+    isStreamingTurnAvatar(i) {
+      if (!this.streaming) return false;
+      const msgs = this.messages;
+      if (!msgs || !msgs[i] || msgs[i].role === "user") return false; // 仅 assistant 侧头像
+      const isTurnStart = i === 0 || (msgs[i - 1] && msgs[i - 1].role === "user");
+      if (!isTurnStart) return false;
+      for (let j = i + 1; j < msgs.length; j++) {
+        if (msgs[j] && msgs[j].role === "user") return false; // 后面还有用户消息 → 不是最新轮
+      }
+      return true;
+    },
     // 显示文案：英文界面 "Muse · Urania · Astronomy"；中文界面 "Muse · 乌拉尼亚 · 天文"（保留希腊名作 hint）
     mascotLabel() {
       const m = this.mascot();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1486,7 +1486,7 @@
                 <div class="asst-msg-wrap">
                   <div class="msg-row">
                     <span class="msg-avatar assistant-avatar"
-                          :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                          :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                           :title="mascotLabel()">
                       <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                     </span>
@@ -1520,7 +1520,7 @@
               <template x-if="m.role === 'thinking'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1546,7 +1546,7 @@
               <template x-if="m.role === 'tool_use' && m.name === 'TodoWrite'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1578,7 +1578,7 @@
               <template x-if="m.role === 'tool_use' && (m.name === 'Task' || m.name === 'Agent')">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1601,7 +1601,7 @@
               <template x-if="m.role === 'tool_use' && m.name === 'ExitPlanMode'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1635,7 +1635,7 @@
               <template x-if="m.role === 'tool_use' && m.name !== 'TodoWrite' && m.name !== 'Task' && m.name !== 'Agent' && m.name !== 'ExitPlanMode' && !isTaskTool(m)">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1739,7 +1739,7 @@
               <template x-if="m.role === 'tool_result' && !shouldHideToolResult(m)">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1899,7 +1899,7 @@
               <template x-if="m.role === 'ask_user_question'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -2002,7 +2002,7 @@
               <template x-if="m.role === 'permission_request'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': streaming && (i === 0 || (messages[i-1] && messages[i-1].role === 'user')) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>


### PR DESCRIPTION
## Summary
- The streaming-avatar (mascot) animation was binding its streaming state in a way that could light up on historical turns, not just the in-flight one.
- Now the streaming animation is scoped to the **latest turn only**, so older message bubbles no longer show a spurious "thinking" state on reconnect / re-render.

## Why
On mobile especially, seeing a past turn's avatar animate as if still streaming is confusing — it reads as a stuck/duplicate turn. The fix keeps the live-streaming affordance where it belongs (the current turn).

## Test plan
- [x] `node --check frontend/app.js` — OK
- [x] `bash scripts/lint.sh` — passes (no `.thinking` class-collision; uses state-prefixed class)
- [ ] Manual: start a turn, observe avatar animates; on completion + new turn, prior avatars are static

🤖 Generated with [Claude Code](https://claude.com/claude-code)