### PR TITLE
fix(frontend): open external chat links in a new tab

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3186,7 +3186,17 @@ function portal() {
         if (a.classList.contains("file-link")) continue;
         let href = a.getAttribute("href") || "";
         if (!href || href.startsWith("#")) continue;
-        if (/^[a-z]+:/i.test(href)) continue;          // http: / https: / mailto: / etc.
+        if (/^[a-z]+:/i.test(href)) {                  // http: / https: / mailto: / etc.
+          // External web links open in a NEW tab so a click never unloads the
+          // chat SPA (the default same-tab navigation threw the user out of
+          // the conversation). rel guards against tab-nabbing + referrer leak.
+          // Non-web schemes (mailto:/tel:/…) are left untouched.
+          if (/^https?:/i.test(href)) {
+            a.setAttribute("target", "_blank");
+            a.setAttribute("rel", "noopener noreferrer");
+          }
+          continue;
+        }
         // marked / the model may URL-encode the href (e.g. Chinese filenames
         // come through as %E8%B5%84...). Decode so the regex + backend list
         // lookup operate on the raw UTF-8 form.
@@ -3219,7 +3229,16 @@ function portal() {
       // it as a file path; fall back to a toast if we can't parse.
       let href = a.getAttribute("href") || "";
       if (!href || href.startsWith("#")) return;
-      if (/^[a-z]+:/i.test(href)) return;             // real protocol → let browser handle
+      // External web link: force a NEW browsing context explicitly. In a
+      // standalone PWA a plain target=_blank anchor often navigates the app
+      // window itself (no tab concept), throwing the user out of the chat.
+      // window.open breaks out to the system browser reliably across PWA/web.
+      if (/^https?:/i.test(href)) {
+        ev.preventDefault();
+        window.open(href, "_blank", "noopener,noreferrer");
+        return;
+      }
+      if (/^[a-z]+:/i.test(href)) return;             // mailto:/tel:/… → let browser handle
       try { href = decodeURIComponent(href); } catch (_) { /* malformed → leave as-is */ }
       ev.preventDefault();
       // Try ROOT-relative normalization first (absolute under ROOT, or ROOT


### PR DESCRIPTION
## Summary
- Clicking an `http(s)` link in a Muse reply used to navigate the current page, unloading the chat SPA. In a standalone **PWA** (no tab concept) this was especially disruptive — the conversation window itself got navigated away.
- External web links now get `target="_blank" rel="noopener noreferrer"` during markdown post-processing, **and** `onChatClick` explicitly `window.open()`s them so the break-out is reliable across PWA and plain browser.
- Internal `.file-link` anchors (open in the archive preview pane) and non-web schemes (`mailto:` / `tel:`) are unchanged.

## Why
`target="_blank"` alone is unreliable inside a standalone PWA — the click often navigates the app window. The explicit `window.open` in the delegated click handler guarantees a new browsing context.

## Test plan
- [x] `node --check frontend/app.js` — OK
- [x] `bash scripts/lint.sh` — passes
- [ ] Manual (browser): click an external link in a reply → opens new tab, chat stays put
- [ ] Manual (PWA): same → breaks out to system browser / in-app Safari view, PWA not navigated
- [ ] Regression: internal file link still opens in preview pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)