### PR TITLE
fix(tree): 支持拖拽移动/上传到根目录

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -207,6 +207,9 @@ function portal() {
     visible: [], expanded: new Set(), childCache: {},
     selected: "",
     dragOver: "",
+    // Highlight flag for the sticky root bar while a tree node / OS file is
+    // dragged over it (drop = move/upload to archive root).
+    dragOverRoot: false,
     searchQ: "", searchMode: false, searching: false,
     searchHits: [], searchTruncated: false,
     grepHits: [], grepTruncated: false,
@@ -10261,10 +10264,17 @@ function portal() {
       }
 
       // OS file upload — dropping onto a file uploads into that file's
-      // parent dir (same dir-resolution as internal moves). Same
-      // parallel-upload + batched-refresh pattern as onPreviewDrop so
-      // a multi-file drop onto a tree node doesn't serialize.
+      // parent dir (same dir-resolution as internal moves).
       const files = Array.from(ev.dataTransfer?.files || []);
+      await this._uploadFilesToDir(targetDir, files);
+    },
+    // Parallel-upload a set of OS files into `targetDir` (empty string =
+    // archive root), then refresh the tree once and surface a single
+    // result toast. Shared by onDrop (drop onto a node) and onTreeRootDrop
+    // (drop onto the sticky root bar) so the two stay behaviorally in sync.
+    // Same parallel-upload + batched-refresh pattern as onPreviewDrop so a
+    // multi-file drop doesn't serialize.
+    async _uploadFilesToDir(targetDir, files) {
       if (!files.length) return;
       const results = await Promise.allSettled(
         files.map(f => this._uploadFileQuiet(targetDir, f))
@@ -10290,6 +10300,36 @@ function portal() {
           ? `已上传 ${ok} 个文件到 ${intoLabel}`
           : `Uploaded ${ok} files to ${intoLabel}`, "success", 2200);
       }
+    },
+    // Drag-over / drop on the sticky root bar = target the archive root
+    // (targetDir = ""). This is the ONLY way to reach root when the top
+    // level has no plain files to drop onto (e.g. only folders) — dropping
+    // onto a folder lands INSIDE it, never at root.
+    onTreeRootDragOver(ev) {
+      const src = this._dragSrcPath || "";
+      // No-op if the dragged tree item already lives at root.
+      if (src && src.split("/").slice(0, -1).join("/") === "") {
+        ev.dataTransfer.dropEffect = "none";
+        return;
+      }
+      this.dragOverRoot = true;
+      const types = Array.from(ev.dataTransfer?.types || []);
+      ev.dataTransfer.dropEffect =
+        types.includes(this._DRAG_MIME_INTERNAL) ? "move" : "copy";
+    },
+    async onTreeRootDrop(ev) {
+      this.dragOverRoot = false;
+      const wasSrc = this._dragSrcPath;
+      this._dragSrcPath = null;
+      const types = Array.from(ev.dataTransfer?.types || []);
+      if (types.includes(this._DRAG_MIME_INTERNAL)) {
+        const src = ev.dataTransfer.getData(this._DRAG_MIME_INTERNAL) || wasSrc;
+        await this.moveTreeItem(src, "");
+        return;
+      }
+      // OS file upload → archive root.
+      const files = Array.from(ev.dataTransfer?.files || []);
+      await this._uploadFilesToDir("", files);
     },
     async moveTreeItem(srcPath, targetDir) {
       if (!srcPath) return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -372,7 +372,11 @@
            "Open files" section above. -->
       <div class="filelist-wrap" x-show="!searchMode">
         <div class="filelist-sticky-root"
-             :title="contextInfo.archive_root || ''">
+             :class="{ 'drag-over': dragOverRoot }"
+             :title="contextInfo.archive_root || ''"
+             @dragover.prevent="onTreeRootDragOver($event)"
+             @dragleave="dragOverRoot = false"
+             @drop.prevent="onTreeRootDrop($event)">
           <span class="icon"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9M5 10v10h14V10"/></svg></span>
           <span class="path" x-text="contextInfo.archive_root || '—'"></span>
         </div>
@@ -385,7 +389,7 @@
               :data-ext="fileExtClass(n)"
               :draggable="isPointerDevice"
               @dragstart="onTreeNodeDragStart($event, n)"
-              @dragend="dragOver=''"
+              @dragend="dragOver=''; dragOverRoot=false"
               @click="onNodeClick(n)"
               @touchstart="onTreeTouchStart($event, n)"
               @touchmove="onTreeTouchMove($event)"

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1444,6 +1444,15 @@ body.kb-open .mobile-tab-bar { display: none; }
 }
 .filelist-sticky-root .icon { display: inline-flex; color: var(--c-accent); flex-shrink: 0; }
 .filelist-sticky-root .path { overflow: hidden; text-overflow: ellipsis; }
+/* Drop target highlight — drag a tree node / OS file onto the root bar to
+   move / upload it to the archive root. Mirrors `li.drag-over` (accent fill
+   + inset ring) so the affordance reads the same as dropping onto a node. */
+.filelist-sticky-root.drag-over {
+  background: var(--c-accent);
+  box-shadow: inset 0 0 0 2px white;
+}
+.filelist-sticky-root.drag-over .icon,
+.filelist-sticky-root.drag-over .path { color: white; }
 
 /* "Open files" section — list shrink-wraps content by default (1 file = 1
    row tall, 2 = 2 rows, ...). max-height kicks in at 5 rows + enables


### PR DESCRIPTION
## 问题
文件树拖拽时，唯一的放置目标是各个节点行：拖到文件夹会落进该文件夹内部，拖到文件会落到该文件的父目录。于是「根目录」（`targetDir=""`）只能通过拖到某个**顶层文件**上才能命中。当顶层只有文件夹（最常见的情况，如 health/ work/ money/ notes/…）时，根本没有可落点——**无法把文件移到根目录**。

## 修复（前端，约 58 行）
把始终可见的「根路径条」`.filelist-sticky-root` 做成放置目标：
- `onTreeRootDragOver` / `onTreeRootDrop` 以根为目标：内部拖拽 → `moveTreeItem(src, "")`，OS 文件 → 上传到根；已在根的项 no-op（`dropEffect:none`）
- 把 OS 上传 + 结果 toast 逻辑从 `onDrop` 抽成 `_uploadFilesToDir`，节点放置与根放置共用，行为一致（DRY）
- `dragOverRoot` 状态 + `.filelist-sticky-root.drag-over` 高亮，复用既有 `li.drag-over` 观感；`dragleave` / `dragend` 时清除

后端 `/api/files/rename` 本就接受根级 `dst`（`test_files.py` 已覆盖），故为纯前端修复。

## Test plan
- [ ] 顶层只有文件夹时，把子目录里的文件拖到顶部根路径条 → 文件移到根
- [ ] 已在根的文件拖到根条 → 无操作、不报错（dropEffect none）
- [ ] 从 OS 拖文件到根条 → 上传到根
- [ ] 拖到普通节点的原有行为不变（移动 / 上传）
- [ ] 拖到自己子树仍被拦（toast 提示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)