### PR TITLE
perf(chat): per-tab DOM persistence to kill tab-switch rebuild

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4657,6 +4657,23 @@ function portal() {
       this._fetchTabUsage(id);
     },
 
+    // P1 (chat-perf-redesign): per-tab DOM persistence. The chat message
+    // list is rendered once PER OPEN TAB (outer x-for over openTabIds), each
+    // pane bound to ITS OWN message array via this method. Switching tabs
+    // then only toggles x-show on the panes instead of swapping the array
+    // backing a single x-for — which used to force Alpine to teardown +
+    // rebuild the entire message subtree (measured: ~88% of switch time was
+    // that JS rebuild, scaling O(messages) and making long/agentic sessions
+    // the worst case). The active tab's
+    // array is still mirrored to this.messages by _activateTabState, so
+    // every existing `messages`-reading binding stays correct for the
+    // VISIBLE pane (paneMessages(currentId) === this.messages by identity).
+    // Hidden panes' bindings still evaluate against this.messages but are
+    // display:none, so the (possibly stale) result is never seen.
+    paneMessages(tid) {
+      return this._ensureTabState(tid).messages;
+    },
+
     async initSessions() {
       await this.refreshSessions();
       if (!this.sessions.length) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1421,7 +1421,19 @@
                to hide the avatar on all but the FIRST assistant-side
                msg in a run — visually the same "one avatar per turn"
                result without a derived data structure. -->
-          <template x-for="(m, i) in messages" :key="m._k || m.uuid || ('m-' + i)">
+          <!-- P1 (chat-perf-redesign): per-tab DOM persistence. One message
+               list is rendered per OPEN tab; switching toggles x-show instead
+               of swapping the array backing a single x-for (which forced a
+               full Alpine teardown+rebuild of the whole subtree on every
+               switch). The single message template below is UNCHANGED — it's
+               just wrapped in a per-tab pane and bound to paneMessages(tid).
+               For the visible pane paneMessages(currentId) === this.messages
+               by identity, so every `messages`-reading binding inside stays
+               correct; hidden panes are display:none so their (stale)
+               result is never seen. -->
+          <template x-for="tid in openTabIds" :key="tid">
+          <div class="msg-pane" x-show="tid === currentId">
+          <template x-for="(m, i) in paneMessages(tid)" :key="m._k || m.uuid || ('m-' + i)">
             <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i) ? '' : ' is-hidden')"
                  :data-uuid="m.uuid || ''">
               <!-- compact-summary pill -->
@@ -2185,6 +2197,12 @@
               </div>
             </div>
           </template>
+          </div>
+          </template>
+          <!-- /P1 per-tab message panes. Siblings below (pending bubble,
+               pending queue, banners) stay single-instance with active-tab
+               semantics — they read currentId / this.messages / streaming,
+               which already track the active tab. -->
           <!-- Pending "Muse 正在思考" bubble — only while we're waiting for
                the very first chunk. Once a streaming assistant message has
                started accumulating text (its bubble is already rendered

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2644,6 +2644,18 @@ html[data-theme="eyecare"] .editor-cm .CodeMirror { background: var(--c-bg-0); }
      with the message column visually. */
   padding-inline: max(var(--sp-3), calc(50% - 440px));
 }
+/* P1 (chat-perf-redesign): per-tab message pane. The message list used to
+   be a single x-for whose items were DIRECT flex children of .chat-body
+   (inheriting its column layout + gap). Now each open tab gets its own pane
+   and the messages live one level deeper, so the pane itself must reproduce
+   .chat-body's `display:flex; flex-direction:column; gap` to keep the exact
+   same inter-message spacing. Only the current tab's pane is shown
+   (x-show); hidden panes are display:none and cost no layout. */
+.msg-pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
 .msg {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Chat tab switching swapped the array backing a single `x-for over messages`; per-session `:key`s differ, so Alpine tore down + **rebuilt the whole message subtree** every switch (~88% of switch time per CDP, scaling O(messages); long/agentic sessions worst case).
- Fix: render **one message list per open tab** and toggle `x-show` on switch — tabs persist in the DOM, switching no longer rebuilds. The single message template is unchanged, just wrapped in a per-tab pane bound to `paneMessages(tid)`.
- `this.messages` alias preserved (active pane `paneMessages(currentId) === this.messages` by identity), so existing `messages`-reading bindings stay correct with no broad refactor.

## Measured (same machine, before/after via git stash; single-core, inflated ~5–10× vs real hardware — ratios are environment-independent)
| session | before | after | speedup |
|---|---|---|---|
| 17 msgs | 1302 ms | 259 ms | 5.0× |
| 30 msgs | 2072 ms | 612 ms | 3.4× |
| 128 msgs | 5710 ms | 392 ms | 14.6× |
| agentic worst case 145–153 | 8.8–13.9 s | ~0.4–0.9 s | ~15–30× |

Switch cost is now **decoupled from session length** (128-msg switch is faster than 30-msg). `highlightCode` median 326→23 ms; longtasks 160→57.

## Tradeoff
Flipping `streaming` now recomputes streaming-dependent bindings across **all** mounted panes (~362 ms median with 4 tabs on single-core; ~1.4× baseline; ~40–70 ms on real hardware, twice per turn). **Per-chunk streaming text is unaffected** — only the active tab's own array mutates. Mitigation (gate those bindings by `tid===currentId`) deferred: it touches fragile streaming reactivity and needs live-SSE regression coverage.

## Files
- `index.html`: wrap message `x-for` in per-tab pane (message template unchanged)
- `app.js`: add `paneMessages(tid)` returning that tab's own array
- `styles.css`: `.msg-pane` reproduces `.chat-body`'s flex column + gap

## Test plan
- [x] Each switch: exactly 1 visible pane; visible `.msg` node count == that tab's array length (no cross-pane bleed)
- [x] No new JS errors (Playwright); render verified via screenshots (bubbles/avatars/code/thinking)
- [x] Before/after switch timing, 3 buckets, ≥6 cycles each
- [x] §5.5 risk quantified: streaming-flip cost with N panes
- [ ] **Live SSE on real hardware**: streaming text updates active tab in real time; switch away mid-stream and back; multi-tab streaming feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)