### PR TITLE
ci: drop macos-13 (Intel) from install-test matrix

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -100,20 +100,17 @@ jobs:
   macos:
     name: macos (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # macos-13 (Intel) routinely queues for 20+ hours on the free GHA
-    # runner pool — but we don't want to drop Intel coverage entirely.
-    # Flag the Intel matrix entry as best-effort: failure or runner
-    # starvation timeout doesn't cascade into an install-test workflow
-    # failure. macos-14 (Apple Silicon) is the required signal.
-    continue-on-error: ${{ matrix.os == 'macos-13' }}
-    # Cap per-job wall time so install-test as a whole returns in
-    # ~20 min worst case (the default is 360 min = 6h, and stuck
-    # queues can sit on top of that pushing total to 24h).
+    # Apple Silicon (macos-14) is the required signal. macos-13 (Intel) was
+    # dropped: GitHub's free Intel pool routinely queued 20+ hours and hit the
+    # 24h queue ceiling (timeout-minutes only caps execution, not queue), so it
+    # gave no reliable signal while leaving every PR perpetually "unstable".
+    # Intel macOS is end-of-life on GHA anyway.
+    # Cap per-job wall time so install-test returns quickly (default is 6h).
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14]
     env:
       MUSELAB_NONINTERACTIVE: "1"
       MUSELAB_SKIP_SERVICE:   "1"


### PR DESCRIPTION
## What this changes

从 `install-test.yml` 的 macos job matrix 移除 `macos-13`（Intel），只保留 `macos-14`（Apple Silicon），并删掉随之多余的 `continue-on-error` 守卫。

## Why

GitHub 免费 Intel runner 池里 `macos-13` 常排队 20+ 小时，撞上 24h 排队上限被杀（`timeout-minutes` 只管执行时间、不管排队），于是**每次**都超时报 failure。即便标了 `continue-on-error` 不会真的 fail 掉 workflow，那个红色 check 仍让**每个 PR**（包括 dependabot 的安全升级）卡在 `unstable` 状态，掩盖真实 CI 信号。

`macos-14`（Apple Silicon）本就是 required signal，且 Intel macOS 在 GitHub Actions 上已 end-of-life，没有继续保留的价值。

## Testing

- [x] YAML 语法校验通过（`yaml.safe_load`）
- [ ] 合并后观察 install-test 的 macos job 仅剩 macos-14、不再有 24h 超时红

## Checklist

- [x] No secrets committed
- [x] Docs updated if behavior visible to users（纯 CI 配置，无用户可见行为）
- [x] If adds runtime dep: install scripts updated（无依赖变化）