### PR TITLE
fix(mobile): 修复键盘收起后布局留白上移

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1299,6 +1299,21 @@ function portal() {
       setTimeout(lift, 400);
     },
 
+    // Paired teardown for onChatInputFocus. MUST reset --kb-inset alongside
+    // removing .kb-open — otherwise the inset goes stale. Failure chain:
+    // focus → keyboard up → _initMobileKeyboardWatch.update() sets
+    // --kb-inset to e.g. 336px → blur fires, we drop .kb-open but the inset
+    // lingers at 336px → the NEXT focus re-adds .kb-open before update()
+    // re-fires (or on iOS PWA where visualViewport resize is flaky and never
+    // re-fires) → `body.kb-open .layout { height: calc(100dvh - 336px) }`
+    // shrinks the layout with no keyboard present → a big blank band appears
+    // at the bottom of the chat. Zeroing the inset here keeps the two CSS
+    // inputs (.kb-open class + --kb-inset) in lockstep, exactly like update().
+    onChatInputBlur() {
+      document.body.classList.remove("kb-open");
+      document.documentElement.style.setProperty("--kb-inset", "0px");
+    },
+
     // Triple-click (or any 3+ rapid click) on the chat input selects all
     // text. Browsers natively give us:
     //   single-click → place cursor
@@ -1353,6 +1368,30 @@ function portal() {
       };
       vv.addEventListener("resize", update);
       vv.addEventListener("scroll", update);
+
+      // Event-independent reconciliation. iOS Safari — and standalone PWA in
+      // particular — frequently FAILS to fire vv `resize` when the keyboard
+      // dismisses: focus is retained via Enter-to-send so no blur path runs,
+      // or the event is simply dropped. update() then never re-runs and
+      // --kb-inset is stranded at the last keyboard height with no keyboard
+      // present → `body.kb-open .layout:focus-within` shrinks the layout to
+      // `100dvh - <stale>` → page rides up with a blank band at the bottom
+      // (the recurring bug). Fix: don't rely on the vv event firing. On any
+      // focus change / foregrounding, re-RUN update() — `vv.height` is a live
+      // property, so re-reading it (after a short settle delay for iOS) yields
+      // the true post-keyboard height and the else-branch zeroes the inset.
+      const reconcile = () => { update(); setTimeout(update, 300); };
+      // focusout bubbles (blur does not), so this catches the composer losing
+      // focus regardless of which element it was — including the
+      // Enter-to-send-then-tap-elsewhere path that onChatInputBlur can miss.
+      document.addEventListener("focusout", reconcile);
+      // Returning to the foreground (PWA re-activation / tab switch) can also
+      // surface a stale inset captured before backgrounding.
+      window.addEventListener("focus", reconcile);
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) reconcile();
+      });
+
       update();
     },
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2677,7 +2677,7 @@
                     @input="onChatInput($event); autoGrow($event.target)"
                     @paste="onImagePaste($event)"
                     @focus="onChatInputFocus($event)"
-                    @blur="document.body.classList.remove('kb-open')"
+                    @blur="onChatInputBlur()"
                     @click="onChatInputClick($event)"
                     :placeholder="t('chat.placeholder')"></textarea>
           </form>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -996,7 +996,24 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
    tab-bar) naturally lifts. iOS Safari's `interactive-widget=resizes-
    content` meta SHOULD do this automatically on 16.4+ but is unreliable
    in PWA standalone mode; this is the JS-driven fallback. */
-body.kb-open .layout {
+/* `:focus-within` is load-bearing, not cosmetic. The layout-shrink must
+   apply ONLY while the composer actually holds focus. A soft keyboard
+   cannot exist without a focused input, so "input focused" is the true
+   precondition for stealing screen height. The old selector keyed solely
+   on `.kb-open` — a JS class that gets out of sync: it's added on focus
+   and is meant to be cleared on blur / by the visualViewport watcher, but
+   several paths leave it stuck ON with no keyboard present (Enter-to-send
+   keeps focus so no blur fires; iOS PWA's visualViewport `resize` is
+   flaky and sometimes never re-fires to clear it; assorted programmatic
+   re-focuses re-arm it). When it stuck ON together with a stale
+   `--kb-inset` (e.g. 400px from the last keyboard), the WHOLE layout
+   collapsed to `100dvh - 400px` mid-conversation → a huge blank band at
+   the bottom with the composer pushed off-screen (the recurring bug).
+   Gating on `:focus-within` makes a stuck `.kb-open` harmless: the moment
+   focus leaves the composer (tap a message, scroll to read a streaming
+   reply, switch tab) the shrink stops applying regardless of the stale
+   class/inset, so the layout snaps back to full height. */
+body.kb-open .layout:focus-within {
   /* 100dvh on iOS doesn't account for the on-screen keyboard — that's
      what visualViewport tracks. Subtract --kb-inset so the layout box
      ends right at the keyboard's top edge. The 100vh fallback exists
@@ -1007,7 +1024,11 @@ body.kb-open .layout {
   grid-template-rows: calc(100dvh - var(--kb-inset, 0px));
   transition: height var(--t-fast) ease-out;
 }
-body.kb-open .mobile-tab-bar { display: none; }
+/* Same `:focus-within` guard as the layout-shrink above — a stuck
+   `.kb-open` must not leave the bottom tab bar permanently hidden (which
+   would strand the user with no way to switch panes). Hide it only while
+   the composer truly holds focus. */
+body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 /* Safety net: even on browsers where layout shrink fails, scrollIntoView
    on focus (see app.js onTextareaFocus) needs the textarea to have
    actual room below to scroll-stop against. scroll-margin-bottom keeps a


### PR DESCRIPTION
## 问题

iOS Safari / PWA standalone 下，虚拟键盘高度补偿变量 `--kb-inset` 会卡在上次键盘高度。键盘收起后布局仍按 `100dvh - <stale>` 收缩，导致**整页上移、底部出现一条空白带**（复现性偶发，移动端长期反复出现）。

根因：`--kb-inset` 由 `visualViewport` 的 resize/scroll 事件驱动写入，但 iOS PWA 下键盘收起时该事件**经常不 fire**（Enter 发送保持聚焦无 blur、或事件被丢弃），`update()` 不再跑，inset 永久残留。

## 改动

| 文件 | 改动 |
|------|------|
| `styles.css` | 收缩规则 + tab-bar 隐藏都加 `:focus-within` 门控——焦点离开输入框立即停止收缩，让卡住的 `.kb-open` 无害化 |
| `index.html` | `@blur` 改调 `onChatInputBlur()`，失焦时同步清空 `--kb-inset` |
| `app.js` | 新增 `onChatInputBlur()`；`_initMobileKeyboardWatch` 增加**不依赖 vv 事件**的兜底——`focusout` / `window focus` / `visibilitychange` 时延迟重测 `vv.height` 并归零 inset |

## 测试

- `node --check frontend/app.js` 通过
- 纯前端 + 后端无关；移动端需强刷绕过 service worker 缓存验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)