### PR TITLE
perf(image): 图片压缩上限对齐 vision API 的 1568px 下采样

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2400,8 +2400,18 @@ function portal() {
       // bytes (the main bottleneck on 4G).
       const COMPRESS_THRESHOLD = 256 * 1024;
       if (file.size < COMPRESS_THRESHOLD) return file;
-      const MAX_DIM = 1280;     // pixel count down ~36% vs 1600
-      const QUALITY = 0.72;     // file size down ~30-40% vs 0.85
+      // 2026-06-23 re-loosened for legibility. The 1280/q0.72 era turned
+      // dense screenshots (game settlement screens, spreadsheets, receipts)
+      // with ~10px text into mush. New ceiling tracks the vision API's own
+      // limit: Claude downsamples any attachment to ≤1568px on the long edge
+      // (~1.15 MP) BEFORE the model sees it, so sending more than 1568 is
+      // pure wasted upload for model-reading purposes — 1568 maximizes legible
+      // detail at the smallest bytes that still saturate what the model gets.
+      // Costs ~2-3× the bytes of the 1280/q0.72 era: a deliberate trade of
+      // 4G upload speed for readability (the original 2026-05-21 retune went
+      // the other way for "图片发送很慢"; this is the considered reversal).
+      const MAX_DIM = 1568;
+      const QUALITY = 0.85;
       try {
         let bitmap;
         try {
@@ -2632,10 +2642,10 @@ function portal() {
       } catch (_) {
         bitmap = await createImageBitmap(file);
       }
-      // Cap canvas at 1280px on the long edge — matches our compress ceiling.
-      // Going larger would burn memory on phones and add latency to every
-      // history-snapshot toDataURL call.
-      const MAX = 1280;
+      // Cap canvas at 1568px on the long edge — matches our compress ceiling
+      // (= the vision API's downsample limit). Going larger would burn memory
+      // on phones and add latency to every history-snapshot toDataURL call.
+      const MAX = 1568;
       const ratio = Math.min(1, MAX / Math.max(bitmap.width, bitmap.height));
       const w = Math.max(1, Math.round(bitmap.width * ratio));
       const h = Math.max(1, Math.round(bitmap.height * ratio));


### PR DESCRIPTION
## 背景

旧的客户端压缩上限 `1280px / q0.72`（2026-05-21 为「图片发送很慢」调低）把密集截图——游戏结算页、表格、票据——里 ~10px 的小字压成糊状。

Claude vision 在模型读图前会把长边下采样到 **≤1568px（~1.15 MP）**，所以发超过 1568 对模型读图纯属浪费上传。`1568px / q0.85` 在最小体积下喂满模型实际能看到的细节。

## 改动

`app.js`：压缩 `MAX_DIM` `1280→1568`、`QUALITY` `0.72→0.85`；canvas 截图上限同步 `1280→1568`。

## 权衡

字节数约 2-3×（用 4G 上传速度换可读性）——对上一次反向调参的有意回调。

## 测试

`node --check frontend/app.js` 通过；纯前端。

🤖 Generated with [Claude Code](https://claude.com/claude-code)