### PR TITLE
fix(push): 常亮桌面 tab 不再永久压制手机推送

### DIFF
--- a/backend/presence.py
+++ b/backend/presence.py
@@ -38,6 +38,7 @@ lock needed.
 
 from __future__ import annotations
 
+import os
 import time
 
 # Grace window: how long a `visible` report stays trusted without a
@@ -48,9 +49,37 @@ import time
 # "visible" record can keep suppressing pushes.
 GRACE_SECONDS: float = 30.0
 
-# device_id -> (last_report_ts, visible). Bounded by the user's device
-# count in practice; pruned opportunistically in mark_seen.
-_devices: dict[str, tuple[float, bool]] = {}
+
+def _max_visible_streak() -> float:
+    """Phantom-tab guard (2026-06-23). A device that reports `visible`
+    every 15s but NEVER sends a `hidden` signal is almost certainly a
+    desktop tab left foregrounded on an always-on machine — not someone
+    actually watching. Because recently_active() is GLOBAL (any visible
+    device suppresses pushes to ALL devices, including the phone), one
+    such parked tab silently silences phone notifications forever.
+
+    So we stop trusting a continuous `visible` streak once it exceeds
+    this many seconds: past that, the device no longer suppresses
+    pushes. A real desktop session almost always breaks visibility
+    within the window — switching tabs, locking the screen, or
+    minimizing all fire visibilitychange→hidden, which resets the
+    streak. Only a genuinely parked tab runs past it.
+
+    Default 30 min; override with MUSELAB_PRESENCE_MAX_VISIBLE_SEC
+    (<=0 disables the guard, restoring the old always-trust behavior)."""
+    try:
+        v = float(os.environ.get("MUSELAB_PRESENCE_MAX_VISIBLE_SEC", "1800"))
+    except (TypeError, ValueError):
+        return 1800.0
+    return v
+
+
+# device_id -> (last_report_ts, visible, visible_since). visible_since is
+# the start of the CURRENT uninterrupted visible streak (None when the
+# device's last report was hidden), used by the phantom-tab guard above.
+# Bounded by the user's device count in practice; pruned opportunistically
+# in mark_seen.
+_devices: dict[str, tuple[float, bool, float | None]] = {}
 
 # Entries untouched for this long are dropped — dead device ids (cleared
 # localStorage, retired phone) shouldn't accumulate forever.
@@ -65,9 +94,19 @@ def mark_seen(device_id: str = "default", visible: bool = True) -> None:
                     immediately releases this device's push suppression.
     """
     now = time.time()
-    _devices[device_id] = (now, visible)
+    prev = _devices.get(device_id)
+    if visible:
+        # Continue the streak if the device was already visible; otherwise
+        # (new device, or coming back from hidden) start a fresh streak now.
+        if prev is not None and prev[1] and prev[2] is not None:
+            visible_since = prev[2]
+        else:
+            visible_since = now
+    else:
+        visible_since = None
+    _devices[device_id] = (now, visible, visible_since)
     if len(_devices) > 8:  # prune only when the dict has visibly grown
-        for k, (ts, _vis) in list(_devices.items()):
+        for k, (ts, _vis, _vs) in list(_devices.items()):
             if now - ts > _PRUNE_SECONDS:
                 _devices.pop(k, None)
 
@@ -75,16 +114,37 @@ def mark_seen(device_id: str = "default", visible: bool = True) -> None:
 def recently_active(grace: float = GRACE_SECONDS) -> bool:
     """True if any device is believed to be foregrounded right now:
     its last report said visible AND arrived within `grace` seconds.
-    Push-gate uses this to skip fan-out when the user is at a device."""
+    Push-gate uses this to skip fan-out when the user is at a device.
+
+    Phantom-tab guard: a device whose continuous `visible` streak has run
+    past _max_visible_streak() is treated as a parked tab and no longer
+    suppresses pushes — see _max_visible_streak() for the rationale."""
     now = time.time()
-    return any(vis and (now - ts) < grace for ts, vis in _devices.values())
+    max_streak = _max_visible_streak()
+    for ts, vis, vsince in _devices.values():
+        if not vis or (now - ts) >= grace:
+            continue
+        if max_streak > 0 and vsince is not None \
+                and (now - vsince) >= max_streak:
+            continue  # parked tab — don't let it gate pushes
+        return True
+    return False
 
 
 def last_seen_age() -> float | None:
-    """Seconds since the freshest still-`visible` report. None when no
-    device currently claims visibility (all hidden, or never reported).
-    Used by the push-skip log line and the /api/presence response so
-    the frontend can self-diagnose."""
+    """Seconds since the freshest report from a device that currently
+    suppresses pushes (visible, within grace, and not a parked tab). None
+    when no such device exists. Mirrors recently_active()'s gate so the
+    push-skip log line and /api/presence response reflect the device that
+    actually caused (or would cause) suppression."""
     now = time.time()
-    ages = [now - ts for ts, vis in _devices.values() if vis]
+    max_streak = _max_visible_streak()
+    ages = []
+    for ts, vis, vsince in _devices.values():
+        if not vis or (now - ts) >= GRACE_SECONDS:
+            continue
+        if max_streak > 0 and vsince is not None \
+                and (now - vsince) >= max_streak:
+            continue
+        ages.append(now - ts)
     return min(ages) if ages else None


### PR DESCRIPTION
## 问题

`recently_active()` 是**全局**判定：任一 device 报告 `visible` 就压制对**所有**设备（含手机）的推送 fan-out。一个挂在常亮机器上、每 15s 报一次 `visible` 却从不发 `hidden` 的桌面 tab，会**永久静默手机通知**。

## 改动

加幽灵 tab 守卫（`backend/presence.py`）：连续 `visible` 时长超过 `_max_visible_streak()` 后，该设备不再压制推送。

- 默认 30min，`MUSELAB_PRESENCE_MAX_VISIBLE_SEC` 可覆盖（`<=0` 关闭、恢复旧行为）
- `_devices` 元组新增 `visible_since`，记录当前不间断 `visible` streak 起点；收到 `hidden` 即清空、重新 visible 即重置
- `recently_active()` 与 `last_seen_age()` 同步按守卫过滤

## 原理

真实桌面会话几乎总会在窗口内中断可见性（切 tab / 锁屏 / 最小化都触发 `visibilitychange→hidden`，重置 streak），只有真正挂着的 parked tab 会跑满 30min。

## 测试

`ast.parse` 语法校验通过；建议补 presence 单测覆盖 streak 重置 / 守卫触发两条路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)