### PR TITLE
docs: README 截图改用缩略图尺寸

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@
 | **移动端 PWA** | 获得接近原生 App 的体验，电脑手机多端同步会话，出门在外手机接着聊 |
 
 <p align="center">
-  <img src="promo/media/screenshot-desktop.png" width="100%"
+  <img src="promo/media/screenshot-desktop.png" width="720"
        alt="muselab 桌面三栏：文件树、对话、预览区——黑夜模式下 HTML 实时渲染">
 </p>
-<p align="center"><em>桌面三栏布局——归档文件区、原生预览区、Muse 会话区（黑夜模式 + HTML 实时渲染）</em></p>
+<p align="center"><em>桌面三栏布局——归档文件区、原生预览区、Muse 会话区（黑夜模式 + HTML 实时渲染）· 点击放大</em></p>
 
-<table>
+<table align="center">
 <tr>
-<td><img src="promo/media/screenshot-mobile-files.jpeg" width="100%"></td>
-<td><img src="promo/media/screenshot-mobile-preview.png" width="100%"></td>
-<td><img src="promo/media/screenshot-mobile-chat.png" width="100%"></td>
+<td><img src="promo/media/screenshot-mobile-files.jpeg" width="200"></td>
+<td><img src="promo/media/screenshot-mobile-preview.png" width="200"></td>
+<td><img src="promo/media/screenshot-mobile-chat.png" width="200"></td>
 </tr>
 <tr>
 <td align="center">移动端文件区</td>

--- a/README_en.md
+++ b/README_en.md
@@ -23,16 +23,16 @@
 | **Mobile PWA** | Near-native App experience, synced sessions across desktop and phone, and continued work while you are away from your desk |
 
 <p align="center">
-  <img src="promo/media/screenshot-desktop.png" width="100%"
+  <img src="promo/media/screenshot-desktop.png" width="720"
        alt="muselab desktop three-pane layout: file tree, chat, and live HTML preview in dark mode">
 </p>
-<p align="center"><em>Desktop three-pane layout — archive area, native preview area, and Muse conversation area (dark mode with live HTML rendering).</em></p>
+<p align="center"><em>Desktop three-pane layout — archive area, native preview area, and Muse conversation area (dark mode with live HTML rendering). Click to enlarge.</em></p>
 
-<table>
+<table align="center">
 <tr>
-<td><img src="promo/media/screenshot-mobile-files.jpeg" width="100%"></td>
-<td><img src="promo/media/screenshot-mobile-preview.png" width="100%"></td>
-<td><img src="promo/media/screenshot-mobile-chat.png" width="100%"></td>
+<td><img src="promo/media/screenshot-mobile-files.jpeg" width="200"></td>
+<td><img src="promo/media/screenshot-mobile-preview.png" width="200"></td>
+<td><img src="promo/media/screenshot-mobile-chat.png" width="200"></td>
 </tr>
 <tr>
 <td align="center">Mobile · files</td>


### PR DESCRIPTION
## 改动

首屏四张截图原来按 `width="100%"` 全宽渲染，太占篇幅。参考 [happyclaw](https://github.com/riba2534/happyclaw) 的做法改成固定缩略图：

| 图 | 原 | 现 |
|----|----|----|
| 桌面图 | `width="100%"` | `width="720"` |
| 移动端三图 | 各 `width="100%"` | 各 `width="200"`，表格 `align="center"` |

GitHub 会自动把 README 图片包成可点击放大的链接，缩略图不损失查看体验（caption 也注明"点击放大"）。中英 `README.md` / `README_en.md` 同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)