### PR TITLE
feat(preview/session): 预览缩放+图片放大、打开会话自动同步消息、修复会话计数为0

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2708,6 +2708,22 @@ def get_session_api(
     # mechanism. The user briefly sees just the user msg, then SSE
     # fills in everything via replay → live.
     total = len(messages)
+    # Self-heal a stale cached message_count. Some sessions carry
+    # message_count=0 in the muselab index despite having a real transcript
+    # (older imports, or turns written outside muselab's bump path), which
+    # made the session list report non-empty sessions as "0 messages" and,
+    # if MUSELAB_PRUNE_EMPTY_SESSIONS is ever enabled, risked pruning them.
+    # `total` is the real shaped count we just computed, so write it back via
+    # the side-effect-free setter (never touches updated_at → no reordering).
+    # Gated on `not full` (full=1 is the larger pre-compact outline/export
+    # count, not the normal view's count) and total>0 (so a transient empty
+    # read can't zero out a real count).
+    if not full and total > 0 and meta.get("message_count", 0) != total:
+        try:
+            _turns = sum(1 for x in messages if x.get("role") == "user")
+            sess.set_message_count(sid, total, turn_count=_turns)
+        except Exception:
+            pass
     # Slice the requested window. full / no-param → whole list (offset 0).
     if full or (tail <= 0 and offset < 0):
         win_offset = 0

--- a/backend/files.py
+++ b/backend/files.py
@@ -8,7 +8,7 @@ import threading
 import time
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, Query
-from fastapi.responses import FileResponse, PlainTextResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
 from pydantic import BaseModel
 from .auth import require_token, require_token_query
 from .settings import ROOT, atomic_write_text, env_int
@@ -661,9 +661,49 @@ INLINE_OK_SUFFIX = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico",
 # same-origin token theft).
 SANDBOXED_INLINE_SUFFIX = {".html", ".htm", ".svg"}
 
+# Click-to-zoom bridge for HTML previews. The preview iframe is sandboxed
+# (opaque origin) so the parent can't reach the framed DOM to intercept image
+# clicks. Instead we inject this tiny script (only when the preview pane asks
+# via ?preview=1) which forwards in-page image clicks to the parent via
+# postMessage — postMessage works fine from a sandboxed origin, so this needs
+# NO sandbox relaxation and leaks nothing (only the clicked image's src/alt).
+# The parent (app.js) validates event.source === the preview iframe before
+# opening its lightbox. Images wrapped in a link are left alone so the link
+# still navigates. CSP allows it: script-src includes 'unsafe-inline'.
+_PREVIEW_IMG_BRIDGE = (
+    "<script>(function(){document.addEventListener('click',function(e){"
+    "var t=e.target;var img=t&&t.closest?t.closest('img'):null;"
+    "if(!img||img.closest('a'))return;var src=img.currentSrc||img.src;"
+    "if(!src)return;e.preventDefault();"
+    "try{parent.postMessage({__muselab:'preview-img',src:src,alt:img.alt||''},'*');}"
+    "catch(_e){}},true);})();</script>"
+)
+# Cap the in-memory read used for injection. Bigger HTML (e.g. reports with
+# megabytes of base64 images) falls back to streaming untouched — it just
+# won't have click-to-zoom, which is an acceptable degradation.
+_PREVIEW_INJECT_MAX_BYTES = 12 * 1024 * 1024
+
+
+def _inject_preview_img_bridge(target: Path) -> str | None:
+    """Return the HTML text with the click-to-zoom bridge injected, or None to
+    signal "fall back to streaming the file untouched" (too big / not utf-8)."""
+    try:
+        if target.stat().st_size > _PREVIEW_INJECT_MAX_BYTES:
+            return None
+        html = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    lower = html.lower()
+    idx = lower.rfind("</body>")
+    if idx == -1:
+        idx = lower.rfind("</html>")
+    if idx == -1:
+        return html + _PREVIEW_IMG_BRIDGE
+    return html[:idx] + _PREVIEW_IMG_BRIDGE + html[idx:]
+
 
 @router.get("/raw", dependencies=[Depends(require_token_query)])
-def raw_file(path: str = Query(...)) -> FileResponse:
+def raw_file(path: str = Query(...), preview: bool = Query(False)):
     """Stream raw file (images, PDF, sandboxed HTML, etc.). Token via query.
     Everything outside the whitelists is forced to download as octet-stream."""
     target = safe_resolve(path)
@@ -701,7 +741,7 @@ def raw_file(path: str = Query(...)) -> FileResponse:
         # are unavailable, so the query token can't be replayed against the API.
         # Previously only the frontend iframe's sandbox attribute provided this
         # isolation, which a top-level open silently bypassed.
-        return FileResponse(target, headers={
+        sandbox_headers = {
             **base_headers,
             "Content-Disposition": f"inline; {disp_filename}",
             "Content-Security-Policy": (
@@ -714,7 +754,15 @@ def raw_file(path: str = Query(...)) -> FileResponse:
                 "connect-src 'self'; "
                 "base-uri 'none'; form-action 'none'"
             ),
-        })
+        }
+        # Preview pane requests ?preview=1 for HTML so we can inject the
+        # click-to-zoom bridge. SVG and the top-level/download paths never
+        # get it (no preview flag) and stream untouched.
+        if preview and suffix in (".html", ".htm"):
+            injected = _inject_preview_img_bridge(target)
+            if injected is not None:
+                return HTMLResponse(content=injected, headers=sandbox_headers)
+        return FileResponse(target, headers=sandbox_headers)
     # FileResponse(filename=) sets Content-Disposition itself; use our safe one.
     return FileResponse(target, media_type="application/octet-stream", headers={
         **base_headers,

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -557,11 +557,27 @@ def prune_empty_sessions(keep_ids: tuple | list = ()) -> list[str]:
     from claude_agent_sdk import delete_session as sdk_delete_session
     keep = set(keep_ids)
     cutoff = _time.time() - 2 * 3600  # 2 小时
+    # Data-loss guard: never delete a session that has an on-disk transcript,
+    # regardless of its cached message_count. A stale message_count=0 (older
+    # imports, transcripts written outside muselab's turn path) would
+    # otherwise let this prune a session full of real messages. Sessions the
+    # SDK can enumerate HAVE a JSONL → treat as non-empty and skip. Only
+    # truly transcript-less index stubs (created-but-never-sent) are eligible.
+    transcript_ids: set[str] = set()
+    if ROOT is not None:
+        try:
+            transcript_ids = {info.session_id
+                              for info in sdk_list_sessions(directory=str(ROOT))}
+        except Exception:
+            # If we can't confirm which sessions have transcripts, fail SAFE:
+            # delete nothing rather than risk nuking real history.
+            return []
     with _INDEX_LOCK:
         idx = _load_index()
         to_delete = [
             s["id"] for s in idx
             if s.get("message_count", 0) == 0
+            and s["id"] not in transcript_ids  # has a JSONL → real content, keep
             and not s.get("pinned")
             and s.get("auto_named", True)
             and s.get("created_at", 0) > cutoff  # 只删 2 小时内的空会话
@@ -863,6 +879,55 @@ def bump_session(sid: str, message_count: int | None = None,
                         s["auto_named"] = False
                 _save_index(idx)
                 return
+
+
+def set_message_count(sid: str, message_count: int,
+                       turn_count: int | None = None) -> None:
+    """Patch ONLY the cached message_count / turn_count for a session,
+    WITHOUT touching updated_at (so it never reorders the session list).
+
+    Why this exists separately from bump_session: bump_session always
+    stamps updated_at (it's the "a turn just happened" signal), so it
+    can't be used to lazily back-fill a stale count on a plain session
+    OPEN — that would float every session you merely glance at to the
+    top. This setter is the side-effect-free counterpart used by the
+    self-heal in chat.get_session_api: some sessions (older imports,
+    transcripts written outside muselab's turn path) carry a stale
+    message_count=0 in the index despite having a real transcript on
+    disk, which made the session list report "0 messages" for non-empty
+    sessions. Writing the real count back here fixes the display and
+    keeps prune_empty_sessions honest.
+
+    Creates a minimal index stub if the session has no entry yet (an
+    SDK-only session whose JSONL exists but was never registered) — same
+    pattern as toggle_pin — so the corrected count actually persists.
+    Idempotent: a no-op when the stored values already match.
+    """
+    with _INDEX_LOCK:
+        idx = _load_index()
+        for s in idx:
+            if s["id"] == sid:
+                changed = False
+                if s.get("message_count") != message_count:
+                    s["message_count"] = message_count
+                    changed = True
+                if turn_count is not None and s.get("turn_count") != turn_count:
+                    s["turn_count"] = turn_count
+                    changed = True
+                if changed:
+                    _save_index(idx)
+                return
+        # No index entry yet — create a minimal stub carrying the count.
+        now = time.time()
+        stub = {
+            "id": sid, "name": "", "model": "", "system_prompt": "",
+            "created_at": now, "updated_at": now,
+            "message_count": message_count, "auto_named": True,
+        }
+        if turn_count is not None:
+            stub["turn_count"] = turn_count
+        idx.append(stub)
+        _save_index(idx)
 
 
 # ============================================================================

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -282,6 +282,15 @@ function portal() {
     // buster on iframe / read URLs so the preview reflects the new content
     // without the user needing to manually refresh the page.
     previewVersion: 0,
+    // Browser-like zoom for the preview content (md/text/img/xlsx/csv/html).
+    // Applied as CSS `zoom` on the content nodes only (NOT the .preview-body
+    // container) so the find bar / drop overlay stay at 100%. Sticky across
+    // file switches like real browser zoom; not persisted across reloads.
+    // pdf is excluded — the browser PDF viewer has its own zoom control.
+    previewZoom: 1,
+    PREVIEW_ZOOM_MIN: 0.5,
+    PREVIEW_ZOOM_MAX: 3,
+    PREVIEW_ZOOM_STEP: 0.1,
     // Compact orchestration: the per-tab `compacting` flag (see
     // _blankTabState) marks the window where the CLI is busy summarising
     // *that session's* history. User messages typed during compact go into
@@ -1150,6 +1159,19 @@ function portal() {
         this.osFileDragging = false;
       });
 
+      // Click-to-zoom bridge for HTML previews. The sandboxed (opaque-origin)
+      // preview iframe can't be reached from here to intercept image clicks,
+      // so files.py injects a script that postMessages the clicked image's
+      // src up. Validate the message came from OUR preview iframe (not some
+      // other framed content posting to window) before opening the lightbox.
+      window.addEventListener("message", (e) => {
+        const f = this.$refs.htmlFrame;
+        if (!f || e.source !== f.contentWindow) return;
+        const d = e.data;
+        if (!d || d.__muselab !== "preview-img" || typeof d.src !== "string") return;
+        this.openLightbox(d.src, typeof d.alt === "string" ? d.alt : "");
+      });
+
       // Listen for SW → page messages. The service worker posts
       // `muselab/notification-clicked` when the user taps a push
       // banner; we ack the unread badge immediately so they don't
@@ -1206,6 +1228,13 @@ function portal() {
       // immediately re-renders the chat-body. localStorage flag persists
       // dismissal across reloads / PWA reopens.
       this._welcomeDismissed = localStorage.getItem("muselab_welcome_dismissed") === "1";
+      // Restore the preview zoom level so it sticks across reloads / PWA
+      // reopens, like a browser's per-site zoom. Clamp the stored value in
+      // case the bounds changed between versions.
+      {
+        const z = parseFloat(localStorage.getItem("muselab_preview_zoom"));
+        if (!Number.isNaN(z)) this.previewZoom = this._clampPreviewZoom(z);
+      }
       // Vibration / push prefs come from localStorage (per-device) so a
       // shared muselab between a desktop + phone keeps independent
       // settings — your phone can vibrate; the desktop tab silently
@@ -5296,6 +5325,11 @@ function portal() {
       if (_pending.length) {
         next = [...(_pending.map(id => _om[id])), ...next];
       }
+      // Keep the OPEN conversation's messages live too — not just the session
+      // LIST. Runs BEFORE the equality early-return so it fires every pull even
+      // when the picker itself doesn't need a re-render (e.g. a turn still
+      // running on the open session that we lost the SSE to). See method doc.
+      this._reconcileOpenSession(next);
       // Shallow-diff guard (2026-06-07, render 治本): the 10s background poll
       // returns 200 (not 304) whenever ANY display field changed — including a
       // streaming session's `active` dot toggling. Re-assigning this.sessions
@@ -5312,6 +5346,57 @@ function portal() {
           const st = this._ensureTabState(s.id);
           if (st && !st.streaming) st.unread = true;
         }
+      }
+    },
+    // Keep the OPEN conversation's MESSAGES in sync — previously only the
+    // session LIST (dots / unread) was polled; the message body of the session
+    // you were looking at only updated on tab-switch / manual refresh. That's
+    // the root cause of "要手动点刷新才有最新消息": anything that changed the open
+    // session from OUTSIDE this tab's own live stream (a turn running on another
+    // device, a background / scheduled turn, or an SSE that silently dropped
+    // while the PWA was suspended) left the view frozen until a manual reload.
+    //
+    // Driven off the session list we already poll every 10s + on visibility /
+    // reconnect — no new backend endpoint, no extra request on the common
+    // "nothing changed" tick. `_openSeenUpdated` is the updated_at the rendered
+    // messages reflect; a real load / switch / our-own-stream-done re-baselines
+    // it (set to undefined) so we never reload a session we just pulled.
+    _reconcileOpenSession(next) {
+      const sid = this.currentId;
+      if (!sid) return;
+      // Hidden tab: defer — visibilitychange→visible re-pulls the list and we
+      // reconcile then. Avoids churn (and battery) while the user isn't looking.
+      if (typeof document !== "undefined"
+          && document.visibilityState !== "visible") return;
+      // Our own live stream already owns the view (renders incrementally).
+      if (this.streaming) return;
+      const cur = (next || []).find(s => s && s.id === sid);
+      if (!cur) return;
+      const newU = Number(cur.updated_at) || 0;
+      const baseline = this._openSeenUpdated;
+      this._openSeenUpdated = newU;
+      // First sight after a fresh load / switch: just baseline. loadSession
+      // already pulled the latest and _checkActiveTurn re-attached any live turn.
+      if (baseline === undefined) return;
+      if (cur.active) {
+        // Server reports a live turn on the OPEN session but this tab isn't
+        // streaming it (PWA resumed with a dropped SSE, or the turn is running
+        // on another device). Quiet-reload pulls the authoritative server view
+        // — including a prompt that was sent on another device, which this tab
+        // never had — and loadSession's internal _checkActiveTurn then reconnects
+        // the SSE so the reply streams in live. (Reconnecting WITHOUT the reload
+        // would let send({reconnect})'s "truncate back to last user msg" eat a
+        // real prior reply when the externally-sent prompt isn't in our view.)
+        // Runs regardless of scroll — reconnect is append-only and honors
+        // atBottom, so a user reading history isn't yanked. Self-limiting: once
+        // the reconnect sets streaming=true the guard above skips repeat ticks.
+        this.loadSession(sid, { quiet: true });
+      } else if (newU > baseline && this.atBottom) {
+        // A turn finished from OUTSIDE this tab (another device / background
+        // task) — its final messages are on disk now. Pull them in place. Gated
+        // on atBottom so a user scrolled up reading history is never yanked down;
+        // they'll get the update on their next scroll-to-bottom / switch / send.
+        this.loadSession(sid, { quiet: true });
       }
     },
     // Field-level equality over the rendered session metadata. Returns true
@@ -6024,8 +6109,19 @@ function portal() {
 
       if (m._is_compact_summary) return true;
       switch (m.role) {
+        case "assistant": {
+          // Empty mid-turn assistant text block (no text, no rendered html) is
+          // noise — typically an empty text block the model emitted between a
+          // thinking block and a tool_use, which on a RELOADED session never
+          // gets html computed (renderMarkdown only fills html when text is
+          // truthy). It used to surface as a literal "undefined" bubble via
+          // x-html. The turn-tail short-circuit above already passes the live
+          // streaming bubble (which legitimately starts empty), so this only
+          // drops genuinely-empty blocks restored from a saved session.
+          if (!(m.text && String(m.text).trim()) && !m.html) return false;
+          return true;
+        }
         case "user":
-        case "assistant":
         case "assistant-turn":
         case "thinking":
         case "permission_request":
@@ -7400,6 +7496,12 @@ function portal() {
       this.savePrefs();
     },
     async switchSession() {
+      // Re-baseline the open-session resync cursor on every switch — incl. the
+      // instant "already-loaded" path below that skips loadSession (which would
+      // otherwise leave the PREVIOUS session's updated_at as the baseline and
+      // mis-fire a quiet reload on the newly-shown tab). The next list poll
+      // records this tab's real updated_at without reloading.
+      this._openSeenUpdated = undefined;
       // Mobile: any session switch implies "I want to see chat" — covers
       // every entry point at once (openTab from picker, activateTab from
       // chat-tabs strip, slash /resume, ctx-menu, programmatic newSession).
@@ -7636,7 +7738,20 @@ function portal() {
       // at the compact summary and can't reach it). Records st._fullLoaded
       // so the jump retry doesn't loop re-requesting full mode.
       const full = !!opts.full;
+      // quiet:true → in-place message refresh with NO skeleton + a scroll-
+      // preserving morph swap. Used by the open-session auto-resync
+      // (_reconcileOpenSession) so a background poll that pulls newly-finished
+      // messages never blanks the conversation or jumps the scroll. Cold opens
+      // and tab switches keep the normal skeleton + chunked-reveal path.
+      const quiet = !!opts.quiet;
       const st = this._ensureTabState(sid);
+      // Hard safety: a quiet refresh must NEVER run while a live stream owns
+      // st.messages — the splice-swap below would wipe the in-flight bubbles
+      // (and orphan the stream's curBubble pointer), blanking the conversation
+      // mid-reply. _reconcileOpenSession already gates on this.streaming, but a
+      // reconnect can flip streaming true during this function's awaits, so we
+      // bail up-front AND re-check right before the swap.
+      if (quiet && (st.streaming || st.es)) return;
       // Skeleton on the active tab during the fetch — markdown rendering of
       // a long history can also take a noticeable beat after the network
       // returns, so the flag must wrap both phases.
@@ -7646,7 +7761,15 @@ function portal() {
       // mid-load corrupts the now-active tab (messages not assigned / skeleton
       // stuck / model/effort overwritten by the old session). See loadSession race.
       const isCurrent = sid === this.currentId;
-      if (isCurrent) { this.messagesLoading = true; this.messagesReady = false; }
+      // Quiet refresh keeps the existing bubbles on screen (morph swap below) —
+      // raising the skeleton would defeat the point, so only cold/switch loads
+      // flip it. Also re-baseline the open-session resync cursor on a real load
+      // so the next list poll doesn't mistake "we just freshly pulled this" for
+      // an external change and reload again.
+      if (isCurrent && !quiet) {
+        this.messagesLoading = true; this.messagesReady = false;
+        this._openSeenUpdated = undefined;
+      }
       // Set true once we've scheduled the reveal (highlight→show). Guards the
       // finally so error / empty-result paths don't leave the skeleton stuck.
       let scheduledReveal = false;
@@ -7780,7 +7903,12 @@ function portal() {
         // scroll-anchored fill (see _fillDeferredHead). Un-rewound windows keep
         // the original one-shot path — zero behaviour change for short sessions.
         let _deferHead = null;
-        if (sid === this.currentId) {
+        if (sid === this.currentId && quiet) {
+          // Quiet refresh: render the whole visible window synchronously (small —
+          // it's a refresh, not a cold open) so the in-place swap below morphs in
+          // fully-rendered bubbles with no deferred-head dance.
+          visible.forEach(renderMarkdown);
+        } else if (sid === this.currentId) {
           if (visible.length > INITIAL_LOAD) {
             const _headCount = visible.length - INITIAL_LOAD;
             for (let j = _headCount; j < visible.length; j++) renderMarkdown(visible[j]);
@@ -7797,13 +7925,24 @@ function portal() {
           await this._renderMessagesChunked(visible, renderMarkdown);
         }
         // Mutate in place — preserves the Array reference Alpine is watching.
-        st.messages.length = 0;
-        // Foreground tab fills st.messages INCREMENTALLY via
-        // _revealMessagesChunked below (spreads Alpine's bubble instantiation
-        // over several frames instead of one multi-second main-thread burst).
-        // Off-screen tabs aren't painted (display:none), so there's no freeze
-        // to spread — push them in one shot.
-        if (sid !== this.currentId) st.messages.push(...visible);
+        if (sid === this.currentId && quiet) {
+          // Re-check after the fetch await: if a stream started meanwhile, abort
+          // the swap so we don't wipe live bubbles (see up-front guard above).
+          if (st.streaming || st.es) return;
+          // One-shot splice swap: Alpine morphs by stable :key (_k = sid+idx), so
+          // already-rendered bubbles stay mounted (no blank flash, scroll kept)
+          // and only the newly-finished tail bubbles get added.
+          this.messages = st.messages;
+          st.messages.splice(0, st.messages.length, ...visible);
+        } else {
+          st.messages.length = 0;
+          // Foreground tab fills st.messages INCREMENTALLY via
+          // _revealMessagesChunked below (spreads Alpine's bubble instantiation
+          // over several frames instead of one multi-second main-thread burst).
+          // Off-screen tabs aren't painted (display:none), so there's no freeze
+          // to spread — push them in one shot.
+          if (sid !== this.currentId) st.messages.push(...visible);
+        }
         // Stash older messages on the per-tab state; the "Load earlier"
         // button reads from here.
         st._earlierMessages = earlier;
@@ -7838,6 +7977,22 @@ function portal() {
           this.effort = s.effort || "";
           // thinking: default true when absent (legacy sessions had no field).
           this.thinkingEnabled = s.thinking !== false;
+          if (quiet) {
+            // Already swapped in place above (no skeleton, no reveal). Just
+            // re-highlight the freshly-added tail and re-pin to the bottom IF the
+            // user was following it — _reconcileOpenSession only quiet-reloads
+            // when atBottom, so this won't yank anyone reading history.
+            const _wasAtBottom = this.atBottom;
+            this.$nextTick(async () => {
+              try { await this.highlightCode(".chat-body"); st._highlighted = true; }
+              catch (_e) { /* highlight best-effort */ }
+              if (sid === this.currentId && _wasAtBottom) {
+                this.atBottom = true; this.scrollToBottom(true);
+              }
+            });
+            await this._fetchTabUsage(sid);
+            return;
+          }
           this.atBottom = true;
           // Hold the skeleton until highlight + artifacts finish, then reveal
           // the whole conversation at once. Without this, a big session paints
@@ -10858,10 +11013,14 @@ function portal() {
       this.savePrefs();
     },
 
-    rawUrl(p) {
+    rawUrl(p, opts = {}) {
       const v = this.previewVersion ? `&_v=${this.previewVersion}` : "";
+      // preview=1 asks the backend to inject the click-to-zoom bridge into
+      // HTML (see files.py). Only the html preview iframe passes it; images /
+      // pdf / downloads stream untouched.
+      const pv = opts.preview ? "&preview=1" : "";
       return "/api/files/raw?path=" + encodeURIComponent(p)
-              + "&token=" + encodeURIComponent(this.token) + v;
+              + "&token=" + encodeURIComponent(this.token) + v + pv;
     },
     async reloadPreview() {
       // Manual "🗘 reload" button in preview header. Bumps previewVersion
@@ -10912,6 +11071,28 @@ function portal() {
       this.toast(this.lang === "zh" ? "已刷新预览" : "Preview reloaded",
                   "success", 1200);
     },
+
+    // ===== Preview zoom (browser-like ±) =====
+    // Modes that support zoom. pdf/loading/unsupported/empty are excluded.
+    previewZoomable() {
+      return !this.editing && this.selected &&
+        ["md", "text", "img", "xlsx", "csv", "html"].includes(this.previewMode);
+    },
+    _clampPreviewZoom(z) {
+      // Round to the step grid to avoid 0.9999… drift, then clamp.
+      const stepped = Math.round(z / this.PREVIEW_ZOOM_STEP) * this.PREVIEW_ZOOM_STEP;
+      return Math.min(this.PREVIEW_ZOOM_MAX,
+              Math.max(this.PREVIEW_ZOOM_MIN, Math.round(stepped * 100) / 100));
+    },
+    setPreviewZoom(z) {
+      this.previewZoom = this._clampPreviewZoom(z);
+      // Persist (per-device) so the level survives reloads / PWA reopens.
+      try { localStorage.setItem("muselab_preview_zoom", String(this.previewZoom)); } catch {}
+    },
+    zoomPreviewIn()  { this.setPreviewZoom(this.previewZoom + this.PREVIEW_ZOOM_STEP); },
+    zoomPreviewOut() { this.setPreviewZoom(this.previewZoom - this.PREVIEW_ZOOM_STEP); },
+    resetPreviewZoom() { this.setPreviewZoom(1); },
+    previewZoomPct() { return Math.round(this.previewZoom * 100) + "%"; },
 
     async _maybeReloadPreview(toolFilePath) {
       // Called from the tool_use SSE handler when a write-style tool fires.
@@ -13768,7 +13949,10 @@ function portal() {
     jumpToPrevUser() {
       const el = this.$refs.chatBody;
       if (!el) return;
-      const users = Array.from(el.querySelectorAll(".msg.user"));
+      // Exclude queued (not-yet-sent) bubbles — they render as .msg.user.queued
+      // but jumping to them is meaningless; the FAB should only target real
+      // sent user messages in history. See index.html `.msg.user.queued`.
+      const users = Array.from(el.querySelectorAll(".msg.user:not(.queued)"));
       if (!users.length) return;
       const contTop = el.getBoundingClientRect().top;
       const threshold = 4; // px; element must be meaningfully above the top
@@ -14756,6 +14940,11 @@ function portal() {
         // is page-reload-then-reconnect picking up a turn that finished
         // after being cancelled before reload.
         es.close(); _markDone(!!d.cancelled); _stopTimer();
+        // We rendered this reply live — re-baseline the open-session resync
+        // cursor so the post-done list poll (updated_at now advanced) doesn't
+        // mistake our own just-finished turn for an external change and quiet-
+        // reload on top of it.
+        if (streamSid === this.currentId) this._openSeenUpdated = undefined;
         this.refreshSessions();
         if (this.currentId === streamSid) {
           // highlightCode resolves AFTER syntax highlight + artifact render
@@ -15202,6 +15391,20 @@ function portal() {
     openLightbox(src, alt) {
       if (!src) return;
       this.lightbox = { show: true, src, alt: alt || "" };
+    },
+
+    // Click-to-zoom for images inside a rendered markdown preview. Delegated
+    // on the .markdown container (covers both the preview pane and the editor
+    // split live-preview). Images wrapped in a link are left alone so the
+    // link still navigates; broken/empty-src images are ignored.
+    onPreviewImgClick(e) {
+      const img = e.target.closest("img");
+      if (!img) return;
+      if (img.closest("a")) return;
+      const src = img.currentSrc || img.getAttribute("src");
+      if (!src) return;
+      e.preventDefault();
+      this.openLightbox(src, img.alt || "");
     },
 
     retryFailedMessage(m) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -549,6 +549,22 @@
             </div>
           </template>
         </div>
+        <!-- Preview zoom (browser-like −/percentage/+). Shown only for the
+             zoomable modes (md/text/img/xlsx/csv/html); pdf has native zoom.
+             Click the percentage to reset to 100%. -->
+        <div class="preview-zoom" x-show="previewZoomable()">
+          <button class="preview-zoom-btn" @click="zoomPreviewOut()"
+                  :disabled="previewZoom <= PREVIEW_ZOOM_MIN"
+                  :title="lang==='zh' ? '缩小' : 'Zoom out'"
+                  :aria-label="lang==='zh' ? '缩小' : 'Zoom out'">−</button>
+          <button class="preview-zoom-pct" @click="resetPreviewZoom()"
+                  :title="lang==='zh' ? '重置为 100%' : 'Reset to 100%'"
+                  x-text="previewZoomPct()"></button>
+          <button class="preview-zoom-btn" @click="zoomPreviewIn()"
+                  :disabled="previewZoom >= PREVIEW_ZOOM_MAX"
+                  :title="lang==='zh' ? '放大' : 'Zoom in'"
+                  :aria-label="lang==='zh' ? '放大' : 'Zoom in'">+</button>
+        </div>
         <button x-show="selected && !editing && (previewMode==='md' || previewMode==='text')"
                 @click="togglePreviewFind()" class="icon-btn preview-keep-mobile"
                 :class="{ active: previewFind.open }"
@@ -570,7 +586,6 @@
         </button>
         <button x-show="editing" @click="saveEdit()" class="btn-primary btn-compact" x-text="t('btn.save')"></button>
         <button x-show="selected" @click="insertFileMention(selected)" class="icon-btn preview-keep-mobile" :title="t('btn.at_mention')"><svg><use href="#i-at"/></svg></button>
-        <a x-show="selected" :href="downloadUrl(selected)" :download="selected.split('/').pop()" class="icon-btn preview-keep-mobile" :title="t('btn.download')"><svg><use href="#i-download"/></svg></a>
         <!-- Desktop fullscreen toggle (hidden on mobile via .pane-fullscreen-btn
              @media in styles.css). Click → preview pane takes whole viewport;
              click again to restore the 3-column layout. -->
@@ -785,7 +800,7 @@
           <div class="editor-main">
             <div x-ref="cmHost" class="editor-cm" x-show="editorView !== 'preview'"></div>
             <div class="editor-live-preview" x-show="editorIsMd && editorView !== 'edit'">
-              <div class="markdown" x-html="livePreviewHtml"></div>
+              <div class="markdown" x-html="livePreviewHtml" @click="onPreviewImgClick($event)"></div>
             </div>
           </div>
           <div class="editor-status">
@@ -806,8 +821,8 @@
           <span class="preview-loading-text"
                 x-text="lang==='zh' ? '加载中…' : 'Loading…'"></span>
         </div>
-        <div x-show="!editing && previewMode==='md' && rawText" class="markdown" x-html="renderedMd"></div>
-        <pre x-show="!editing && previewMode==='text' && rawText" class="text"><code :class="'language-' + previewLang" x-text="rawText"></code></pre>
+        <div x-show="!editing && previewMode==='md' && rawText" class="markdown" x-html="renderedMd" :style="'zoom:' + previewZoom" @click="onPreviewImgClick($event)"></div>
+        <pre x-show="!editing && previewMode==='text' && rawText" class="text" :style="'zoom:' + previewZoom"><code :class="'language-' + previewLang" x-text="rawText"></code></pre>
         <!-- 0-byte / empty file: a blank md/text pane is indistinguishable from
              "still loading" or "render broke". Show an explicit placeholder. -->
         <div x-show="!editing && (previewMode==='md' || previewMode==='text') && selected && !rawText" class="empty">
@@ -818,13 +833,15 @@
         <!-- src 仅在该模式激活时才指向真实 URL，否则空字符串/about:blank，
              避免隐藏元素请求 raw URL 触发对 md/txt 的下载。 -->
         <iframe x-show="!editing && previewMode==='html'"
-                :src="previewMode==='html' ? rawUrl(selected) : 'about:blank'"
+                x-ref="htmlFrame"
+                :src="previewMode==='html' ? rawUrl(selected, {preview:true}) : 'about:blank'"
+                :style="'zoom:' + previewZoom"
                 class="frame" sandbox="allow-scripts"></iframe>
         <!-- Use template x-if (not x-show) so the <img> isn't even in the DOM
              when not active — :src="" would otherwise resolve to the page URL
              and fire a spurious resource-load-failed error in console. -->
         <template x-if="!editing && previewMode==='img' && selected">
-          <img :src="rawUrl(selected)" :alt="selected ? selected.split('/').pop() : ''" class="preview-img" />
+          <img :src="rawUrl(selected)" :alt="selected ? selected.split('/').pop() : ''" class="preview-img" :style="'zoom:' + previewZoom" />
         </template>
         <iframe x-show="!editing && previewMode==='pdf'"
                 :src="previewMode==='pdf' ? rawUrl(selected) : 'about:blank'"
@@ -856,7 +873,7 @@
           <template x-for="sh in xlsxSheets.filter(s => s.name === xlsxActive)" :key="sh.name">
             <div class="xlsx-sheet-wrap">
               <div class="xlsx-scroll">
-                <table class="xlsx-table">
+                <table class="xlsx-table" :style="'zoom:' + previewZoom">
                   <tbody>
                     <template x-for="(row, ri) in sh.rows" :key="ri">
                       <tr>
@@ -902,7 +919,7 @@
                   x-text="lang==='zh' ? '（列数已截断）' : '(cols truncated)'"></span>
           </div>
           <div class="xlsx-scroll" x-show="csvData">
-            <table class="xlsx-table">
+            <table class="xlsx-table" :style="'zoom:' + previewZoom">
               <thead x-show="csvData && csvData.has_header && csvData.header && csvData.header.length">
                 <tr>
                   <th class="xlsx-rownum"></th>
@@ -1557,7 +1574,7 @@
           <template x-for="tid in residentPaneIds()" :key="tid">
           <div class="msg-pane" x-show="tid === currentId">
           <template x-for="(m, i) in paneMessages(tid)" :key="m._k || m.uuid || ('m-' + i)">
-            <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i) ? '' : ' is-hidden')"
+            <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i) ? '' : ' is-hidden') + ((streaming && i >= messages.length - 8) ? ' is-streaming-tail' : '')"
                  :data-uuid="m.uuid || ''"
                  :style="'contain-intrinsic-size: auto ' + estIntrinsicH(m) + 'px'">
               <!-- compact-summary pill -->
@@ -1691,7 +1708,7 @@
                     </span>
                     <div class="bubble"
                          :class="{ 'is-streaming-bubble': streaming && i === messages.length - 1 }"
-                         x-html="m.html"></div>
+                         x-html="m.html || ''"></div>
                   </div>
                   <!-- Per-bubble footer removed. Time + streaming dots
                        are rendered once per turn in the turn-footer

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2115,6 +2115,37 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 
 /* Find-in-preview widget — floats top-right over the scrolling content,
    VSCode-style. Sticky so it stays pinned while the user scrolls hits. */
+/* Preview zoom control (browser-like −/percentage/+) in the preview header */
+.preview-zoom {
+  flex: 0 0 auto;
+  display: inline-flex; align-items: center; gap: 1px;
+  margin-right: var(--sp-1);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  background: var(--c-bg-2);
+  overflow: hidden;
+}
+.preview-zoom-btn, .preview-zoom-pct {
+  border: none; background: transparent; cursor: pointer;
+  color: var(--c-fg-1); font: inherit;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.preview-zoom-btn {
+  width: 22px; height: 22px;
+  font-size: 15px; line-height: 1;
+}
+.preview-zoom-pct {
+  min-width: 3.2em; height: 22px; padding: 0 4px;
+  font-size: var(--fs-xs); font-variant-numeric: tabular-nums;
+  color: var(--c-fg-2);
+}
+.preview-zoom-btn:hover, .preview-zoom-pct:hover {
+  background: var(--c-bg-3); color: var(--c-accent);
+}
+.preview-zoom-btn:disabled {
+  opacity: 0.4; cursor: default; background: transparent; color: var(--c-fg-1);
+}
+
 .preview-find {
   position: sticky; top: var(--sp-2); z-index: 60;
   width: max-content; max-width: calc(100% - var(--sp-4));
@@ -2350,7 +2381,9 @@ html[data-theme="eyecare"] .editor-cm .CodeMirror { background: var(--c-bg-0); }
   width: 3px; background: var(--c-accent); border-radius: 2px; opacity: 0.6;
 }
 .markdown a { color: var(--c-accent-hover); text-decoration: underline; text-decoration-color: var(--c-accent-soft); }
-.markdown img { max-width: 100%; border-radius: var(--r-md); }
+.markdown img { max-width: 100%; border-radius: var(--r-md); cursor: zoom-in; }
+/* Linked images keep the normal link cursor (click follows the link). */
+.markdown a img { cursor: pointer; }
 .markdown hr { border: 0; border-top: 1px solid var(--c-border-strong); margin: 2em 0; }
 .markdown ul, .markdown ol { padding-left: 1.6em; }
 
@@ -2927,6 +2960,20 @@ pre.text {
      collapse to the 200px placeholder and jump the scrollbar. */
   content-visibility: auto;
   contain-intrinsic-size: auto 200px;
+}
+/* The recent bubbles of an actively-streaming turn must ALWAYS paint (the last
+   ~8 — the whole region the user is watching the agent work in). The tail's
+   turn-footer (the "running" thinking-dots + elapsed counter) lives INSIDE its
+   .msg, so when content-visibility:auto skips it — which happens any time
+   auto-follow hasn't fully pinned the tail into the viewport (slight scroll,
+   fast agentic turn with many tool cards) — the footer silently disappears AND
+   each skipped bubble collapses to its contain-intrinsic-size estimate, leaving
+   blank bands mid-conversation. Forcing `visible` on only the recent streaming
+   region keeps the long-session perf win for all scrolled-away history while
+   guaranteeing the live turn never blanks out or shows the "running" footer. */
+.msg.is-streaming-tail {
+  content-visibility: visible;
+  contain-intrinsic-size: auto;
 }
 @keyframes msg-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 /* Collapse empty message wrappers. Every msg is rendered as


### PR DESCRIPTION
一个分支累积的四块相关改动，合并为一个 PR。

## 1. 打开会话的消息自动同步
治本「要手动点刷新才有最新消息」：之前只轮询会话**列表**（圆点/未读），正在看的会话**正文**只在切 tab / 手动刷新时更新。外部设备发的 prompt、后台/定时 turn、PWA 挂起期间掉线的 SSE 都会让视图卡住。

- `_reconcileOpenSession` 复用已有的 10s 列表轮询 + visibility/reconnect 触发，无新后端接口、无「无变化」时的额外请求
- 新消息在 `atBottom` 时**就地 quiet 刷新**，不闪烁、不抢滚动；翻历史的用户不会被拽到底
- `loadSession` 新增 `quiet` 模式：按稳定 `:key` 做 splice морф 交换，无骨架、保滚动位置；多重防护确保直播流进行中绝不触发（避免擦掉在途气泡）

## 2. 预览缩放（浏览器式 −/百分比/+）
- md / text / img / xlsx / csv / html 走 CSS `zoom`（pdf 用浏览器原生缩放）
- 仅作用于内容节点，find bar / 拖拽 overlay 保持 100%
- 级别 `localStorage` 持久化，跨刷新 / PWA 重开保留；点百分比重置 100%

## 3. HTML 预览图片点击放大
- 预览 iframe 是沙箱（opaque origin），父窗口够不到框内 DOM。`files.py` 在 `?preview=1` 时注入极小脚本，把点击图片的 src 经 `postMessage` 上抛——**无需放宽 sandbox**，只泄露被点图片的 src/alt
- 父窗口校验 `event.source === 预览 iframe` 后再开 lightbox
- markdown 预览 / 编辑器 live preview 内的图片走 `onPreviewImgClick`；包在链接里的图保持跳转

## 4. 修复会话 message_count=0
非空会话在列表里显示「0 messages」，且若开启 `MUSELAB_PRUNE_EMPTY_SESSIONS` 有被误删风险。
- `chat.py`: 打开会话时用刚算出的真实条数回填陈旧计数，经无副作用 setter（**不动 `updated_at` → 不重排列表**）
- `sessions.py`: 新增 `set_message_count`；`prune_empty_sessions` 增加数据丢失防护——**凡有 on-disk transcript 的会话一律跳过**，枚举失败时 fail-safe 不删任何东西

## 附带小修
- 空 assistant text block 不再渲染成字面 `undefined` 气泡（仅丢弃 saved session 里真正空的块，不影响直播首帧空气泡）
- streaming-tail 最近 ~8 条强制 `content-visibility:visible`，修复直播中途气泡塌缩成空白带、「running」footer 消失
- `jumpToPrevUser` 排除未发送的 `.queued` 气泡

🤖 Generated with [Claude Code](https://claude.com/claude-code)