### PR TITLE
feat(preview): 预览缩放 + 图片点击放大

### DIFF
--- a/backend/files.py
+++ b/backend/files.py
@@ -8,7 +8,7 @@ import threading
 import time
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, Query
-from fastapi.responses import FileResponse, PlainTextResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
 from pydantic import BaseModel
 from .auth import require_token, require_token_query
 from .settings import ROOT, atomic_write_text, env_int
@@ -661,9 +661,49 @@ INLINE_OK_SUFFIX = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico",
 # same-origin token theft).
 SANDBOXED_INLINE_SUFFIX = {".html", ".htm", ".svg"}
 
+# Click-to-zoom bridge for HTML previews. The preview iframe is sandboxed
+# (opaque origin) so the parent can't reach the framed DOM to intercept image
+# clicks. Instead we inject this tiny script (only when the preview pane asks
+# via ?preview=1) which forwards in-page image clicks to the parent via
+# postMessage — postMessage works fine from a sandboxed origin, so this needs
+# NO sandbox relaxation and leaks nothing (only the clicked image's src/alt).
+# The parent (app.js) validates event.source === the preview iframe before
+# opening its lightbox. Images wrapped in a link are left alone so the link
+# still navigates. CSP allows it: script-src includes 'unsafe-inline'.
+_PREVIEW_IMG_BRIDGE = (
+    "<script>(function(){document.addEventListener('click',function(e){"
+    "var t=e.target;var img=t&&t.closest?t.closest('img'):null;"
+    "if(!img||img.closest('a'))return;var src=img.currentSrc||img.src;"
+    "if(!src)return;e.preventDefault();"
+    "try{parent.postMessage({__muselab:'preview-img',src:src,alt:img.alt||''},'*');}"
+    "catch(_e){}},true);})();</script>"
+)
+# Cap the in-memory read used for injection. Bigger HTML (e.g. reports with
+# megabytes of base64 images) falls back to streaming untouched — it just
+# won't have click-to-zoom, which is an acceptable degradation.
+_PREVIEW_INJECT_MAX_BYTES = 12 * 1024 * 1024
+
+
+def _inject_preview_img_bridge(target: Path) -> str | None:
+    """Return the HTML text with the click-to-zoom bridge injected, or None to
+    signal "fall back to streaming the file untouched" (too big / not utf-8)."""
+    try:
+        if target.stat().st_size > _PREVIEW_INJECT_MAX_BYTES:
+            return None
+        html = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    lower = html.lower()
+    idx = lower.rfind("</body>")
+    if idx == -1:
+        idx = lower.rfind("</html>")
+    if idx == -1:
+        return html + _PREVIEW_IMG_BRIDGE
+    return html[:idx] + _PREVIEW_IMG_BRIDGE + html[idx:]
+
 
 @router.get("/raw", dependencies=[Depends(require_token_query)])
-def raw_file(path: str = Query(...)) -> FileResponse:
+def raw_file(path: str = Query(...), preview: bool = Query(False)):
     """Stream raw file (images, PDF, sandboxed HTML, etc.). Token via query.
     Everything outside the whitelists is forced to download as octet-stream."""
     target = safe_resolve(path)
@@ -701,7 +741,7 @@ def raw_file(path: str = Query(...)) -> FileResponse:
         # are unavailable, so the query token can't be replayed against the API.
         # Previously only the frontend iframe's sandbox attribute provided this
         # isolation, which a top-level open silently bypassed.
-        return FileResponse(target, headers={
+        sandbox_headers = {
             **base_headers,
             "Content-Disposition": f"inline; {disp_filename}",
             "Content-Security-Policy": (
@@ -714,7 +754,15 @@ def raw_file(path: str = Query(...)) -> FileResponse:
                 "connect-src 'self'; "
                 "base-uri 'none'; form-action 'none'"
             ),
-        })
+        }
+        # Preview pane requests ?preview=1 for HTML so we can inject the
+        # click-to-zoom bridge. SVG and the top-level/download paths never
+        # get it (no preview flag) and stream untouched.
+        if preview and suffix in (".html", ".htm"):
+            injected = _inject_preview_img_bridge(target)
+            if injected is not None:
+                return HTMLResponse(content=injected, headers=sandbox_headers)
+        return FileResponse(target, headers=sandbox_headers)
     # FileResponse(filename=) sets Content-Disposition itself; use our safe one.
     return FileResponse(target, media_type="application/octet-stream", headers={
         **base_headers,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -282,6 +282,15 @@ function portal() {
     // buster on iframe / read URLs so the preview reflects the new content
     // without the user needing to manually refresh the page.
     previewVersion: 0,
+    // Browser-like zoom for the preview content (md/text/img/xlsx/csv/html).
+    // Applied as CSS `zoom` on the content nodes only (NOT the .preview-body
+    // container) so the find bar / drop overlay stay at 100%. Sticky across
+    // file switches like real browser zoom; not persisted across reloads.
+    // pdf is excluded — the browser PDF viewer has its own zoom control.
+    previewZoom: 1,
+    PREVIEW_ZOOM_MIN: 0.5,
+    PREVIEW_ZOOM_MAX: 3,
+    PREVIEW_ZOOM_STEP: 0.1,
     // Compact orchestration: the per-tab `compacting` flag (see
     // _blankTabState) marks the window where the CLI is busy summarising
     // *that session's* history. User messages typed during compact go into
@@ -1150,6 +1159,19 @@ function portal() {
         this.osFileDragging = false;
       });
 
+      // Click-to-zoom bridge for HTML previews. The sandboxed (opaque-origin)
+      // preview iframe can't be reached from here to intercept image clicks,
+      // so files.py injects a script that postMessages the clicked image's
+      // src up. Validate the message came from OUR preview iframe (not some
+      // other framed content posting to window) before opening the lightbox.
+      window.addEventListener("message", (e) => {
+        const f = this.$refs.htmlFrame;
+        if (!f || e.source !== f.contentWindow) return;
+        const d = e.data;
+        if (!d || d.__muselab !== "preview-img" || typeof d.src !== "string") return;
+        this.openLightbox(d.src, typeof d.alt === "string" ? d.alt : "");
+      });
+
       // Listen for SW → page messages. The service worker posts
       // `muselab/notification-clicked` when the user taps a push
       // banner; we ack the unread badge immediately so they don't
@@ -1206,6 +1228,13 @@ function portal() {
       // immediately re-renders the chat-body. localStorage flag persists
       // dismissal across reloads / PWA reopens.
       this._welcomeDismissed = localStorage.getItem("muselab_welcome_dismissed") === "1";
+      // Restore the preview zoom level so it sticks across reloads / PWA
+      // reopens, like a browser's per-site zoom. Clamp the stored value in
+      // case the bounds changed between versions.
+      {
+        const z = parseFloat(localStorage.getItem("muselab_preview_zoom"));
+        if (!Number.isNaN(z)) this.previewZoom = this._clampPreviewZoom(z);
+      }
       // Vibration / push prefs come from localStorage (per-device) so a
       // shared muselab between a desktop + phone keeps independent
       // settings — your phone can vibrate; the desktop tab silently
@@ -10858,10 +10887,14 @@ function portal() {
       this.savePrefs();
     },
 
-    rawUrl(p) {
+    rawUrl(p, opts = {}) {
       const v = this.previewVersion ? `&_v=${this.previewVersion}` : "";
+      // preview=1 asks the backend to inject the click-to-zoom bridge into
+      // HTML (see files.py). Only the html preview iframe passes it; images /
+      // pdf / downloads stream untouched.
+      const pv = opts.preview ? "&preview=1" : "";
       return "/api/files/raw?path=" + encodeURIComponent(p)
-              + "&token=" + encodeURIComponent(this.token) + v;
+              + "&token=" + encodeURIComponent(this.token) + v + pv;
     },
     async reloadPreview() {
       // Manual "🗘 reload" button in preview header. Bumps previewVersion
@@ -10912,6 +10945,28 @@ function portal() {
       this.toast(this.lang === "zh" ? "已刷新预览" : "Preview reloaded",
                   "success", 1200);
     },
+
+    // ===== Preview zoom (browser-like ±) =====
+    // Modes that support zoom. pdf/loading/unsupported/empty are excluded.
+    previewZoomable() {
+      return !this.editing && this.selected &&
+        ["md", "text", "img", "xlsx", "csv", "html"].includes(this.previewMode);
+    },
+    _clampPreviewZoom(z) {
+      // Round to the step grid to avoid 0.9999… drift, then clamp.
+      const stepped = Math.round(z / this.PREVIEW_ZOOM_STEP) * this.PREVIEW_ZOOM_STEP;
+      return Math.min(this.PREVIEW_ZOOM_MAX,
+              Math.max(this.PREVIEW_ZOOM_MIN, Math.round(stepped * 100) / 100));
+    },
+    setPreviewZoom(z) {
+      this.previewZoom = this._clampPreviewZoom(z);
+      // Persist (per-device) so the level survives reloads / PWA reopens.
+      try { localStorage.setItem("muselab_preview_zoom", String(this.previewZoom)); } catch {}
+    },
+    zoomPreviewIn()  { this.setPreviewZoom(this.previewZoom + this.PREVIEW_ZOOM_STEP); },
+    zoomPreviewOut() { this.setPreviewZoom(this.previewZoom - this.PREVIEW_ZOOM_STEP); },
+    resetPreviewZoom() { this.setPreviewZoom(1); },
+    previewZoomPct() { return Math.round(this.previewZoom * 100) + "%"; },
 
     async _maybeReloadPreview(toolFilePath) {
       // Called from the tool_use SSE handler when a write-style tool fires.
@@ -15202,6 +15257,20 @@ function portal() {
     openLightbox(src, alt) {
       if (!src) return;
       this.lightbox = { show: true, src, alt: alt || "" };
+    },
+
+    // Click-to-zoom for images inside a rendered markdown preview. Delegated
+    // on the .markdown container (covers both the preview pane and the editor
+    // split live-preview). Images wrapped in a link are left alone so the
+    // link still navigates; broken/empty-src images are ignored.
+    onPreviewImgClick(e) {
+      const img = e.target.closest("img");
+      if (!img) return;
+      if (img.closest("a")) return;
+      const src = img.currentSrc || img.getAttribute("src");
+      if (!src) return;
+      e.preventDefault();
+      this.openLightbox(src, img.alt || "");
     },
 
     retryFailedMessage(m) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -549,6 +549,22 @@
             </div>
           </template>
         </div>
+        <!-- Preview zoom (browser-like −/percentage/+). Shown only for the
+             zoomable modes (md/text/img/xlsx/csv/html); pdf has native zoom.
+             Click the percentage to reset to 100%. -->
+        <div class="preview-zoom" x-show="previewZoomable()">
+          <button class="preview-zoom-btn" @click="zoomPreviewOut()"
+                  :disabled="previewZoom <= PREVIEW_ZOOM_MIN"
+                  :title="lang==='zh' ? '缩小' : 'Zoom out'"
+                  :aria-label="lang==='zh' ? '缩小' : 'Zoom out'">−</button>
+          <button class="preview-zoom-pct" @click="resetPreviewZoom()"
+                  :title="lang==='zh' ? '重置为 100%' : 'Reset to 100%'"
+                  x-text="previewZoomPct()"></button>
+          <button class="preview-zoom-btn" @click="zoomPreviewIn()"
+                  :disabled="previewZoom >= PREVIEW_ZOOM_MAX"
+                  :title="lang==='zh' ? '放大' : 'Zoom in'"
+                  :aria-label="lang==='zh' ? '放大' : 'Zoom in'">+</button>
+        </div>
         <button x-show="selected && !editing && (previewMode==='md' || previewMode==='text')"
                 @click="togglePreviewFind()" class="icon-btn preview-keep-mobile"
                 :class="{ active: previewFind.open }"
@@ -570,7 +586,6 @@
         </button>
         <button x-show="editing" @click="saveEdit()" class="btn-primary btn-compact" x-text="t('btn.save')"></button>
         <button x-show="selected" @click="insertFileMention(selected)" class="icon-btn preview-keep-mobile" :title="t('btn.at_mention')"><svg><use href="#i-at"/></svg></button>
-        <a x-show="selected" :href="downloadUrl(selected)" :download="selected.split('/').pop()" class="icon-btn preview-keep-mobile" :title="t('btn.download')"><svg><use href="#i-download"/></svg></a>
         <!-- Desktop fullscreen toggle (hidden on mobile via .pane-fullscreen-btn
              @media in styles.css). Click → preview pane takes whole viewport;
              click again to restore the 3-column layout. -->
@@ -785,7 +800,7 @@
           <div class="editor-main">
             <div x-ref="cmHost" class="editor-cm" x-show="editorView !== 'preview'"></div>
             <div class="editor-live-preview" x-show="editorIsMd && editorView !== 'edit'">
-              <div class="markdown" x-html="livePreviewHtml"></div>
+              <div class="markdown" x-html="livePreviewHtml" @click="onPreviewImgClick($event)"></div>
             </div>
           </div>
           <div class="editor-status">
@@ -806,8 +821,8 @@
           <span class="preview-loading-text"
                 x-text="lang==='zh' ? '加载中…' : 'Loading…'"></span>
         </div>
-        <div x-show="!editing && previewMode==='md' && rawText" class="markdown" x-html="renderedMd"></div>
-        <pre x-show="!editing && previewMode==='text' && rawText" class="text"><code :class="'language-' + previewLang" x-text="rawText"></code></pre>
+        <div x-show="!editing && previewMode==='md' && rawText" class="markdown" x-html="renderedMd" :style="'zoom:' + previewZoom" @click="onPreviewImgClick($event)"></div>
+        <pre x-show="!editing && previewMode==='text' && rawText" class="text" :style="'zoom:' + previewZoom"><code :class="'language-' + previewLang" x-text="rawText"></code></pre>
         <!-- 0-byte / empty file: a blank md/text pane is indistinguishable from
              "still loading" or "render broke". Show an explicit placeholder. -->
         <div x-show="!editing && (previewMode==='md' || previewMode==='text') && selected && !rawText" class="empty">
@@ -818,13 +833,15 @@
         <!-- src 仅在该模式激活时才指向真实 URL，否则空字符串/about:blank，
              避免隐藏元素请求 raw URL 触发对 md/txt 的下载。 -->
         <iframe x-show="!editing && previewMode==='html'"
-                :src="previewMode==='html' ? rawUrl(selected) : 'about:blank'"
+                x-ref="htmlFrame"
+                :src="previewMode==='html' ? rawUrl(selected, {preview:true}) : 'about:blank'"
+                :style="'zoom:' + previewZoom"
                 class="frame" sandbox="allow-scripts"></iframe>
         <!-- Use template x-if (not x-show) so the <img> isn't even in the DOM
              when not active — :src="" would otherwise resolve to the page URL
              and fire a spurious resource-load-failed error in console. -->
         <template x-if="!editing && previewMode==='img' && selected">
-          <img :src="rawUrl(selected)" :alt="selected ? selected.split('/').pop() : ''" class="preview-img" />
+          <img :src="rawUrl(selected)" :alt="selected ? selected.split('/').pop() : ''" class="preview-img" :style="'zoom:' + previewZoom" />
         </template>
         <iframe x-show="!editing && previewMode==='pdf'"
                 :src="previewMode==='pdf' ? rawUrl(selected) : 'about:blank'"
@@ -856,7 +873,7 @@
           <template x-for="sh in xlsxSheets.filter(s => s.name === xlsxActive)" :key="sh.name">
             <div class="xlsx-sheet-wrap">
               <div class="xlsx-scroll">
-                <table class="xlsx-table">
+                <table class="xlsx-table" :style="'zoom:' + previewZoom">
                   <tbody>
                     <template x-for="(row, ri) in sh.rows" :key="ri">
                       <tr>
@@ -902,7 +919,7 @@
                   x-text="lang==='zh' ? '（列数已截断）' : '(cols truncated)'"></span>
           </div>
           <div class="xlsx-scroll" x-show="csvData">
-            <table class="xlsx-table">
+            <table class="xlsx-table" :style="'zoom:' + previewZoom">
               <thead x-show="csvData && csvData.has_header && csvData.header && csvData.header.length">
                 <tr>
                   <th class="xlsx-rownum"></th>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2115,6 +2115,37 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 
 /* Find-in-preview widget — floats top-right over the scrolling content,
    VSCode-style. Sticky so it stays pinned while the user scrolls hits. */
+/* Preview zoom control (browser-like −/percentage/+) in the preview header */
+.preview-zoom {
+  flex: 0 0 auto;
+  display: inline-flex; align-items: center; gap: 1px;
+  margin-right: var(--sp-1);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  background: var(--c-bg-2);
+  overflow: hidden;
+}
+.preview-zoom-btn, .preview-zoom-pct {
+  border: none; background: transparent; cursor: pointer;
+  color: var(--c-fg-1); font: inherit;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.preview-zoom-btn {
+  width: 22px; height: 22px;
+  font-size: 15px; line-height: 1;
+}
+.preview-zoom-pct {
+  min-width: 3.2em; height: 22px; padding: 0 4px;
+  font-size: var(--fs-xs); font-variant-numeric: tabular-nums;
+  color: var(--c-fg-2);
+}
+.preview-zoom-btn:hover, .preview-zoom-pct:hover {
+  background: var(--c-bg-3); color: var(--c-accent);
+}
+.preview-zoom-btn:disabled {
+  opacity: 0.4; cursor: default; background: transparent; color: var(--c-fg-1);
+}
+
 .preview-find {
   position: sticky; top: var(--sp-2); z-index: 60;
   width: max-content; max-width: calc(100% - var(--sp-4));
@@ -2350,7 +2381,9 @@ html[data-theme="eyecare"] .editor-cm .CodeMirror { background: var(--c-bg-0); }
   width: 3px; background: var(--c-accent); border-radius: 2px; opacity: 0.6;
 }
 .markdown a { color: var(--c-accent-hover); text-decoration: underline; text-decoration-color: var(--c-accent-soft); }
-.markdown img { max-width: 100%; border-radius: var(--r-md); }
+.markdown img { max-width: 100%; border-radius: var(--r-md); cursor: zoom-in; }
+/* Linked images keep the normal link cursor (click follows the link). */
+.markdown a img { cursor: pointer; }
 .markdown hr { border: 0; border-top: 1px solid var(--c-border-strong); margin: 2em 0; }
 .markdown ul, .markdown ol { padding-left: 1.6em; }
 


### PR DESCRIPTION
两块预览体验增强。

## 1. 预览缩放（浏览器式 −/百分比/+）
- md / text / img / xlsx / csv / html 走 CSS `zoom`（pdf 用浏览器原生缩放）
- 仅作用于内容节点，find bar / 拖拽 overlay 保持 100%
- 级别 `localStorage` 持久化，跨刷新 / PWA 重开保留；点百分比重置 100%

## 2. HTML 预览图片点击放大
预览 iframe 是沙箱（opaque origin），父窗口够不到框内 DOM。
- **files.py**：`?preview=1` 时向 iframe 注入极小脚本，把点击图片的 src 经 `postMessage` 上抛——**无需放宽 sandbox**，只泄露被点图片的 src/alt；超过 12MB 或非 utf-8 的 HTML 回退为原样流式传输（仅失去点击放大）
- **app.js**：父窗口校验 `event.source === 预览 iframe` 后再开 lightbox；markdown 预览 / 编辑器 live preview 内的图片走 `onPreviewImgClick`，包在链接里的图保持跳转
- 顺手移除预览头部冗余的下载按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)