### PR TITLE
fix(chat): remove duplicate edit diff stats

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6007,7 +6007,7 @@ function portal() {
 
     // Find the matching tool_use for a given tool_result by walking
     // backwards through messages and matching tool_use_id. Used by the
-    // diff-badge renderer to count +/- on Edit/Write/MultiEdit.
+    // diff preview renderer to count +/- on Edit/Write/MultiEdit.
     findToolUseFor(toolResult, fromIdx) {
       if (!toolResult || fromIdx === undefined || fromIdx === null) return null;
       const id = toolResult.tool_use_id || toolResult.tool_id;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1925,17 +1925,6 @@
                          :title="toolFilePath(m)"
                          x-text="toolFilePath(m)"></a>
                     </template>
-                    <!-- Edit / Write / MultiEdit: +X / -Y badge showing
-                         change magnitude at a glance without expanding diff. -->
-                    <template x-if="['Edit','MultiEdit','Write'].includes(m.name) && editDiffStats(m)">
-                      <span class="diff-badge"
-                            :title="lang==='zh' ? '本次改动行数(+插入 / −删除)' : 'lines changed (+insert / −delete)'">
-                        <span class="diff-badge-plus" x-show="(editDiffStats(m)?.plus ?? 0) > 0"
-                              x-text="'+' + (editDiffStats(m)?.plus ?? 0)"></span>
-                        <span class="diff-badge-minus" x-show="(editDiffStats(m)?.minus ?? 0) > 0"
-                              x-text="'−' + (editDiffStats(m)?.minus ?? 0)"></span>
-                      </span>
-                    </template>
                     <!-- MCP input preview: compact key:val · key:val list -->
                     <template x-if="!toolFilePath(m) && m.name && m.name.startsWith('mcp__') && mcpInputPreview(m)">
                       <span class="tool-arg mcp-input-preview" x-text="mcpInputPreview(m)"></span>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -8386,32 +8386,6 @@ html { scrollbar-width: thin; scrollbar-color: var(--c-bg-4) transparent; }
 .mcp-result-text p:last-child  { margin-bottom: 0; }
 
 /* ============================================================
-   Edit / Write / MultiEdit — +X/−Y diff badge in tool bubble.
-   ============================================================ */
-.diff-badge {
-  display: inline-flex;
-  gap: 5px;
-  margin-left: var(--sp-2);
-  font-family: monospace;
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  align-items: center;
-  cursor: help;
-}
-.diff-badge-plus {
-  color: #16a34a;
-  background: rgba(22, 163, 74, 0.1);
-  padding: 1px 6px;
-  border-radius: var(--r-sm);
-}
-.diff-badge-minus {
-  color: #dc2626;
-  background: rgba(220, 38, 38, 0.1);
-  padding: 1px 6px;
-  border-radius: var(--r-sm);
-}
-
-/* ============================================================
    Grep / Glob — clickable search hits replacing raw <pre>.
    ============================================================ */
 .search-hits-list {
@@ -8679,14 +8653,6 @@ html[data-theme="eyecare"] .diff-body-cr .diff-line.diff-ins .diff-sign,
 html[data-theme="eyecare"] .diff-strip-plus { color: #5e8a56; }
 html[data-theme="eyecare"] .diff-body-cr .diff-line.diff-del .diff-sign,
 html[data-theme="eyecare"] .diff-strip-minus { color: #aa503c; }
-
-/* ---- Diff badge on tool bubble ---- */
-.diff-badge-plus  { color: #22c55e; background: rgba(34, 197, 94, 0.14); }
-.diff-badge-minus { color: #ef4444; background: rgba(239, 68, 68, 0.12); }
-html[data-theme="light"] .diff-badge-plus  { color: #16a34a; background: rgba(22, 163, 74, 0.10); }
-html[data-theme="light"] .diff-badge-minus { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
-html[data-theme="eyecare"] .diff-badge-plus  { color: #5e8a56; background: rgba(94, 138, 86, 0.12); }
-html[data-theme="eyecare"] .diff-badge-minus { color: #aa503c; background: rgba(170, 80, 60, 0.10); }
 
 /* ---- Task log lines (plan panel) ---- */
 .task-log-line {


### PR DESCRIPTION
## Summary\n- Remove the redundant +/− diff badge from Edit / Write / MultiEdit tool bubbles\n- Keep the line-count stats in the diff preview header only\n- Rename the related comment to refer to the diff preview renderer\n\n## Verification\n- rg -n "diff-badge|本次改动行数|lines changed" frontend --glob '!vendor'\n- git diff --check\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)