### PR TITLE
docs: update provider wording for Codex Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 |---|---|
 | **完整的用户上下文** | 不断累积的个人档案，越用越懂你，产生 context 复利 |
 | **领先的 Agent Harness** | 基于 Claude Agent SDK 构建，具备工具调用、Skills、MCP 扩展等 Agent 能力|
-| **灵活切换的基座模型** | Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE / Codex Gateway 等 9 类模型提供方一键切换 |
+| **灵活切换的基座模型** | Claude（OAuth） / GPT（通过本地 Codex Gateway） / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE 等 9 类模型提供方一键切换 |
 | **跨领域交叉分析** | 家庭信息 ✖️ 职业规划 ✖️ 健康档案 ✖️ 财务数据 ，Muse 给出跨领域洞察 |
 | **原生渲染能力** | HTML 页面、Markdown 文档即写即渲染，无需插件 |
 | **移动端 PWA** | 获得接近原生 App 的体验，电脑手机多端同步会话，出门在外手机接着聊 |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 |---|---|
 | **完整的用户上下文** | 不断累积的个人档案，越用越懂你，产生 context 复利 |
 | **领先的 Agent Harness** | 基于 Claude Agent SDK 构建，具备工具调用、Skills、MCP 扩展等 Agent 能力|
-| **灵活切换的基座模型** |Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE 等 8 家模型一键切换 |
+| **灵活切换的基座模型** | Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE / Codex Gateway 等 9 类模型提供方一键切换 |
 | **跨领域交叉分析** | 家庭信息 ✖️ 职业规划 ✖️ 健康档案 ✖️ 财务数据 ，Muse 给出跨领域洞察 |
 | **原生渲染能力** | HTML 页面、Markdown 文档即写即渲染，无需插件 |
 | **移动端 PWA** | 获得接近原生 App 的体验，电脑手机多端同步会话，出门在外手机接着聊 |

--- a/README_en.md
+++ b/README_en.md
@@ -36,7 +36,7 @@
 |---|---|
 | **Complete user context** | Your personal archive keeps accumulating; the more you use it, the better Muse understands you, creating compounding context |
 | **Leading Agent Harness** | Built on the Claude Agent SDK, with agent capabilities such as tool use, Skills, and MCP extensions |
-| **Switchable foundation models** | One-click switching across 9 providers: Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE / Codex Gateway |
+| **Switchable foundation models** | One-click switching across 9 provider families: Claude (OAuth) / GPT via local Codex Gateway / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE |
 | **Cross-domain analysis** | Family information, career planning, health records, and financial data live in one context, so Muse can surface cross-domain insights |
 | **Native rendering** | HTML pages and Markdown documents render live as they are written, with no plugins required |
 | **Mobile PWA** | Near-native App experience, synced sessions across desktop and phone, and continued work while you are away from your desk |

--- a/README_en.md
+++ b/README_en.md
@@ -36,7 +36,7 @@
 |---|---|
 | **Complete user context** | Your personal archive keeps accumulating; the more you use it, the better Muse understands you, creating compounding context |
 | **Leading Agent Harness** | Built on the Claude Agent SDK, with agent capabilities such as tool use, Skills, and MCP extensions |
-| **Switchable foundation models** | One-click switching across 8 model providers: Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE |
+| **Switchable foundation models** | One-click switching across 9 providers: Claude / DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo / ERNIE / Codex Gateway |
 | **Cross-domain analysis** | Family information, career planning, health records, and financial data live in one context, so Muse can surface cross-domain insights |
 | **Native rendering** | HTML pages and Markdown documents render live as they are written, with no plugins required |
 | **Mobile PWA** | Near-native App experience, synced sessions across desktop and phone, and continued work while you are away from your desk |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ flowchart TB
   V --> QW[Qwen]
   V --> XM[Xiaomi MiMo]
   V --> QF[Baidu Qianfan (ERNIE)]
+  V --> CG[Codex Gateway]
 ```
 
 ## Key design decisions

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -22,6 +22,7 @@ flowchart TB
   V --> QW[Qwen]
   V --> XM[小米 MiMo]
   V --> QF[百度千帆（ERNIE）]
+  V --> CG[Codex Gateway]
 ```
 
 ## 关键设计决策

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -16,9 +16,10 @@ systemd service** — no root, no system-wide config, easy to undo.
   ```bash
   claude login
   ```
-  Non-Claude providers (DeepSeek / GLM / MiniMax / Kimi / Qwen /
+  Most non-Claude providers (DeepSeek / GLM / MiniMax / Kimi / Qwen /
   Xiaomi MiMo / Baidu Qianfan (ERNIE)) only need API keys — paste them in the
-  Settings UI after install, no CLI needed.
+  Settings UI after install, no CLI needed. Codex Gateway needs a local sidecar
+  and local token; see [Codex Gateway](codex-gateway.md).
 
 ## Install
 

--- a/docs/install-linux_zh.md
+++ b/docs/install-linux_zh.md
@@ -16,7 +16,7 @@
   ```bash
   claude login
   ```
-  非 Claude provider（DeepSeek / GLM / MiniMax / Kimi / Qwen / 小米 MiMo / 百度千帆（ERNIE））只需 API key——稍后在 Settings UI 内填即可，无需 CLI。
+  多数非 Claude provider（DeepSeek / GLM / MiniMax / Kimi / Qwen / 小米 MiMo / 百度千帆（ERNIE））只需 API key——稍后在 Settings UI 内填即可，无需 CLI。Codex Gateway 需要本地 sidecar 和本地 token，见 [Codex Gateway](codex-gateway_zh.md)。
 
 ## 安装
 

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -17,9 +17,10 @@ no `sudo`, autostarts on login, restarts on crash.
   ```bash
   claude login
   ```
-  This stores OAuth in `~/.claude/` which the agent reuses. Non-Claude providers
-  (DeepSeek / GLM / MiniMax / Kimi / Qwen / Xiaomi MiMo / Baidu Qianfan (ERNIE)) only need
-  API keys via Settings UI.
+  This stores OAuth in `~/.claude/` which the agent reuses. Most non-Claude
+  providers (DeepSeek / GLM / MiniMax / Kimi / Qwen / Xiaomi MiMo / Baidu
+  Qianfan (ERNIE)) only need API keys via Settings UI. Codex Gateway needs a
+  local sidecar and local token; see [Codex Gateway](codex-gateway.md).
 
 ## Install
 

--- a/docs/install-macos_zh.md
+++ b/docs/install-macos_zh.md
@@ -17,7 +17,7 @@
   ```bash
   claude login
   ```
-  会把 OAuth 写到 `~/.claude/`，agent 会直接使用。非 Claude provider（DeepSeek / GLM / MiniMax / Kimi / Qwen / 小米 MiMo / 百度千帆（ERNIE））只需 API key——稍后在 Settings UI 里填。
+  会把 OAuth 写到 `~/.claude/`，agent 会直接使用。多数非 Claude provider（DeepSeek / GLM / MiniMax / Kimi / Qwen / 小米 MiMo / 百度千帆（ERNIE））只需 API key——稍后在 Settings UI 里填。Codex Gateway 需要本地 sidecar 和本地 token，见 [Codex Gateway](codex-gateway_zh.md)。
 
 ## 安装
 


### PR DESCRIPTION
## Summary
- update README provider count from 8 to 9 and include Codex Gateway
- clarify install docs that Codex Gateway needs a local sidecar and token, unlike API-key-only providers
- add Codex Gateway to the architecture provider diagram

## Verification
- git diff --check
- rg stale provider wording checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)