### PR TITLE
perf(chat): 优化移动端长会话与流式恢复

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import base64
+from contextlib import contextmanager, suppress
 import hashlib
 import json
 import asyncio
@@ -49,6 +50,7 @@ from .settings import (
 )
 from . import sessions as sess
 from . import endpoints
+from . import transcript_index as transcript_idx
 from .workspaces import (
     registry as workspace_registry,
     resolve_workspace_root,
@@ -186,34 +188,33 @@ def _find_session_jsonl(sid: str) -> Path | None:
     return None
 
 
-def _get_session_msgs(sid: str, model: str = "") -> list:
-    """Wrapper around the SDK's get_session_messages() that temporarily sets
-    CLAUDE_CONFIG_DIR to the vendor-isolated temp dir when the session uses a
-    third-party model.
+@contextmanager
+def _session_config_dir(model: str = ""):
+    """Serialize SDK session-store calls and select the matching CLI root.
 
-    Without this, vendor-session JSONLs (written by the CLI subprocess into
-    the per-uid vendor config dir's projects/ subdir) are invisible to the
-    parent process, which defaults to ~/.claude/projects/. The result is that
-    refreshing a DeepSeek / GLM / MiniMax / Kimi / Qwen / MiMo session shows
-    zero messages."""
-    if model and endpoints.is_third_party(model):
-        vendor_dir = str(endpoints._vendor_config_dir())
-        with _vendor_msg_lock:
-            old = os.environ.get("CLAUDE_CONFIG_DIR")
-            try:
-                os.environ["CLAUDE_CONFIG_DIR"] = vendor_dir
-                return get_session_messages(
-                    sid, directory=str(sess.session_workspace(sid)))
-            finally:
-                if old is not None:
-                    os.environ["CLAUDE_CONFIG_DIR"] = old
-                else:
-                    os.environ.pop("CLAUDE_CONFIG_DIR", None)
-    # Non-vendor path: still take the lock so this read can't run
-    # concurrently (in another thread) with a vendor read that has the
-    # global CLAUDE_CONFIG_DIR temporarily flipped — otherwise we could
-    # resolve against the vendor projects dir and return wrong messages.
+    Claude Agent SDK session helpers consult the process-global
+    ``CLAUDE_CONFIG_DIR`` instead of accepting it as an argument. Vendor
+    sessions therefore need a temporary override, while native Claude calls
+    must wait for that override to be restored. Keep the mutation behind one
+    context manager so reads, forks, and future SDK session operations cannot
+    drift onto different roots.
+    """
     with _vendor_msg_lock:
+        old = os.environ.get("CLAUDE_CONFIG_DIR")
+        try:
+            if model and endpoints.is_third_party(model):
+                os.environ["CLAUDE_CONFIG_DIR"] = str(endpoints._vendor_config_dir())
+            yield
+        finally:
+            if old is not None:
+                os.environ["CLAUDE_CONFIG_DIR"] = old
+            else:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+
+def _get_session_msgs(sid: str, model: str = "") -> list:
+    """Read SDK messages from the native or vendor-isolated session store."""
+    with _session_config_dir(model):
         return get_session_messages(
             sid, directory=str(sess.session_workspace(sid)))
 
@@ -356,17 +357,14 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 # fan-out for the privacy rationale.
 
 
-# Clients keyed by (session_id, model, effort). model + effort are part of
-# the key so that switching model OR reasoning-effort mid-session creates a
-# fresh client (which uses resume=session_id to inherit the conversation
-# history from disk). The effort dimension was added 2026-05-21 so per-tab
-# "research mode" doesn't leak into other tabs of the same session.
-_clients: dict[tuple[str, str, str], ClaudeSDKClient] = {}
+# Clients keyed by (session_id, model, effort).
+_ClientKey = tuple[str, str, str]
+_clients: dict[_ClientKey, ClaudeSDKClient] = {}
 # Tracks the permission_mode currently active on each cached client. SDK
 # doesn't expose a getter, so we shadow what we asked for. Lets a cached
 # client whose mode no longer matches the request swap via
 # client.set_permission_mode() instead of needing a full rebuild.
-_client_permission: dict[tuple[str, str, str], str] = {}
+_client_permission: dict[_ClientKey, str] = {}
 # Per-client mutable bypass flag, shared by reference with the can_use_tool
 # closure built in permission_request. Switching permission mode on a pooled
 # client (set_permission_mode) must flip this flag so the closure stops/starts
@@ -374,7 +372,99 @@ _client_permission: dict[tuple[str, str, str], str] = {}
 # leaks across mode switches (2026-05-29 audit). Value is `{"bypass": bool}`;
 # the SAME dict object is captured by the closure, so mutating it here takes
 # effect on the next tool call without a rebuild.
-_bypass_state: dict[tuple[str, str, str], dict] = {}
+_bypass_state: dict[_ClientKey, dict] = {}
+
+
+_BROADCAST_REPLAY_MAX_EVENTS = env_int(
+    "MUSELAB_STREAM_REPLAY_MAX_EVENTS", 512, min_value=8)
+_BROADCAST_REPLAY_MAX_BYTES = env_int(
+    "MUSELAB_STREAM_REPLAY_MAX_BYTES", 2 * 1024 * 1024, min_value=1024)
+_BROADCAST_SUBSCRIBER_MAX_EVENTS = env_int(
+    "MUSELAB_STREAM_SUBSCRIBER_MAX_EVENTS", 256, min_value=8)
+_BROADCAST_SUBSCRIBER_MAX_BYTES = env_int(
+    "MUSELAB_STREAM_SUBSCRIBER_MAX_BYTES", 1024 * 1024, min_value=1024)
+
+
+def _broadcast_event_size(event: dict) -> int:
+    try:
+        return len(json.dumps(
+            event, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8"))
+    except (TypeError, ValueError):
+        return _BROADCAST_SUBSCRIBER_MAX_BYTES + 1
+
+
+def _stream_text_payload(event: dict) -> tuple[str, str] | None:
+    """Return ``(event_name, text)`` for a plain text/thinking delta."""
+    kind = event.get("event")
+    if kind not in {"text", "thinking"}:
+        return None
+    try:
+        payload = json.loads(event.get("data") or "{}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if (not isinstance(payload, dict) or set(payload) != {"text"}
+            or not isinstance(payload.get("text"), str)):
+        return None
+    return kind, payload["text"]
+
+
+class _TurnSubscriber:
+    """Count- and byte-bounded handoff for one HTTP SSE reader."""
+
+    def __init__(self, max_events: int, max_bytes: int):
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._max_events = max_events
+        self._max_bytes = max_bytes
+        self._pending_bytes = 0
+        self._accepting = True
+
+    async def get(self):
+        item = await self._queue.get()
+        if isinstance(item, tuple) and len(item) == 2:
+            event, size = item
+            self._pending_bytes = max(0, self._pending_bytes - int(size))
+            return event
+        return item
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
+    def publish(self, event: dict) -> bool:
+        if not self._accepting:
+            return False
+        size = _broadcast_event_size(event)
+        if (self._queue.qsize() >= self._max_events
+                or self._pending_bytes + size > self._max_bytes):
+            self.resync("slow_subscriber")
+            return False
+        self._pending_bytes += size
+        self._queue.put_nowait((event, size))
+        return True
+
+    def replay(self, event: dict) -> bool:
+        # Event data is a JSON string and therefore immutable, but copy the
+        # envelope so later replay coalescing can never mutate queued state.
+        return self.publish(dict(event))
+
+    def resync(self, reason: str) -> None:
+        if not self._accepting:
+            return
+        self._accepting = False
+        while not self._queue.empty():
+            with suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+        self._pending_bytes = 0
+        self._queue.put_nowait({
+            "event": "resync",
+            "data": json.dumps({"reason": reason, "retryable": True}),
+        })
+        self._queue.put_nowait(None)
+
+    def close(self) -> None:
+        if self._accepting:
+            self._accepting = False
+            self._queue.put_nowait(None)
 
 
 class TurnBroadcast:
@@ -392,11 +482,26 @@ class TurnBroadcast:
     on the SDK side. Up to 30 min per turn (asyncio.wait_for at the
     background-task level). Removed from `_active_turns` when finished.
     """
-    def __init__(self, session_id: str, model: str = ""):
+    def __init__(
+        self,
+        session_id: str,
+        model: str = "",
+        *,
+        replay_max_events: int = _BROADCAST_REPLAY_MAX_EVENTS,
+        replay_max_bytes: int = _BROADCAST_REPLAY_MAX_BYTES,
+        subscriber_max_events: int = _BROADCAST_SUBSCRIBER_MAX_EVENTS,
+        subscriber_max_bytes: int = _BROADCAST_SUBSCRIBER_MAX_BYTES,
+    ):
         self.session_id = session_id
         self.model = model
         self.events: list[dict] = []
-        self.subscribers: set[asyncio.Queue] = set()
+        self.subscribers: set[_TurnSubscriber] = set()
+        self.replay_max_events = replay_max_events
+        self.replay_max_bytes = replay_max_bytes
+        self.subscriber_max_events = subscriber_max_events
+        self.subscriber_max_bytes = subscriber_max_bytes
+        self._replay_bytes = 0
+        self._replay_truncated = False
         self.done = False
         # Set True when this turn ended via an explicit user /interrupt (vs.
         # natural completion or error). The server-side queue drain reads it
@@ -441,55 +546,82 @@ class TurnBroadcast:
         self.task: "asyncio.Task | None" = None
 
     def publish(self, event: dict) -> None:
-        self.events.append(event)
-        for q in list(self.subscribers):
-            try:
-                q.put_nowait(event)
-            except Exception:
-                pass
+        # Live readers receive every delta. Reconnect replay keeps the exact
+        # accumulated text while coalescing adjacent token envelopes, avoiding
+        # one Python dict + JSON string per token on very long answers.
+        if not self._replay_truncated:
+            current_text = _stream_text_payload(event)
+            replay = dict(event)
+            self.events.append(replay)
+            self._replay_bytes += _broadcast_event_size(replay)
+            # Binary compaction: merge equal-kind adjacent chunks only when
+            # the older chunk is no larger than the newer one. For one-byte
+            # deltas this forms power-of-two chunks, so each byte is copied
+            # O(log n) times instead of repeatedly re-serialising the entire
+            # accumulated answer (the naive adjacent merge is O(n²)).
+            if current_text is not None:
+                while len(self.events) >= 2:
+                    left = self.events[-2]
+                    right = self.events[-1]
+                    left_text = _stream_text_payload(left)
+                    right_text = _stream_text_payload(right)
+                    if (left_text is None or right_text is None
+                            or left_text[0] != right_text[0]
+                            or len(left_text[1]) > len(right_text[1])):
+                        break
+                    merged = {
+                        "event": left_text[0],
+                        "data": json.dumps(
+                            {"text": left_text[1] + right_text[1]},
+                            ensure_ascii=False,
+                        ),
+                    }
+                    self._replay_bytes -= (
+                        _broadcast_event_size(left)
+                        + _broadcast_event_size(right)
+                    )
+                    self.events[-2:] = [merged]
+                    self._replay_bytes += _broadcast_event_size(merged)
+            if (len(self.events) > self.replay_max_events
+                    or self._replay_bytes > self.replay_max_bytes):
+                # Never offer a partial tool/result or assistant replay. The
+                # turn continues for live clients; reconnects explicitly wait
+                # for canonical transcript persistence via `resync`.
+                self.events.clear()
+                self._replay_bytes = 0
+                self._replay_truncated = True
+        for subscriber in tuple(self.subscribers):
+            if not subscriber.publish(event):
+                self.subscribers.discard(subscriber)
 
     def finish(self) -> None:
         if self.done:
             return
         self.done = True
         self.finished_at = time.time()
-        for q in list(self.subscribers):
-            try:
-                q.put_nowait(None)   # sentinel — subscribers stop yielding
-            except Exception:
-                pass
-        # Do NOT clear self.events here — late subscribers (reconnecting
-        # browsers) still need the full replay buffer.
-        # Memory note: `events` holds EVERY SSE event of the turn, including
-        # one dict per streamed text_delta token. For a very long turn (tens
-        # of thousands of output tokens) this is NOT "small" — it can reach
-        # tens of MB. It IS bounded though: the number of concurrent live
-        # turns is capped by the client pool, and the whole TurnBroadcast
-        # (events included) is GC'd the moment the turn is popped from
-        # _active_turns at turn end. So worst-case RSS is "(active turns) ×
-        # (largest turn's deltas)", a transient spike rather than a leak.
-        # If that spike ever matters, coalesce consecutive text_delta events
-        # in publish() — but that would change replay fidelity, so it's left
-        # as-is deliberately.
+        for subscriber in tuple(self.subscribers):
+            subscriber.close()
+        self.subscribers.clear()
+        # Keep only the bounded replay for late reconnects during the grace TTL.
 
-    def subscribe(self) -> asyncio.Queue:
-        q: asyncio.Queue = asyncio.Queue()
-        self.subscribers.add(q)
-        # If the turn already finished, finish() has already iterated the
-        # subscriber set and fired the sentinel — but THIS queue wasn't
-        # in it yet. Without seeding the sentinel here, _subscribe_broadcast
-        # would hang on `await q.get()` until the HTTP read times out.
-        # Late subscribers (e.g. a browser reconnecting just after the
-        # turn closed) must still see the replay-then-terminate flow.
+    def subscribe(self) -> _TurnSubscriber:
+        subscriber = _TurnSubscriber(
+            self.subscriber_max_events, self.subscriber_max_bytes)
+        if self._replay_truncated:
+            subscriber.resync("replay_truncated")
+            return subscriber
+        for event in self.events:
+            if not subscriber.replay(event):
+                return subscriber
         if self.done:
-            try:
-                q.put_nowait(None)
-            except Exception:
-                pass
-        return q
+            subscriber.close()
+        else:
+            self.subscribers.add(subscriber)
+        return subscriber
 
-    def unsubscribe(self, q: asyncio.Queue) -> None:
-        self.subscribers.discard(q)
+    def unsubscribe(self, subscriber: _TurnSubscriber) -> None:
+        self.subscribers.discard(subscriber)
+        subscriber.close()
 
 
 # In-flight turns by session id. Lookup target for reconnect.
@@ -530,7 +662,7 @@ def _get_recent_turn(session_id: str) -> TurnBroadcast | None:
 # LRU bookkeeping. Each CLI subprocess holds ~30-50 MB RSS; without a cap
 # muselab leaks memory as users open more sessions. New clients append to
 # the tail; on cache miss with len > cap, oldest gets disconnected.
-_client_lru: list[tuple[str, str, str]] = []   # (session_id, model, effort)
+_client_lru: list[_ClientKey] = []   # (session_id, model, effort)
 _CLIENT_POOL_CAP = env_int("MUSELAB_CLIENT_POOL_CAP", 3, min_value=1)
 _lock = asyncio.Lock()
 
@@ -553,6 +685,11 @@ _lock = asyncio.Lock()
 # it starts reading; the watcher only runs in the gap between turns.
 _sessions_with_inflight_tasks: dict[str, set[str]] = {}
 _task_watchers: dict[str, asyncio.Task] = {}
+# Monotonic per-session ownership token for detached continuation readers.
+# Cancelling a task is cooperative, so a replaced watcher can receive one more
+# message before CancelledError lands. Generation checks keep that stale reader
+# from opening or closing a newer continuation in that window.
+_continuation_generations: dict[str, int] = {}
 _TASK_WATCH_TIMEOUT = env_int("MUSELAB_TASK_WATCH_TIMEOUT", 1800, min_value=60)
 # After the LAST in-flight task delivers its terminal notification, the CLI
 # auto-continues a short turn (model reacts to the result). The probe (§3.4)
@@ -1306,10 +1443,10 @@ CLAUDE.md wins — they wrote it on purpose.
 # leaving DIFFERENT keys free to build concurrently. Replaces the global
 # _lock-across-await pattern that froze every other request for 3-5 s while
 # one slow `client.connect()` ran.
-_creation_locks: dict[tuple[str, str, str], asyncio.Lock] = {}
+_creation_locks: dict[_ClientKey, asyncio.Lock] = {}
 
 
-def _creation_lock_for(key: tuple[str, str, str]) -> asyncio.Lock:
+def _creation_lock_for(key: _ClientKey) -> asyncio.Lock:
     return _creation_locks.setdefault(key, asyncio.Lock())
 
 
@@ -1470,6 +1607,18 @@ async def _build_and_connect_client(
     # Claude models still go direct so Pro OAuth keeps working.
     env_ovr = endpoints.env_override(model)
     if env_ovr is not None:
+        env_ovr = dict(env_ovr)
+        # Agent/Task's `model` field is intentionally an alias enum
+        # (sonnet|opus|haiku|fable), not an arbitrary model ID. Without these
+        # CLI-native alias overrides, a subagent launched inside a Codex or
+        # other third-party session resolves `opus` to `claude-opus-*` while
+        # still inheriting the vendor ANTHROPIC_BASE_URL → deterministic 502
+        # "unknown provider". Pin every tier to the parent provider's actual
+        # model so built-in, custom, foreground, and background agents all stay
+        # on the same route. The top-level --model is explicit and unaffected.
+        routed_model = endpoints.normalize_model_id(model)
+        for tier in ("OPUS", "SONNET", "HAIKU", "FABLE"):
+            env_ovr[f"ANTHROPIC_DEFAULT_{tier}_MODEL"] = routed_model
         if _is_codex_gateway_model(model):
             # Claude CLI cannot infer Codex/GPT windows from its native model
             # table and otherwise hard-codes 200K (auto-compact around 167K).
@@ -1876,7 +2025,8 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
                 return cached
 
         # Slow path — no awaits hold _lock.
-        client = await _build_and_connect_client(session_id, model, permission, effort)
+        client = await _build_and_connect_client(
+            session_id, model, permission, effort)
 
         # Wedge gate: freeze the tool-set before anyone can run a turn on this
         # client. Runs under the per-key creation lock (blocks only same-key
@@ -1894,7 +2044,7 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
         # also SKIPS any client whose session has an in-flight turn —
         # dropping a live stream mid-flow looked like "Muse just stopped
         # talking" to the user (no error event, just dead air).
-        to_disconnect: list[tuple[tuple[str, str, str], ClaudeSDKClient]] = []
+        to_disconnect: list[tuple[_ClientKey, ClaudeSDKClient]] = []
         async with _lock:
             _clients[key] = client
             _client_permission[key] = permission
@@ -2891,10 +3041,14 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
     # under whichever entry is the turn tail; making sure all of them
     # carry ts means whatever block ends up at the tail can display
     # the time. Cheap O(N) — annotations is already a dict lookup.
+    key_ordinals: dict[str, int] = {}
     for entry in out:
         u = entry.get("uuid")
         if not u:
             continue
+        ordinal = key_ordinals.get(u, 0)
+        key_ordinals[u] = ordinal + 1
+        entry["_key"] = f"{u}:{ordinal}"
         ann = annotations.get(u, {})
         ts = ann.get("ts")
         if ts is not None and "ts" not in entry:
@@ -2917,6 +3071,99 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
         if ann_docs and entry.get("role") == "user":
             entry["docs"] = ann_docs
     return out
+
+
+def _transcript_index_path(sid: str) -> Path:
+    return sess.SESS_DIR / f"{sid}.transcript-index.json"
+
+
+def _describe_transcript_record(entry: dict) -> dict:
+    """Build persistent index metadata using the real UI expansion logic.
+
+    Calling `_sdk_messages_to_ui` for one record makes `bubble_count` an exact
+    contract rather than a second, approximate block counter that can drift
+    when slash wrappers, task notifications, or new block types are added.
+    """
+    msg = _RawMsg(str(entry.get("uuid") or ""), str(entry.get("type") or ""),
+                  entry.get("message") or {})
+    compact = {msg.uuid} if entry.get("isCompactSummary") else set()
+    bubbles = _sdk_messages_to_ui([msg], {}, compact)
+    tool_uses: list[dict] = []
+    content = (entry.get("message") or {}).get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_uses.append({
+                    "id": block.get("id") or "",
+                    "name": block.get("name") or "",
+                })
+    notifications = (
+        _parse_task_notifications(content) if isinstance(content, str) else []
+    )
+    user_bubble = next((b for b in bubbles if b.get("role") == "user"), None)
+    user_text = (user_bubble or {}).get("text", "")
+    has_inline_images = (
+        isinstance(content, list)
+        and any(isinstance(block, dict) and block.get("type") == "image"
+                for block in content)
+    )
+    return {
+        "bubble_count": len(bubbles),
+        "user_preview": _outline_preview(user_text) if user_bubble is not None else "",
+        "real_user_prompt": _is_real_user_prompt(msg) and not notifications,
+        "has_inline_images": has_inline_images,
+        "tool_uses": tool_uses,
+        "task_notifications": notifications,
+    }
+
+
+def _ensure_transcript_index(sid: str) -> tuple[Path, dict] | None:
+    path = _find_session_jsonl(sid)
+    if path is None:
+        return None
+    return path, transcript_idx.ensure_index(
+        sid, path, _transcript_index_path(sid), _describe_transcript_record)
+
+
+def _indexed_ui_records(
+    transcript_path: Path,
+    index: dict,
+    record_indices: list[int],
+    annotations: dict[str, dict],
+) -> list[dict]:
+    """Seek/read and shape only selected records from a transcript index."""
+    entries = transcript_idx.read_records(transcript_path, index, record_indices)
+    raw = [
+        _RawMsg(str(e.get("uuid") or ""), str(e.get("type") or ""),
+                e.get("message") or {})
+        for e in entries
+    ]
+    compact = {str(e.get("uuid")) for e in entries if e.get("isCompactSummary")}
+    bubbles = _sdk_messages_to_ui(raw, annotations, compact)
+
+    # Cross-window context is stored in the index: a page may begin with a
+    # tool_result whose tool_use is outside the read window, and a launching
+    # card may need a terminal task notification appended much later.
+    tool_names = index.get("tool_use_names") or {}
+    task_status = index.get("task_status") or {}
+    ordinals: dict[str, int] = {}
+    for bubble in bubbles:
+        uid = str(bubble.get("uuid") or "")
+        ordinal = ordinals.get(uid, 0)
+        ordinals[uid] = ordinal + 1
+        bubble["_key"] = f"{uid}:{ordinal}"
+        tool_id = str(bubble.get("id") or "")
+        if bubble.get("role") == "tool_result" and tool_id:
+            tool_name = tool_names.get(tool_id) or ""
+            if tool_name:
+                bubble["tool_name"] = tool_name
+                if tool_name == "Bash" and "bash" not in bubble:
+                    parsed = _parse_bash_result(bubble.get("text") or "")
+                    if parsed:
+                        bubble["bash"] = parsed
+        elif bubble.get("role") == "tool_use" and tool_id in task_status:
+            bubble["task_status"] = task_status[tool_id]
+    return bubbles
 
 
 def _bind_pending_attachments(sid: str, messages: list[dict]) -> None:
@@ -3248,6 +3495,10 @@ def get_session_api(
     tail: int = Query(0, ge=0),
     offset: int = Query(-1),
     limit: int = Query(0, ge=0),
+    history_generation: str = Query(""),
+    around_uuid: str = Query(""),
+    before: int = Query(0, ge=0),
+    after: int = Query(0, ge=0),
 ) -> dict:
     """Read session: metadata from muselab sidecar + transcript from CLI JSONL
     via SDK. Merges per-message annotations (cost, model, images) into the
@@ -3281,74 +3532,131 @@ def get_session_api(
     if meta is None:
         raise HTTPException(404, "session not found")
     model = meta.get("model", "")
-    messages = _shaped_ui_messages(sid, model, full)
-    # Bind any unbound pending image/doc attachments (those persisted
-    # before the stream completed could write a uuid annotation) to the
-    # user messages that have inline image refs but no thumb/url yet.
-    # Runs on the cached list too: idempotent, and a successful bind
-    # rewrites the sidecar → sidecar_sig changes → next call re-shapes.
-    if sess.has_pending_attachments(sid):
-        _bind_pending_attachments(sid, messages)
-    # Mid-turn merge: SDK CLI writes the JSONL incrementally — the
-    # user prompt lands immediately when the turn starts, but the
-    # assistant reply (text/thinking/tool blocks) only commits when
-    # the whole turn finishes. So a reload during streaming sees the
-    # user msg but no reply. The active TurnBroadcast has the live
-    # event stream → reconstruct an in-progress view from it and
-    # splice it in place of the last (incomplete) user msg the SDK
-    # returned. When the turn finishes, the active broadcast is
-    # popped and this branch becomes inert; the SDK JSONL alone is
-    # the source of truth again.
-    # NOTE: deliberately NOT layering broadcast rebuild on top of the
-    # SDK transcript here. The frontend's _checkActiveTurn fires SSE
-    # reconnect when the backend says active=true, and the reconnect
-    # endpoint replays the broadcast buffer + streams live events.
-    # If we rebuilt the in-flight portion here too, the user would
-    # either:
-    #  a) see static partial content with no further streaming
-    #     (frontend skips reconnect because messages already ends in
-    #     assistant), or
-    #  b) see duplicated content (SDK partial + broadcast replay).
-    # Keeping this path SDK-only lets reconnect be the sole live-tail
-    # mechanism. The user briefly sees just the user msg, then SSE
-    # fills in everything via replay → live.
-    total = len(messages)
-    # Self-heal a stale cached message_count. Some sessions carry
-    # message_count=0 in the muselab index despite having a real transcript
-    # (older imports, or turns written outside muselab's bump path), which
-    # made the session list report non-empty sessions as "0 messages" and,
-    # if MUSELAB_PRUNE_EMPTY_SESSIONS is ever enabled, risked pruning them.
-    # `total` is the real shaped count we just computed, so write it back via
-    # the side-effect-free setter (never touches updated_at → no reordering).
-    # Gated on `not full` (full=1 is the larger pre-compact outline/export
-    # count, not the normal view's count) and total>0 (so a transient empty
-    # read can't zero out a real count).
-    if not full and total > 0 and meta.get("message_count", 0) != total:
-        try:
-            _turns = sum(1 for x in messages if x.get("role") == "user")
-            sess.set_message_count(sid, total, turn_count=_turns)
-        except Exception:
-            pass
-    # Slice the requested window. full / no-param → whole list (offset 0).
-    if full or (tail <= 0 and offset < 0):
+    # Any bounded request uses the byte-offset index, including bounded
+    # ``full``-order paging after an outline jump.  Keeping normal/full as an
+    # explicit response coordinate prevents a full-order offset from later
+    # being sent to the default normal-order endpoint.
+    uses_index = bool(around_uuid or tail > 0 or offset >= 0)
+    generation = ""
+    has_later = False
+    history_order = "full" if (full or around_uuid) else "normal"
+
+    if uses_index:
+        indexed = _ensure_transcript_index(sid)
+        if indexed is None:
+            messages: list[dict] = []
+            total = 0
+            win_offset = 0
+            window = []
+        else:
+            transcript_path, index = indexed
+            generation = str(index.get("history_generation") or "")
+            if history_generation and history_generation != generation:
+                raise HTTPException(409, detail={
+                    "error": "history_generation_mismatch",
+                    "history_generation": generation,
+                })
+            if sess.has_pending_attachments(sid):
+                # Pending bundles are FIFO. Reconcile against every active-chain
+                # image record in transcript order before slicing, otherwise a
+                # tail page could bind an older bundle to a newer message.
+                records = index["records"]
+                image_record_ids = [
+                    record_i for record_i in index["orders"]["normal"]
+                    if records[record_i].get("has_inline_images")
+                ]
+                image_messages = _indexed_ui_records(
+                    transcript_path, index, image_record_ids,
+                    sess.get_message_annotations(sid))
+                _bind_pending_attachments(sid, image_messages)
+            annotations = sess.get_message_annotations(sid)
+            if around_uuid:
+                # before/after and the legacy limit are all expressed in UI
+                # bubbles.  The index maps that exact range back to the small
+                # set of JSONL records that intersects it.
+                around_limit = limit if before == 0 and after == 0 else 0
+                record_ids, inner_start, win_offset, win_end, total = (
+                    transcript_idx.record_indices_around_uuid(
+                        index, around_uuid, before, after, limit=around_limit))
+                if not record_ids:
+                    raise HTTPException(404, "message uuid not found")
+                shaped = _indexed_ui_records(
+                    transcript_path, index, record_ids, annotations)
+                window = shaped[inner_start:inner_start + (win_end - win_offset)]
+                # A corrupt/drifted index must not silently turn a successful
+                # around request into a window that omits its target.
+                if not any(item.get("uuid") == around_uuid for item in window):
+                    raise HTTPException(409, detail={
+                        "error": "history_index_mismatch",
+                        "history_generation": generation,
+                    })
+                has_later = win_end < total
+            else:
+                order = "full" if full else "normal"
+                history_order = order
+                total = index["bubble_prefix"][order][-1]
+                if offset >= 0:
+                    start = max(0, min(offset, total))
+                    end = total if limit <= 0 else min(total, start + limit)
+                else:
+                    start = max(0, total - tail)
+                    end = total
+                record_ids, inner_start, _ = (
+                    transcript_idx.record_indices_for_bubble_window(
+                        index, order, start, end))
+                shaped = _indexed_ui_records(
+                    transcript_path, index, record_ids, annotations)
+                window = shaped[inner_start:inner_start + (end - start)]
+                win_offset = start
+                has_later = end < total
+            messages = window
+
+            # The index already has the exact normal-order bubble total, so
+            # window requests can self-heal message_count without shaping the
+            # entire transcript.
+            normal_total = index["bubble_prefix"]["normal"][-1]
+            if not full and meta.get("message_count", 0) != normal_total:
+                try:
+                    records = index["records"]
+                    turns = sum(
+                        1 for rec_i in index["orders"]["normal"]
+                        if records[rec_i].get("real_user_prompt")
+                    )
+                    sess.set_message_count(sid, normal_total, turn_count=turns)
+                except Exception:
+                    pass
+    else:
+        # Compatibility path for callers that explicitly request the complete
+        # normal/full transcript. Windowed callers never enter this O(N) SDK
+        # parse-and-shape path.
+        messages = _shaped_ui_messages(sid, model, full)
+        if sess.has_pending_attachments(sid):
+            _bind_pending_attachments(sid, messages)
+        total = len(messages)
         win_offset = 0
         window = messages
-    elif offset >= 0:
-        # Explicit range (Load-earlier paging). Clamp into [0, total].
-        start = max(0, min(offset, total))
-        end = total if limit <= 0 else min(total, start + limit)
-        win_offset = start
-        window = messages[start:end]
-    else:
-        # tail > 0 → last N bubbles (initial load).
-        win_offset = max(0, total - tail)
-        window = messages[win_offset:]
+        try:
+            indexed = _ensure_transcript_index(sid)
+            if indexed is not None:
+                generation = str(indexed[1].get("history_generation") or "")
+        except Exception:
+            generation = ""
+        if not full and total > 0 and meta.get("message_count", 0) != total:
+            try:
+                turns = sum(1 for item in messages if item.get("role") == "user")
+                sess.set_message_count(sid, total, turn_count=turns)
+            except Exception:
+                pass
+
     return {
         **meta,
         "messages": window,
         "total": total,
         "offset": win_offset,
         "has_more": win_offset > 0,
+        "has_later": has_later,
+        "history_generation": generation,
+        "history_order": history_order,
     }
 
 
@@ -3382,18 +3690,25 @@ def get_session_outline_api(sid: str) -> dict:
     if meta is None:
         raise HTTPException(404, "session not found")
     try:
-        sdk_msgs = _full_session_msgs(sid)
-        annotations = sess.get_message_annotations(sid)
-        compact_uuids = _compact_summary_uuids(sid)
-        messages = _sdk_messages_to_ui(sdk_msgs, annotations, compact_uuids)
+        indexed = _ensure_transcript_index(sid)
+        if indexed is None:
+            return {"outline": [], "history_generation": ""}
+        _, index = indexed
+        records = index["records"]
+        items = [
+            {"preview": records[record_i]["user_preview"],
+             "uuid": records[record_i]["uuid"]}
+            for record_i in index["orders"]["full"]
+            if records[record_i]["type"] == "user"
+            and records[record_i]["user_preview"]
+            and not records[record_i]["compact"]
+        ]
+        return {
+            "outline": items,
+            "history_generation": index.get("history_generation") or "",
+        }
     except Exception:
-        messages = []
-    items = [
-        {"preview": _outline_preview(m.get("text", "")), "uuid": m.get("uuid")}
-        for m in messages
-        if m.get("role") == "user" and not m.get("_is_compact_summary")
-    ]
-    return {"outline": items}
+        return {"outline": [], "history_generation": ""}
 
 
 def _broadcast_to_ui_messages(bc: "TurnBroadcast") -> list[dict]:
@@ -3536,6 +3851,25 @@ def export_session_markdown(sid: str) -> Response:
                     headers=headers)
 
 
+def _clear_session_runtime_state(sid: str) -> None:
+    """Forget detached turn/continuation state owned by a deleted session."""
+    _continuation_generations[sid] = _continuation_generations.get(sid, 0) + 1
+    watcher = _task_watchers.pop(sid, None)
+    if watcher is not None and not watcher.done():
+        watcher.cancel()
+    task_ids = _sessions_with_inflight_tasks.pop(sid, set())
+    for task_id in task_ids:
+        _bg_task_descriptions.pop(task_id, None)
+    _recent_turns.pop(sid, None)
+    broadcast = _active_turns.pop(sid, None)
+    if broadcast is not None:
+        task = getattr(broadcast, "task", None)
+        if task is not None and not task.done():
+            task.cancel()
+        broadcast.cancelled = True
+        broadcast.finish()
+
+
 def purge_session_storage(sid: str) -> bool:
     """Remove EVERY per-session artifact: SDK JSONL, muselab sidecar/index/
     queue, attachments dir, and in-memory state. Returns True if any layer
@@ -3557,6 +3891,10 @@ def purge_session_storage(sid: str) -> bool:
         pass   # JSONL never existed (session never streamed) — that's fine
     if sess.delete_session(sid):
         removed = True
+    try:
+        _transcript_index_path(sid).unlink(missing_ok=True)
+    except OSError:
+        pass
     # Sweep per-session attachments dir (uploaded image full-res originals
     # persisted by upload-image → send pipeline). Without this, deleting
     # a session would orphan its image files on disk forever.
@@ -3572,6 +3910,7 @@ def purge_session_storage(sid: str) -> bool:
     # sidecar file both keyed by sid).
     _session_usage.pop(sid, None)
     _interrupted_at_startup.pop(sid, None)
+    _clear_session_runtime_state(sid)
     _delete_active_turn_sidecar(sid)
     return removed
 
@@ -3944,7 +4283,7 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
                         # Preserve the effort dimension when remapping under
                         # the new model — set_model() keeps the SDK options
                         # object, which still has the prior effort baked in.
-                        new_key = (sid, req.model, old_key[2])
+                        new_key = (sid, req.model, old_key[2], old_key[3])
                         _clients[new_key] = client
                         _client_permission[new_key] = perm
                         if bstate is not None:
@@ -4771,6 +5110,108 @@ def _empty_dashboard_response(days: int, tz_offset_minutes: int, now) -> dict:
     }
 
 
+def _dedupe_error_parts(parts: list[Any]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        text = str(part or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _sdk_assistant_error(msg: Any) -> dict | None:
+    error = getattr(msg, "error", None)
+    if not error:
+        return None
+    text_parts = [
+        getattr(block, "text", "")
+        for block in (getattr(msg, "content", None) or [])
+        if isinstance(block, TextBlock)
+    ]
+    parts = _dedupe_error_parts([*text_parts, error])
+    return {
+        "message": "; ".join(parts) or "assistant API error",
+        "source": "assistant",
+        "api_error_status": None,
+    }
+
+
+def _sdk_result_error(msg: Any) -> dict | None:
+    if not bool(getattr(msg, "is_error", False)):
+        return None
+    errors = getattr(msg, "errors", None) or []
+    if not isinstance(errors, (list, tuple)):
+        errors = [errors]
+    parts = _dedupe_error_parts([
+        *errors,
+        getattr(msg, "result", None),
+        getattr(msg, "subtype", None),
+    ])
+    status = getattr(msg, "api_error_status", None)
+    if not parts and status:
+        parts = [f"API error {status}"]
+    return {
+        "message": "; ".join(parts) or "SDK command failed",
+        "source": "result",
+        "api_error_status": status,
+    }
+
+
+def _merge_sdk_errors(errors: list[dict]) -> dict | None:
+    if not errors:
+        return None
+    parts = _dedupe_error_parts([e.get("message") for e in errors])
+    status = next(
+        (e.get("api_error_status") for e in reversed(errors)
+         if e.get("api_error_status")),
+        None,
+    )
+    return {
+        "message": "; ".join(parts) or "SDK command failed",
+        "source": "+".join(dict.fromkeys(e.get("source", "sdk") for e in errors)),
+        "api_error_status": status,
+    }
+
+
+class _SDKCommandError(RuntimeError):
+    def __init__(self, info: dict):
+        self.info = info
+        super().__init__(info.get("message") or "SDK command failed")
+
+
+async def _run_sdk_command_checked(client: ClaudeSDKClient, command: str) -> ResultMessage:
+    """Run a CLI slash command and require an explicitly successful Result.
+
+    Assistant/API errors are in-band SDK messages, not Python exceptions. Drain
+    through the terminal Result before raising so a failed command cannot leave
+    a stale Result in the pooled client's receive queue for the next turn.
+    """
+    await client.query(command)
+    errors: list[dict] = []
+    result: ResultMessage | None = None
+    async for msg in client.receive_response():
+        if isinstance(msg, AssistantMessage):
+            if info := _sdk_assistant_error(msg):
+                errors.append(info)
+        if isinstance(msg, ResultMessage):
+            result = msg
+            if info := _sdk_result_error(msg):
+                errors.append(info)
+            break
+    if result is None:
+        errors.append({
+            "message": f"{command} ended without a ResultMessage",
+            "source": "transport",
+            "api_error_status": None,
+        })
+    if merged := _merge_sdk_errors(errors):
+        raise _SDKCommandError(merged)
+    return result
+
+
 @router.get("/context-breakdown/{session_id}", dependencies=[Depends(require_token)])
 async def context_breakdown(session_id: str, model: str = "") -> dict:
     """Detailed context breakdown via SDK — answers "where did my 100K go?".
@@ -4863,17 +5304,43 @@ async def native_compact_session_api(sid: str) -> dict:
     # permission cards for every subsequent turn on this session.
     prior_perm = _client_permission.get((sid, model, effort))
     client = await get_client(sid, model, "bypassPermissions", effort=effort)
+    before_total = 0
+    post_compact_usage: dict | None = None
     try:
-        await client.query("/compact")
+        try:
+            before_total = _positive_int((await client.get_context_usage()).get("totalTokens"))
+        except Exception:
+            pass
         # Bound the wait: a hung CLI /compact would otherwise leave this HTTP
         # request open forever (the main turn loop has its own 1800s guard).
         async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 600, min_value=1)):
-            async for _ in client.receive_response():
-                pass
+            await _run_sdk_command_checked(client, "/compact")
+        post_compact_usage = dict(await client.get_context_usage())
+        after_total = _positive_int(post_compact_usage.get("totalTokens"))
+        if before_total and after_total and after_total >= before_total:
+            raise _SDKCommandError({
+                "message": (
+                    "native /compact reported success but context usage did not decrease "
+                    f"({before_total} -> {after_total})"
+                ),
+                "source": "verification",
+                "api_error_status": None,
+            })
     except asyncio.TimeoutError:
         sys.stderr.write(f"[chat] native /compact timed out for sid={sid[:8]}\n")
         sys.stderr.flush()
         raise HTTPException(504, "native /compact timed out — CLI may be hung") from None
+    except _SDKCommandError as e:
+        classified = _classify_stream_error(str(e))
+        status = (409 if classified["kind"] == "context_window"
+                  else 502 if classified["kind"] == "model_route"
+                  else int(e.info.get("api_error_status") or 500))
+        if status < 400 or status > 599:
+            status = 500
+        sys.stderr.write(
+            f"[chat] native /compact rejected for sid={sid[:8]}: {e}\n")
+        sys.stderr.flush()
+        raise HTTPException(status, str(e)) from None
     except Exception as e:
         sys.stderr.write(f"[chat] native /compact failed for sid={sid[:8]}: "
                           f"{type(e).__name__}: {e}\n")
@@ -4906,7 +5373,7 @@ async def native_compact_session_api(sid: str) -> dict:
     # /compact on (its in-memory context is the compacted one) and write them
     # back into _session_usage so every subsequent /usage poll is correct.
     try:
-        cu = await client.get_context_usage()
+        cu = post_compact_usage or dict(await client.get_context_usage())
         real_max = int(cu.get("maxTokens") or 0)
         real_total = int(cu.get("totalTokens") or 0)
         sess_u = _session_usage.setdefault(sid, {
@@ -4989,13 +5456,15 @@ def fork_session_api(sid: str, req: ForkReq) -> dict:
     src_meta = sess.get_session_meta(sid)
     if src_meta is None:
         raise HTTPException(404, "session not found")
+    source_model = (src_meta.get("model") or MODEL).strip()
     try:
-        result = sdk_fork_session(
-            sid,
-            directory=str(sess.session_workspace(sid)),
-            up_to_message_id=req.up_to_message_id,
-            title=req.title,
-        )
+        with _session_config_dir(source_model):
+            result = sdk_fork_session(
+                sid,
+                directory=str(sess.session_workspace(sid)),
+                up_to_message_id=req.up_to_message_id,
+                title=req.title,
+            )
     except FileNotFoundError:
         raise HTTPException(404, "source transcript not found")
     except ValueError as e:
@@ -5353,6 +5822,11 @@ async def interrupt(session_id: str) -> dict:
     """Stop the current turn via SDK control protocol. Keeps the client
     connected so the next message continues the same conversation without
     re-spawning the CLI / re-loading CLAUDE.md / re-initializing MCP."""
+    # Stop means "do not continue autonomously". Pause queued work before the
+    # SDK interrupt can race the current turn's finally block and dequeue the
+    # next item. The helper is atomic with dequeue_message and is a no-op for an
+    # empty queue, so ordinary one-off interrupts do not create paused state.
+    sess.pause_queue_if_nonempty(session_id)
     async with _lock:
         targets = [(k, c) for k, c in _clients.items() if k[0] == session_id]
     # Mark the active turn user-cancelled up front (BEFORE calling SDK's
@@ -5657,6 +6131,22 @@ def _classify_stream_error(err: Any) -> dict:
     cta: str | None = "retry"
     retryable = True
     if any(t in low for t in (
+        "context window", "context length", "input exceeds",
+        "input tokens exceed", "maximum tokens", "maximum context",
+        "prompt too long", "input is too long", "request too large",
+        "too many tokens",
+    )):
+        kind = "context_window"
+        cta = "compact_or_fork"
+        retryable = False
+    elif any(t in low for t in (
+        "unknown provider", "provider not found", "unsupported provider",
+        "no provider for model", "unknown model provider",
+    )):
+        kind = "model_route"
+        cta = "switch_model"
+        retryable = False
+    elif any(t in low for t in (
         "401", "invalid api key", "invalid_api_key",
         "not logged in", "requires auth", "no api key",
         "anthropic_api_key", "authentication",
@@ -7387,6 +7877,7 @@ async def _watch_inflight_tasks(
     session_id: str,
     client: ClaudeSDKClient,
     pending: dict[str, str | None],
+    generation: int | None = None,
 ) -> None:
     """Detached reader keeping an originating CLI client alive past its turn so
     SDK background tasks started in that turn can deliver their terminal
@@ -7419,14 +7910,22 @@ async def _watch_inflight_tasks(
     cont: TurnBroadcast | None = None
     cont_state: dict | None = None
 
+    def _owns_generation() -> bool:
+        return (generation is None
+                or _continuation_generations.get(session_id) == generation)
+
     async def _open_continuation() -> None:
         """Register a fresh continuation broadcast in _active_turns[sid] under
         the lock. If a live turn somehow holds the slot, leave cont None and
         let that turn's in-turn dispatch surface the notification instead."""
         nonlocal cont, cont_state
+        if not _owns_generation():
+            return
         b = TurnBroadcast(session_id=session_id, model="")
         b.is_continuation = True
         async with _lock:
+            if not _owns_generation():
+                return
             existing = _active_turns.get(session_id)
             if existing is not None and not existing.done:
                 return   # a live turn raced in — defer to it
@@ -7487,6 +7986,9 @@ async def _watch_inflight_tasks(
                 except asyncio.TimeoutError:
                     # Grace elapsed with no auto-continue (rare). Close the
                     # open continuation and stop — all tasks already settled.
+                    break
+
+                if not _owns_generation():
                     break
 
                 if isinstance(msg, TaskNotificationMessage):
@@ -7693,11 +8195,13 @@ def _spawn_task_watcher(
     old = _task_watchers.get(session_id)
     if old is not None and not old.done():
         old.cancel()
+    generation = _continuation_generations.get(session_id, 0) + 1
+    _continuation_generations[session_id] = generation
     sys.stderr.write(
         f"[chat] task watcher spawned sid={session_id[:8]} "
-        f"pending={sorted(pending)}\n")
+        f"generation={generation} pending={sorted(pending)}\n")
     _task_watchers[session_id] = asyncio.create_task(
-        _watch_inflight_tasks(session_id, client, pending))
+        _watch_inflight_tasks(session_id, client, pending, generation))
 
 
 async def _handoff_task_watcher(session_id: str) -> None:
@@ -7706,6 +8210,8 @@ async def _handoff_task_watcher(session_id: str) -> None:
     at once, and wait for it to fully stop. The pins stay (the watcher's
     CancelledError path keeps them) so the client isn't evicted in the gap; the
     new turn's in-turn dispatch settles the buffered notification."""
+    _continuation_generations[session_id] = (
+        _continuation_generations.get(session_id, 0) + 1)
     watcher = _task_watchers.pop(session_id, None)
     if watcher is not None and not watcher.done():
         watcher.cancel()
@@ -8055,6 +8561,10 @@ async def _start_turn(
     # and Phase 2's cross-turn watcher takes over. Lives in event_gen closure,
     # cleared per turn.
     inflight_tasks: dict[str, dict] = {}
+    # SDK API failures can arrive as synthetic AssistantMessage objects before
+    # the terminal ResultMessage. Accumulate them so the turn's done payload is
+    # marked failed even when ResultMessage itself omits the detail.
+    turn_sdk_errors: list[dict] = []
 
     async def _preflight_compact_if_needed() -> None:
         """Use Claude Code's native context accounting before sending a turn.
@@ -8124,63 +8634,66 @@ async def _start_turn(
             f"total={total} next~={next_est} threshold={threshold} limit={limit}\n")
         sys.stderr.flush()
         try:
-            await client.query("/compact")
             async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 600, min_value=1)):
-                async for msg in client.receive_response():
-                    if isinstance(msg, ResultMessage):
-                        break
+                await _run_sdk_command_checked(client, "/compact")
+            cu2 = await client.get_context_usage()
         except Exception as e:
-            # Do not swallow the user's actual turn forever. If compact failed
-            # because the session is already over the gateway's true limit, the
-            # subsequent turn will surface the vendor error; this log preserves why
-            # preflight did not prevent it.
+            # Once the SDK says compaction is required, failure is terminal for
+            # this turn. Sending the original prompt anyway only produces a
+            # second context-window error and trains the UI to offer a useless
+            # retry loop.
             sys.stderr.write(
                 f"[chat-preflight] native compact failed sid={session_id[:8]} "
                 f"model={model_to_use}: {type(e).__name__}: {e}\n")
             sys.stderr.flush()
-            return
-        try:
-            cu2 = await client.get_context_usage()
-            real_total = _positive_int(cu2.get("totalTokens"))
-            real_max = _positive_int(cu2.get("maxTokens"))
-            real_raw = _positive_int(cu2.get("rawMaxTokens"))
-            refreshed_details = _context_limit_details(
-                model_to_use,
-                sdk_max=real_max,
-                sdk_raw=real_raw,
-                capability=capability,
-            )
-            lim = _positive_int(refreshed_details.get("context_limit"))
-            sess_u = _session_usage.setdefault(session_id, {
-                "input_tokens": 0, "output_tokens": 0,
-                "cache_read_tokens": 0, "cache_creation_tokens": 0,
-                "total_cost_usd": 0.0, "last_turn_at": 0.0,
-                "context_used": 0, "context_used_pct": 0.0,
-                "context_limit": 0,
+            raise
+        real_total = _positive_int(cu2.get("totalTokens"))
+        if total and real_total and real_total >= total:
+            raise _SDKCommandError({
+                "message": (
+                    "native /compact reported success but context usage did not decrease "
+                    f"({total} -> {real_total})"
+                ),
+                "source": "verification",
+                "api_error_status": None,
             })
-            if real_total:
-                sess_u["context_used"] = real_total
-                _mark_context_used(
-                    sess_u,
-                    "sdk_context",
-                    estimate=endpoints.is_third_party(model_to_use),
-                )
-            _apply_context_limit_details(sess_u, refreshed_details)
-            sess_u["sdk_context_max_tokens"] = real_max
-            sess_u["sdk_context_raw_max_tokens"] = real_raw
-            th = _compact_threshold(
-                model_to_use,
-                lim,
-                _positive_int(cu2.get("autoCompactThreshold")),
-                sdk_max=real_max,
-                capability=capability,
+        real_max = _positive_int(cu2.get("maxTokens"))
+        real_raw = _positive_int(cu2.get("rawMaxTokens"))
+        refreshed_details = _context_limit_details(
+            model_to_use,
+            sdk_max=real_max,
+            sdk_raw=real_raw,
+            capability=capability,
+        )
+        lim = _positive_int(refreshed_details.get("context_limit"))
+        sess_u = _session_usage.setdefault(session_id, {
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_creation_tokens": 0,
+            "total_cost_usd": 0.0, "last_turn_at": 0.0,
+            "context_used": 0, "context_used_pct": 0.0,
+            "context_limit": 0,
+        })
+        if real_total:
+            sess_u["context_used"] = real_total
+            _mark_context_used(
+                sess_u,
+                "sdk_context",
+                estimate=endpoints.is_third_party(model_to_use),
             )
-            if th:
-                sess_u["auto_compact_threshold"] = th
-            if real_total and lim:
-                sess_u["context_used_pct"] = round(real_total / lim * 100, 1)
-        except Exception:
-            pass
+        _apply_context_limit_details(sess_u, refreshed_details)
+        sess_u["sdk_context_max_tokens"] = real_max
+        sess_u["sdk_context_raw_max_tokens"] = real_raw
+        th = _compact_threshold(
+            model_to_use,
+            lim,
+            _positive_int(cu2.get("autoCompactThreshold")),
+            sdk_max=real_max,
+            capability=capability,
+        )
+        if th:
+            sess_u["auto_compact_threshold"] = th
+        if real_total and lim:
+            sess_u["context_used_pct"] = round(real_total / lim * 100, 1)
 
     async def event_gen():
         nonlocal assistant_acc, streamed_in_bubble
@@ -8332,6 +8845,12 @@ async def _start_turn(
                  stream may have skipped; forward tool_use / tool_result.
             """
             nonlocal assistant_acc, streamed_in_bubble
+            if error_info := _sdk_assistant_error(msg):
+                turn_sdk_errors.append(error_info)
+                # Synthetic API-error assistants often carry the raw error as a
+                # TextBlock. Do not render it as if it were a normal Muse reply;
+                # the terminal done event below surfaces the classified failure.
+                return
             a_usage = getattr(msg, "usage", None) or {}
             if a_usage:
                 in_t = int(a_usage.get("input_tokens", 0) or 0)
@@ -8989,10 +9508,24 @@ async def _start_turn(
             # is_error=True (+ subtype / errors detail). Surface them in the
             # done payload so the FE can render a failure state — previously
             # these turns looked identical to successes in UI and history.
-            _is_error = bool(getattr(msg, "is_error", False))
+            _result_error = _sdk_result_error(msg)
+            _turn_error = _merge_sdk_errors([
+                *turn_sdk_errors,
+                *([_result_error] if _result_error else []),
+            ])
+            _is_error = _turn_error is not None
             _subtype = getattr(msg, "subtype", None)
             _errors = getattr(msg, "errors", None) or []
-            _api_error_status = getattr(msg, "api_error_status", None)
+            if not isinstance(_errors, (list, tuple)):
+                _errors = [_errors]
+            _api_error_status = (
+                (_turn_error or {}).get("api_error_status")
+                or getattr(msg, "api_error_status", None)
+            )
+            _error_message = (_turn_error or {}).get("message", "")
+            _error_class = _classify_stream_error(_error_message) if _is_error else {
+                "kind": None, "cta": None, "retryable": False,
+            }
             yield {"event": "done", "data": json.dumps({
                 "duration_ms": getattr(msg, "duration_ms", None),
                 "total_cost_usd": cost,
@@ -9003,8 +9536,13 @@ async def _start_turn(
                 # cancelled turn — they clicked stop, they know).
                 "cancelled": was_cancelled,
                 "is_error": _is_error,
+                "error": _error_message,
+                "kind": _error_class["kind"],
+                "cta": _error_class["cta"],
+                "retryable": _error_class["retryable"],
                 "result_subtype": _subtype,
-                "errors": [str(e) for e in _errors],
+                "errors": (_dedupe_error_parts([*_errors, _error_message])
+                           if _is_error else []),
                 "api_error_status": _api_error_status,
                 # turn_usage: cumulative (ResultMessage.usage). FE should
                 # prefer session_usage.context_* for window display. Will be
@@ -9349,19 +9887,13 @@ async def _maybe_drain_queue(session_id: str) -> None:
 
 
 async def _subscribe_broadcast(broadcast: TurnBroadcast):
-    """Yields buffered events first (replay), then live events as they
-    publish, terminating on the broadcast's finish sentinel. A late
-    subscriber (reconnecting browser) gets the complete history plus
-    everything that arrives after.
+    """Yield bounded replay followed by the live tail.
 
-    Atomicity note: `broadcast.subscribe()` adds the queue and
-    `len(...)` snapshots the buffer length in one synchronous block
-    (no `await` between them). asyncio is single-threaded and won't
-    preempt — publishes that happen before subscribe are entirely in
-    the buffer, publishes after go into BOTH the buffer and the queue.
-    Slicing the buffer up to `snap_len` gives us exactly the "before"
-    set, and the queue gives us exactly the "after" set, with no
-    duplication and no missed events."""
+    ``subscribe()`` synchronously snapshots replay into the subscriber before
+    registering it for live delivery, so asyncio cannot publish into the gap.
+    A truncated replay or slow client receives one explicit ``resync`` event
+    and disconnects; neither condition can block or cancel the model turn.
+    """
     # A subscriber is now attached. For a CONTINUATION broadcast this is the
     # one-and-only reconnect that replays the finished task's card flip +
     # reaction; mark it consumed so `/active` stops advertising it (else the
@@ -9369,26 +9901,15 @@ async def _subscribe_broadcast(broadcast: TurnBroadcast):
     # reaction bubbles). Harmless no-op for normal turns.
     if getattr(broadcast, "is_continuation", False):
         broadcast.continuation_consumed = True
-    q = broadcast.subscribe()
-    snap_len = len(broadcast.events)
+    subscriber = broadcast.subscribe()
     try:
-        # Replay the buffered prefix (events published BEFORE we
-        # subscribed — they're not in our queue).
-        for i in range(snap_len):
-            try:
-                chunk = broadcast.events[i]
-            except IndexError:
-                break  # events 被意外清空，停止 replay
-            yield chunk
-        # If the turn already finished before we subscribed, the queue
-        # holds nothing but the None sentinel.
         while True:
-            ev = await q.get()
+            ev = await subscriber.get()
             if ev is None:
                 break
             yield ev
     finally:
-        broadcast.unsubscribe(q)
+        broadcast.unsubscribe(subscriber)
 
 
 @router.get("/sessions/{sid}/active", dependencies=[Depends(require_token)])

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -588,6 +588,12 @@ def delete_session(sid: str) -> bool:
             p.unlink()
         except OSError:
             pass
+    transcript_index = SESS_DIR / f"{sid}.transcript-index.json"
+    if transcript_index.exists():
+        try:
+            transcript_index.unlink()
+        except OSError:
+            pass
     q = _queue_path(sid)
     if q.exists():
         try:
@@ -661,6 +667,12 @@ def prune_empty_sessions(keep_ids: tuple | list = ()) -> list[str]:
         if q.exists():
             try:
                 q.unlink()
+            except OSError:
+                pass
+        transcript_index = SESS_DIR / f"{sid}.transcript-index.json"
+        if transcript_index.exists():
+            try:
+                transcript_index.unlink()
             except OSError:
                 pass
         try:
@@ -1132,6 +1144,21 @@ def set_queue_paused(sid: str, paused: bool) -> dict:
         data = _load_queue(sid)
         data["paused"] = bool(paused)
         _save_queue(sid, data)
+        return data
+
+
+def pause_queue_if_nonempty(sid: str) -> dict:
+    """Atomically pause ``sid`` only when queued work still exists.
+
+    The interrupt path uses this before asking the SDK to stop. Sharing the
+    queue lock with ``dequeue_message`` closes the race where turn completion
+    could otherwise pop the next item between a separate get/pause pair.
+    """
+    with _QUEUE_LOCK:
+        data = _load_queue(sid)
+        if data["items"] and not data.get("paused"):
+            data["paused"] = True
+            _save_queue(sid, data)
         return data
 
 

--- a/backend/transcript_index.py
+++ b/backend/transcript_index.py
@@ -1,0 +1,475 @@
+"""Persistent byte-offset index for Claude CLI JSONL transcripts.
+
+The index is intentionally transcript-format aware but UI-format agnostic.  A
+caller supplies ``describe_record`` so bubble counting uses the exact same
+record expansion code as the endpoint that later renders a window.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import uuid
+from bisect import bisect_left, bisect_right
+from contextlib import contextmanager
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .settings import atomic_write_text
+
+# Increment whenever persisted descriptor semantics (bubble expansion, preview,
+# tool/task metadata) change, not only when the JSON container shape changes.
+SCHEMA_VERSION = 2
+_TRANSCRIPT_TYPES = {"user", "assistant", "progress", "system", "attachment"}
+
+@dataclass
+class _LockSlot:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    users: int = 0
+
+
+_locks_guard = threading.Lock()
+_locks: dict[str, _LockSlot] = {}
+_index_cache: dict[str, tuple[Path, tuple[int, int] | None, dict[str, Any]]] = {}
+_INDEX_CACHE_MAX = 64
+
+
+@contextmanager
+def _sid_lock(sid: str):
+    """Serialize one sid without retaining every sid forever.
+
+    ``users`` is incremented before a caller can block on the per-sid lock, so
+    the slot cannot disappear while waiters still reference it.  The final
+    holder removes the registry entry after releasing the lock.
+    """
+    with _locks_guard:
+        slot = _locks.setdefault(sid, _LockSlot())
+        slot.users += 1
+    try:
+        with slot.lock:
+            yield
+    finally:
+        with _locks_guard:
+            slot.users -= 1
+            if slot.users == 0 and _locks.get(sid) is slot:
+                _locks.pop(sid, None)
+
+
+def _source_stat(path: Path) -> dict[str, int]:
+    st = path.stat()
+    return {
+        "dev": int(st.st_dev),
+        "inode": int(st.st_ino),
+        "size": int(st.st_size),
+        "mtime_ns": int(st.st_mtime_ns),
+    }
+
+
+def _prefix_digest(path: Path, length: int, block: int = 1024 * 1024) -> str:
+    """Fingerprint every byte in an indexed prefix.
+
+    Unchanged requests return from ``ensure_index`` before calling this helper.
+    On append, however, correctness requires proving that the already-indexed
+    prefix was not rewritten in place.  Sampling only the first/last blocks can
+    accept stale byte offsets when a sync/restore process changes the middle
+    and then grows the file, so append refreshes deliberately hash the prefix.
+    """
+    if length <= 0:
+        return ""
+    remaining = length
+    digest = hashlib.blake2b(digest_size=16)
+    digest.update(str(length).encode("ascii"))
+    with path.open("rb") as handle:
+        while remaining > 0:
+            chunk = handle.read(min(block, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    if remaining:
+        raise OSError(f"transcript prefix shortened while hashing: {path}")
+    return digest.hexdigest()
+
+
+def _empty_index(generation: str | None = None) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "history_generation": generation or uuid.uuid4().hex,
+        "source": {
+            "dev": 0,
+            "inode": 0,
+            "size": 0,
+            "mtime_ns": 0,
+            "scanned_bytes": 0,
+            "prefix_digest": "",
+        },
+        "records": [],
+        "orders": {"normal": [], "full": []},
+        "bubble_prefix": {"normal": [0], "full": [0]},
+        "tool_use_names": {},
+        "task_status": {},
+    }
+
+
+def _index_signature(path: Path) -> tuple[int, int] | None:
+    try:
+        stat = path.stat()
+        return int(stat.st_mtime_ns), int(stat.st_size)
+    except OSError:
+        return None
+
+
+def _load(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict) or data.get("schema") != SCHEMA_VERSION:
+        return None
+    source = data.get("source")
+    if not isinstance(source, dict) or not isinstance(data.get("records"), list):
+        return None
+    return data
+
+
+def _task_status_from_descriptor(desc: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    out: list[tuple[str, dict[str, Any]]] = []
+    for item in desc.get("task_notifications") or []:
+        tool_id = str(item.get("tool_use_id") or "")
+        if not tool_id:
+            continue
+        raw_state = str(item.get("status") or "")
+        state = raw_state if raw_state in {"completed", "failed", "stopped"} else "done"
+        out.append((tool_id, {
+            "task_id": item.get("task_id") or "",
+            "state": state,
+            "summary": item.get("summary") or "",
+            "output_file": item.get("output_file") or "",
+        }))
+    return out
+
+
+def _append_complete_lines(
+    transcript_path: Path,
+    index: dict[str, Any],
+    start: int,
+    end: int,
+    describe_record: Callable[[dict[str, Any]], dict[str, Any]],
+) -> int:
+    """Scan complete newline-terminated records in ``[start, end)``.
+
+    The returned offset is the beginning of an incomplete tail, or ``end`` if
+    every byte through ``end`` belongs to a complete line.  Malformed complete
+    lines advance the cursor but are deliberately absent from ``records``.
+    """
+    records = index["records"]
+    with transcript_path.open("rb") as handle:
+        handle.seek(start)
+        while handle.tell() < end:
+            line_start = handle.tell()
+            raw_line = handle.readline(end - line_start)
+            if not raw_line:
+                return line_start
+            # A torn append remains pending until a later write supplies the
+            # newline; re-scan from its beginning next time.
+            if not raw_line.endswith(b"\n"):
+                return line_start
+            line_end = handle.tell()
+            raw = raw_line[:-1].strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            record_type = entry.get("type")
+            record_uuid = entry.get("uuid")
+            if record_type not in _TRANSCRIPT_TYPES or not isinstance(record_uuid, str):
+                continue
+            desc = describe_record(entry) or {}
+            records.append({
+                "offset": line_start,
+                "length": line_end - line_start,
+                "uuid": record_uuid,
+                "parent": entry.get("parentUuid"),
+                "type": record_type,
+                "is_sidechain": bool(entry.get("isSidechain")),
+                "team_name": entry.get("teamName"),
+                "is_meta": bool(entry.get("isMeta")),
+                "compact": bool(entry.get("isCompactSummary")),
+                "bubble_count": int(desc.get("bubble_count") or 0),
+                "user_preview": desc.get("user_preview") or "",
+                "real_user_prompt": bool(desc.get("real_user_prompt")),
+                "has_inline_images": bool(desc.get("has_inline_images")),
+                "tool_uses": desc.get("tool_uses") or [],
+                "task_notifications": desc.get("task_notifications") or [],
+            })
+    return end
+
+
+def _rebuild_derived(index: dict[str, Any]) -> None:
+    records: list[dict[str, Any]] = index["records"]
+
+    # Full history preserves the old raw-reader contract: first UUID wins,
+    # user/assistant records only, chronological file order, no branch filters.
+    full: list[int] = []
+    full_seen: set[str] = set()
+    for i, rec in enumerate(records):
+        uid = rec["uuid"]
+        if rec["type"] in {"user", "assistant"} and uid not in full_seen:
+            full_seen.add(uid)
+            full.append(i)
+
+    # Match claude_agent_sdk._build_conversation_chain: last duplicate UUID
+    # wins; terminal and leaf tie-breaking use the latest file position.
+    by_uuid: dict[str, int] = {}
+    for i, rec in enumerate(records):
+        by_uuid[rec["uuid"]] = i
+    parent_uuids = {rec.get("parent") for rec in records if rec.get("parent")}
+    terminals = [i for i, rec in enumerate(records) if rec["uuid"] not in parent_uuids]
+    leaves: list[int] = []
+    for terminal in terminals:
+        cur: int | None = terminal
+        seen: set[str] = set()
+        while cur is not None:
+            rec = records[cur]
+            uid = rec["uuid"]
+            if uid in seen:
+                break
+            seen.add(uid)
+            if rec["type"] in {"user", "assistant"}:
+                leaves.append(cur)
+                break
+            parent = rec.get("parent")
+            cur = by_uuid.get(parent) if parent else None
+    main_leaves = [
+        i for i in leaves
+        if not records[i]["is_sidechain"]
+        and not records[i]["team_name"]
+        and not records[i]["is_meta"]
+    ]
+    normal: list[int] = []
+    if leaves:
+        leaf = max(main_leaves or leaves)
+        reverse_chain: list[int] = []
+        seen: set[str] = set()
+        cur: int | None = leaf
+        while cur is not None:
+            rec = records[cur]
+            uid = rec["uuid"]
+            if uid in seen:
+                break
+            seen.add(uid)
+            reverse_chain.append(cur)
+            parent = rec.get("parent")
+            cur = by_uuid.get(parent) if parent else None
+        for i in reversed(reverse_chain):
+            rec = records[i]
+            if (rec["type"] in {"user", "assistant"}
+                    and not rec["is_meta"]
+                    and not rec["is_sidechain"]
+                    and not rec["team_name"]):
+                normal.append(i)
+
+    index["orders"] = {"normal": normal, "full": full}
+    prefixes: dict[str, list[int]] = {}
+    for name, order in index["orders"].items():
+        prefix = [0]
+        for i in order:
+            prefix.append(prefix[-1] + max(0, int(records[i].get("bubble_count") or 0)))
+        prefixes[name] = prefix
+    index["bubble_prefix"] = prefixes
+
+    tool_names: dict[str, str] = {}
+    statuses: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        for tool in rec.get("tool_uses") or []:
+            tool_id = str(tool.get("id") or "")
+            if tool_id:
+                tool_names[tool_id] = str(tool.get("name") or "")
+        for tool_id, status in _task_status_from_descriptor(rec):
+            statuses[tool_id] = status
+    index["tool_use_names"] = tool_names
+    index["task_status"] = statuses
+
+
+def ensure_index(
+    sid: str,
+    transcript_path: Path,
+    index_path: Path,
+    describe_record: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    """Load, incrementally extend, or rebuild one transcript index.
+
+    Calls for the same session are single-flight within this process.  Append
+    scans begin at ``source.scanned_bytes``; unchanged calls never read the
+    transcript body.
+    """
+    with _sid_lock(sid):
+        stat = _source_stat(transcript_path)
+        cached = _index_cache.get(sid)
+        index = (
+            cached[2]
+            if cached is not None
+            and cached[0] == index_path
+            and cached[1] == _index_signature(index_path)
+            else None
+        )
+        if index is not None:
+            source = index["source"]
+            if all(source.get(key) == stat[key]
+                   for key in ("dev", "inode", "size", "mtime_ns")):
+                return index
+        if index is None:
+            index = _load(index_path)
+        rebuild = index is None
+        if index is not None:
+            source = index["source"]
+            scanned_before = int(source.get("scanned_bytes") or 0)
+            prefix_changed = (
+                stat["size"] > int(source.get("size") or 0)
+                and source.get("prefix_digest", "")
+                != _prefix_digest(transcript_path, scanned_before)
+            )
+            rebuild = (
+                source.get("dev") != stat["dev"]
+                or source.get("inode") != stat["inode"]
+                or stat["size"] < scanned_before
+                or stat["size"] < int(source.get("size") or 0)
+                or prefix_changed
+                # Same-size content changes cannot be an append.
+                or (stat["size"] == source.get("size")
+                    and stat["mtime_ns"] != source.get("mtime_ns"))
+            )
+        if rebuild:
+            index = _empty_index()
+            start = 0
+        else:
+            start = int(index["source"].get("scanned_bytes") or 0)
+
+        changed = rebuild or stat["size"] != index["source"].get("size")
+        if changed:
+            records_before = len(index["records"])
+            scanned = _append_complete_lines(
+                transcript_path, index, start, stat["size"], describe_record)
+            if not rebuild and len(index["records"]) != records_before:
+                index["history_generation"] = uuid.uuid4().hex
+            index["source"] = {
+                **stat,
+                "scanned_bytes": scanned,
+                "prefix_digest": _prefix_digest(transcript_path, scanned),
+            }
+            _rebuild_derived(index)
+            atomic_write_text(
+                index_path,
+                json.dumps(index, ensure_ascii=False, separators=(",", ":")),
+            )
+        _index_cache.pop(sid, None)
+        _index_cache[sid] = (index_path, _index_signature(index_path), index)
+        while len(_index_cache) > _INDEX_CACHE_MAX:
+            _index_cache.pop(next(iter(_index_cache)))
+        return index
+
+
+def record_indices_for_bubble_window(
+    index: dict[str, Any],
+    order: str,
+    start: int,
+    end: int,
+) -> tuple[list[int], int, int]:
+    """Return records intersecting a bubble range and their exact slice bounds."""
+    order_ids = index["orders"][order]
+    prefix = index["bubble_prefix"][order]
+    total = prefix[-1]
+    start = max(0, min(start, total))
+    end = max(start, min(end, total))
+    if start == end:
+        return [], 0, total
+    first = min(len(order_ids) - 1, bisect_right(prefix, start) - 1)
+    last = min(len(order_ids), bisect_left(prefix, end))
+    return order_ids[first:last], start - prefix[first], total
+
+
+def record_indices_around_uuid(
+    index: dict[str, Any],
+    uuid_value: str,
+    before: int,
+    after: int,
+    *,
+    limit: int = 0,
+) -> tuple[list[int], int, int, int, int]:
+    """Return a full-order *bubble* window containing ``uuid_value``.
+
+    ``before`` and ``after`` are bubble counts, not JSONL-record counts.  When
+    ``limit`` is supplied (the legacy ``around_uuid + limit`` request shape),
+    it caps the whole returned bubble window and reserves space for at least
+    the first bubble produced by the target record.  The returned tuple is
+    ``(record_ids, inner_start, window_start, window_end, total)``; callers
+    shape only those records and then apply the exact inner bubble slice.
+    """
+    order = index["orders"]["full"]
+    prefix = index["bubble_prefix"]["full"]
+    total = prefix[-1]
+    pos = next((i for i, rec_i in enumerate(order)
+                if index["records"][rec_i]["uuid"] == uuid_value), -1)
+    if pos < 0:
+        return [], 0, 0, 0, total
+
+    target_start = prefix[pos]
+    target_end = prefix[pos + 1]
+    if target_end <= target_start:
+        return [], 0, 0, 0, total
+
+    if limit > 0:
+        # A multi-bubble record may itself exceed the cap.  Keeping the slice
+        # anchored at target_start still guarantees the requested UUID is in
+        # the response without allowing a pathological record to explode the
+        # frontend's mounted-window budget.
+        span = min(limit, target_end - target_start)
+        context = max(0, limit - span)
+        before_budget = context // 2
+        after_budget = context - before_budget
+        start = max(0, target_start - before_budget)
+        end = min(total, target_start + span + after_budget)
+        # Rebalance at either history boundary so a nominal limit remains a
+        # limit-sized window whenever enough bubbles exist.
+        if end - start < limit:
+            start = max(0, end - limit)
+            end = min(total, start + limit)
+        # Boundary rebalancing must never shift beyond the target anchor.
+        if not (start <= target_start < end):
+            start = max(0, min(target_start, total - limit))
+            end = min(total, start + limit)
+    else:
+        start = max(0, target_start - max(0, before))
+        end = min(total, target_end + max(0, after))
+
+    record_ids, inner_start, _ = record_indices_for_bubble_window(
+        index, "full", start, end)
+    return record_ids, inner_start, start, end, total
+
+
+def read_records(
+    transcript_path: Path,
+    index: dict[str, Any],
+    record_indices: list[int],
+) -> list[dict[str, Any]]:
+    """Seek and parse only selected indexed JSONL records."""
+    out: list[dict[str, Any]] = []
+    records = index["records"]
+    with transcript_path.open("rb") as handle:
+        for record_i in record_indices:
+            meta = records[record_i]
+            handle.seek(meta["offset"])
+            raw = handle.read(meta["length"]).strip()
+            try:
+                entry = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+                continue
+            if isinstance(entry, dict):
+                out.append(entry)
+    return out

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -362,6 +362,9 @@ function portal() {
     // see "Muse · Calliope / empty chat" for the second a big session
     // takes to fetch.
     messagesLoading: false,
+    // Compatibility mirrors for the active tab only. The authoritative values
+    // live in tabState[currentId]; resident panes must read their own pane state.
+    historyGeneration: "",
     // Gates revealing a freshly-loaded session: stays false from load-start
     // until syntax-highlight + artifacts finish, so the whole conversation
     // appears at once instead of janking in code-block-by-code-block (the
@@ -380,6 +383,10 @@ function portal() {
       history: [],
       unreadCount: 0,
       loading: false,
+      // Task ids whose DELETE request is waiting for a running turn to cancel.
+      // Kept separate from server `run.status` so a slow, destructive action
+      // remains visibly owned by the row that initiated it.
+      deleting: {},
       // Per-task expansion state for the "show runs" affordance.
       // Keyed by task id → { open: bool, runs: [...], loading: bool }.
       // Only populated for tasks the user clicks to expand; lazy fetch.
@@ -488,7 +495,9 @@ function portal() {
     // bubbles from tabState[id].messages (data always survives; only the DOM is
     // dropped). _MAX_RESIDENT_PANES caps the set.
     _residentTabIds: [],
-    _MAX_RESIDENT_PANES: 4,
+    // Strict DOM budget. Mobile retains only the visible pane; desktop may keep
+    // one warm neighbour. Streaming in a hidden tab keeps its data/SSE but not DOM.
+    _MAX_RESIDENT_PANES: 2,
     renamingTabId: "",   // session id whose name is currently being inline-edited
     renameDraft: "",     // current value of the inline rename <input>
     tabCtxMenu: null,    // {id, x, y} for the right-click tab menu, or null
@@ -535,6 +544,9 @@ function portal() {
     // 2026-05-19/05-20 — adaptive thinking was causing invisible mid-reply
     // stalls when hidden; thinking display is now unconditional (see comment
     // in chat.py near ThinkingConfigEnabled).
+    // Active-tab composer mirror. The durable-in-memory owner is
+    // tabState[currentId].draft; capture/activate keeps these template-facing
+    // fields aligned without persisting drafts across a page reload.
     input: "", streaming: false, es: null,
     // 锁定当前在跑的那条请求用的模型——dropdown 切到别的，pending bubble 不能跟着变。
     streamingModel: "",
@@ -556,6 +568,9 @@ function portal() {
     imageEditor: {
       show: false,
       entryIndex: -1,
+      ownerSid: "",
+      ownerState: null,
+      ownerEntry: null,
       tool: "pen",           // pen / rect / arrow / eraser
       color: "#ef4444",      // red default — most common for "look at this"
       size: 6,
@@ -581,11 +596,12 @@ function portal() {
       jobsLoading: false,
       pollTimer: null,
       error: "",
+      ownerSid: "",
     },
-    // Flipped true inside sendMessage when the user clicks send while an
-    // attachment upload is still in flight. Disables the send button so a
-    // double-click can't enqueue two sends. Auto-resets when the wait
-    // resolves (usually < 1 s; 30 s hard timeout).
+    // Active-tab mirror of tabState[currentId].draft._sendWaitingForUpload.
+    // Each session owns its own wait flag, so an upload in A never disables B.
+    // It disables duplicate sends only while that draft's attachment upload is
+    // in flight; each upload has its own five-minute AbortController deadline.
     _sendWaitingForUpload: false,
     dragHover: false,
 
@@ -1087,7 +1103,7 @@ function portal() {
         // is pressed out of habit (blur the focus). Only confirm when dirty.
         if (this.editing) { if (this._confirmLoseEdits()) this.editing = false; return; }
         if (this.selectedPaths.size) { this.clearTreeSelection(); return; }  // 清空多选
-        if (this.streaming) { this.stop(); return; }          // 停止流式
+        if (this.isTabStreaming(this.currentId)) { this.stop(); return; } // 停止当前会话
       }
       // Delete / Backspace → batch-trash the multi-selection. Only fires when
       // there's an explicit batch set (size > 0) and focus is outside any
@@ -2353,9 +2369,8 @@ function portal() {
     // 命中的是「每一个 assistant 轮次的首条」——历史里每个轮次都满足，
     // 于是流式时所有轮次的头像一起动。正确语义是「仅当前（最新）轮」：
     // 既是轮首（前一条是 user 或开头），又是最后一轮（自此往后不再有 user）。
-    isStreamingTurnAvatar(i) {
-      if (!this.streaming) return false;
-      const msgs = this.messages;
+    isStreamingTurnAvatar(i, msgs = this.messages, streaming = this.streaming) {
+      if (!streaming) return false;
       if (!msgs || !msgs.length) return false;
       // 最新轮的轮首 = 最后一个 user 之后紧邻的第一条 assistant。这等价于旧
       // 实现「轮首(前一条是 user 或 i===0) + 其后无 user + 非 user」三条件的
@@ -2642,6 +2657,14 @@ function portal() {
       }
     },
     async _attachFile(file) {
+      if (this.workspaceSwitching) return;
+      const ownerSid = this.currentId;
+      if (!ownerSid) return;
+      this._captureComposerState(ownerSid);
+      const ownerState = this._ensureTabState(ownerSid);
+      const ownerDraft = ownerState.draft;
+      const ownsDraft = () => this.tabState[ownerSid] === ownerState
+        && ownerState.draft === ownerDraft;
       if (file.size > 10 * 1024 * 1024) {
         this.toast(this.t("img.too_big"), "warn", 2500);
         return;
@@ -2655,12 +2678,9 @@ function portal() {
       // Diagnostic timing — when uploads feel slow the user has no way to
       // tell if it's compression CPU on the phone or network throughput.
       // We split the timeline into "compress" / "data-url" / "upload" and
-      // attach the totals to a console.log + the chip's title attribute.
-      // Cheap (just performance.now() calls) and only kept user-visible
-      // via a debug toast when an upload exceeds 3 s (likely-feeble feedback
-      // surface; cleaner mechanism than scattering prompts).
+      // surface only aggregate timing/size in a slow-upload toast. Never log the
+      // original filename: attachment names can contain private document titles.
       const t0 = performance.now();
-      const origSize = file.size;
       let tCompressEnd = t0;
 
       let entry;
@@ -2675,13 +2695,14 @@ function portal() {
         // the data URI is a self-contained string that never expires.
         // The chip and the sent-message bubble both use this thumbnail.
         const preview = await this._imageToThumbDataURL(file);
+        if (!ownsDraft()) return;
         // Stash the compressed File on the entry so the in-chip "✎ Annotate"
         // button can re-open the bitmap in the image editor without
         // round-tripping back to the server. Memory cost is small (~300 KB
         // per image after compression), cleared on send.
         const raw = { id: null, mime: file.type, preview,
                        uploading: true, error: false, file };
-        this.pendingImages.push(raw);
+        ownerDraft.pendingImages.push(raw);
         // Alpine v3 wraps each pushed item in a Proxy. The local `raw`
         // reference still points at the original (non-proxied) object;
         // mutating raw.uploading bypasses the Proxy's set trap and
@@ -2690,23 +2711,32 @@ function portal() {
         // even after the upload completes. Bug observed 2026-05-21.
         // Pull the proxied version back out of the array so subsequent
         // mutations go through Alpine's reactive layer.
-        entry = this.pendingImages[this.pendingImages.length - 1];
+        entry = ownerDraft.pendingImages[ownerDraft.pendingImages.length - 1];
       } else {
         const raw = { id: null, name: file.name, kind,
                        uploading: true, error: false };
-        this.pendingDocs.push(raw);
+        ownerDraft.pendingDocs.push(raw);
         // Same Alpine-proxy gotcha as above — must use the proxied
         // reference for entry.uploading = false to actually trigger UI.
-        entry = this.pendingDocs[this.pendingDocs.length - 1];
+        entry = ownerDraft.pendingDocs[ownerDraft.pendingDocs.length - 1];
       }
 
       const tUploadStart = performance.now();
       const fd = new FormData();
       fd.append("file", file);
+      const uploadController = new AbortController();
+      ownerDraft._uploadControllers.add(uploadController);
+      const uploadTimeout = setTimeout(
+        () => uploadController.abort(), 5 * 60 * 1000,
+      );
+      const ownsEntry = () => ownsDraft()
+        && (ownerDraft.pendingImages.includes(entry) || ownerDraft.pendingDocs.includes(entry));
       try {
         const r = await fetch("/api/chat/upload-image", {
           method: "POST", headers: this.hdr(), body: fd,
+          signal: uploadController.signal,
         });
+        if (!ownsEntry()) return;
         if (!r.ok) {
           entry.error = true; entry.uploading = false;
           // Include HTTP status in the toast so "image upload failed: 413
@@ -2720,6 +2750,7 @@ function portal() {
           return;
         }
         const d = await r.json();
+        if (!ownsEntry()) return;
         entry.id = d.id; entry.uploading = false;
         // Stash the on-disk extension the server will use when persisting
         // this image at send-time. Used to construct the lightbox URL
@@ -2734,13 +2765,6 @@ function portal() {
         const networkMs = Math.round(tEnd - tUploadStart);
         const totalMs = Math.round(tEnd - t0);
         const finalKB = Math.round(file.size / 1024);
-        const origKB = Math.round(origSize / 1024);
-        // Console line is always emitted (only visible if devtools open).
-        console.log(
-          `[muselab][upload] ${file.name || "(unnamed)"} ` +
-          `orig=${origKB}KB → final=${finalKB}KB · ` +
-          `compress=${compressMs}ms · network=${networkMs}ms · total=${totalMs}ms`
-        );
         // Visible toast ONLY when upload felt slow (>3 s). On phone this
         // turns "huh, that was slow" into "ah, network was 4.2 s — my Wi-Fi
         // is bad", actionable instead of mysterious. Below threshold we
@@ -2753,6 +2777,7 @@ function portal() {
             "info", 4000);
         }
       } catch (e) {
+        if (!ownsEntry()) return;
         entry.error = true; entry.uploading = false;
         // Network-level failure (TypeError: Failed to fetch / NetworkError /
         // AbortError). Surface the error name so user sees whether it's
@@ -2761,6 +2786,9 @@ function portal() {
         const reason = (e && (e.name + (e.message ? ": " + e.message : "")))
                          || "network error";
         this.toast(`${this.t("img.upload_failed")} — ${reason}`, "error", 5000);
+      } finally {
+        clearTimeout(uploadTimeout);
+        ownerDraft._uploadControllers.delete(uploadController);
       }
     },
     async onAttachPicked(ev) {
@@ -2801,7 +2829,10 @@ function portal() {
     // long edge (matches _maybeCompressImage's cap), and start the history
     // stack with this clean frame.
     async openImageEditor(i) {
-      const entry = this.pendingImages[i];
+      const ownerSid = this.currentId;
+      this._captureComposerState(ownerSid);
+      const ownerState = ownerSid && this.tabState[ownerSid];
+      const entry = ownerState && ownerState.draft.pendingImages[i];
       if (!entry || !entry.file) {
         this.toast(this.lang === "zh"
           ? "无法编辑此图（原图引用丢失）"
@@ -2810,6 +2841,9 @@ function portal() {
       }
       this.imageEditor.show = true;
       this.imageEditor.entryIndex = i;
+      this.imageEditor.ownerSid = ownerSid;
+      this.imageEditor.ownerState = ownerState;
+      this.imageEditor.ownerEntry = entry;
       this.imageEditor.history = [];
       this.imageEditor.historyIdx = -1;
       this.imageEditor._drawing = false;
@@ -2818,8 +2852,14 @@ function portal() {
       // Defer canvas init until Alpine has rendered the modal — $refs is
       // only populated for visible elements.
       await this.$nextTick();
+      if (this.tabState[ownerSid] !== ownerState
+          || !ownerState.draft.pendingImages.includes(entry)) return;
       try {
         await this._initImageEditorCanvas(entry.file);
+        if (this.tabState[ownerSid] !== ownerState
+            || !ownerState.draft.pendingImages.includes(entry)) {
+          await this.closeImageEditor(false);
+        }
       } catch (e) {
         console.error("[imgEditor] init failed:", e);
         this.toast(this.lang === "zh" ? "图片加载失败" : "Failed to load image",
@@ -3034,6 +3074,9 @@ function portal() {
       const ed = this.imageEditor;
       ed.show = false;
       ed.entryIndex = -1;
+      ed.ownerSid = "";
+      ed.ownerState = null;
+      ed.ownerEntry = null;
       ed.history = [];
       ed.historyIdx = -1;
       if (ed._baseBitmap && ed._baseBitmap.close) {
@@ -3045,12 +3088,17 @@ function portal() {
 
     async _saveImageEdit() {
       const canvas = this.$refs.imgEditorCanvas;
-      const i = this.imageEditor.entryIndex;
-      const entry = this.pendingImages[i];
-      if (!canvas || !entry) return;
+      const ed = this.imageEditor;
+      const ownerSid = ed.ownerSid;
+      const ownerState = ed.ownerState;
+      const entry = ed.ownerEntry;
+      const ownsEntry = () => !!ownerSid && this.tabState[ownerSid] === ownerState
+        && ownerState.draft.pendingImages.includes(entry);
+      if (!canvas || !ownsEntry()) return;
       // Flatten the canvas to a JPEG blob @ 88% — high enough to look
       // crisp, low enough that re-upload payload doesn't balloon.
       const blob = await new Promise(res => canvas.toBlob(res, "image/jpeg", 0.88));
+      if (!ownsEntry()) return;
       if (!blob) {
         this.toast(this.lang === "zh" ? "保存失败：导出 blob 失败"
                                        : "Save failed: blob export error",
@@ -3068,13 +3116,22 @@ function portal() {
       entry.uploading = true;
       entry.error = false;
       entry.preview = await this._imageToThumbDataURL(file);
+      if (!ownsEntry()) return;
       // Re-upload to the same endpoint. Backend returns a fresh `id` —
       // tool_use messages built at send-time use this latest id.
       const fd = new FormData();
       fd.append("file", file);
+      const uploadController = new AbortController();
+      ownerState.draft._uploadControllers.add(uploadController);
+      const uploadTimeout = setTimeout(
+        () => uploadController.abort(), 5 * 60 * 1000,
+      );
       try {
-        const r = await fetch("/api/chat/upload-image",
-                                { method: "POST", headers: this.hdr(), body: fd });
+        const r = await fetch("/api/chat/upload-image", {
+          method: "POST", headers: this.hdr(), body: fd,
+          signal: uploadController.signal,
+        });
+        if (!ownsEntry()) return;
         if (!r.ok) {
           entry.error = true; entry.uploading = false;
           let body = "";
@@ -3084,17 +3141,24 @@ function portal() {
           return;
         }
         const d = await r.json();
+        if (!ownsEntry()) return;
         entry.id = d.id; entry.uploading = false;
         if (d.attach_ext) entry.attach_ext = d.attach_ext;
       } catch (e) {
+        if (!ownsEntry()) return;
         entry.error = true; entry.uploading = false;
         const reason = (e && (e.name + (e.message ? ": " + e.message : "")))
                           || "network error";
         this.toast(`${this.t("img.upload_failed")} — ${reason}`, "error", 4000);
+      } finally {
+        clearTimeout(uploadTimeout);
+        ownerState.draft._uploadControllers.delete(uploadController);
       }
     },
 
     openImageGen() {
+      this._captureComposerState(this.currentId);
+      this.imageGen.ownerSid = this.currentId || "";
       this.imageGen.show = true;
       this.imageGen.error = "";
       if (!this.imageGen.prompt && this.input.trim()) {
@@ -3175,7 +3239,8 @@ function portal() {
     },
     imageGenReferenceIds() {
       if (!this.imageGen.useReferences) return [];
-      return (this.pendingImages || [])
+      const ownerState = this.tabState[this.imageGen.ownerSid];
+      return ((ownerState && ownerState.draft.pendingImages) || [])
         .filter(x => x && x.id && !x.uploading && !x.error)
         .map(x => x.id);
     },
@@ -3215,8 +3280,10 @@ function portal() {
         this.imageGen.loading = false;
       }
     },
-    async attachGeneratedImage(img) {
-      if (!img || !img.id) return;
+    async attachGeneratedImage(img, ownerSid = this.imageGen.ownerSid || this.currentId) {
+      if (!img || !img.id || !ownerSid) return false;
+      const ownerState = this.tabState[ownerSid];
+      if (!ownerState) return false;
       const entry = {
         id: img.id,
         mime: img.mime || "image/png",
@@ -3226,20 +3293,25 @@ function portal() {
         attach_ext: img.attach_ext || "png",
         generated: true,
       };
-      this.pendingImages.push(entry);
-      this.toast(this.lang === "zh" ? "已加入当前消息" : "Added to current message",
+      ownerState.draft.pendingImages.push(entry);
+      this.toast(this.lang === "zh" ? "已加入对应会话草稿" : "Added to the session draft",
                  "success", 1800);
       this.imageGen.show = false;
+      return true;
     },
     async attachImageGenHistory(job, img) {
       if (!job || !job.id || !img || !img.image_id) return;
+      const ownerSid = this.imageGen.ownerSid || this.currentId;
+      const ownerState = ownerSid && this.tabState[ownerSid];
+      if (!ownerState) return;
       try {
         const res = await this.api(
           `/api/chat/image-generate/jobs/${encodeURIComponent(job.id)}/attach/${encodeURIComponent(img.image_id)}`,
           { method: "POST" },
         );
         if (!res.ok) throw new Error(res.error || `HTTP ${res.status}`);
-        await this.attachGeneratedImage(res.data.image);
+        if (this.tabState[ownerSid] !== ownerState) return;
+        await this.attachGeneratedImage(res.data.image, ownerSid);
       } catch (e) {
         const msg = e && e.message ? e.message : String(e || "");
         this.toast((this.lang === "zh" ? "加入失败：" : "Attach failed: ") + msg,
@@ -3327,6 +3399,52 @@ function portal() {
       return (this.messages || []).filter(
         m => m && m.role === "user" && !m._is_compact_summary);
     },
+    async _loadAroundMessage(sid, uuid, retryAfterConflict = true) {
+      const st = this.tabState && this.tabState[sid];
+      if (!st || !uuid || st.streaming || st.es) return false;
+      const limit = this._mountedMessageCap();
+      const generation = st.historyGeneration
+        ? "&history_generation=" + encodeURIComponent(st.historyGeneration) : "";
+      const r = await fetch("/api/chat/sessions/" + sid
+        + "?around_uuid=" + encodeURIComponent(uuid) + "&limit=" + limit + generation,
+        { headers: this.hdr() });
+      if (r.status === 409) {
+        if (!retryAfterConflict) return false;
+        const reloaded = await this._reloadHistoryTailAfterConflict(sid, st);
+        if (!reloaded || this.tabState[sid] !== st) return false;
+        // Reloading the tail refreshes historyGeneration but does not load an
+        // old outline target. Retry around_uuid exactly once against the new
+        // generation instead of reporting the tail reload as target success.
+        return this._loadAroundMessage(sid, uuid, false);
+      }
+      if (!r.ok) return false;
+      const data = await r.json();
+      if (this.tabState[sid] !== st) return false;
+      const win = this._historyEnvelopes(sid, data.messages || []);
+      for (const m of win) {
+        if (m.role === "assistant" && m.text && !m.html) m.html = this.mdRender(m.text);
+      }
+      if (!win.some(m => m.uuid === uuid)) return false;
+      st.messages.splice(0, st.messages.length, ...win);
+      st._earlierMessages = [];
+      st._laterMessages = [];
+      st._loadedOffset = Number.isInteger(data.offset) ? data.offset : 0;
+      st._total = Number.isInteger(data.total) ? data.total : win.length;
+      st.historyGeneration = data.history_generation || st.historyGeneration || "";
+      st._historyOrder = data.history_order === "normal" ? "normal" : "full";
+      st._hasServerLater = !!data.has_later;
+      // Set the server coordinate before defensive trimming: if a malformed
+      // or older backend returns more than the cache cap, _capHistoryCache
+      // advances _loadedOffset for every discarded head bubble.
+      this._capMountedWindow(st, "around", uuid);
+      st._hasMoreHistory = st._earlierMessages.length > 0 || st._loadedOffset > 0;
+      if (sid === this.currentId) {
+        this.messages = st.messages;
+        this.historyGeneration = st.historyGeneration;
+      }
+      return st.messages.some(m => m.uuid === uuid);
+    },
+
     // Outline click → scroll the chat to that user msg + flash highlight.
     // .msg[data-uuid] is rendered for every message (see chat template);
     // on mobile we also switch to the chat tab so the jump is visible.
@@ -3361,36 +3479,15 @@ function portal() {
         const earlier = (st && st._earlierMessages) || [];
         const idx = earlier.findIndex(em => em && em.uuid === uuid);
         if (idx < 0) {
-          // Not in DOM and not in the in-memory stash. Two possibilities:
-          //  1) Older post-compact history still on the server — page a
-          //     window back from the backend, then retry (cheap, repeats
-          //     until the target lands in the stash or we exhaust offset).
-          //  2) PRE-compaction (absent from the post-compact chain entirely)
-          //     — reload in full raw-JSONL mode once. _fullLoaded guards
-          //     against an infinite reload loop if the uuid isn't on disk.
-          if (st && st._loadedOffset > 0 && !st._fetchingOlder) {
-            (async () => {
-              const pulled = await this._fetchOlderWindow(sid);
-              if (this.tabState[sid] !== st || sid !== this.currentId) return;
-              if (pulled > 0) {
-                this.$nextTick(() => this._scrollToUserMsg(m, sid));
-              } else if (!st._fullLoaded) {
-                await this.loadSession(sid, { full: true });
-                if (this.tabState[sid] === st && sid === this.currentId) {
-                  this.$nextTick(() => this._scrollToUserMsg(m, sid));
-                }
-              }
-            })();
-            return;
-          }
-          if (st && !st._fullLoaded) {
-            (async () => {
-              await this.loadSession(sid, { full: true });
-              if (this.tabState[sid] === st && sid === this.currentId) {
-                this.$nextTick(() => this._scrollToUserMsg(m, sid));
-              }
-            })();
-          }
+          (async () => {
+            const loaded = await this._loadAroundMessage(sid, uuid);
+            if (!loaded || this.tabState[sid] !== st || sid !== this.currentId) return;
+            this.$nextTick(() => {
+              const pane = this._paneElement(sid);
+              this.highlightCode(".chat-body", pane ? [pane] : null);
+              setTimeout(tryScroll, 0);
+            });
+          })();
           return;
         }
         const batch = earlier.splice(idx);
@@ -3399,24 +3496,15 @@ function portal() {
             em.html = this.mdRender(em.text);
           }
         });
-        const oldScrollEl = this.$refs.chatBody;
-        const oldScrollHeight = oldScrollEl ? oldScrollEl.scrollHeight : 0;
-        const oldScrollTop = oldScrollEl ? oldScrollEl.scrollTop : 0;
         st.messages.unshift(...batch);
+        this._capMountedWindow(st, "around", uuid);
         if (sid === this.currentId) this.messages = st.messages;
         st._hasMoreHistory =
           (st._earlierMessages || []).length > 0 || st._loadedOffset > 0;
         this.$nextTick(() => {
           if (this.tabState[sid] !== st || sid !== this.currentId) return;
-          if (oldScrollEl) {
-            const newScrollHeight = oldScrollEl.scrollHeight;
-            oldScrollEl.scrollTop = oldScrollTop + (newScrollHeight - oldScrollHeight);
-          }
-          // Scope highlight to the bubbles we just unshifted (the first
-          // batch.length `.msg` children) rather than rescanning the whole
-          // chat body.
-          const newEls = this._leadingMsgEls(batch.length);
-          this.highlightCode(".chat-body", newEls.length ? newEls : null);
+          const pane = this._paneElement(sid);
+          this.highlightCode(".chat-body", pane ? [pane] : null);
           setTimeout(() => {
             if (this.tabState[sid] === st) tryScroll();
           }, 50);
@@ -4910,6 +4998,7 @@ function portal() {
         newSt._loaded = true;
         if (!this.openTabIds.includes(meta.id)) this.openTabIds.push(meta.id);
         if (this._conversationWorkspaceIsCurrent(ownerWorkspace) && this.currentId === sid) {
+          this._captureComposerState(sid);
           this.currentId = meta.id;
           this._activateTabState(meta.id);
           this.workspaceLastSession = {
@@ -5147,6 +5236,29 @@ function portal() {
     _blankTabState() {
       return {
         messages: [],
+        messagesReady: true,
+        messagesLoading: false,
+        historyGeneration: "",
+        // Bubble offsets are meaningful only inside one server order. Normal
+        // tail loads use the active chain; outline/around windows use full
+        // file order (including pre-compact history).
+        _historyOrder: "normal",
+        _hasServerLater: false,
+        // Monotonic per-tab sequence for optimistic/live messages. Historical
+        // envelopes use transcript identity; live keys never depend on array index.
+        _nextLiveKey: 1,
+        // Newer half of the bounded bidirectional window. Chronological order is
+        // always: _earlierMessages + messages + _laterMessages.
+        _laterMessages: [],
+        // Composer state is intentionally memory-only. Closing/deleting the tab
+        // drops this object; savePrefs never serializes it, so refresh does too.
+        draft: {
+          input: "",
+          pendingImages: [],
+          pendingDocs: [],
+          _sendWaitingForUpload: false,
+          _uploadControllers: new Set(),
+        },
         sessionUsage: { input_tokens: 0, output_tokens: 0,
                          cache_read_tokens: 0, cache_creation_tokens: 0,
                          context_limit: 0, context_used: 0, context_used_pct: 0,
@@ -5157,17 +5269,25 @@ function portal() {
                          context_is_estimate: true },
         streaming: false,
         es: null,
+        // Deduplicate stop taps while the interrupt request is in flight.
+        _stopping: false,
         streamingModel: "",
         streamElapsed: 0,
         _streamTimer: null,
         _streamStartedAt: 0,
+        _streamRichRenderCount: 0,
+        _streamPlainRenderCount: 0,
         _lastSseActivity: 0,
         _stallWatch: null,
         _serverActiveObserved: false,
         _streamHealthProbe: null,
         _reconnectTimer: null,
+        _canonicalResyncTimer: null,
+        _canonicalResyncPending: false,
         _effortPatchSeq: 0,
         _thinkingPatchSeq: 0,
+        _queueSyncSeq: 0,
+        _queueAppliedSeq: 0,
         _effortExpected: null,
         _thinkingExpected: null,
         _effortPatchTail: null,
@@ -5238,18 +5358,30 @@ function portal() {
         // True while an async backend older-window fetch is in flight, so
         // rapid "Load earlier" clicks don't fire duplicate requests.
         _fetchingOlder: false,
+        _fetchingLater: false,
       };
     },
     _ensureTabState(id) {
       if (!this.tabState[id]) {
         this.tabState[id] = this._blankTabState();
+        this.tabState[id]._sid = id;
         // The queue now lives server-side (sessions/{sid}.queue.json). We do
         // NOT pull it here — _ensureTabState is called synchronously all over
         // the place and shouldn't fire a fetch each time. The queue mirror is
         // refreshed by _syncQueueFromServer, invoked on load (_checkActiveTurn),
         // tab activation, and after every turn/queue mutation.
       }
-      return this.tabState[id];
+      const st = this.tabState[id];
+      if (!st._sid) st._sid = id;
+      if (!Array.isArray(st._laterMessages)) st._laterMessages = [];
+      if (st.messagesReady === undefined) st.messagesReady = true;
+      if (st.messagesLoading === undefined) st.messagesLoading = false;
+      if (st.historyGeneration === undefined) st.historyGeneration = "";
+      if (st._historyOrder !== "full") st._historyOrder = "normal";
+      if (st._hasServerLater === undefined) st._hasServerLater = false;
+      if (st._fetchingLater === undefined) st._fetchingLater = false;
+      if (!Number.isInteger(st._nextLiveKey)) st._nextLiveKey = 1;
+      return st;
     },
 
     // ===== Per-session message queue =====
@@ -5263,7 +5395,31 @@ function portal() {
     _isBusy(sid) {
       if (!sid) return false;
       const st = this.tabState[sid];
-      return !!(st && (st.streaming || st.compacting));
+      return !!(this.isTabStreaming(sid) || (st && st.compacting));
+    },
+    async _confirmSessionBusy(sid, st = this.tabState[sid]) {
+      if (!sid) return false;
+      if (st && (st.streaming || st.compacting)) return true;
+      const session = (this.sessions || []).find(s => s.id === sid);
+      if (!session || !session.active) return false;
+      // session.active is a polled cache and can remain true for one response
+      // after a turn's final drain already ran. Confirm it before enqueueing;
+      // otherwise an idle queue item can be stranded with no turn left to drain.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 8000);
+      try {
+        const r = await fetch("/api/chat/sessions/" + sid + "/active", {
+          headers: this.hdr(), signal: controller.signal,
+        });
+        if (!r.ok) return true; // conservative on an unknown server state
+        const active = !!(await r.json()).active;
+        if (!active && session) session.active = false;
+        return active;
+      } catch (_) {
+        return true;
+      } finally {
+        clearTimeout(timeout);
+      }
     },
     // True when the CSS @media single-pane mobile layout is active —
     // EITHER the viewport is narrow (≤900px) OR we're on a touch device
@@ -5310,6 +5466,7 @@ function portal() {
     async _syncQueueFromServer(sid) {
       if (!sid) return;
       const st = this._ensureTabState(sid);
+      const seq = ++st._queueSyncSeq;
       let data;
       try {
         const r = await fetch("/api/chat/sessions/" + sid + "/queue",
@@ -5317,6 +5474,8 @@ function portal() {
         if (!r.ok) return;   // graceful: leave the current mirror untouched
         data = await r.json();
       } catch (_e) { return; }
+      if (this.tabState[sid] !== st || seq < st._queueAppliedSeq) return;
+      st._queueAppliedSeq = seq;
       st.pendingQueue = (data.items || []).map(it => {
         // FIX ③: the server now resolves each upload id against its in-memory
         // store and returns `attachments: [{id, kind, name, mime, available}]`.
@@ -5375,7 +5534,7 @@ function portal() {
           // drain replays the turn under this mode (fixes queued messages
           // bypassing tool approval the UI said was required).
           body: JSON.stringify({ text: item.text || "", image_ids,
-                                 permission: this.permission || "" }),
+                                 permission: item.permission || "" }),
         });
         if (r.status === 409) {
           this.toast(this.lang === "zh"
@@ -5472,7 +5631,7 @@ function portal() {
         }
         if ((uText || uImages.length || uDocs.length) && lastUserText !== uText) {
           this._capLiveMessages(st);
-          msgs.push({
+          this._appendLiveMessage(st, {
             role: "user",
             text: uText,
             images: uImages,
@@ -5612,6 +5771,56 @@ function portal() {
         delete this._bgContPollers[sid];
       }
     },
+    _reconcileCompletedContinuation(sid, ownerState, expectedText = "", attempt = 0) {
+      // The live continuation is an optimistic rendering of the server-owned
+      // transcript. Do not replace it until the canonical tail contains the
+      // final assistant text we just rendered; this avoids a persistence race
+      // making the reply disappear during the very reconciliation meant to fix it.
+      const retry = () => {
+        if (attempt < 20) {
+          this._reconcileCompletedContinuation(
+            sid, ownerState, expectedText, attempt + 1,
+          );
+        }
+      };
+      setTimeout(async () => {
+        if (this.tabState[sid] !== ownerState || ownerState.streaming || ownerState.es) return;
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        const stillOwned = () => this.tabState[sid] === ownerState
+          && !ownerState.streaming && !ownerState.es;
+        try {
+          const activeResponse = await fetch("/api/chat/sessions/" + sid + "/active", {
+            headers: this.hdr(), signal: controller.signal,
+          });
+          if (!stillOwned()) return;
+          if (!activeResponse.ok || !!(await activeResponse.json()).active) {
+            retry();
+            return;
+          }
+          if (expectedText) {
+            const historyResponse = await fetch(
+              "/api/chat/sessions/" + sid + "?tail=80",
+              { headers: this.hdr(), signal: controller.signal },
+            );
+            if (!stillOwned()) return;
+            if (!historyResponse.ok) { retry(); return; }
+            const history = await historyResponse.json();
+            const hasFinal = (history.messages || []).some(
+              m => m && m.role === "assistant" && (m.text || "") === expectedText,
+            );
+            if (!hasFinal) { retry(); return; }
+          }
+          if (!stillOwned()) return;
+          const loaded = await this.loadSession(sid, { quiet: true });
+          if (!loaded) retry();
+        } catch (_) {
+          retry();
+        } finally {
+          clearTimeout(timeout);
+        }
+      }, attempt ? 250 : 80);
+    },
     async removePendingQueueItem(sid, idx) {
       const st = this.tabState[sid];
       if (!st || !st.pendingQueue) return;
@@ -5634,6 +5843,7 @@ function portal() {
       const item = st.pendingQueue[idx];
       if (!item) return;
       // Snapshot before _syncQueueFromServer wipes the mirror.
+      const text = item.text || "";
       const imgs = (item.images || []).slice();
       const docs = (item.docs || []).slice();
       try {
@@ -5641,23 +5851,27 @@ function portal() {
                     { method: "DELETE", headers: this.hdr() });
       } catch (_e) {}
       await this._syncQueueFromServer(sid);
-      if (sid !== this.currentId) return;
-      this.input = item.text || "";
+      if (this.tabState[sid] !== st) return;
+      const draft = st.draft;
+      draft.input = text;
       // Rebuild the input-tray chips. No `file` on restored images, so the
       // in-chip "Annotate" button stays disabled (it guards on `!img.file`),
       // but the thumbnail + re-send path work fully.
-      this.pendingImages = imgs.map(im => ({
+      draft.pendingImages.splice(0, draft.pendingImages.length, ...imgs.map(im => ({
         id: im.id, mime: im.mime || "", preview: im.src,
         uploading: false, error: false,
-      }));
-      this.pendingDocs = docs.map(d => ({
+      })));
+      draft.pendingDocs.splice(0, draft.pendingDocs.length, ...docs.map(d => ({
         id: d.id, name: d.name, kind: d.kind,
         uploading: false, error: false,
-      }));
-      this.$nextTick(() => {
-        const ta = this.$refs.chatInput;
-        if (ta) { this.autoGrow(ta); ta.focus(); }
-      });
+      })));
+      if (sid === this.currentId) {
+        this._activateComposerState(sid);
+        this.$nextTick(() => {
+          const ta = this.$refs.chatInput;
+          if (ta) { this.autoGrow(ta); ta.focus(); }
+        });
+      }
     },
     async resumeQueueDrain(sid) {
       // Un-pause server-side (which kicks its own drain), then attach to the
@@ -5708,18 +5922,46 @@ function portal() {
       }
     },
 
+    _captureComposerState(id = this.currentId) {
+      if (!id || id !== this.currentId) return;
+      const st = this.tabState && this.tabState[id];
+      if (!st || !st.draft) return;
+      st.draft.input = this.input || "";
+      st.draft.pendingImages = this.pendingImages || [];
+      st.draft.pendingDocs = this.pendingDocs || [];
+      st.draft._sendWaitingForUpload = !!this._sendWaitingForUpload;
+    },
+    _activateComposerState(id) {
+      const st = this._ensureTabState(id);
+      const draft = st.draft;
+      this.input = draft.input || "";
+      this.pendingImages = draft.pendingImages;
+      this.pendingDocs = draft.pendingDocs;
+      this._sendWaitingForUpload = !!draft._sendWaitingForUpload;
+      this.$nextTick(() => {
+        if (this.currentId === id && this.$refs.chatInput) {
+          this.autoGrow(this.$refs.chatInput);
+        }
+      });
+      return draft;
+    },
+
     // Mirror this tab's state into root fields so the UI sees it. Object refs
-    // (messages, sessionUsage) are shared — mutations from anywhere reflect.
-    // Primitives (streaming, es, ...) must be copied; they get re-synced as
-    // the active stream progresses.
+    // (messages, sessionUsage, composer attachments) are shared — mutations
+    // from anywhere reflect. Primitives are copied and explicitly captured
+    // before ownership changes.
     _activateTabState(id) {
       const st = this._ensureTabState(id);
+      this._activateComposerState(id);
       this.messages = st.messages;
       this.sessionUsage = st.sessionUsage;
       this.streaming = st.streaming;
       this.es = st.es;
       this.streamingModel = st.streamingModel;
       this.streamElapsed = st.streamElapsed;
+      this.messagesReady = st.messagesReady !== false;
+      this.messagesLoading = !!st.messagesLoading;
+      this.historyGeneration = st.historyGeneration || "";
       this._streamTimer = st._streamTimer;
       this._streamStartedAt = st._streamStartedAt;
       this.atBottom = st.atBottom !== false;
@@ -5742,6 +5984,20 @@ function portal() {
     // VISIBLE pane (paneMessages(currentId) === this.messages by identity).
     // Hidden panes' bindings still evaluate against this.messages but are
     // display:none, so the (possibly stale) result is never seen.
+    _paneElement(tid) {
+      const body = this.$refs && this.$refs.chatBody;
+      if (!body || !tid) return null;
+      return body.querySelector(`.msg-pane[data-tid="${CSS.escape(tid)}"]`);
+    },
+    _messageElement(tid, key) {
+      const pane = this._paneElement(tid);
+      if (!pane || !key) return null;
+      return pane.querySelector(`.msg[data-message-key="${CSS.escape(key)}"]`);
+    },
+    paneState(tid) {
+      if (!tid) return null;
+      return (this.tabState && this.tabState[tid]) || null;
+    },
     paneMessages(tid) {
       // Pure read: must NOT mutate tabState (this runs inside an x-for render
       // getter — creating state here via _ensureTabState both side-effects the
@@ -5762,11 +6018,12 @@ function portal() {
     // pane set re-evaluates exactly when either changes; :key="tid" keeps stable
     // panes from rebuilding.
     residentPaneIds() {
-      const list = this._residentTabIds || [];
-      if (this.currentId && !list.includes(this.currentId)) {
-        return [this.currentId, ...list];
-      }
-      return list;
+      const budget = this._isMobileLayout() ? 1 : 2;
+      const list = (this._residentTabIds || []).filter(Boolean);
+      const ordered = this.currentId
+        ? [this.currentId, ...list.filter(id => id !== this.currentId)]
+        : list;
+      return ordered.slice(0, budget);
     },
     // [resident-panes] LRU bookkeeping. Promote `tid` to most-recently-used, then
     // evict panes past _MAX_RESIDENT_PANES from the LRU end — but NEVER evict the
@@ -5778,20 +6035,13 @@ function portal() {
       if (!tid) return;
       const list = (this._residentTabIds || []).filter(x => x !== tid);
       list.unshift(tid);   // MRU at the front
-      while (list.length > this._MAX_RESIDENT_PANES) {
-        let evicted = false;
-        // Scan from the LRU end for the first evictable (unprotected) pane.
-        for (let i = list.length - 1; i >= 0; i--) {
-          const cand = list[i];
-          if (cand === this.currentId) continue;          // never the visible pane
-          const cst = this.tabState && this.tabState[cand];
-          if (cst && cst.streaming) continue;             // never a live stream
-          list.splice(i, 1);
-          if (cst) cst._highlighted = false;              // rebuilt DOM must re-highlight
-          evicted = true;
-          break;
-        }
-        if (!evicted) break;   // everything left is protected — keep them all
+      const budget = this._isMobileLayout() ? 1 : this._MAX_RESIDENT_PANES;
+      while (list.length > budget) {
+        const cand = list.pop();
+        const cst = this.tabState && this.tabState[cand];
+        // DOM residency is independent from stream ownership. Hidden streams keep
+        // mutating their tab state through SSE and rebuild when activated.
+        if (cst) cst._highlighted = false;
       }
       this._residentTabIds = list;
     },
@@ -6118,8 +6368,59 @@ function portal() {
       }
     },
 
+    _scheduleCanonicalStreamReload(sid, st, { minimumWaitMs = 0 } = {}) {
+      if (!sid || !st || this.tabState[sid] !== st) return;
+      if (st._canonicalResyncTimer) return;
+      st._canonicalResyncPending = true;
+      const started = Date.now();
+      const poll = async () => {
+        st._canonicalResyncTimer = null;
+        if (this.tabState[sid] !== st) return;
+        let active = true;
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 8000);
+          try {
+            const r = await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/active`, {
+              headers: this.hdr(), signal: controller.signal,
+            });
+            if (r.ok) active = !!(await r.json()).active;
+          } finally {
+            clearTimeout(timeout);
+          }
+        } catch (_) {
+          active = true;
+        }
+        const waited = Date.now() - started;
+        if (active || waited < minimumWaitMs) {
+          // Backend turns are capped at 30 minutes. Keep the poll itself
+          // bounded too; after that canonical history is the only safe truth.
+          if (waited < 31 * 60_000) {
+            st._canonicalResyncTimer = setTimeout(poll, 1000);
+            return;
+          }
+        }
+        this._retireStaleSessionStream(sid, st);
+        st._pendingExternalUpdate = true;
+        const loaded = await this.loadSession(sid, {
+          quiet: sid === this.currentId,
+        });
+        if (this.tabState[sid] !== st) return;
+        st._canonicalResyncPending = false;
+        if (loaded) {
+          st._loaded = true;
+          st._pendingExternalUpdate = false;
+          this._syncQueueFromServer(sid);
+        }
+      };
+      st._canonicalResyncTimer = setTimeout(poll, 250);
+    },
+
     _retireStaleSessionStream(sid, st) {
       if (st.es) { try { st.es.close(); } catch (_) {} st.es = null; }
+      if (st._canonicalResyncTimer) clearTimeout(st._canonicalResyncTimer);
+      st._canonicalResyncTimer = null;
+      st._canonicalResyncPending = false;
       if (st._streamTimer) {
         clearInterval(st._streamTimer);
         st._streamTimer = null;
@@ -6674,17 +6975,49 @@ function portal() {
       if (!id) return;
       const st = this.tabState[id];
       if (st) {
+        const draft = st.draft;
+        if (draft && draft._uploadControllers) {
+          for (const controller of draft._uploadControllers) {
+            try { controller.abort(); } catch (_) {}
+          }
+          draft._uploadControllers.clear();
+          draft.input = "";
+          draft.pendingImages.splice(0);
+          draft.pendingDocs.splice(0);
+          draft._sendWaitingForUpload = false;
+        }
+        if (this.imageEditor.ownerSid === id) {
+          this.imageEditor.show = false;
+          this.imageEditor.ownerSid = "";
+          this.imageEditor.ownerState = null;
+          this.imageEditor.ownerEntry = null;
+          this.imageEditor.entryIndex = -1;
+          this.imageEditor.history = [];
+          this.imageEditor.historyIdx = -1;
+          if (this.imageEditor._baseBitmap && this.imageEditor._baseBitmap.close) {
+            try { this.imageEditor._baseBitmap.close(); } catch (_) {}
+          }
+          this.imageEditor._baseBitmap = null;
+          this.imageEditor._snapshot = null;
+        }
+        if (this.imageGen.ownerSid === id) {
+          this.imageGen.show = false;
+          this.imageGen.ownerSid = "";
+        }
         const ownedEs = st.es;
         if (ownedEs) { try { ownedEs.close(); } catch {} }
         if (st._streamTimer) clearInterval(st._streamTimer);
         if (st._stallWatch) clearInterval(st._stallWatch);
         if (st._reconnectTimer) clearTimeout(st._reconnectTimer);
+        if (st._canonicalResyncTimer) clearTimeout(st._canonicalResyncTimer);
         if (st._reconcileRetryTimer) clearTimeout(st._reconcileRetryTimer);
         st.es = null;
         st.streaming = false;
         st._streamTimer = null;
         st._stallWatch = null;
         st._reconnectTimer = null;
+        st._canonicalResyncTimer = null;
+        st._canonicalResyncPending = false;
         st._streamHealthProbe = null;
         st._serverActiveObserved = false;
         st._reconcileRetryTimer = null;
@@ -6754,6 +7087,55 @@ function portal() {
         this.workspaceSwitching = false;
       }
     },
+    _registerOptimisticSession(meta) {
+      const id = meta && meta.id;
+      if (!id) return Promise.resolve(false);
+      if (this._sessionRegistrationPromises[id]) {
+        return this._sessionRegistrationPromises[id];
+      }
+      const promise = (async () => {
+        try {
+          const r = await fetch("/api/chat/sessions", {
+            method: "POST",
+            headers: { ...this.hdr(), "Content-Type": "application/json" },
+            keepalive: true,
+            body: JSON.stringify({
+              id, name: meta.name, model: meta.model || "", cwd: meta.cwd || "",
+              open_ids: this.openTabIds || [],
+            }),
+          });
+          if (!r || !r.ok) return false;
+          let srv = null;
+          try { srv = await r.json(); } catch (_) { /* registration still succeeded */ }
+          delete this._optimisticMetas[id];
+          if (srv && srv.id === id) {
+            const i = this.sessions.findIndex(s => s.id === id);
+            if (i >= 0) this.sessions[i] = { ...this.sessions[i], ...srv };
+          }
+          this._fetchTabUsage(id);
+          return true;
+        } catch (_) {
+          return false;
+        } finally {
+          if (this._sessionRegistrationPromises[id] === promise) {
+            delete this._sessionRegistrationPromises[id];
+          }
+        }
+      })();
+      this._sessionRegistrationPromises[id] = promise;
+      return promise;
+    },
+    async _ensureSessionRegistered(id) {
+      const optimistic = this._optimisticMetas[id];
+      if (!optimistic) return true;
+      let meta = { ...optimistic, ...(this.sessions.find(s => s.id === id) || {}) };
+      let ok = await this._registerOptimisticSession(meta);
+      if (!ok && this._optimisticMetas[id]) {
+        meta = { ...this._optimisticMetas[id], ...(this.sessions.find(s => s.id === id) || {}) };
+        ok = await this._registerOptimisticSession(meta);
+      }
+      return ok || !this._optimisticMetas[id];
+    },
     newSession(options = {}) {
       // No longer stops streams in OTHER tabs — each tab has its own ES in
       // tabState[id].es. The new session starts fresh in its own tab.
@@ -6768,10 +7150,10 @@ function portal() {
       // yet this used to `await` the create POST (~561ms, and MULTIPLE SECONDS
       // on a flaky mobile radio) before the tab could open. We now mint the
       // UUID client-side, build the full meta locally, open the tab
-      // SYNCHRONOUSLY, and fire registration in the BACKGROUND. The send path
-      // binds the SDK session to this same UUID on first message whether or not
-      // the POST has landed yet (chat.py uses session_id= when no JSONL exists
-      // for the id), so the chat works even mid-registration.
+      // SYNCHRONOUSLY, and start registration in the BACKGROUND. The first send
+      // waits for this registration (and retries once) before launching a turn:
+      // otherwise a fast cancel can happen before either the index row or SDK
+      // JSONL exists, leaving an activity entry that no session list can open.
       const now = new Date();
       const pad = n => String(n).padStart(2, "0");
       const stamp = `${pad(now.getMonth() + 1)}-${pad(now.getDate())} ` +
@@ -6821,40 +7203,10 @@ function portal() {
       if (!this.openTabIds.includes(id)) this.openTabIds.push(id);
       if (this._isMobileLayout()) this.setMobileTab("chat");
       this.savePrefs();
-      // --- background registration (fire-and-forget) ---
-      // keepalive: lets the POST survive a tab navigation right after clicking.
-      // We send our minted `id` so the server registers THAT uuid (validated
-      // server-side as a canonical UUID before it touches any file path).
-      fetch("/api/chat/sessions", {
-        method: "POST",
-        headers: { ...this.hdr(), "Content-Type": "application/json" },
-        keepalive: true,
-        // open_ids: protect THIS browser's open tabs from the backend's
-        // empty-session recycler (prune_empty_sessions keep_ids) — an open but
-        // still-empty scratch tab must not be swept when a new one is created.
-        body: JSON.stringify({
-          id, name: meta.name, model: seedModel, cwd: seedCwd,
-          open_ids: this.openTabIds || [],
-        }),
-      }).then(r => (r && r.ok ? r.json() : null)).then(srv => {
-        // Confirmed: drop the optimistic guard and reconcile any server-side
-        // normalisation (e.g. provider model fallback) into the local row.
-        // The id is ours, so there's nothing to swap.
-        delete this._optimisticMetas[id];
-        if (srv && srv.id === id) {
-          const i = this.sessions.findIndex(s => s.id === id);
-          if (i >= 0) this.sessions[i] = { ...this.sessions[i], ...srv };
-        }
-        // Now that the session exists server-side, the usage meter can bind to
-        // the right model. (Deferred from the click path; the early fetch
-        // inside _activateTabState may 404 harmlessly before registration.)
-        this._fetchTabUsage(id);
-      }).catch(() => {
-        // Registration failed (offline / 5xx). The open tab still works — on
-        // first send the backend writes the JSONL (session_id=id) and the
-        // session reappears in the list via the SDK merge. Keep the optimistic
-        // guard so the row doesn't vanish before then.
-      });
+      // Start registration without delaying the new-tab interaction. send()
+      // awaits this same promise before the first real turn and retries once if
+      // the background request lost a mobile-radio race.
+      this._registerOptimisticSession(meta);
       return meta;
     },
 
@@ -7097,9 +7449,9 @@ function portal() {
     _kindExpansionPrefs: {},
     _msgKey(i, m) {
       if (!m) return "";
-      return m.uuid || m._k || ("m-" + i);
+      return m._k || m._key || m.uuid || ("m-" + i);
     },
-    isMsgExpanded(i, m, defaultOpen) {
+    isMsgExpanded(i, m, defaultOpen, paneState = null, paneMsgs = null) {
       if (!m) return true;
       const k = this._msgKey(i, m);
       if (k in this._expandedMsgs) return this._expandedMsgs[k];
@@ -7108,8 +7460,9 @@ function portal() {
       // user's explicit toggle (the _expandedMsgs check above).
       if (defaultOpen) return true;
       // Default: only the actively-streaming last block is expanded.
-      const msgs = this.messages || [];
-      return !!this.streaming && i === msgs.length - 1;
+      const msgs = paneMsgs || this.messages || [];
+      const streaming = paneState ? !!paneState.streaming : !!this.streaming;
+      return streaming && i === msgs.length - 1;
     },
     toggleMsgExpanded(m, i) {
       if (!m) return;
@@ -7120,17 +7473,17 @@ function portal() {
       // Spread-assign so Alpine sees the replacement and re-evaluates.
       this._expandedMsgs = { ...this._expandedMsgs, [k]: newState };
     },
-    toolResultClass(i, m) {
+    toolResultClass(i, m, paneState = null, paneMsgs = null) {
       let cls = "tool-result";
       if (m && m.is_error) cls += " err";
-      if (!this.isMsgExpanded(i, m)) cls += " collapsed";
+      if (!this.isMsgExpanded(i, m, false, paneState, paneMsgs)) cls += " collapsed";
       // Per-tool class hooks let CSS show terminal / read-gutter / web-card
       // styling only for the relevant result. Falls back to plain text.
       const kind = this.toolResultKind(m);
       if (kind) cls += " kind-" + kind;
       return cls;
     },
-    toolResultSummary(m, i) {
+    toolResultSummary(m, i, paneMsgs = this.messages) {
       const text = (m && (m.text || m.preview)) || "";
       const lines = text.split("\n").length;
       const kind = this.toolResultKind(m);
@@ -7148,7 +7501,7 @@ function portal() {
       // by peeking at the immediately-preceding tool_use. With this the
       // user can see what was read even when the result is collapsed.
       if ((kind === "read" || kind === "search") && i !== undefined && i > 0) {
-        const prev = this.messages[i - 1];
+        const prev = paneMsgs[i - 1];
         if (prev && prev.role === "tool_use") {
           const path = this.toolFilePath(prev);
           if (path) {
@@ -7265,6 +7618,21 @@ function portal() {
           ? "提示：权限不足。可能需要 chmod / sudo，或者文件被另一个进程占用。"
           : "Hint: permission denied. Try chmod, or check if another process has the file locked.";
       }
+      // Provider/model routing — common when a subagent hard-codes a Claude
+      // model while the parent session is running through a third-party gateway.
+      if (txt.includes("unknown provider") || txt.includes("provider not found") ||
+          txt.includes("no provider for model") || txt.includes("unsupported provider")) {
+        return zh
+          ? "提示：子 Agent 的模型和当前 Gateway 不匹配。请切换模型；修复后的会话会自动让子 Agent 继承父模型。"
+          : "Hint: the subagent model does not match the current gateway. Switch models; fixed sessions make subagents inherit the parent model.";
+      }
+      if (txt.includes("context window") || txt.includes("context length") ||
+          txt.includes("input exceeds") || txt.includes("maximum tokens") ||
+          txt.includes("prompt too long")) {
+        return zh
+          ? "提示：上下文已满。先压缩；如果压缩本身失败，请从较早的完整回合恢复分支。"
+          : "Hint: the context is full. Compact first; if compaction itself fails, recover a branch from an earlier complete turn.";
+      }
       // Timeout / hung
       if (txt.includes("timed out") || txt.includes("timeout")) {
         return zh
@@ -7303,13 +7671,13 @@ function portal() {
     // Find the matching tool_use for a given tool_result by walking
     // backwards through messages and matching tool_use_id. Used by the
     // diff preview renderer to count +/- on Edit/Write/MultiEdit.
-    findToolUseFor(toolResult, fromIdx) {
+    findToolUseFor(toolResult, fromIdx, paneMsgs = this.messages) {
       if (!toolResult || fromIdx === undefined || fromIdx === null) return null;
       const id = toolResult.tool_use_id || toolResult.tool_id;
       if (!id) {
         // Fallback: walk backwards looking for the nearest tool_use
         for (let j = fromIdx - 1; j >= Math.max(0, fromIdx - 3); j--) {
-          const c = this.messages[j];
+          const c = paneMsgs[j];
           if (c && c.role === "tool_use") return c;
         }
         return null;
@@ -7391,10 +7759,10 @@ function portal() {
     // 不会出现 footer 了". Cost: a 28px timestamp-only row at the end of
     // turns whose last msg has no body content — acceptable visual artifact
     // since it preserves the "turn ended at HH:MM" signal.
-    isMsgRenderable(m, i) {
+    isMsgRenderable(m, i, paneMsgs = this.messages) {
       if (!m) return false;
       // Tail check first: dominates any "body is empty" judgment below.
-      const msgs = this.messages || [];
+      const msgs = paneMsgs || [];
       const isTurnTail = m.role !== "user"
         && (i === msgs.length - 1
             || (msgs[i + 1] && msgs[i + 1].role === "user"));
@@ -7453,9 +7821,9 @@ function portal() {
     // index are appends / evictions (length changes) and tab switches
     // (currentId changes); in-place streaming text mutations don't. Writing
     // the cache only on key change keeps it loop-safe under Alpine.
-    _latestEditToolIdx() {
-      const msgs = this.messages || [];
-      const key = (this.currentId || "_") + ":" + msgs.length;
+    _latestEditToolIdx(paneMsgs = this.messages, tid = this.currentId) {
+      const msgs = paneMsgs || [];
+      const key = (tid || "_") + ":" + msgs.length;
       const cached = this._cachedLatestEditIdx;
       if (cached && cached.key === key) return cached.idx;
       // Last Edit/Write/MultiEdit tool_use in the list…
@@ -7481,9 +7849,9 @@ function portal() {
       this._cachedLatestEditIdx = { key, idx };
       return idx;
     },
-    isLatestEditTool(i, m) {
+    isLatestEditTool(i, m, paneMsgs = this.messages, tid = this.currentId) {
       if (!m || !(m.name === "Edit" || m.name === "Write" || m.name === "MultiEdit")) return false;
-      return i === this._latestEditToolIdx();
+      return i === this._latestEditToolIdx(paneMsgs, tid);
     },
 
     // Public hook for plugins / extensions. Adds an entry to the registry
@@ -7899,7 +8267,7 @@ function portal() {
         return this.lang === "zh" ? "换个模型" : "Switch model";
       }
       if (cta === "compact_or_fork") {
-        return this.lang === "zh" ? "压缩对话" : "Compact session";
+        return this.lang === "zh" ? "压缩／恢复" : "Compact / recover";
       }
       return this.lang === "zh" ? "重试" : "Retry";
     },
@@ -7926,8 +8294,9 @@ function portal() {
         this.retryFailedMessage(m);
       }
     },
-    thinkingClass(i, m) {
-      return this.isMsgExpanded(i, m) ? "thinking" : "thinking collapsed";
+    thinkingClass(i, m, paneState = null, paneMsgs = null) {
+      return this.isMsgExpanded(i, m, false, paneState, paneMsgs)
+        ? "thinking" : "thinking collapsed";
     },
     thinkingPreview(m) {
       const text = (m && m.text) || "";
@@ -8499,6 +8868,9 @@ function portal() {
     // the brand-new row from the sidebar (the open tab itself survives via
     // openTabIds, but the list would flicker). Cleared once the POST confirms.
     _optimisticMetas: {},
+    // id→Promise for the in-flight optimistic registration. The first send
+    // awaits this promise so a cancelled first turn cannot outlive its session.
+    _sessionRegistrationPromises: {},
     filteredSessions() {
       const q = (this.sessionPickerSearch || "").trim().toLowerCase();
       const cwd = this.currentWorkspacePath();
@@ -8819,12 +9191,9 @@ function portal() {
     },
     async menuEditPrompt(id) {
       this.closeTabMenu();
-      // editSessionPrompt() reads currentId. Borrow it briefly to target this
-      // tab's session without forcing a full switch.
-      const orig = this.currentId;
-      this.currentId = id;
-      try { await this.editSessionPrompt(); }
-      finally { this.currentId = orig; }
+      // Target the requested session directly. Temporarily changing currentId
+      // would activate the wrong composer owner while the prompt modal awaits.
+      await this.editSessionPrompt(id);
     },
     async menuClose(id) { this.closeTabMenu(); await this.closeChatTab(id); },
     menuExportMarkdown(id) {
@@ -8939,9 +9308,11 @@ function portal() {
         // while still landing correctly on tall histories.
         const settle = () => this._restoreChatPosition(target);
         if (histLen > 60 && shouldFollow) {
+          stCur.messagesReady = false;
           this.messagesReady = false;          // msgs-hidden → bubbles display:none + skeleton
           this._afterPaint(() => {
             if (this.currentId !== target) return;
+            stCur.messagesReady = true;
             this.messagesReady = true;         // reveal bubbles (layout now, post-switch-paint)
             this._afterPaint(() => {
               if (this.currentId !== target) return;
@@ -8950,6 +9321,7 @@ function portal() {
             });
           });
         } else {
+          stCur.messagesReady = true;
           this.messagesReady = true;           // cheap reveal → no skeleton flash
           this._afterPaint(() => {
             if (this.currentId !== target) return;
@@ -8973,9 +9345,11 @@ function portal() {
         // Hide bubbles for one frame so the tab-bar flip + skeleton paint
         // instantly; reveal next frame so the O(M) fresh-mount layout lands AFTER
         // the switch is on-screen (same trick as the heavy-warm path above).
+        stCur.messagesReady = false;
         this.messagesReady = false;
         this._afterPaint(() => {
           if (this.currentId !== target) return;
+          stCur.messagesReady = true;
           this.messagesReady = true;
           this._afterPaint(() => {
             if (this.currentId !== target) return;
@@ -9129,13 +9503,14 @@ function portal() {
       // and tab switches keep the normal skeleton + chunked-reveal path.
       const quiet = !!opts.quiet;
       const st = this._ensureTabState(sid);
-      // Hard safety: a quiet refresh must NEVER run while a live stream owns
-      // st.messages — the splice-swap below would wipe the in-flight bubbles
-      // (and orphan the stream's curBubble pointer), blanking the conversation
-      // mid-reply. _reconcileOpenSession already gates on this.streaming, but a
-      // reconnect can flip streaming true during this function's awaits, so we
-      // bail up-front AND re-check right before the swap.
-      if (quiet && (st.streaming || st.es)) return true;
+      // A live stream owns st.messages and every SSE closure points directly at
+      // objects inside that array. No load mode may clear/splice it while the
+      // owner is active — continuation text otherwise keeps mutating an orphaned
+      // curBubble and the final reply disappears even though tool cards survive.
+      // Canonical history reconciliation runs only after the stream retires.
+      // Return false so full-history/outline callers know the requested load was
+      // deferred instead of recursively treating it as completed.
+      if (st.streaming || st.es) return false;
       // Skeleton on the active tab during the fetch — markdown rendering of
       // a long history can also take a noticeable beat after the network
       // returns, so the flag must wrap both phases.
@@ -9152,9 +9527,14 @@ function portal() {
       // flip it. Also re-baseline the open-session resync cursor on a real load
       // so the next list poll doesn't mistake "we just freshly pulled this" for
       // an external change and reload again.
-      if (isCurrent && !quiet) {
-        this.messagesLoading = true; this.messagesReady = false;
-        this._openSeenUpdated = undefined;
+      if (!quiet) {
+        st.messagesLoading = true;
+        st.messagesReady = false;
+        if (isCurrent) {
+          this.messagesLoading = true;
+          this.messagesReady = false;
+          this._openSeenUpdated = undefined;
+        }
       }
       // Set true once we've scheduled the reveal (highlight→show). Guards the
       // finally so error / empty-result paths don't leave the skeleton stuck.
@@ -9197,7 +9577,6 @@ function portal() {
         const s = this._retainExpectedSessionSettings(await r.json());
         if (this.tabState[sid] !== st) return false;
         const loadedUpdated = Number(s.updated_at) || 0;
-        if (loadedUpdated) st._seenUpdated = loadedUpdated;
         // Build a lookup of blob preview URLs from the current in-memory
         // messages so we can carry them over after the server rebuild.
         // Server messages only store {mime} for images — no preview URL —
@@ -9216,8 +9595,8 @@ function portal() {
         // Build message envelopes WITHOUT running mdRender — the heavy
         // markdown→HTML pass is the dominant cost for long sessions, so we
         // defer it until the message is actually about to be shown.
-        const buildEnvelope = (m, idx) => {
-          const out = { ...m, _k: sid + "-" + idx };
+        const buildEnvelope = (m) => {
+          const out = { ...m, _k: this._historyMessageKey(sid, m) };
           // Restore blob preview URLs on user messages with images
           if (m.role === "user" && m.images && m.images.length) {
             const key = (m.text || "") + ":" + m.images.length;
@@ -9232,7 +9611,7 @@ function portal() {
           }
           return out;
         };
-        const all = (s.messages || []).map(buildEnvelope);
+        const all = this._historyEnvelopes(sid, (s.messages || []).map(buildEnvelope));
         // Lazy-load thresholds — only render the tail of the conversation on
         // first paint; older messages stay in a "to-render" stash and get
         // mdRender'd on demand when the user clicks "Load earlier".
@@ -9320,11 +9699,16 @@ function portal() {
             visible.forEach(renderMarkdown);
           }
         } else {
-          // Off-screen idle-preload: chunk + yield so warming a big background
-          // tab never freezes the page. Awaited, so _loaded (set by the
-          // preload's .then) only flips once every bubble has html.
-          await this._renderMessagesChunked(visible, renderMarkdown);
+          // Desktop may prewarm one envelope only; mobile background markdown
+          // work is disabled entirely. No hidden pane DOM is mounted here.
+          if (!this._isMobileLayout() && visible.length) {
+            renderMarkdown(visible[visible.length - 1]);
+          }
         }
+        // The tab may have been disposed/recreated, or a stream may have claimed
+        // this state while markdown rendering yielded. Never write into a stale
+        // generation or replace an active owner's message array.
+        if (this.tabState[sid] !== st || st.streaming || st.es) return true;
         // Mutate in place — preserves the Array reference Alpine is watching.
         if (sid === this.currentId && quiet) {
           // Re-check after the fetch await: if a stream started meanwhile, abort
@@ -9347,19 +9731,34 @@ function portal() {
         // Stash older messages on the per-tab state; the "Load earlier"
         // button reads from here.
         st._earlierMessages = earlier;
+        st._laterMessages = [];
+        st.historyGeneration = s.history_generation || s.historyGeneration || "";
+        st._historyOrder = (s.history_order === "full" || full) ? "full" : "normal";
+        st._hasServerLater = !!s.has_later;
+        if (sid === this.currentId) this.historyGeneration = st.historyGeneration;
         // Backend windowing cursor. The server told us the index of the
         // first bubble it returned (`s.offset`); everything before that
         // still lives on disk and pages in via _fetchOlderWindow. full /
         // no-window responses report offset 0 (whole chain in hand).
         st._loadedOffset = Number.isInteger(s.offset) ? s.offset : 0;
         st._total = Number.isInteger(s.total) ? s.total : all.length;
+        // Trimming may evict the oldest cached bubbles and advance the cursor,
+        // so it must run after the response coordinate has been installed.
+        // A canonical load is anchored at the newest end. If the selected
+        // visible slice exceeds the DOM cap, retain its tail so the actual
+        // latest reply remains mounted.
+        this._capMountedWindow(st, "newer");
         // More history exists if either the in-memory stash has older
         // bubbles OR the server holds bubbles before our window.
-        st._hasMoreHistory = earlier.length > 0 || st._loadedOffset > 0;
+        st._hasMoreHistory = st._earlierMessages.length > 0 || st._loadedOffset > 0;
         // Remember whether this load pulled the full raw-JSONL history, so
         // _scrollToUserMsg knows it can stop retrying after one full reload.
         st._fullLoaded = full;
         st._truncatedFromTop = false;
+        // Advance the rendered revision only after this state generation actually
+        // accepted the canonical message window. A stream claiming the pane mid-
+        // read returns above without falsely marking an unseen revision as loaded.
+        if (loadedUpdated) st._seenUpdated = loadedUpdated;
         // (The session outline is sourced from the backend via
         // refreshOutlineFromBackend (GET …/outline), not built here.)
         if (sid === this.currentId) {
@@ -9411,10 +9810,12 @@ function portal() {
           // resolves, so the user sees a responsive page (tabs / sidebar stay
           // clickable) instead of a frozen one ("卡死").
           await this._revealMessagesChunked(sid, st, visible);
+          if (this.tabState[sid] !== st || st.streaming || st.es) return true;
           this.$nextTick(async () => {
             try { await this.highlightCode(".chat-body"); st._highlighted = true; }
             catch (_e) { /* highlight best-effort — reveal regardless */ }
             if (sid === this.currentId) {
+              st.messagesReady = true;
               this.messagesReady = true;
               this.$nextTick(() => {
                 this.atBottom = true; this.scrollToBottom(true);
@@ -9438,16 +9839,18 @@ function portal() {
         // Re-check live: only clear the skeleton if this sid is STILL the
         // active tab. If the user switched away mid-load, the now-active tab
         // owns messagesLoading and must not be cleared by our stale completion.
-        if (sid === this.currentId) {
-          this.messagesLoading = false;
-          // No reveal scheduled (error / early return) → don't trap the
-          // skeleton: show whatever we have.
-          if (!scheduledReveal) this.messagesReady = true;
-          // The active tab is now warm — opportunistically warm the OTHER
-          // open tabs during idle time so switching to them is instant
-          // (no fetch + parse + render on click). Self-chaining + idle-gated,
-          // so it never competes with foreground work.
-          this._scheduleIdlePreload();
+        if (this.tabState[sid] === st) {
+          st.messagesLoading = false;
+          if (!scheduledReveal || sid !== this.currentId) st.messagesReady = true;
+          if (sid === this.currentId) {
+            this.messagesLoading = false;
+            // No reveal scheduled (error / early return) → don't trap the
+            // skeleton: show whatever we have.
+            if (!scheduledReveal) this.messagesReady = true;
+            // The active tab is now warm — opportunistically warm one desktop
+            // envelope without mounting another pane.
+            this._scheduleIdlePreload();
+          }
         }
       }
     },
@@ -9463,6 +9866,7 @@ function portal() {
     // active view; the backend parse it triggers is now cached by
     // (mtime, size), making repeat/preload loads cheap.
     _scheduleIdlePreload() {
+      if (this._isMobileLayout()) return;
       // Background preload runs on ALL layouts (desktop + mobile). It was
       // previously desktop-only to avoid iOS dropping the keyboard on the
       // first composer tap (an off-screen loadSession landing mid-tap); that
@@ -9524,7 +9928,7 @@ function portal() {
         // Tab was closed+reopened mid-reveal (a fresh st replaced ours, or it
         // was deleted): our st is now orphaned. Stop pushing — the new
         // loadSession owns the reveal. Prevents double-fill / duplicate keys.
-        if (this.tabState[sid] !== st) return;
+        if (this.tabState[sid] !== st || st.streaming || st.es) return;
         st.messages.push(...visible.slice(i, i + CH));
         i += CH;
         // Tab switched away mid-reveal: the array is no longer on screen and a
@@ -9540,6 +9944,7 @@ function portal() {
             ? requestAnimationFrame(() => r()) : setTimeout(r, 16)));
         }
       }
+      if (this.tabState[sid] === st) this._capMountedWindow(st, "older");
     },
     // E5: render the deferred HEAD — the rewound, above-the-fold bubbles whose
     // markdown loadSession skipped so first paint wasn't blocked on the whole
@@ -9624,27 +10029,165 @@ function portal() {
         })
         .finally(() => {
           delete this._prefetching[next];
-          this._scheduleIdlePreload();         // chain to the next unloaded tab
+          // One envelope per idle opportunity. A later foreground completion or
+          // hover may schedule another; never chain through every open tab.
         });
     },
 
     // ===== Lazy-loaded history controls =====
+    _stableHash(value) {
+      const text = String(value || "");
+      let h = 2166136261;
+      for (let i = 0; i < text.length; i++) {
+        h ^= text.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+      }
+      return (h >>> 0).toString(36);
+    },
+    _historyMessageKey(sid, m) {
+      if (m && m._k) return m._k;
+      if (m && m._key) return sid + ":idx:" + m._key;
+      if (m && m.uuid) return sid + ":uuid:" + m.uuid;
+      const identity = [m && m.role, m && (m.id || m.tool_use_id || ""),
+        m && (m.ts || ""), m && (m.name || m.tool_name || ""),
+        m && (m.text || m.preview || m.summary || "")].join("");
+      return sid + ":hist:" + this._stableHash(identity);
+    },
+    _historyEnvelopes(sid, list) {
+      const seen = new Map();
+      return (list || []).map(m => {
+        const base = this._historyMessageKey(sid, m);
+        const n = seen.get(base) || 0;
+        seen.set(base, n + 1);
+        return { ...m, _k: n ? base + ":dup:" + n : base };
+      });
+    },
+    _assignLiveKey(st, m) {
+      if (!m._k) m._k = (st._sid || "tab") + ":live:" + st._nextLiveKey++;
+      return m;
+    },
+    _allPaneMessages(st) {
+      return [].concat(st._earlierMessages || [], st.messages || [], st._laterMessages || []);
+    },
+    _containsPaneMessage(st, m) {
+      return !!m && ((st.messages || []).includes(m)
+        || (st._earlierMessages || []).includes(m)
+        || (st._laterMessages || []).includes(m));
+    },
+    _appendLiveMessage(st, m) {
+      this._assignLiveKey(st, m);
+      const target = (st._laterMessages && st._laterMessages.length)
+        ? st._laterMessages : st.messages;
+      target.push(m);
+      if (target === st.messages) this._capMountedWindow(st, "newer");
+      this._capHistoryCache(st);
+      return target[target.length - 1];
+    },
+    _mountedMessageCap() { return this._isMobileLayout() ? 60 : 120; },
+    _historyCacheCap() { return this._isMobileLayout() ? 120 : 240; },
+    _capMountedWindow(st, direction = "newer", anchorUuid = "") {
+      const cap = this._mountedMessageCap();
+      if (!st || !st.messages || st.messages.length <= cap) {
+        return { head: [], tail: [] };
+      }
+      let head = [];
+      let tail = [];
+      if (direction === "older") {
+        tail = st.messages.splice(cap);
+        st._laterMessages = tail.concat(st._laterMessages || []);
+      } else if (direction === "around") {
+        const target = st.messages.findIndex(m => m && m.uuid === anchorUuid);
+        const centered = target < 0 ? 0 : target - Math.floor(cap / 2);
+        const start = Math.max(0, Math.min(centered, st.messages.length - cap));
+        head = st.messages.splice(0, start);
+        tail = st.messages.splice(cap);
+        st._earlierMessages = (st._earlierMessages || []).concat(head);
+        st._laterMessages = tail.concat(st._laterMessages || []);
+      } else {
+        head = st.messages.splice(0, st.messages.length - cap);
+        st._earlierMessages = (st._earlierMessages || []).concat(head);
+      }
+      this._capHistoryCache(st, direction);
+      return { head, tail };
+    },
+    _capHistoryCache(st, direction = "newer") {
+      if (!st) return;
+      const cap = this._historyCacheCap();
+      let held = (st._earlierMessages || []).length + (st.messages || []).length
+        + (st._laterMessages || []).length;
+      const dropEarlier = () => {
+        if (!(st._earlierMessages && st._earlierMessages.length) || held <= cap) return;
+        const drop = Math.min(held - cap, st._earlierMessages.length);
+        st._earlierMessages.splice(0, drop);
+        st._loadedOffset = (st._loadedOffset || 0) + drop;
+        held -= drop;
+      };
+      const dropLater = () => {
+        if (!(st._laterMessages && st._laterMessages.length) || held <= cap) return;
+        // Keep the messages adjacent to the mounted window. Dropping from the
+        // front creates an unrecoverable hole before loadLaterMessages' next
+        // item; dropping the far future preserves one contiguous range.
+        const drop = Math.min(held - cap, st._laterMessages.length);
+        st._laterMessages.splice(st._laterMessages.length - drop, drop);
+        st._hasServerLater = true;
+        held -= drop;
+      };
+      if (direction === "older") {
+        // Paging backward must retain the newly fetched past and evict the far
+        // future. The old earlier-first policy hit the cap once and made every
+        // older server page permanently unreachable.
+        dropLater();
+        dropEarlier();
+      } else if (direction === "around") {
+        // Defensive path for an oversized around response. Preserve the
+        // mounted target and discard whichever off-screen side is farther.
+        while (held > cap) {
+          const earlier = (st._earlierMessages || []).length;
+          const later = (st._laterMessages || []).length;
+          if (later >= earlier && later) dropLater();
+          else if (earlier) dropEarlier();
+          else break;
+        }
+      } else {
+        // Latest/newer navigation is the mirror image: keep the future and
+        // evict the far past, advancing the absolute first-held coordinate.
+        dropEarlier();
+        dropLater();
+      }
+    },
+    _captureMessageAnchor(scrollEl, m) {
+      const key = m && m._k;
+      if (!scrollEl || !key) return null;
+      const pane = scrollEl.querySelector(
+        `.msg-pane[data-tid="${CSS.escape(this.currentId || "")}"]`);
+      const el = (pane || scrollEl).querySelector(
+        `.msg[data-message-key="${CSS.escape(key)}"]`);
+      if (!el) return null;
+      return { key, top: el.getBoundingClientRect().top };
+    },
+    _restoreMessageAnchor(scrollEl, anchor) {
+      if (!scrollEl || !anchor) return;
+      const el = scrollEl.querySelector(
+        `.msg[data-message-key="${CSS.escape(anchor.key)}"]`);
+      if (!el) return;
+      scrollEl.scrollTop += el.getBoundingClientRect().top - anchor.top;
+    },
     // Pop the next batch of older messages off the per-tab stash, mdRender
     // them on demand, prepend to messages[]. Critical: preserve scroll
     // position so the user's current viewport doesn't jump when older
     // content unfolds above.
-    LOAD_MORE_BATCH: 50,
+    LOAD_MORE_BATCH: 40,
     // How many older bubbles to pull from the server in one backend page
     // when the in-memory stash runs dry (see _fetchOlderWindow). Larger
     // than LOAD_MORE_BATCH so several "Load earlier" clicks are served from
     // memory between network round-trips.
-    HISTORY_PAGE: 200,
+    HISTORY_PAGE: 120,
     // Absolute in-memory ceiling across messages[] + _earlierMessages. Once
     // hit we stop paging older windows from the server (full history stays
     // in the JSONL); historyTruncated() then surfaces the "not everything is
     // reachable" hint. Bounds memory on pathological thousands-of-bubbles
     // sessions even if the user keeps clicking "Load earlier".
-    MAX_IN_MEMORY: 2000,
+    MAX_IN_MEMORY: 240,
     // Live-session DOM ceiling. loadSession's INITIAL_LOAD / MAX caps
     // only apply when (re)entering a session — NOTHING trims messages[] while
     // a session is actively chatted in, so a long coding session grows DOM
@@ -9652,7 +10195,7 @@ function portal() {
     // headroom to mask it). Before each new user turn _capLiveMessages evicts
     // the oldest rendered bubbles back into the _earlierMessages stash so
     // "Load earlier" can page them back in. Mobile uses a tighter ceiling.
-    LIVE_MESSAGE_CAP: 200,
+    LIVE_MESSAGE_CAP: 120,
     // Reactivity ping: bumped whenever refreshOutlineFromBackend writes
     // new data. outlineMessages() reads it so Alpine knows to re-render
     // the msg-outline-modal when async fetch completes. Without this,
@@ -9705,6 +10248,19 @@ function portal() {
       }
     },
 
+    async _reloadHistoryTailAfterConflict(sid, ownerState) {
+      if (!sid || this.tabState[sid] !== ownerState || ownerState.streaming || ownerState.es) {
+        return false;
+      }
+      ownerState._earlierMessages = [];
+      ownerState._laterMessages = [];
+      ownerState._loadedOffset = 0;
+      ownerState.historyGeneration = "";
+      ownerState._historyOrder = "normal";
+      ownerState._hasServerLater = false;
+      return this.loadSession(sid, { quiet: sid === this.currentId });
+    },
+
     // Pull the next older window of bubbles from the server into the FRONT
     // of the in-memory stash and rewind _loadedOffset. Used when the stash
     // is exhausted but the server still holds older history (the backend-
@@ -9717,27 +10273,45 @@ function portal() {
       const st = this._ensureTabState(sid);
       if (st._fetchingOlder) return 0;
       if (!(st._loadedOffset > 0)) return 0;
-      // Respect the in-memory ceiling — stop paging once we hold too much.
       const held = (st.messages ? st.messages.length : 0)
-                 + (st._earlierMessages ? st._earlierMessages.length : 0);
-      if (held >= this.MAX_IN_MEMORY) return 0;
-      const newOffset = Math.max(0, st._loadedOffset - this.HISTORY_PAGE);
+                 + (st._earlierMessages ? st._earlierMessages.length : 0)
+                 + (st._laterMessages ? st._laterMessages.length : 0);
+      // Reclaim the far-future cache while moving backward. This keeps a
+      // bounded contiguous window that can slide through the entire history,
+      // instead of treating the memory cap as a permanent navigation wall.
+      const room = Math.max(0, this._historyCacheCap() - held)
+        + (st._laterMessages ? st._laterMessages.length : 0);
+      const pageSize = Math.min(this.HISTORY_PAGE, st._loadedOffset, room);
+      if (pageSize <= 0) return 0;
+      const newOffset = st._loadedOffset - pageSize;
       const limit = st._loadedOffset - newOffset;
       st._fetchingOlder = true;
       try {
+        const generation = st.historyGeneration
+          ? "&history_generation=" + encodeURIComponent(st.historyGeneration) : "";
+        const order = st._historyOrder === "full" ? "&full=1" : "";
         const r = await fetch(
-          "/api/chat/sessions/" + sid + "?offset=" + newOffset + "&limit=" + limit,
+          "/api/chat/sessions/" + sid + "?offset=" + newOffset + "&limit=" + limit
+          + order + generation,
           { headers: this.hdr() });
+        if (r.status === 409) {
+          await this._reloadHistoryTailAfterConflict(sid, st);
+          return 0;
+        }
         if (!r.ok) return 0;
         const data = await r.json();
-        const win = (data.messages || []).map((m, idx) => ({
-          ...m, _k: sid + "-o" + newOffset + "-" + idx,
-        }));
+        const win = this._historyEnvelopes(sid, data.messages || []);
         // Prepend (older bubbles go to the front of the stash). mdRender is
         // still deferred until a bubble is paged into messages[].
         st._earlierMessages = win.concat(st._earlierMessages || []);
         st._loadedOffset = Number.isInteger(data.offset) ? data.offset : newOffset;
         if (Number.isInteger(data.total)) st._total = data.total;
+        st.historyGeneration = data.history_generation || st.historyGeneration || "";
+        st._historyOrder = data.history_order === "full" ? "full" : "normal";
+        if (sid === this.currentId) this.historyGeneration = st.historyGeneration;
+        this._capHistoryCache(st, "older");
+        st._hasServerLater = (st._loadedOffset + this._allPaneMessages(st).length)
+          < st._total;
         st._hasMoreHistory =
           (st._earlierMessages.length > 0) || st._loadedOffset > 0;
         return win.length;
@@ -9745,6 +10319,55 @@ function portal() {
         return 0;
       } finally {
         st._fetchingOlder = false;
+      }
+    },
+    async _fetchLaterWindow(sid) {
+      sid = sid || this.currentId;
+      if (!sid) return 0;
+      const st = this._ensureTabState(sid);
+      if (st._fetchingLater || !st._hasServerLater) return 0;
+      const held = this._allPaneMessages(st).length;
+      const start = (st._loadedOffset || 0) + held;
+      if (start >= (st._total || 0)) {
+        st._hasServerLater = false;
+        return 0;
+      }
+      // Mirror the older-page policy: reclaim the far-past stash so forward
+      // paging can also slide through history without exceeding the cache.
+      const room = Math.max(0, this._historyCacheCap() - held)
+        + (st._earlierMessages ? st._earlierMessages.length : 0);
+      const limit = Math.min(this.HISTORY_PAGE, st._total - start, room);
+      if (limit <= 0) return 0;
+      st._fetchingLater = true;
+      try {
+        const generation = st.historyGeneration
+          ? "&history_generation=" + encodeURIComponent(st.historyGeneration) : "";
+        const order = st._historyOrder === "full" ? "&full=1" : "";
+        const r = await fetch(
+          "/api/chat/sessions/" + sid + "?offset=" + start + "&limit=" + limit
+          + order + generation,
+          { headers: this.hdr() });
+        if (r.status === 409) {
+          await this._reloadHistoryTailAfterConflict(sid, st);
+          return 0;
+        }
+        if (!r.ok) return 0;
+        const data = await r.json();
+        if (this.tabState[sid] !== st) return 0;
+        const win = this._historyEnvelopes(sid, data.messages || []);
+        st._laterMessages = (st._laterMessages || []).concat(win);
+        if (Number.isInteger(data.total)) st._total = data.total;
+        st.historyGeneration = data.history_generation || st.historyGeneration || "";
+        st._historyOrder = data.history_order === "full" ? "full" : "normal";
+        if (sid === this.currentId) this.historyGeneration = st.historyGeneration;
+        this._capHistoryCache(st, "newer");
+        st._hasServerLater = (st._loadedOffset + this._allPaneMessages(st).length)
+          < st._total;
+        return win.length;
+      } catch (_) {
+        return 0;
+      } finally {
+        st._fetchingLater = false;
       }
     },
     // Per-message placeholder height (px) for content-visibility's
@@ -9828,17 +10451,19 @@ function portal() {
       // Capture scroll geometry BEFORE the DOM grows so we can restore the
       // user's visible-content offset after Alpine re-renders.
       const scrollEl = isCurrent ? this.$refs.chatBody : null;
-      const oldScrollHeight = scrollEl ? scrollEl.scrollHeight : 0;
-      const oldScrollTop = scrollEl ? scrollEl.scrollTop : 0;
+      // The previous first bubble survives an older-direction cap. Anchoring
+      // that exact keyed element stays correct even when the same mutation
+      // also removes tall bubbles from the bottom.
+      const anchor = this._captureMessageAnchor(scrollEl, st.messages[0]);
       st.messages.unshift(...batch);
+      this._capMountedWindow(st, "older");
       if (isCurrent) this.messages = st.messages;
       st._hasMoreHistory = st._earlierMessages.length > 0 || st._loadedOffset > 0;
       // Restore scroll position so the message the user was looking at
       // stays in place. Without this the viewport snaps to the new top.
       if (scrollEl) {
         this.$nextTick(() => {
-          const newScrollHeight = scrollEl.scrollHeight;
-          scrollEl.scrollTop = oldScrollTop + (newScrollHeight - oldScrollHeight);
+          this._restoreMessageAnchor(scrollEl, anchor);
           // Re-run code highlighting ONLY on the newly prepended bubbles
           // (the first batch.length `.msg` children). Rescanning the whole
           // chat body each click is O(total) — wasteful once a long history
@@ -9852,6 +10477,75 @@ function portal() {
         st._loadingEarlier = false;
       }
     },
+    async loadLaterMessages(sid) {
+      sid = sid || this.currentId;
+      const st = sid && this.tabState[sid];
+      if (!st) return;
+      if ((!st._laterMessages || !st._laterMessages.length) && st._hasServerLater) {
+        await this._fetchLaterWindow(sid);
+      }
+      if (!st._laterMessages || !st._laterMessages.length) return;
+      const batchSize = this._isMobileLayout() ? 20 : this.LOAD_MORE_BATCH;
+      const batch = st._laterMessages.splice(0, batchSize);
+      const scrollEl = sid === this.currentId ? this.$refs.chatBody : null;
+      // The previous last bubble survives a newer-direction cap; preserve its
+      // screen coordinate instead of restoring an absolute scrollTop after
+      // removing an arbitrary-height prefix.
+      const anchor = this._captureMessageAnchor(
+        scrollEl, st.messages[st.messages.length - 1]);
+      st.messages.push(...batch);
+      this._capMountedWindow(st, "newer");
+      if (sid === this.currentId) {
+        this.messages = st.messages;
+        this.$nextTick(() => this._restoreMessageAnchor(scrollEl, anchor));
+      }
+    },
+    async returnToLatest(sid) {
+      sid = sid || this.currentId;
+      const st = sid && this.tabState[sid];
+      if (!st) return false;
+      if (st._hasServerLater) {
+        // An around/full-order window intentionally holds only a bounded
+        // middle slice. A local reshuffle cannot reach the canonical tail;
+        // reload it from the normal active order instead.
+        const loaded = await this.loadSession(sid, { quiet: sid === this.currentId });
+        if (!loaded || this.tabState[sid] !== st) return false;
+        st.atBottom = true;
+        if (sid === this.currentId) {
+          this.atBottom = true;
+          this.$nextTick(() => this.scrollToBottom(true));
+        }
+        return true;
+      }
+      const all = this._allPaneMessages(st);
+      const cap = this._mountedMessageCap();
+      st.messages.splice(0, st.messages.length, ...all.slice(-cap));
+      st._earlierMessages = all.slice(0, Math.max(0, all.length - cap));
+      st._laterMessages = [];
+      this._capHistoryCache(st, "newer");
+      st.atBottom = true;
+      if (sid === this.currentId) {
+        this.messages = st.messages;
+        this.atBottom = true;
+        this.$nextTick(() => this.scrollToBottom(true));
+      }
+      return true;
+    },
+    hasLaterMessages(sid) {
+      const st = this.tabState[sid || this.currentId];
+      return !!(st && ((st._laterMessages && st._laterMessages.length)
+        || st._hasServerLater));
+    },
+    laterMessageCount(sid) {
+      const st = this.tabState[sid || this.currentId];
+      if (!st) return 0;
+      const local = st._laterMessages ? st._laterMessages.length : 0;
+      const held = this._allPaneMessages(st).length;
+      const server = st._hasServerLater
+        ? Math.max(0, (st._total || 0) - (st._loadedOffset || 0) - held) : 0;
+      return local + server;
+    },
+
     // Evict the oldest rendered messages back to the lazy stash so a long
     // LIVE session doesn't accumulate unbounded DOM (the mobile OOM root
     // cause). Called right before a new user turn is appended — the mirror
@@ -9861,9 +10555,7 @@ function portal() {
     // the user sits at the bottom sending, so there's no scroll jump.
     _capLiveMessages(st) {
       if (!st || !st.messages) return;
-      const cap = this._isMobileLayout()
-        ? Math.min(50, this.LIVE_MESSAGE_CAP)
-        : this.LIVE_MESSAGE_CAP;
+      const cap = this._mountedMessageCap();
       const overflow = st.messages.length - cap;
       if (overflow <= 0) return;
       const evicted = st.messages.splice(0, overflow);
@@ -9871,6 +10563,7 @@ function portal() {
       // everything already stashed but older than what stays visible, so
       // they're the "closest in time" batch loadEarlierMessages pops first.
       st._earlierMessages = (st._earlierMessages || []).concat(evicted);
+      this._capHistoryCache(st);
       st._hasMoreHistory = st._earlierMessages.length > 0 || st._loadedOffset > 0;
     },
     hasMoreHistory(sid) {
@@ -9878,13 +10571,10 @@ function portal() {
       if (!sid) return false;
       const st = this.tabState[sid];
       if (!st) return false;
-      // More to show if the in-memory stash has older bubbles OR the server
-      // still holds bubbles before our window — but not once we've hit the
-      // in-memory ceiling (then historyTruncated() takes over).
-      const held = (st.messages ? st.messages.length : 0)
-                 + (st._earlierMessages ? st._earlierMessages.length : 0);
+      // The bounded cache is a sliding window: reaching its size cap no longer
+      // blocks older paging because the far-future side is evicted on demand.
       if (st._earlierMessages && st._earlierMessages.length) return true;
-      return st._loadedOffset > 0 && held < this.MAX_IN_MEMORY;
+      return st._loadedOffset > 0;
     },
     earlierMessageCount(sid) {
       sid = sid || this.currentId;
@@ -9901,12 +10591,9 @@ function portal() {
       if (!sid) return false;
       const st = this.tabState[sid];
       if (!st) return false;
-      // Hit the in-memory ceiling while older history still exists on the
-      // server: "Load earlier" stops here, the rest stays in the JSONL.
-      const held = (st.messages ? st.messages.length : 0)
-                 + (st._earlierMessages ? st._earlierMessages.length : 0);
-      return st._loadedOffset > 0 && held >= this.MAX_IN_MEMORY
-             && !(st._earlierMessages && st._earlierMessages.length);
+      // Retained as a compatibility hook for the template. Sliding-window
+      // paging now makes every indexed bubble reachable within the cap.
+      return false;
     },
 
     async renameSession() {
@@ -9925,8 +10612,8 @@ function portal() {
       if (r.ok) { await this.refreshSessions(); this.toast(this.t("toast.renamed"), "success"); }
     },
 
-    async editSessionPrompt() {
-      const cur = this.sessions.find(x => x.id === this.currentId);
+    async editSessionPrompt(sid = this.currentId) {
+      const cur = this.sessions.find(x => x.id === sid);
       if (!cur) return;
       // 取最新（含 system_prompt）
       const r0 = await fetch("/api/chat/sessions/" + cur.id, { headers: this.hdr() });
@@ -13475,6 +14162,10 @@ function portal() {
     // highlighted AND artifacts (mermaid/HTML) are rendered. Most callers
     // fire-and-forget; loadSession awaits it to know when to reveal the view.
     highlightCode(root, scopeEls = null) {
+      if (root === ".chat-body" && !scopeEls) {
+        const pane = this._paneElement(this.currentId);
+        scopeEls = pane ? [pane] : [];
+      }
       // Collect the not-yet-highlighted BLOCK code FIRST, before touching hljs.
       // Inline `code` spans are never syntax-highlighted (see _highlightOne),
       // so collecting them just to early-return wastes a full-body
@@ -15669,7 +16360,9 @@ function portal() {
           if (!r.ok) { this.toast(this.t("slash.failed"), "error"); return; }
           const meta = await r.json();
           await this.refreshSessions();
+          this._captureChatPosition(this.currentId);
           this.currentId = meta.id;
+          this._activateTabState(meta.id);
           await this.loadSession(meta.id);
           // Pre-fill input with the compact prompt — user reviews then sends
           this.input = this.t("slash.compact_prompt");
@@ -15702,7 +16395,9 @@ function portal() {
           const hit = (this.sessions || []).find(s =>
             s.id.startsWith(arg) || s.name.toLowerCase().includes(q));
           if (!hit) { this.toast(this.t("slash.resume_no_match"), "warn", 2000); return; }
+          this._captureChatPosition(this.currentId);
           this.currentId = hit.id;
+          this._activateTabState(hit.id);
           await this.loadSession(hit.id);
           this.toast(this.t("slash.resumed", { name: hit.name }), "success", 1500);
           return;
@@ -15724,7 +16419,7 @@ function portal() {
           return;
         }
         case "config": this.openSettings(); return;
-        case "stop":   if (this.streaming) this.stop(); return;
+        case "stop":   if (this.isTabStreaming(this.currentId)) await this.stop(); return;
         default:
           this.toast(this.t("slash.unknown", { cmd }), "warn", 2000);
       }
@@ -15733,7 +16428,8 @@ function portal() {
     // Inject a synthetic assistant bubble (markdown rendered) for slash output.
     // Not persisted — slash output is ephemeral, doesn't pollute session history.
     _injectAssistantNote(md) {
-      this.messages.push({
+      const st = this._ensureTabState(this.currentId);
+      this._appendLiveMessage(st, {
         role: "assistant", text: md, html: this.mdRender(md),
         cost: "", model: "muselab", _ephemeral: true,
       });
@@ -16156,8 +16852,21 @@ function portal() {
         const r = await fetch(`/api/chat/sessions/${sid}/native-compact`,
                                 { method: "POST", headers: this.hdr() });
         if (!r.ok) {
-          const txt = await r.text();
-          this.toast((this.lang === "zh" ? "压缩失败：" : "Compact failed: ") + txt, "error", 5000);
+          const raw = await r.text();
+          let detail = raw;
+          try {
+            const body = JSON.parse(raw);
+            detail = body.detail || body.error || raw;
+          } catch (_) {}
+          const human = this._humanizeStreamError(detail);
+          this.toast((this.lang === "zh" ? "压缩失败：" : "Compact failed: ") + human,
+            "error", 7000,
+            /context window|context length|input exceeds|did not decrease/i.test(detail)
+              ? {
+                  label: this.lang === "zh" ? "新建会话" : "New session",
+                  onClick: () => this.newSession && this.newSession(),
+                }
+              : undefined);
           return;
         }
         // Reload the compacted session if it's the active one; on a
@@ -16378,6 +17087,7 @@ function portal() {
       this.send();
     },
     _captureChatPosition(sid = this.currentId) {
+      this._captureComposerState(sid);
       const st = sid && this.tabState && this.tabState[sid];
       const el = this.$refs.chatBody;
       if (!st || !el || sid !== this.currentId) return;
@@ -16656,14 +17366,49 @@ function portal() {
       // both stay in the original tab — visible only when they switch
       // back — which is the contract `streamSid` was supposed to enforce
       // all along.
-      const sendSid = this.currentId;
+      // Workspace changes rebind the active conversation owner. Refuse user
+      // sends (including keyboard/programmatic calls) during the transition;
+      // already-owned reconnects and queue drains remain safely session-pinned.
+      if (this.workspaceSwitching && !opts.reconnect && !opts.resumedItem) return false;
+      const sendSid = opts.sessionId || this.currentId;
+      if (!sendSid) return false;
+      if (sendSid === this.currentId) this._captureComposerState(sendSid);
+      const sendState = this._ensureTabState(sendSid);
+      const sendDraft = sendState.draft;
+      // Snapshot the pinned session's draft before any await. Every later read,
+      // clear, upload wait and enqueue remains owned by this exact state object.
+      const composerText = sendDraft.input || "";
+      const composerImages = sendDraft.pendingImages.slice();
+      const composerDocs = sendDraft.pendingDocs.slice();
+      const ownsSendDraft = () => this.tabState[sendSid] === sendState
+        && sendState.draft === sendDraft;
+      const clearSubmittedComposer = () => {
+        if (!ownsSendDraft()) return;
+        if (sendDraft.input === composerText) sendDraft.input = "";
+        const removeOwned = (items, sent) => {
+          for (let i = items.length - 1; i >= 0; i--) {
+            if (sent.has(items[i])) items.splice(i, 1);
+          }
+        };
+        removeOwned(sendDraft.pendingImages, new Set(composerImages));
+        removeOwned(sendDraft.pendingDocs, new Set(composerDocs));
+        if (sendSid === this.currentId) {
+          this._activateComposerState(sendSid);
+          this.$nextTick(() => {
+            if (this.$refs.chatInput) this.autoGrow(this.$refs.chatInput);
+          });
+        }
+      };
       // Snapshot model/permission alongside sendSid — the attachment-upload
       // awaits below can span a tab switch, after which this.model /
       // this.permission belong to the NEWLY focused session. Without the
       // snapshot, session A's send could fire under session B's model and
       // permission mode (D4 audit).
-      const sendModel = this.model;
-      const sendPermission = this.permission;
+      const sendMeta = (this.sessions || []).find(s => s.id === sendSid);
+      const sendModel = sendSid === this.currentId
+        ? this.model : ((sendMeta && sendMeta.model) || this.model);
+      const sendPermission = sendSid === this.currentId
+        ? this.permission : ((sendMeta && sendMeta.permission) || "default");
       // Reconnect mode: skip user-input validation + user-msg push.
       // Used by _reconnectActiveTurn() when loadSession discovers an
       // in-flight background turn on the current session — we just want
@@ -16698,7 +17443,7 @@ function portal() {
       let text;
       if (isReconnect) text = "";
       else if (resumed) text = (resumed.text || "").trim();
-      else text = this.input.trim();
+      else text = composerText.trim();
       // Slash command: intercept BEFORE hitting the SDK. /word or /word arg.
       // Resumed items can't reach the slash branch — slash is processed
       // before enqueue, so a queued item is always plain text. While
@@ -16709,59 +17454,27 @@ function portal() {
       if (!isReconnect && !resumed && text.startsWith("/")) {
         const m = text.match(/^\/(\w+)(?:\s+(.*))?$/);
         if (m) {
-          if (this._isBusy(this.currentId)) {
+          if (await this._confirmSessionBusy(sendSid, sendState)) {
             this.toast(this.t("queue.slash_blocked"), "warn", 3000);
             return;
           }
-          this.input = "";
-          this.$nextTick(() => { if (this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
+          if (ownsSendDraft() && sendDraft.input === composerText) {
+            sendDraft.input = "";
+            if (this.currentId === sendSid) this.input = "";
+          }
+          this.$nextTick(() => { if (this.currentId === sendSid && this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
           await this._runSlash(m[1], m[2] || "");
           return;
         }
       }
-      let readyImages, readyDocs;
+      let readyImages = [], readyDocs = [];
       if (isReconnect) {
-        readyImages = []; readyDocs = [];
-      } else if (resumed) {
-        readyImages = (resumed.pendingImages || []).filter(im => im.id && !im.error);
-        readyDocs = (resumed.pendingDocs || []).filter(d => d.id && !d.error);
+        if (sendState.streaming || sendState.es) return;
       } else {
-        readyImages = this.pendingImages.filter(im => im.id && !im.error);
-        readyDocs = this.pendingDocs.filter(d => d.id && !d.error);
-      }
-      if (isReconnect) {
-        if (this.streaming || !this.currentId) return;
-      } else {
-        if (!text && !readyImages.length && !readyDocs.length) return;
-        if (!this.currentId) return;
-      }
-      // Busy: streaming OR compacting → park on this session's
-      // pendingQueue. Auto-drain happens on done / compact-finally /
-      // activateTab. Reconnect path skips enqueue (it's already a
-      // subscribe, no new message). Resumed path also skips — by
-      // construction, drain only fires when not busy.
-      if (!isReconnect && !resumed && this._isBusy(this.currentId)) {
-        // Server-backed enqueue (POST → sessions/{sid}.queue.json). Only clear
-        // the composer once the server accepted it; on failure (queue full /
-        // network) _enqueueMessage toasts and we leave the draft intact so the
-        // user can retry. The server drains the queue itself when the current
-        // turn finishes — no client-side drain.
-        const ok = await this._enqueueMessage(this.currentId, {
-          text,
-          pendingImages: this.pendingImages.slice(),
-          pendingDocs: this.pendingDocs.slice(),
-        });
-        if (!ok) return;
-        this.pendingImages = [];
-        this.pendingDocs = [];
-        this.input = "";
-        this.$nextTick(() => { if (this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
-        // Scroll the chat-body to the bottom so the new queued bubble is
-        // visible. Without this the user can be scrolled mid-history and
-        // would never see their just-enqueued message land.
-        this.atBottom = true;
-        this.scrollToBottom(true);
-        return;
+        const hasAttachments = resumed
+          ? !!((resumed.pendingImages || []).length || (resumed.pendingDocs || []).length)
+          : !!(composerImages.length || composerDocs.length);
+        if (!text && !hasAttachments) return;
       }
       // If any attachment is still mid-upload, silently wait for it to
       // finish before kicking off the turn. Per 2026-05-21 user feedback
@@ -16776,46 +17489,95 @@ function portal() {
       // The send button stays disabled (_sendWaitingForUpload) so a double-
       // tap can't enqueue a second send while we wait.
       if (!isReconnect) {
-        // For resumed (drained-from-queue) items, the relevant attachments
-        // are the snapshot inside the queue item, not this.pendingImages
-        // (which may belong to a different draft the user has typed since
-        // enqueue). Snapshot stores object refs, so .uploading reflects
-        // current state — we just have to look at the right collection.
-        const stillUploading = () => {
-          if (resumed) {
-            return (resumed.pendingImages || []).some(im => im.uploading)
-              || (resumed.pendingDocs || []).some(d => d.uploading);
-          }
-          return this.pendingImages.some(im => im.uploading)
-            || this.pendingDocs.some(d => d.uploading);
-        };
+        // For resumed items use their own snapshot; otherwise use the composer
+        // snapshot captured before any await. Never drift to another tab's
+        // current global composer while waiting for uploads.
+        const ownedImages = resumed ? (resumed.pendingImages || []) : composerImages;
+        const ownedDocs = resumed ? (resumed.pendingDocs || []) : composerDocs;
+        const stillUploading = () => ownedImages.some(im => im.uploading)
+          || ownedDocs.some(d => d.uploading);
         if (stillUploading()) {
-          this._sendWaitingForUpload = true;
-          while (stillUploading()) {
-            await new Promise(r => setTimeout(r, 80));
+          sendDraft._sendWaitingForUpload = true;
+          if (sendSid === this.currentId) this._sendWaitingForUpload = true;
+          try {
+            while (ownsSendDraft() && stillUploading()) {
+              await new Promise(r => setTimeout(r, 80));
+            }
+          } finally {
+            sendDraft._sendWaitingForUpload = false;
+            if (sendSid === this.currentId && this.tabState[sendSid] === sendState) {
+              this._sendWaitingForUpload = false;
+            }
           }
-          this._sendWaitingForUpload = false;
+          if (!ownsSendDraft()) return false;
         }
-        // The uploads may have just finished — re-resolve ready{Images,Docs}
-        // now that .id is set (eager filter above could have returned empty).
-        if (resumed) {
-          readyImages = (resumed.pendingImages || []).filter(im => im.id && !im.error);
-          readyDocs = (resumed.pendingDocs || []).filter(d => d.id && !d.error);
+        // An attachment is part of the user's send intent. If any upload failed,
+        // keep every chip/draft in place and refuse the send instead of silently
+        // degrading the turn to text-only (or a partial attachment set).
+        const failedAttachments = ownedImages.filter(im => im.error || !im.id)
+          .concat(ownedDocs.filter(d => d.error || !d.id));
+        if (failedAttachments.length) {
+          this.toast(this.lang === "zh"
+            ? "附件上传失败，请移除失败项或重新上传后再发送"
+            : "Attachment upload failed — remove or re-upload it before sending",
+            "error", 5000);
+          return false;
         }
+        readyImages = ownedImages.slice();
+        readyDocs = ownedDocs.slice();
+      }
+      // A newly opened tab is optimistic until POST /sessions lands. Do not
+      // launch the first turn before that durable index row exists: if the user
+      // cancels before the SDK writes its JSONL, activity would otherwise point
+      // at a session that was never persisted. Registration failure leaves the
+      // composer/attachments untouched so the user can retry safely.
+      if (!isReconnect && this._optimisticMetas[sendSid]) {
+        const registered = await this._ensureSessionRegistered(sendSid);
+        if (!registered) {
+          this.toast(this.lang === "zh"
+            ? "发送失败：新会话未能保存，请检查连接后重试"
+            : "Send failed: the new session could not be saved — check your connection and retry",
+            "error", 4500);
+          return false;
+        }
+      }
+      // Busy: streaming OR compacting → park on the pinned session's queue.
+      // Upload waiting and failure validation happen first so a programmatic
+      // send can never enqueue a text-only fallback while its attachment fails.
+      if (!isReconnect && !resumed
+          && await this._confirmSessionBusy(sendSid, sendState)) {
+        const ok = await this._enqueueMessage(sendSid, {
+          text,
+          pendingImages: composerImages,
+          pendingDocs: composerDocs,
+          permission: sendPermission,
+        });
+        if (!ok) return false;
+        clearSubmittedComposer();
+        if (this.currentId === sendSid) {
+          this.atBottom = true;
+          this.scrollToBottom(true);
+        }
+        return true;
       }
       // Push to the SENDING tab's messages array (looked up via sendSid),
       // not this.messages — `this.messages` may have been re-aliased to a
       // different tab if the user switched mid-await. See the "Pin target
       // session" block at function entry for the full story.
-      const sendState = this._ensureTabState(sendSid);
       // Reconnect mode skips pushing a user msg — the backend already
       // has the user prompt from the original turn, and the
       // broadcast-rebuild on `/sessions/{sid}` GET produced it for us.
       if (!isReconnect) {
+        // Sending starts a new latest turn. If the user paged into an older
+        // window, collapse the bounded cache back to its newest window first.
+        if (this.hasLaterMessages(sendSid)) {
+          const latestLoaded = await this.returnToLatest(sendSid);
+          if (!latestLoaded || this.tabState[sendSid] !== sendState) return false;
+        }
         // Trim the live backlog before growing it again — keeps long
         // sessions from ballooning the DOM past the mobile crash point.
         this._capLiveMessages(sendState);
-        sendState.messages.push({
+        this._appendLiveMessage(sendState, {
           role: "user", text,
           images: readyImages.map(im => ({
             preview: im.preview,
@@ -16858,26 +17620,13 @@ function portal() {
       // already cleared at enqueue time, and the user may have typed a
       // new draft since — don't touch their work-in-progress.
       if (!isReconnect && !resumed) {
-        const erroredImages = this.pendingImages.filter(im => im.error);
-        const erroredDocs = this.pendingDocs.filter(d => d.error);
-        if (erroredImages.length || erroredDocs.length) {
-          this.toast(this.lang === "zh"
-            ? `${erroredImages.length + erroredDocs.length} 个附件上传失败，已跳过`
-            : `${erroredImages.length + erroredDocs.length} attachment(s) failed and were skipped`,
-            "warn", 4000);
-        }
-        // Note (2026-04): previews are now data URIs from canvas.toDataURL
-        // (see _imageToThumbDataURL), not blob: URLs — they're safe to
-        // hold across reloads with no revoke needed. The only path that
-        // creates a blob URL is the img.onerror fallback, which now
-        // returns "" rather than leaking — so no sweep here is needed.
-        this.pendingImages = [];
-        this.pendingDocs = [];
-        this.input = "";
+        // Remove only the captured payload; a newer draft typed during an await
+        // stays in the still-global Phase 1 composer.
+        clearSubmittedComposer();
         this.$nextTick(() => {
+          if (this.currentId !== sendSid) return;
           const ta = this.$refs.chatInput;
           if (!ta) return;
-          this.autoGrow(ta);
           // Desktop: refocus so the user can fire off the next message
           // without re-clicking the input. Mobile: DON'T. A programmatic
           // focus here re-fires onChatInputFocus → adds body.kb-open, but
@@ -16923,6 +17672,8 @@ function portal() {
       // the "new session, first reply invisible until restart" report. Force the
       // reveal whenever we stream into the ACTIVE tab; there is nothing to
       // lazy-reveal once the user is actively sending into the pane they see.
+      streamState.messagesReady = true;
+      streamState.messagesLoading = false;
       if (streamSid === this.currentId) {
         this.messagesReady = true;
         this.messagesLoading = false;
@@ -16981,7 +17732,7 @@ function portal() {
         const elapsed = (Date.now() - streamState._streamStartedAt) / 1000;
         streamState.streamElapsed = elapsed;
         if (this.currentId === streamSid) this.streamElapsed = elapsed;
-      }, 200);
+      }, 1000);
       if (streamSid === this.currentId) this._streamTimer = streamState._streamTimer;
       if (streamSid === this.currentId) {
         this.atBottom = true;
@@ -17078,7 +17829,7 @@ function portal() {
       };
       ["text", "thinking", "tool_use", "tool_result", "task_started",
        "task_progress", "task_notification", "rate_limit", "ping",
-       "done", "error", "cancelled"].forEach(
+       "done", "error", "cancelled", "resync"].forEach(
         t => es.addEventListener(t, _bumpSse));
       if (streamState._stallWatch) clearInterval(streamState._stallWatch);
       streamState._stallWatch = setInterval(() => {
@@ -17108,6 +17859,7 @@ function portal() {
       // Scroll only if the active tab is the one receiving the stream;
       // otherwise we'd yank the user away from whatever they're reading.
       const _scrollIfActive = () => {
+        this._capLiveMessages(streamState);
         if (this.currentId !== streamSid) return;
         // Mid-stream DOM cap (root-cause fix for the mobile freeze on long
         // turns). _capLiveMessages otherwise only runs at user-send, so a
@@ -17120,11 +17872,18 @@ function portal() {
         // Gate on atBottom — the same guard scrollToBottom uses — so we
         // never evict (and visually jump) while the user has scrolled up to
         // read history. Evicted bubbles land in the "Load earlier" stash.
-        if (this.atBottom) this._capLiveMessages(streamState);
-        this.scrollToBottom(false);
+        if (this.atBottom) this.scrollToBottom(false);
       };
+      const ownsStreamState = () => this.tabState[streamSid] === streamState;
+      const ownsCurBubble = () => ownsStreamState() && !!curBubble
+        && this._containsPaneMessage(streamState, curBubble);
       const openAsst = () => {
-        if (curBubble) return;
+        if (!ownsStreamState()) return false;
+        if (ownsCurBubble()) return true;
+        // A state replacement/disposal must never leave this SSE writing into an
+        // orphan object. Reset the segment and create a new owned bubble.
+        curBubble = null;
+        acc = "";
         // Pre-declare every key the template might read so Alpine's
         // Proxy tracks them from t=0. Adding a key post-push (e.g.
         // m.elapsed in _markDone) doesn't reliably trigger x-show
@@ -17139,7 +17898,7 @@ function portal() {
           ts: null,
           elapsed: 0,
         };
-        streamState.messages.push(bubble);
+        curBubble = this._appendLiveMessage(streamState, bubble);
         // CRITICAL: pull the reactive-wrapped object back out of the
         // array, not the raw `bubble` reference. Alpine 3 (and Vue 3
         // reactivity under it) intercepts at the array level — accessing
@@ -17151,8 +17910,8 @@ function portal() {
         // initial state) but every subsequent chunk only became visible
         // after switching tabs (which forced Alpine to re-read the
         // array through the proxy).
-        curBubble = streamState.messages[streamState.messages.length - 1];
         acc = "";
+        return true;
       };
       // Throttle markdown rendering during fast token streams. mdRender
       // re-parses the FULL accumulated text every tick, so the per-render cost
@@ -17182,9 +17941,21 @@ function portal() {
       // full render (KaTeX + file-link linkify). final=false → throttled
       // in-flight tick: cheap parse+sanitize only.
       const renderNow = (final = false) => {
-        if (!curBubble) { pendingTimer = null; return; }
-        // Uncached: each `acc` is a one-shot intermediate, never reused.
-        curBubble.html = this._mdRenderUncached(acc, { streaming: !final });
+        if (!ownsCurBubble()) {
+          curBubble = null; acc = ""; pendingTimer = null; return;
+        }
+        // Beyond 32 KiB, repeatedly reparsing the full accumulated markdown is
+        // quadratic. Keep a safe x-text preview until the segment/done boundary,
+        // then perform exactly one final rich render.
+        if (!final && acc.length > 32 * 1024) {
+          curBubble._streamPlain = true;
+          curBubble.html = "";
+          streamState._streamPlainRenderCount++;
+        } else {
+          curBubble.html = this._mdRenderUncached(acc, { streaming: !final });
+          curBubble._streamPlain = false;
+          streamState._streamRichRenderCount++;
+        }
         lastRender = Date.now();
         pendingTimer = null;
         // Coalesce auto-scroll onto the throttled render tick. Scrolling on
@@ -17208,7 +17979,8 @@ function portal() {
         // final=true: this bubble is done (stream end / tool boundary), so do
         // the full render incl. KaTeX + file-path linkify that the throttled
         // ticks skipped.
-        if (curBubble) renderNow(true);
+        if (ownsCurBubble()) renderNow(true);
+        else { curBubble = null; acc = ""; }
       };
       const closeAsst = () => { flushRender(); curBubble = null; acc = ""; };
 
@@ -17221,7 +17993,17 @@ function portal() {
       const renderStreamingHtml = () => {
         // Mid-stream deferred render (selection cleared): cheap path. The
         // done-handler's flushRender does the full final pass.
-        if (curBubble) curBubble.html = this._mdRenderUncached(acc, { streaming: true });
+        if (ownsCurBubble()) {
+          if (acc.length > 32 * 1024) {
+            curBubble._streamPlain = true;
+            curBubble.html = "";
+            streamState._streamPlainRenderCount++;
+          } else {
+            curBubble.html = this._mdRenderUncached(acc, { streaming: true });
+            curBubble._streamPlain = false;
+            streamState._streamRichRenderCount++;
+          }
+        } else { curBubble = null; acc = ""; }
         streamState._pendingHtmlRender = null;
       };
       streamState._renderStreamingHtml = renderStreamingHtml;
@@ -17234,7 +18016,7 @@ function portal() {
       // ⏳ running → ✅/❌ from this. merge=true so a later progress/terminal
       // event keeps fields an earlier event already set.
       const applyTaskStatus = (toolUseId, patch, merge = true) => {
-        const msgs = streamState.messages;
+        const msgs = this._allPaneMessages(streamState);
         for (let k = msgs.length - 1; k >= 0; k--) {
           // role check is LOAD-BEARING: the tool_result bubble carries the
           // SAME toolu_xxx id as its tool_use card and sits AFTER it, so a
@@ -17262,7 +18044,7 @@ function portal() {
       es.addEventListener("text", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
-        openAsst();
+        if (!openAsst()) return;
         acc += d.text;
         curBubble.text = acc;
         // Skip the mdRender → x-html assignment while the user has an active
@@ -17292,13 +18074,13 @@ function portal() {
         // into the most recent thinking message so we see ONE block per
         // reasoning segment, not N tiny ones. If the tail isn't a thinking
         // message (e.g. previous was tool_use), start a new one.
-        const msgs = streamState.messages;
+        const msgs = this._allPaneMessages(streamState);
         const last = msgs[msgs.length - 1];
         let pushed = false;
         if (last && last.role === "thinking") {
           last.text = (last.text || "") + (d.text || "");
         } else {
-          msgs.push({ role: "thinking", text: d.text || "" });
+          this._appendLiveMessage(streamState, { role: "thinking", text: d.text || "" });
           pushed = true;
         }
 
@@ -17327,7 +18109,7 @@ function portal() {
         if (d.todos != null) msg.todos = d.todos;
         if (d.task != null) msg.task = d.task;
         if (d.plan != null) msg.plan = d.plan;
-        streamState.messages.push(msg);
+        this._appendLiveMessage(streamState, msg);
         // File-mutating tools invalidate any open preview of the same file.
         // Bump previewVersion → rawUrl picks up a new ?_v= → iframe reloads;
         // _reloadPreviewIfDirty re-fetches md/text contents inline.
@@ -17347,7 +18129,7 @@ function portal() {
         // `tool_name` lets the FE pick a renderer without scanning backwards
         // for the matching tool_use. `bash` is pre-parsed exit_code +
         // stdout/stderr when the result came from a Bash call.
-        streamState.messages.push({
+        this._appendLiveMessage(streamState, {
           role: "tool_result",
           id: d.id,
           tool_name: d.tool_name || "",
@@ -17444,7 +18226,7 @@ function portal() {
         for (const q of (d.questions || [])) {
           pendingAnswers[q.question] = q.multiSelect ? [] : null;
         }
-        streamState.messages.push({
+        this._appendLiveMessage(streamState, {
           role: "ask_user_question",
           id: d.id,
           questions: d.questions,
@@ -17460,7 +18242,7 @@ function portal() {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         closeAsst();
-        streamState.messages.push({
+        this._appendLiveMessage(streamState, {
           role: "permission_request",
           id: d.id,
           tool: d.tool,
@@ -17523,8 +18305,9 @@ function portal() {
         // jump after "done" lands would feel like a bug.
         const _now = Date.now();
         const _elapsed = streamState.streamElapsed || 0;
-        for (let k = streamState.messages.length - 1; k >= 0; k--) {
-          const m = streamState.messages[k];
+        const turnMessages = this._allPaneMessages(streamState);
+        for (let k = turnMessages.length - 1; k >= 0; k--) {
+          const m = turnMessages[k];
           if (m.role === "user") break;          // entered the previous turn
           // Skip tool blocks / standalone thinking; they're not the
           // "reply" the user reads time off.
@@ -17548,6 +18331,20 @@ function portal() {
           });
         }
       };
+      const markUserFailed = (errorText, kind, cta, retryable) => {
+        const allMessages = this._allPaneMessages(streamState);
+        for (let i = allMessages.length - 1; i >= 0; i--) {
+          const m = allMessages[i];
+          if (m.role === "user") {
+            m._failed = true;
+            m._error_kind = kind || "unknown";
+            m._error_cta = cta || "retry";
+            m._error_retryable = retryable !== false;
+            m._error_text = errorText || "";
+            break;
+          }
+        }
+      };
       es.addEventListener("done", ev => {
         flushRender();
         // Guard JSON.parse: a malformed/empty `done` payload must NOT throw
@@ -17557,7 +18354,7 @@ function portal() {
         // d.* read below is null-safe on a missing field.
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { d = {}; }
-        if (d.total_cost_usd != null && curBubble) {
+        if (d.total_cost_usd != null && ownsCurBubble()) {
           curBubble.cost = "$" + d.total_cost_usd.toFixed(4);
         }
         if (d.stats) this.stats = { ...this.stats, ...d.stats };
@@ -17605,13 +18402,14 @@ function portal() {
         // API error) arrives as a NORMAL done event with is_error=true —
         // previously rendered identically to success. Surface it.
         if (d.is_error) {
-          const _detail = (Array.isArray(d.errors) && d.errors.length)
+          const _detail = d.error || ((Array.isArray(d.errors) && d.errors.length)
             ? d.errors.join("; ")
-            : (d.result_subtype || "unknown");
-          this.toast(this.lang === "zh"
-            ? "本轮回复出错：" + _detail
-            : "Turn failed: " + _detail, "error", 6000);
-          if (curBubble) curBubble.error = _detail;
+            : (d.result_subtype || "unknown"));
+          this.toast(this._humanizeStreamError(_detail), "error", 6000);
+          if (!isContinuation) {
+            markUserFailed(_detail, d.kind, d.cta, d.retryable);
+          }
+          if (ownsCurBubble()) curBubble.error = _detail;
         }
         // Pass the backend's `cancelled` flag through to _markDone so it
         // can skip the green-dot unread cue for user-cancelled turns.
@@ -17620,7 +18418,14 @@ function portal() {
         // stop — stop closes the ES). The relevant case for this branch
         // is page-reload-then-reconnect picking up a turn that finished
         // after being cancelled before reload.
+        const continuationFinalText = isContinuation && ownsCurBubble()
+          ? (curBubble.text || "") : "";
         es.close(); _markDone(!!d.cancelled); _stopTimer();
+        if (isContinuation && !d.cancelled) {
+          this._reconcileCompletedContinuation(
+            streamSid, streamState, continuationFinalText,
+          );
+        }
         const _viewedStream = this.currentId === streamSid
           || (this.tabState && this.tabState[this.currentId] === streamState);
         if (!d.cancelled && _viewedStream) {
@@ -17644,9 +18449,13 @@ function portal() {
           // async growth — so if the user is still at the bottom, re-pin once
           // the final layout settles. Gated on atBottom so a user who scrolled
           // up to read history isn't yanked back down.
-          this.$nextTick(() => this.highlightCode(".chat-body").then(() => {
-            if (this.currentId === streamSid && this.atBottom) this.scrollToBottom(true);
-          }));
+          const finalKey = ownsCurBubble() ? curBubble._k : "";
+          this.$nextTick(() => {
+            const finalEl = this._messageElement(streamSid, finalKey);
+            this.highlightCode(".chat-body", finalEl ? [finalEl] : []).then(() => {
+              if (this.currentId === streamSid && this.atBottom) this.scrollToBottom(true);
+            });
+          });
         }
         // Auto-drain the next queued message, if any. nextTick lets
         // _markDone's streaming=false propagate before _isBusy() reads it.
@@ -17654,7 +18463,18 @@ function portal() {
         // drain will hit st.compacting=true and bail; the compact-finally
         // path will pick it up. If the queue's tab isn't the active one,
         // drain bails too and activateTab handles it on return.
-        this.$nextTick(() => this._drainPendingQueue(streamSid));
+        if (d.is_error) {
+          if (streamState.pendingQueue && streamState.pendingQueue.length > 0) {
+            streamState._queuePaused = true;
+            setTimeout(() => {
+              if (this.tabState[streamSid] === streamState) {
+                this._syncQueueFromServer(streamSid);
+              }
+            }, 800);
+          }
+        } else {
+          this.$nextTick(() => this._drainPendingQueue(streamSid));
+        }
         // If this turn left an SDK background task running (its card is still
         // ⏳), start polling /active so the server's continuation turn (card
         // flip + model auto-continue) surfaces live when the task finishes.
@@ -17663,8 +18483,33 @@ function portal() {
         // _ensureBgContPoller no-ops and the existing poller self-stops.
         this.$nextTick(() => this._ensureBgContPoller(streamSid));
       });
+      es.addEventListener("resync", ev => {
+        flushRender();
+        let reason = "replay_truncated";
+        try { reason = JSON.parse(ev.data).reason || reason; } catch (_) {}
+        streamState._canonicalResyncPending = true;
+        streamState._serverActiveObserved = true;
+        try { es.close(); } catch (_) {}
+        if (streamState._stallWatch) clearInterval(streamState._stallWatch);
+        streamState._stallWatch = null;
+        streamState.es = null;
+        if (this.currentId === streamSid) this.es = null;
+        this.toast(this.lang === "zh"
+          ? "回复数据量较大，完成后会自动从会话记录同步"
+          : "This reply exceeded the live replay window; canonical history will sync when it finishes",
+          "info", 5000);
+        this._scheduleCanonicalStreamReload(streamSid, streamState);
+        // `reason` is intentionally retained for browser diagnostics without
+        // changing user-facing retry semantics.
+        streamState._canonicalResyncReason = reason;
+      });
       es.addEventListener("error", ev => {
         flushRender();
+        // A deliberate bounded-stream resync closes EventSource and can queue
+        // a transport `error` event. Its canonical poll owns recovery; never
+        // enter the ordinary reconnect loop (which would immediately receive
+        // another resync and spin forever).
+        if (streamState._canonicalResyncPending) return;
         // Two distinct error paths share this handler:
         //   1. Server-sent `event: error` (well-formed JSON in ev.data) —
         //      a real turn failure (vendor 401, quota, 30-min timeout).
@@ -17689,23 +18534,6 @@ function portal() {
         } catch (_) {
           // ev.data missing → transport-level. Fall through to auto-retry.
         }
-        const markUserFailed = () => {
-          for (let i = streamState.messages.length - 1; i >= 0; i--) {
-            const m = streamState.messages[i];
-            if (m.role === "user") {
-              m._failed = true;
-              // Stash the classification so the FE can render a useful
-              // CTA button under the failed bubble (Open Settings on auth,
-              // Switch model on quota, Compact on cross-vendor signature).
-              m._error_kind = errKind;
-              m._error_cta = errCta;
-              m._error_retryable = errRetryable;
-              m._error_text = serverError || "";
-              break;
-            }
-          }
-        };
-
         // Benign: "no active turn" means a RECONNECT raced a turn that already
         // finished on the server (and aged past the grace-keep TTL, so it's not
         // in _recent_turns either). The reply IS persisted in the session JSONL
@@ -17723,7 +18551,9 @@ function portal() {
 
         if (serverError) {
           this.toast(this._humanizeStreamError(serverError), "error", 6000);
-          markUserFailed();
+          if (!isContinuation) {
+            markUserFailed(serverError, errKind, errCta, errRetryable);
+          }
           es.close(); _markDone(); _stopTimer();
           // Pause auto-drain — same context likely fails the next message
           // too (quota / auth / cross-vendor signature). The failed user
@@ -17734,7 +18564,11 @@ function portal() {
             // finally (Task 3) when an errored turn has items waiting. Show
             // the banner now, reconcile with server truth a beat later.
             streamState._queuePaused = true;
-            setTimeout(() => this._syncQueueFromServer(streamSid), 800);
+            setTimeout(() => {
+              if (this.tabState[streamSid] === streamState) {
+                this._syncQueueFromServer(streamSid);
+              }
+            }, 800);
           }
           return;
         }
@@ -17753,14 +18587,18 @@ function portal() {
                       ? "和 Muse 的连接断开了，重试一下"
                       : "Lost connection to Muse — try again",
                       "error");
-          markUserFailed();
+          if (!isContinuation) markUserFailed();
           _markDone(); _stopTimer();
           if (streamState.pendingQueue && streamState.pendingQueue.length > 0) {
             // Optimistic — the server also pauses the queue in the turn's
             // finally (Task 3) when an errored turn has items waiting. Show
             // the banner now, reconcile with server truth a beat later.
             streamState._queuePaused = true;
-            setTimeout(() => this._syncQueueFromServer(streamSid), 800);
+            setTimeout(() => {
+              if (this.tabState[streamSid] === streamState) {
+                this._syncQueueFromServer(streamSid);
+              }
+            }, 800);
           }
           return;
         }
@@ -17823,7 +18661,7 @@ function portal() {
                           ? "和 Muse 的连接断开了，重试一下"
                           : "Lost connection to Muse — try again",
                           "error");
-              markUserFailed();
+              if (!isContinuation) markUserFailed();
             } else {
               // Schedule next retry ourselves since no new ES error will fire.
               setTimeout(() => {
@@ -17848,7 +18686,11 @@ function portal() {
           // Optimistic — the server pauses on an explicit interrupt too
           // (broadcast.cancelled → finally pauses the queue). Reconcile after.
           streamState._queuePaused = true;
-          setTimeout(() => this._syncQueueFromServer(streamSid), 800);
+          setTimeout(() => {
+              if (this.tabState[streamSid] === streamState) {
+                this._syncQueueFromServer(streamSid);
+              }
+            }, 800);
         }
       });
       // NOTE: errors are owned exclusively by the addEventListener("error")
@@ -17860,45 +18702,81 @@ function portal() {
       // turn to "done" (input re-enabled, footer stamped, unread dot) ~800ms
       // before the reconnect restored streaming. Removing it stops that flicker.
     },
-    stop() {
-      // Two-stage stop:
-      //   1. If the pending queue is non-empty, pop the TAIL (the
-      //      most-recently enqueued message) and toast what was removed.
-      //      The current streaming turn is left alone — the assumption
-      //      is "I just typed something I want to take back, but keep
-      //      the reply that's already running."
-      //   2. Once the queue is empty, the same button interrupts the
-      //      in-flight turn (the original stop behaviour).
-      // The button title swaps to communicate which action will fire.
+    async stop() {
+      // Stop has exactly one meaning: interrupt the active turn for the current
+      // session. Queued messages keep their independent edit/delete actions.
       const sid = this.currentId;
+      if (!sid || !this.isTabStreaming(sid)) return;
       const st = this._ensureTabState(sid);
-      if (st && st.pendingQueue && st.pendingQueue.length > 0) {
-        const lastIdx = st.pendingQueue.length - 1;
-        const removed = st.pendingQueue[lastIdx];
-        // Server-backed delete of the tail item (DELETE by id → re-sync).
-        // removePendingQueueItem reads the item at lastIdx, so don't splice
-        // the mirror first — let the re-sync inside it update the display.
-        this.removePendingQueueItem(sid, lastIdx);
-        const preview = (removed.text || "").trim().slice(0, 40);
+      if (st._stopping) return;
+      st._stopping = true;
+      if (st.pendingQueue && st.pendingQueue.length > 0) st._queuePaused = true;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 15000);
+      try {
+        const r = await fetch(
+          "/api/chat/interrupt?session_id=" + encodeURIComponent(sid),
+          { method: "POST", headers: this.hdr(), signal: controller.signal },
+        );
+        if (!r.ok) throw new Error("interrupt failed");
+        let stopResult = {};
+        try { stopResult = await r.json(); } catch (_) { stopResult = {}; }
+        const hasInterruptedList = Array.isArray(stopResult.interrupted);
+        // Claude clients are keyed as "session@model" in the pool, while older
+        // backends returned the bare session id. Accept both response shapes.
+        const didInterrupt = !hasInterruptedList || stopResult.interrupted.some(
+          item => item === sid || String(item).startsWith(sid + "@"),
+        );
+        if (this.tabState[sid] !== st) return;
+        if (!didInterrupt) {
+          // An empty interrupted list means the SDK client was detached or its
+          // best-effort interrupt failed. The backend watchdog is now forcing the
+          // turn down; keep the EventSource/Stop control alive until its terminal
+          // event arrives instead of falsely presenting an idle session.
+          this.toast(this.lang === "zh" ? "正在强制中断当前会话…"
+                                        : "Forcing the current session to stop…",
+                     "warn", 2500);
+          return;
+        }
+
+        // Flush selection-deferred text before retiring the EventSource, then use
+        // the shared lifecycle cleanup so reconnect counters/timers cannot leak
+        // into the next turn.
+        if (st._renderStreamingHtml) st._renderStreamingHtml();
+        const now = Date.now();
+        const clockElapsed = st._streamStartedAt
+          ? (now - st._streamStartedAt) / 1000 : 0;
+        const elapsed = Math.max(0, Number(st.streamElapsed) || 0,
+          Number.isFinite(clockElapsed) ? clockElapsed : 0);
+        this._retireStaleSessionStream(sid, st);
+        st._renderStreamingHtml = null;
+        st._pendingHtmlRender = null;
+        for (let i = st.messages.length - 1; i >= 0; i--) {
+          const message = st.messages[i];
+          if (!message) continue;
+          if (message.role === "user") break;
+          if (message.role !== "assistant") continue;
+          if (!message.ts) message.ts = now;
+          if (!message.elapsed && elapsed >= 1) message.elapsed = elapsed;
+          break;
+        }
+        const session = (this.sessions || []).find(s => s.id === sid);
+        if (session) session.active = false;
+        this.toast(this.lang === "zh" ? "已中断当前会话" : "Session interrupted",
+                   "warn", 2000);
+      } catch (_e) {
         this.toast(this.lang === "zh"
-                    ? `已撤回队列最后一条：${preview}…`
-                    : `Removed last queued: ${preview}…`,
-                    "info", 2200);
-        return;
+                    ? "停止失败，当前会话仍在运行"
+                    : "Could not stop; the session is still running",
+                   "error", 3000);
+      } finally {
+        clearTimeout(timeout);
+        if (this.tabState[sid] === st) {
+          st._stopping = false;
+          this._syncQueueFromServer(sid);
+        }
+        setTimeout(() => this.refreshSessions(), 800);
       }
-      // Queue empty — interrupt the active turn (original behaviour).
-      // Backend uses SDK's client.interrupt() — keeps the client / CLI
-      // subprocess alive so the next message continues the same
-      // conversation without reloading CLAUDE.md / MCP / system prompt.
-      if (st.es) { try { st.es.close(); } catch {} st.es = null; }
-      st.streaming = false;
-      this.streaming = false; this.es = null;
-      if (st._streamTimer) { clearInterval(st._streamTimer); st._streamTimer = null; }
-      this._streamTimer = null; this.streamElapsed = 0;
-      // Token via header (not query) so it stays out of access / proxy logs
-      // and history. /interrupt accepts header-or-query backend-side.
-      fetch("/api/chat/interrupt?session_id=" + encodeURIComponent(sid),
-            { method: "POST", headers: this.hdr() });
     },
 
     // ====== ask_user_question UI helpers ======
@@ -18099,6 +18977,7 @@ function portal() {
 
     retryFailedMessage(m) {
       if (!m || m.role !== "user" || !m._failed) return;
+      if (this.workspaceSwitching) return;
       // Drop the failed bubble, put text back in input, and send.
       const idx = this.messages.indexOf(m);
       if (idx >= 0) this.messages.splice(idx, 1);
@@ -18147,7 +19026,7 @@ function portal() {
     },
 
     commitEditMessage(m) {
-      if (!m) return;
+      if (!m || this.workspaceSwitching) return;
       const newText = (m._editText || "").trim();
       if (!newText) return;
       m._editing = false;
@@ -18179,12 +19058,14 @@ function portal() {
         return zh ? "请求频率超限，等几秒再试" : "Rate limit hit — wait a few seconds";
       if (/quota|credit|insufficient.*balance/i.test(s))
         return zh ? "账户额度不足，去 vendor 控制台充值" : "Out of credit — top up at vendor console";
+      if (/unknown provider|provider not found|unsupported provider|no provider for model/i.test(s))
+        return zh ? "子 Agent 使用了当前 Gateway 不支持的模型，请切换模型" : "Subagent model is unsupported by this gateway — switch model";
+      if (/context window|context.*length|input exceeds|input tokens exceed|maximum.*tokens|prompt.*too long|request too large|too many tokens/i.test(s))
+        return zh ? "对话已超过上下文窗口，请压缩；若压缩失败则恢复到较早分支" : "Context window exceeded — compact, or recover an earlier branch if compact fails";
       if (/timeout|timed out/i.test(s))
         return zh ? "请求超时，可能模型在长上下文上忙，重试一下" : "Timed out — retry";
       if (/network|connection|ECONNREFUSED|fetch/i.test(s))
         return zh ? "网络断开，检查连接后重试" : "Network down — check connection";
-      if (/context.*length|maximum.*tokens|too long/i.test(s))
-        return zh ? "对话太长了，先压缩历史再试" : "Conversation too long — compact then retry";
       if (/already in use/i.test(s))
         return zh ? "session 还被上一次的 CLI 占着 — 等几秒再试或切回原模型" : "Session still locked by previous CLI — wait a moment or switch model back";
       if (/Command failed with exit code|ProcessError/i.test(s))
@@ -18276,18 +19157,23 @@ function portal() {
       await this.openTab(sid);
       if (this.currentId !== sid) return;
       // openTab fires loadSession async — give it a tick or two to render.
-      for (let i = 0; i < 20; i++) {
-        await new Promise(r => setTimeout(r, 50));
-        if (this.currentId !== sid) return;
+      const scroll = () => {
         const body = this.$refs && this.$refs.chatBody;
         const target = body && body.querySelector(
           `.msg[data-uuid="${CSS.escape(uuid)}"]`);
-        if (target) {
-          target.scrollIntoView({ behavior: "smooth", block: "center" });
-          target.classList.add("msg-highlight");
-          setTimeout(() => target.classList.remove("msg-highlight"), 2400);
-          return;
-        }
+        if (!target) return false;
+        target.scrollIntoView({ behavior: "smooth", block: "center" });
+        target.classList.add("msg-highlight");
+        setTimeout(() => target.classList.remove("msg-highlight"), 2400);
+        return true;
+      };
+      for (let i = 0; i < 6; i++) {
+        await new Promise(r => setTimeout(r, 50));
+        if (this.currentId !== sid) return;
+        if (scroll()) return;
+      }
+      if (await this._loadAroundMessage(sid, uuid)) {
+        this.$nextTick(() => scroll());
       }
     },
     // Fetch files matching the current palette query against the whole
@@ -18920,10 +19806,11 @@ function portal() {
           // did nothing" mystery (previously: silent return on r.ok=false).
           let body = "";
           try { body = await r.text(); } catch (_) {}
-          this.toast(
-            (zh ? "删除失败 HTTP " : "Delete failed HTTP ")
-              + r.status + (body ? ": " + body.slice(0, 200) : ""),
-            "error", 5000);
+          const prefix = r.status === 409
+            ? (zh ? "任务仍在结束，请稍后重试" : "The task is still stopping; retry shortly")
+            : ((zh ? "删除失败 HTTP " : "Delete failed HTTP ") + r.status);
+          this.toast(prefix + (body ? ": " + body.slice(0, 200) : ""),
+                     "error", 5000);
           return;
         }
         if (this.scheduler.draft.editingId === t.id) this._resetSchedDraft();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1685,10 +1685,12 @@
                correct; hidden panes are display:none so their (stale)
                result is never seen. -->
           <template x-for="tid in residentPaneIds()" :key="tid">
-          <div class="msg-pane" x-show="tid === currentId">
-          <template x-for="(m, i) in paneMessages(tid)" :key="m._k || m.uuid || ('m-' + i)">
-            <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i) ? '' : ' is-hidden') + (m._noAnim ? ' no-anim' : '')"
-                 :data-uuid="m.uuid || ''"
+          <div class="msg-pane" x-show="tid === currentId"
+               :data-tid="tid"
+               x-data="{ get pane(){ return paneState(tid) }, get paneMsgs(){ return paneMessages(tid) } }">
+          <template x-for="(m, i) in paneMsgs" :key="m._k">
+            <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i, paneMsgs) ? '' : ' is-hidden') + (m._noAnim ? ' no-anim' : '')"
+                 :data-uuid="m.uuid || ''" :data-message-key="m._k"
                  :style="'contain-intrinsic-size: auto ' + estIntrinsicH(m) + 'px'">
               <!-- compact-summary pill -->
               <template x-if="m._is_compact_summary">
@@ -1772,7 +1774,7 @@
                       <svg x-show="!m._copied"><use href="#i-copy"/></svg>
                       <svg x-show="m._copied"><use href="#i-check"/></svg>
                     </button>
-                    <button x-show="!streaming && !m._editing"
+                    <button x-show="pane && !pane.streaming && !m._editing"
                             @click="startEditMessage(m)" class="icon-btn sm"
                             :title="t('btn.edit')">
                       <svg><use href="#i-edit"/></svg>
@@ -1815,13 +1817,15 @@
                 <div class="asst-msg-wrap">
                   <div class="msg-row">
                     <span class="msg-avatar assistant-avatar"
-                          :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                          :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                           :title="mascotLabel()">
                       <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                     </span>
                     <div class="bubble"
-                         :class="{ 'is-streaming-bubble': streaming && i === messages.length - 1 }"
-                         x-html="m.html || ''"></div>
+                         :class="{ 'is-streaming-bubble': pane && pane.streaming && i === paneMsgs.length - 1 }">
+                      <div x-show="m._streamPlain" class="stream-plain" x-text="m.text || ''"></div>
+                      <div x-show="!m._streamPlain" x-html="m.html || ''"></div>
+                    </div>
                   </div>
                   <!-- Per-bubble footer removed. Time + streaming dots
                        are rendered once per turn in the turn-footer
@@ -1849,24 +1853,24 @@
               <template x-if="m.role === 'thinking'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
-                  <div :class="thinkingClass(i, m)">
+                  <div :class="thinkingClass(i, m, pane, paneMsgs)">
                     <div class="thinking-head"
                          @click.stop="toggleMsgExpanded(m, i)"
                          :title="lang==='zh' ? '点击展开/折叠' : 'Click to expand / collapse'">
                       <span class="thinking-chevron">
                         <svg viewBox="0 0 16 16" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2">
-                          <path :d="isMsgExpanded(i, m) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
+                          <path :d="isMsgExpanded(i, m, false, pane, paneMsgs) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
                         </svg>
                       </span>
                       <span class="icon"><svg><use href="#i-brain"/></svg></span>
                       <span class="thinking-label-text">thinking</span>
-                      <span x-show="!isMsgExpanded(i, m)" class="thinking-preview" x-text="thinkingPreview(m)"></span>
+                      <span x-show="!isMsgExpanded(i, m, false, pane, paneMsgs)" class="thinking-preview" x-text="thinkingPreview(m)"></span>
                     </div>
-                    <pre x-show="isMsgExpanded(i, m)" x-text="m.text"></pre>
+                    <pre x-show="isMsgExpanded(i, m, false, pane, paneMsgs)" x-text="m.text"></pre>
                   </div>
                 </div>
               </template>
@@ -1875,7 +1879,7 @@
               <template x-if="m.role === 'tool_use' && m.name === 'TodoWrite'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1907,7 +1911,7 @@
               <template x-if="m.role === 'tool_use' && (m.name === 'Task' || m.name === 'Agent')">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1957,7 +1961,7 @@
               <template x-if="m.role === 'tool_use' && m.name === 'ExitPlanMode'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -1991,7 +1995,7 @@
               <template x-if="m.role === 'tool_use' && m.name !== 'TodoWrite' && m.name !== 'Task' && m.name !== 'Agent' && m.name !== 'ExitPlanMode' && !isTaskTool(m)">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -2074,11 +2078,11 @@
                    filter for. -->
               <template x-if="m.role === 'tool_use' && ['Edit','MultiEdit','Write'].includes(m.name) && m.input && (m.input.old_string || m.input.new_string || m.input.edits || m.input.content)">
                 <div class="diff-strip diff-strip-cr"
-                     :class="{ 'is-collapsed': !isMsgExpanded(i, m, isLatestEditTool(i, m)) }">
+                     :class="{ 'is-collapsed': !isMsgExpanded(i, m, isLatestEditTool(i, m, paneMsgs, tid), pane, paneMsgs) }">
                   <div class="diff-strip-head" @click.stop="toggleMsgExpanded(m, i)">
                     <span class="thinking-chevron">
                       <svg viewBox="0 0 16 16" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2">
-                        <path :d="isMsgExpanded(i, m, isLatestEditTool(i, m)) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
+                        <path :d="isMsgExpanded(i, m, isLatestEditTool(i, m, paneMsgs, tid), pane, paneMsgs) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
                       </svg>
                     </span>
                     <span class="diff-strip-label" x-text="lang==='zh' ? '改动预览' : 'diff'"></span>
@@ -2091,7 +2095,7 @@
                       </span>
                     </template>
                   </div>
-                  <div x-show="isMsgExpanded(i, m, isLatestEditTool(i, m))" class="diff-body diff-body-cr">
+                  <div x-show="isMsgExpanded(i, m, isLatestEditTool(i, m, paneMsgs, tid), pane, paneMsgs)" class="diff-body diff-body-cr">
                     <template x-for="(op, oi) in editDiffOps(m)" :key="oi">
                       <div :class="'diff-line diff-' + op.op">
                         <span class="diff-sign" x-text="op.op === 'ins' ? '+' : op.op === 'del' ? '−' : op.op === 'sep' ? '⋯' : ' '"></span>
@@ -2112,27 +2116,27 @@
               <template x-if="m.role === 'tool_result' && !shouldHideToolResult(m)">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
-                  <div :class="toolResultClass(i, m)">
+                  <div :class="toolResultClass(i, m, pane, paneMsgs)">
                     <div class="tool-result-head"
                          @click.stop="toggleMsgExpanded(m, i)"
                          :title="lang==='zh' ? '点击展开/折叠' : 'Click to expand / collapse'">
                       <span class="thinking-chevron">
                         <svg viewBox="0 0 16 16" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2">
-                          <path :d="isMsgExpanded(i, m) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
+                          <path :d="isMsgExpanded(i, m, false, pane, paneMsgs) ? 'M4 6l4 4 4-4' : 'M6 4l4 4-4 4'"/>
                         </svg>
                       </span>
-                      <span x-show="!isMsgExpanded(i, m)" class="tool-result-summary"
-                            x-text="toolResultSummary(m, i)"></span>
+                      <span x-show="!isMsgExpanded(i, m, false, pane, paneMsgs)" class="tool-result-summary"
+                            x-text="toolResultSummary(m, i, paneMsgs)"></span>
                     </div>
                     <!-- Error hint banner — shown for failed tool calls when
                          we can detect a common pattern + give a fix. Only
                          visible when the user explicitly expands the result;
                          collapsed state should stay quiet. -->
-                    <template x-if="m.is_error && errorFixHint(m) && isMsgExpanded(i, m)">
+                    <template x-if="m.is_error && errorFixHint(m) && isMsgExpanded(i, m, false, pane, paneMsgs)">
                       <div class="tool-error-hint">
                         <span class="tool-error-hint-icon">💡</span>
                         <span class="tool-error-hint-text" x-text="errorFixHint(m)"></span>
@@ -2140,7 +2144,7 @@
                     </template>
                     <!-- expanded body: per-tool renderer takes precedence,
                          falls back to plain text for unknown tool types -->
-                    <template x-if="isMsgExpanded(i, m)">
+                    <template x-if="isMsgExpanded(i, m, false, pane, paneMsgs)">
                       <div class="tool-result-body">
                         <!-- Bash: terminal-style w/ stdout / stderr split -->
                         <template x-if="toolResultKind(m) === 'bash'">
@@ -2177,19 +2181,19 @@
                         <!-- WebFetch / WebSearch: card w/ source badge on top -->
                         <template x-if="toolResultKind(m) === 'web'">
                           <div class="web-card">
-                            <template x-if="findToolUseFor(m, i) && webSourceUrl(findToolUseFor(m, i))">
+                            <template x-if="findToolUseFor(m, i, paneMsgs) && webSourceUrl(findToolUseFor(m, i, paneMsgs))">
                               <div class="web-source">
                                 <span class="web-source-icon"
-                                      x-text="webIsUrl(webSourceUrl(findToolUseFor(m, i))) ? '🔗' : '🔍'"></span>
-                                <template x-if="webIsUrl(webSourceUrl(findToolUseFor(m, i)))">
+                                      x-text="webIsUrl(webSourceUrl(findToolUseFor(m, i, paneMsgs))) ? '🔗' : '🔍'"></span>
+                                <template x-if="webIsUrl(webSourceUrl(findToolUseFor(m, i, paneMsgs)))">
                                   <a class="web-source-link"
-                                     :href="webSourceUrl(findToolUseFor(m, i))"
+                                     :href="webSourceUrl(findToolUseFor(m, i, paneMsgs))"
                                      target="_blank" rel="noopener"
-                                     x-text="webSourceDomain(webSourceUrl(findToolUseFor(m, i)))"></a>
+                                     x-text="webSourceDomain(webSourceUrl(findToolUseFor(m, i, paneMsgs)))"></a>
                                 </template>
-                                <template x-if="!webIsUrl(webSourceUrl(findToolUseFor(m, i)))">
+                                <template x-if="!webIsUrl(webSourceUrl(findToolUseFor(m, i, paneMsgs)))">
                                   <span class="web-source-query"
-                                        x-text="webSourceUrl(findToolUseFor(m, i))"></span>
+                                        x-text="webSourceUrl(findToolUseFor(m, i, paneMsgs))"></span>
                                 </template>
                               </div>
                             </template>
@@ -2272,7 +2276,7 @@
               <template x-if="m.role === 'ask_user_question'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -2375,7 +2379,7 @@
               <template x-if="m.role === 'permission_request'">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
-                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i) }"
+                        :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
                         :title="mascotLabel()">
                     <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
                   </span>
@@ -2429,19 +2433,19 @@
                    messages.length) directly — method calls aren't
                    guaranteed to wire up reactivity inside x-for. -->
               <div class="turn-footer"
-                   x-show="m.role !== 'user' && (i === messages.length - 1 || (messages[i + 1] && messages[i + 1].role === 'user'))"
+                   x-show="m.role !== 'user' && (i === paneMsgs.length - 1 || (paneMsgs[i + 1] && paneMsgs[i + 1].role === 'user'))"
                    aria-hidden="true">
-                <span x-show="streaming && i === messages.length - 1"
+                <span x-show="pane && pane.streaming && i === paneMsgs.length - 1"
                       class="thinking-dots">
                   <span></span><span></span><span></span>
                 </span>
                 <!-- Elapsed counter next to the streaming dots — kicks in
                      after 1s so fast replies don't flash a "0s" label.
                      Format: 12s / 2m50s / 1h05m (see fmtStreamElapsed). -->
-                <span x-show="streaming && i === messages.length - 1 && streamElapsed >= 1"
+                <span x-show="pane && pane.streaming && i === paneMsgs.length - 1 && pane.streamElapsed >= 1"
                       class="stream-elapsed"
-                      x-text="fmtStreamElapsed(streamElapsed)"></span>
-                <span x-show="m.ts && !(streaming && i === messages.length - 1)"
+                      x-text="fmtStreamElapsed((pane && pane.streamElapsed) || 0)"></span>
+                <span x-show="m.ts && !(pane && pane.streaming && i === paneMsgs.length - 1)"
                       class="msg-ts" :title="m.model || ''"
                       x-text="fmtTurnTime(m.ts)"></span>
                 <!-- Total elapsed kept after done so the user can
@@ -2449,7 +2453,7 @@
                      for long agentic runs). Stamped in _markDone next
                      to .ts; only shown when both exist and m.elapsed
                      >= 1s (sub-second replies don't need the noise). -->
-                <span x-show="m.elapsed && m.ts && !(streaming && i === messages.length - 1)"
+                <span x-show="m.elapsed && m.ts && !(pane && pane.streaming && i === paneMsgs.length - 1)"
                       class="msg-elapsed"
                       x-text="'· ' + fmtStreamElapsed(m.elapsed)"></span>
               </div>
@@ -2457,6 +2461,13 @@
           </template>
           </div>
           </template>
+          <div x-show="messagesReady && hasLaterMessages()" class="load-later-wrap">
+            <button class="load-earlier-btn" @click="loadLaterMessages()"
+                    x-text="lang==='zh' ? '加载较新消息（' + laterMessageCount() + '）' : 'Load newer (' + laterMessageCount() + ')'">
+            </button>
+            <button class="load-earlier-btn latest" @click="returnToLatest()"
+                    x-text="lang==='zh' ? '回到最新' : 'Back to latest'"></button>
+          </div>
           <!-- /P1 per-tab message panes. Siblings below (pending bubble,
                pending queue, banners) stay single-instance with active-tab
                semantics — they read currentId / this.messages / streaming,
@@ -2749,7 +2760,8 @@
                actually gets inlined; unsupported types are rejected with
                a clear toast instead of being hidden in the picker. -->
           <input type="file" x-ref="attachInput"
-                 multiple style="display:none" @change="onAttachPicked($event)" />
+                 multiple style="display:none" :disabled="workspaceSwitching"
+                 @change="onAttachPicked($event)" />
           <!-- No-provider gate banner: when no model is configured the
                composer below is disabled (every send would 401 + lock the
                session to an unreachable model). Point the user at Settings
@@ -2780,7 +2792,7 @@
           <form autocomplete="off" onsubmit="return false" style="display:contents">
           <textarea x-model="input" x-ref="chatInput"
                     rows="1"
-                    :disabled="!availableModels.length"
+                    :disabled="!availableModels.length || workspaceSwitching"
                     class="chat-input-textarea"
                     name="muselab-chat-message"
                     inputmode="text"
@@ -2807,6 +2819,7 @@
                  the running turn). -->
             <button @click="$refs.attachInput.click()"
                     class="chat-toolbar-btn"
+                    :disabled="workspaceSwitching"
                     :title="t('attach.title')">
               <svg><use href="#i-paperclip"/></svg>
             </button>
@@ -2972,20 +2985,18 @@
                  shows while streaming. Same shape + size + fill — they
                  read as a sibling pair (blue send / red stop). -->
             <button @click="send()"
-                    :disabled="!availableModels.length || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingImages.length && !pendingDocs.length)"
+                    :disabled="workspaceSwitching || !availableModels.length || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingImages.length && !pendingDocs.length)"
                     class="btn-primary chat-toolbar-send chat-toolbar-queue"
-                    :title="streaming ? t('queue.button_hint') : t('btn.send')">
+                    :title="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')">
               <span class="icon"><svg><use href="#i-send"/></svg></span><span x-text="t('btn.send')"></span>
               <span class="chat-toolbar-queue-badge"
                     x-show="_currentQueueLen() > 0"
                     x-text="_currentQueueLen()"></span>
             </button>
-            <button x-show="streaming" @click="stop()" class="btn-danger chat-toolbar-send"
-                    :title="_currentQueueLen() > 0
-                              ? (lang==='zh'
-                                  ? '撤回队尾（队列 ' + _currentQueueLen() + ' 条）'
-                                  : 'Pop last queued (' + _currentQueueLen() + ' waiting)')
-                              : (t('btn.stop') + ' (Esc)')">
+            <button x-show="isTabStreaming(currentId)" @click="stop()"
+                    class="btn-danger chat-toolbar-send chat-toolbar-stop"
+                    :disabled="workspaceSwitching || !!(tabState[currentId] && tabState[currentId]._stopping)"
+                    :title="t('btn.stop') + ' (Esc)'">
               <span class="icon"><svg><use href="#i-square"/></svg></span><span x-text="t('btn.stop')"></span>
             </button>
           </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3166,6 +3166,18 @@ pre.text {
   flex-direction: column;
   gap: var(--sp-2);
 }
+.load-later-wrap {
+  display: flex;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding-block: var(--sp-2);
+}
+.load-later-wrap .latest { font-weight: 600; }
+.stream-plain {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: inherit;
+}
 .msg {
   display: flex;
   flex-direction: column;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -165,6 +165,7 @@ def _route_windowed_session(page: Page, sid: str, messages: list[dict]) -> list[
                 "offset": offset,
                 "total": total,
                 "has_more": offset > 0,
+                "history_generation": "gen-e2e-1",
             }),
         )
 
@@ -270,7 +271,7 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
           model: "e2e-model", permission: "bypassPermissions", thinking: true,
         }));
         app.openTabIds = sessionIds.slice();
-        app._MAX_RESIDENT_PANES = 4;
+        app._MAX_RESIDENT_PANES = 2;
         app._residentTabIds = sessionIds.slice(0, 4);
         app.tabState = {};
         for (const [idx, id] of sessionIds.entries()) {
@@ -288,6 +289,8 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
             });
           }
           app.tabState[id] = st;
+          app._ensureTabState(id);
+          app._capLiveMessages(st);
         }
         app.currentId = sessionIds[0];
         app.messagesReady = true;
@@ -304,7 +307,7 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
         """() => {
           const panes = Array.from(document.querySelectorAll(".msg-pane"))
             .filter(p => getComputedStyle(p).display !== "none");
-          return panes.length === 1 && panes[0].querySelectorAll(".msg").length === 90;
+          return panes.length === 1 && panes[0].querySelectorAll(".msg").length === 60;
         }""",
         timeout=5000,
     )
@@ -329,7 +332,7 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
                   const panes = Array.from(document.querySelectorAll(".msg-pane"))
                     .filter(p => getComputedStyle(p).display !== "none");
                   return panes.some(p => p.textContent.includes(expected)
-                    && p.querySelectorAll(".msg").length === 90);
+                    && p.querySelectorAll(".msg").length === 60);
                 }""",
                 arg=expected_tail,
                 timeout=5000,
@@ -352,10 +355,10 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
             )
             raise AssertionError(f"target tail not visible: {expected_tail}; diag={diag}") from exc
         snap = _visible_pane_with_text_snapshot(page, expected_tail)
-        assert snap["msgCount"] == 90
+        assert snap["msgCount"] <= 60
         assert expected_tail in snap["text"]
-        assert page.locator(".msg-pane").count() <= 4
-        assert _app_eval(page, "return app.residentPaneIds().length;") <= 4
+        assert page.locator(".msg-pane").count() <= 1
+        assert _app_eval(page, "return app.residentPaneIds().length;") <= 1
 
     _assert_no_browser_errors(page, errors)
 
@@ -391,6 +394,7 @@ def test_mobile_windowed_load_session_pages_older_history(page: Page, backend_ur
         return {
           messages: st.messages.length,
           earlier: st._earlierMessages.length,
+          later: st._laterMessages.length,
           loadedOffset: st._loadedOffset,
           total: st._total,
           hasMore: st._hasMoreHistory,
@@ -402,26 +406,25 @@ def test_mobile_windowed_load_session_pages_older_history(page: Page, backend_ur
         sid,
     )
     assert requests and requests[0]["tail"] == 75
-    assert state["messages"] < 75
-    assert state["messages"] <= 75
+    assert state["messages"] <= 60
     assert state["loadedOffset"] == 105
     assert state["total"] == 180
     assert state["hasMore"] is True
-    assert state["resident"] <= 4
+    assert state["resident"] <= 1
     assert "WINDOW_MSG_179" in state["bodyText"]
     assert "WINDOW_MSG_000" not in state["bodyText"]
-    assert page.locator(".msg-pane").count() <= 4
+    assert page.locator(".msg-pane").count() <= 1
     assert page.locator(".msg-pane:visible .msg").count() <= 75
 
-    # Drain the tail-local stash, then force the server-backed older window.
-    # Mobile intentionally uses a smaller load-more batch to keep each tap
-    # responsive, so avoid coupling this regression check to an exact tap count.
-    for _ in range(10):
+    # Traverse all the way through a history larger than the memory cap. The
+    # window must slide backward (evicting far-future bubbles) until message 0
+    # is mounted; the old implementation stopped forever at the first cap.
+    for _ in range(24):
         _app_eval(page, "return app.loadEarlierMessages(arg);", sid)
         page.wait_for_timeout(50)
         if _app_eval(
             page,
-            """return app.messages.some(m => (m.text || "").includes("WINDOW_MSG_100"));""",
+            """return app.messages.some(m => (m.text || "").includes("WINDOW_MSG_000"));""",
         ):
             break
 
@@ -429,7 +432,7 @@ def test_mobile_windowed_load_session_pages_older_history(page: Page, backend_ur
         """() => {
           const app = document.querySelector("#app")._x_dataStack[0];
           return app.messagesReady === true
-            && app.messages.some(m => (m.text || "").includes("WINDOW_MSG_100"));
+            && app.messages.some(m => (m.text || "").includes("WINDOW_MSG_000"));
         }""",
         timeout=10000,
     )
@@ -440,9 +443,12 @@ def test_mobile_windowed_load_session_pages_older_history(page: Page, backend_ur
         return {
           messages: st.messages.length,
           earlier: st._earlierMessages.length,
+          later: st._laterMessages.length,
           loadedOffset: st._loadedOffset,
           total: st._total,
           hasMore: st._hasMoreHistory,
+          hasServerLater: st._hasServerLater,
+          cached: st.messages.length + st._earlierMessages.length + st._laterMessages.length,
           ready: app.messagesReady,
           visibleText: Array.from(document.querySelectorAll(".msg-pane"))
             .filter(p => getComputedStyle(p).display !== "none")
@@ -452,30 +458,269 @@ def test_mobile_windowed_load_session_pages_older_history(page: Page, backend_ur
         """,
         sid,
     )
-    assert any(req["offset"] == 0 and req["limit"] == 105 for req in requests), requests
+    assert any(req["offset"] == 0 for req in requests), requests
+    assert any("history_generation=gen-e2e-1" in req["url"] for req in requests[1:]), requests
     assert final_state["loadedOffset"] == 0
     assert final_state["total"] == 180
     assert final_state["ready"] is True
     assert final_state["bodyHeight"] > 100
-    assert "WINDOW_MSG_100" in final_state["visibleText"]
+    assert "WINDOW_MSG_000" in final_state["visibleText"]
+    assert final_state["messages"] <= 60
+    assert final_state["cached"] <= 120
+    assert final_state["later"] > 0
+    assert final_state["hasServerLater"] is True
     latest_after_load_earlier = _app_eval(
         page,
         """
+        const st = app._ensureTabState(arg);
         return {
-          latestInMessages: app.messages.some(m => (m.text || "").includes("WINDOW_MSG_179")),
+          latestInMessages: st.messages.some(m => (m.text || "").includes("WINDOW_MSG_179")),
+          latestInLater: st._laterMessages.some(m => (m.text || "").includes("WINDOW_MSG_179")),
           latestInDom: document.querySelector(".chat-body")?.textContent.includes("WINDOW_MSG_179"),
-          ready: app.messagesReady,
+          hasServerLater: st._hasServerLater,
+          ready: st.messagesReady,
         };
         """,
+        sid,
     )
     assert latest_after_load_earlier == {
-        "latestInMessages": True,
-        "latestInDom": True,
+        "latestInMessages": False,
+        "latestInLater": False,
+        "latestInDom": False,
+        "hasServerLater": True,
         "ready": True,
     }
-    assert page.locator(".msg-pane").count() <= 4
-    assert page.locator(".msg-pane:visible .msg").count() <= 100
+    _app_eval(page, "app.returnToLatest(arg); return true;", sid)
+    page.wait_for_function(
+        """() => Array.from(document.querySelectorAll('.msg-pane'))
+          .filter(p => getComputedStyle(p).display !== 'none')
+          .some(p => p.textContent.includes('WINDOW_MSG_179'))""",
+        timeout=5000,
+    )
+    assert _app_eval(page, "return app._ensureTabState(arg)._laterMessages.length;", sid) == 0
+    assert page.locator(".msg-pane").count() <= 1
+    assert page.locator(".msg-pane:visible .msg").count() <= 60
 
+    _assert_no_browser_errors(page, errors)
+
+
+def test_outline_around_conflict_retries_and_returns_to_real_tail(
+    page: Page, backend_url, auth_token,
+):
+    """A stale outline generation retries its target and preserves full order."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 390, "height": 844})
+    sid = "perf-around-conflict"
+    target_uuid = "around-target"
+    calls: list[dict] = []
+    around_messages = _make_mixed_messages(85, "AROUND_MSG")
+    around_messages[70] = {
+        "role": "user",
+        "text": "AROUND_TARGET_VISIBLE",
+        "uuid": target_uuid,
+        "ts": 1_700_020_070,
+    }
+    latest_messages = _make_mixed_messages(75, "LATEST_MSG")
+    latest_messages[-1] = {
+        "role": "assistant",
+        "text": "CANONICAL_LATEST_VISIBLE",
+        "html": "<p>CANONICAL_LATEST_VISIBLE</p>",
+        "uuid": "canonical-latest",
+        "ts": 1_700_030_000,
+    }
+
+    def handle(route):
+        qs = parse_qs(urlparse(route.request.url).query)
+        calls.append({key: values[0] for key, values in qs.items()})
+        if "around_uuid" in qs and qs.get("history_generation") == ["gen-old"]:
+            route.fulfill(
+                status=409,
+                content_type="application/json",
+                body=json.dumps({
+                    "detail": {
+                        "error": "history_generation_mismatch",
+                        "history_generation": "gen-new",
+                    },
+                }),
+            )
+            return
+        if "around_uuid" in qs:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "id": sid,
+                    "messages": around_messages,
+                    "offset": 200,
+                    "total": 500,
+                    "has_more": True,
+                    "has_later": True,
+                    "history_generation": "gen-new",
+                    "history_order": "full",
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "id": sid,
+                "name": "Perf around conflict",
+                "model": "e2e-model",
+                "permission": "bypassPermissions",
+                "thinking": True,
+                "messages": latest_messages,
+                "offset": 425,
+                "total": 500,
+                "has_more": True,
+                "has_later": False,
+                "history_generation": "gen-new",
+                "history_order": "normal",
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}?*", handle)
+    _login(page, backend_url, auth_token)
+    _bootstrap_session_for_real_load(page, sid, "Perf around conflict")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st.historyGeneration = "gen-old";
+        st._loaded = true;
+        st.messagesReady = true;
+        return true;
+        """,
+        sid,
+    )
+
+    loaded = _app_eval(
+        page,
+        "return app._loadAroundMessage(arg.sid, arg.uuid);",
+        {"sid": sid, "uuid": target_uuid},
+    )
+    assert loaded is True
+    page.wait_for_function(
+        """uuid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app._ensureTabState(app.currentId);
+          return st.messages.some(m => m.uuid === uuid)
+            && document.querySelector(`.msg[data-uuid="${CSS.escape(uuid)}"]`);
+        }""",
+        arg=target_uuid,
+        timeout=10000,
+    )
+    around_state = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        return {
+          mounted: st.messages.length,
+          earlier: st._earlierMessages.length,
+          later: st._laterMessages.length,
+          targetMounted: st.messages.some(m => m.uuid === "around-target"),
+          order: st._historyOrder,
+          hasServerLater: st._hasServerLater,
+        };
+        """,
+        sid,
+    )
+    assert around_state["mounted"] <= 60
+    assert around_state["targetMounted"] is True
+    assert around_state["order"] == "full"
+    assert around_state["hasServerLater"] is True
+    assert len([call for call in calls if "around_uuid" in call]) == 2
+    assert len([call for call in calls if "tail" in call]) == 1
+
+    returned = _app_eval(page, "return app.returnToLatest(arg);", sid)
+    assert returned is True
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app._ensureTabState(app.currentId);
+          return st._historyOrder === 'normal' && !st._hasServerLater
+            && st.messages.some(m => (m.text || '').includes('CANONICAL_LATEST_VISIBLE'));
+        }""",
+        timeout=10000,
+    )
+    assert len([call for call in calls if "tail" in call]) == 2
+    assert page.locator(".msg-pane:visible .msg").count() <= 60
+    _assert_no_browser_errors(page, errors)
+
+
+def test_bidirectional_cap_preserves_keyed_scroll_anchor(
+    page: Page, backend_url, auth_token,
+):
+    """Top/bottom eviction must not move the surviving reading anchor."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 390, "height": 844})
+    _login(page, backend_url, auth_token)
+    sid = _app_eval(page, "return app.currentId;")
+    _app_eval(
+        page,
+        """
+        const sid = arg;
+        const st = app._ensureTabState(sid);
+        const make = (prefix, i) => ({
+          role: "assistant", uuid: `${prefix}-uuid-${i}`,
+          _k: `${prefix}-key-${i}`, _noAnim: true,
+          text: `${prefix}-${i} ` + "variable height ".repeat(8 + (i % 5) * 8),
+          html: `<p>${prefix}-${i} ${"variable height ".repeat(8 + (i % 5) * 8)}</p>`,
+        });
+        st.messages.splice(0, st.messages.length,
+          ...Array.from({ length: 60 }, (_, i) => make("mounted", i)));
+        st._earlierMessages = Array.from({ length: 10 }, (_, i) => make("older", i));
+        st._laterMessages = [];
+        st._loadedOffset = 0;
+        st._total = 70;
+        st._hasServerLater = false;
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        app.currentId = sid;
+        app._residentTabIds = [sid];
+        app._activateTabState(sid);
+        app._promoteResident(sid);
+        app.mobileTab = "chat";
+        return true;
+        """,
+        sid,
+    )
+    page.wait_for_function(
+        """() => Array.from(document.querySelectorAll('.msg-pane'))
+          .filter(p => getComputedStyle(p).display !== 'none')
+          .reduce((n, p) => n + p.querySelectorAll('.msg').length, 0) === 60""",
+        timeout=10000,
+    )
+    page.evaluate(
+        """() => {
+          const body = document.querySelector('.chat-body');
+          body.scrollTop = Math.min(500, body.scrollHeight - body.clientHeight);
+        }"""
+    )
+    before_older = page.evaluate(
+        """() => document.querySelector(
+          '.msg[data-message-key="mounted-key-0"]').getBoundingClientRect().top"""
+    )
+    _app_eval(page, "return app.loadEarlierMessages(arg);", sid)
+    page.wait_for_timeout(100)
+    after_older = page.evaluate(
+        """() => document.querySelector(
+          '.msg[data-message-key="mounted-key-0"]').getBoundingClientRect().top"""
+    )
+    assert abs(after_older - before_older) < 2
+
+    before_newer = page.evaluate(
+        """() => document.querySelector(
+          '.msg[data-message-key="mounted-key-49"]').getBoundingClientRect().top"""
+    )
+    _app_eval(page, "return app.loadLaterMessages(arg);", sid)
+    page.wait_for_timeout(100)
+    after_newer = page.evaluate(
+        """() => document.querySelector(
+          '.msg[data-message-key="mounted-key-49"]').getBoundingClientRect().top"""
+    )
+    assert abs(after_newer - before_newer) < 2
+    assert page.locator(".msg-pane:visible .msg").count() == 60
     _assert_no_browser_errors(page, errors)
 
 
@@ -767,7 +1012,7 @@ def test_mobile_pwa_tabs_preview_rotation_keep_chat_usable(page: Page, backend_u
         assert 0 < box["right"] <= layout["viewport"]["width"]
     assert layout["input"]["bottom"] <= layout["toolbar"]["top"] + 2
     assert layout["latest"]["height"] > 0
-    assert page.locator(".msg-pane").count() <= 4
+    assert page.locator(".msg-pane").count() <= 1
     assert _app_eval(page, "return app.messagesReady === true && !app.messagesLoading;") is True
 
     _assert_no_browser_errors(page, errors)
@@ -890,6 +1135,17 @@ def test_120kb_mixed_sse_stream_renders_final_assistant_html(page: Page, backend
         return true;
         """,
     )
+    page.evaluate(
+        """() => {
+          window.__longTasks = [];
+          if (window.PerformanceObserver && PerformanceObserver.supportedEntryTypes?.includes('longtask')) {
+            window.__longTaskObserver = new PerformanceObserver(list => {
+              for (const e of list.getEntries()) window.__longTasks.push(e.duration);
+            });
+            window.__longTaskObserver.observe({ type: 'longtask', buffered: true });
+          }
+        }"""
+    )
     _app_eval(page, "app.send(); return true;")
     page.wait_for_function("() => window.__fakeStreams && window.__fakeStreams.length === 1")
 
@@ -979,11 +1235,22 @@ def test_120kb_mixed_sse_stream_renders_final_assistant_html(page: Page, backend
             text: "todos updated", truncated: false, is_error: false,
           });
           window.__emitSse("text", { text: finalText });
-          window.__emitSse("done", {
-            total_cost_usd: 0.001,
-            session_usage: { context_used_pct: 10, context_used: 1000, context_limit: 100000 },
-          });
         }"""
+    )
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const last = app.messages[app.messages.length - 1];
+          return app.streaming === true && last && last._streamPlain === true
+            && last.text.includes('FINAL_ASSISTANT_HTML_COMPLETE');
+        }""",
+        timeout=10000,
+    )
+    page.evaluate(
+        """() => window.__emitSse("done", {
+          total_cost_usd: 0.001,
+          session_usage: { context_used_pct: 10, context_used: 1000, context_limit: 100000 },
+        })"""
     )
 
     page.wait_for_function(
@@ -1013,8 +1280,29 @@ def test_120kb_mixed_sse_stream_renders_final_assistant_html(page: Page, backend
           && roles.includes("tool_result")
           && last.role === "assistant"
           && last.text.length >= 120000
-          && last.html.length > 0;
+          && last.html.length > 0
+          && !last._streamPlain;
         """,
     )
+    render_stats = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(app.currentId);
+        return {
+          rich: st._streamRichRenderCount,
+          plain: st._streamPlainRenderCount,
+          mounted: Array.from(document.querySelectorAll('.msg-pane'))
+            .filter(p => getComputedStyle(p).display !== 'none')
+            .reduce((n, p) => n + p.querySelectorAll('.msg').length, 0),
+          cached: st.messages.length + st._earlierMessages.length + st._laterMessages.length,
+        };
+        """,
+    )
+    assert render_stats["plain"] >= 1
+    assert render_stats["rich"] <= 8
+    assert render_stats["mounted"] <= 60
+    assert render_stats["cached"] <= 120
+    long_tasks = page.evaluate("() => window.__longTasks || []")
+    assert max(long_tasks or [0]) < 2000, long_tasks
 
     _assert_no_browser_errors(page, errors)

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -31,6 +31,20 @@ SEL_TAB_CLOSE = ".chat-tab-close"
 SEL_TAB_NEW = ".chat-tab-new"
 
 
+def _activate_chat_tab(page: Page, sid: str) -> None:
+    page.evaluate(
+        """async ([target]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          await app.activateTab(target);
+        }""",
+        arg=[sid],
+    )
+    page.wait_for_function(
+        "([target]) => document.querySelector('#app')._x_dataStack[0].currentId === target",
+        arg=[sid],
+    )
+
+
 def _login(page: Page, base: str, token: str) -> None:
     page.goto(base)
     # Wait for either the login screen or (if a token is already stored)
@@ -62,8 +76,10 @@ def test_new_and_switch_and_close_tabs(page: Page, backend_url, auth_token):
     expect(page.locator(SEL_TAB)).to_have_count(initial + 2)
 
     # Switch to the first tab.
-    page.locator(SEL_TAB).first.click()
+    page.locator(f"{SEL_TAB} {SEL_TAB_NAME}").first.click()
     expect(page.locator(SEL_TAB_ACTIVE)).to_have_count(1)
+    if page.locator("#jserr").is_visible():
+        pytest.fail(page.locator("#jserr").inner_text())
 
     # Close the active tab via its × button.
     page.locator(f"{SEL_TAB_ACTIVE} {SEL_TAB_CLOSE}").click()
@@ -107,9 +123,226 @@ def test_keyboard_shortcut_ctrl_t_opens_tab(page: Page, backend_url, auth_token)
     expect(page.locator(SEL_TAB)).to_have_count(start + 1)
 
 
-def test_workspace_picker_switches_files_previews_and_sessions_together(
+def test_composer_drafts_are_isolated_between_tabs(page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    textarea = page.locator(".chat-input-textarea")
+    sid_a = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    textarea.fill("draft-a")
+    page.wait_for_function(
+        "() => document.querySelector('#app')._x_dataStack[0].input === 'draft-a'")
+
+    page.locator(SEL_TAB_NEW).click()
+    sid_b = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    assert sid_b != sid_a
+    expect(textarea).to_have_value("")
+    textarea.fill("draft-b")
+    page.wait_for_function(
+        "() => document.querySelector('#app')._x_dataStack[0].input === 'draft-b'")
+
+    _activate_chat_tab(page, sid_a)
+    expect(textarea).to_have_value("draft-a")
+    _activate_chat_tab(page, sid_b)
+    expect(textarea).to_have_value("draft-b")
+
+
+def test_upload_completion_stays_with_starting_tab(page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    sid_a = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    page.locator(SEL_TAB_NEW).click()
+    sid_b = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    _activate_chat_tab(page, sid_a)
+
+    page.evaluate(
+        """() => {
+          const originalFetch = window.fetch.bind(window);
+          window.__resolveUpload = null;
+          window.fetch = (url, init) => {
+            if (String(url).includes('/api/chat/upload-image')) {
+              return new Promise(resolve => { window.__resolveUpload = resolve; });
+            }
+            return originalFetch(url, init);
+          };
+        }""")
+    page.locator('input[type="file"][x-ref="attachInput"]').set_input_files({
+        "name": "race.txt",
+        "mimeType": "text/plain",
+        "buffer": b"owner-a",
+    })
+    page.wait_for_function(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.tabState[sid]?.draft.pendingDocs.length === 1
+            && app.tabState[sid].draft.pendingDocs[0].uploading;
+        }""",
+        arg=[sid_a],
+    )
+
+    _activate_chat_tab(page, sid_b)
+    page.evaluate(
+        """() => window.__resolveUpload(new Response(
+          JSON.stringify({id: 'upload-a', kind: 'text'}),
+          {status: 200, headers: {'Content-Type': 'application/json'}}))""")
+    page.wait_for_function(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const doc = app.tabState[sid]?.draft.pendingDocs[0];
+          return doc?.id === 'upload-a' && doc.uploading === false;
+        }""",
+        arg=[sid_a],
+    )
+    state = page.evaluate(
+        """([a, b]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            current: app.currentId,
+            aDocs: app.tabState[a].draft.pendingDocs.length,
+            bDocs: app.tabState[b].draft.pendingDocs.length,
+            visibleDocs: app.pendingDocs.length,
+          };
+        }""",
+        arg=[sid_a, sid_b],
+    )
+    assert state == {"current": sid_b, "aDocs": 1, "bDocs": 0, "visibleDocs": 0}
+
+
+def test_send_upload_wait_is_owned_by_starting_tab(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    sid_a = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    page.locator(SEL_TAB_NEW).click()
+    sid_b = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    _activate_chat_tab(page, sid_a)
+
+    page.evaluate(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.availableModels = [{model: 'fake-model', group: 'test'}];
+          app.input = 'send-a';
+          app.pendingDocs.push({
+            id: null, name: 'slow.txt', kind: 'text', uploading: true, error: false,
+          });
+          app._captureComposerState(sid);
+          window.__sendPromise = app.send();
+        }""",
+        arg=[sid_a],
+    )
+    page.wait_for_function(
+        """([sid]) => document.querySelector('#app')._x_dataStack[0]
+          .tabState[sid]?.draft._sendWaitingForUpload === true""",
+        arg=[sid_a],
+    )
+    _activate_chat_tab(page, sid_b)
+    waiting = page.evaluate(
+        """([a, b]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            root: app._sendWaitingForUpload,
+            a: app.tabState[a].draft._sendWaitingForUpload,
+            b: app.tabState[b].draft._sendWaitingForUpload,
+          };
+        }""",
+        arg=[sid_a, sid_b],
+    )
+    assert waiting == {"root": False, "a": True, "b": False}
+
+    result = page.evaluate(
+        """async ([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const doc = app.tabState[sid].draft.pendingDocs[0];
+          doc.error = true;
+          doc.uploading = false;
+          return await window.__sendPromise;
+        }""",
+        arg=[sid_a],
+    )
+    assert result is False
+    settled = page.evaluate(
+        """([a, b]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return [
+            app.tabState[a].draft._sendWaitingForUpload,
+            app.tabState[b].draft._sendWaitingForUpload,
+            app._sendWaitingForUpload,
+          ];
+        }""",
+        arg=[sid_a, sid_b],
+    )
+    assert settled == [False, False, False]
+
+
+def test_queue_edit_restores_original_tab_during_switch(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    sid_a = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    page.locator(SEL_TAB_NEW).click()
+    sid_b = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId")
+    page.locator(".chat-input-textarea").fill("draft-b")
+    page.wait_for_function(
+        "() => document.querySelector('#app')._x_dataStack[0].input === 'draft-b'")
+    _activate_chat_tab(page, sid_a)
+
+    page.evaluate(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.tabState[sid].pendingQueue = [{
+            id: 'q1', text: 'queued-a',
+            images: [{id: 'img-a', mime: 'image/png', src: 'data:image/png;base64,AA=='}],
+            docs: [{id: 'doc-a', name: 'a.txt', kind: 'text'}],
+          }];
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (url, init) => String(url).includes('/queue/q1')
+            ? Promise.resolve(new Response('{}', {status: 200}))
+            : originalFetch(url, init);
+          window.__queueResolvers = [];
+          app._syncQueueFromServer = () => new Promise(
+            resolve => { window.__queueResolvers.push(resolve); });
+          app.editPendingQueueItem(sid, 0);
+        }""",
+        arg=[sid_a],
+    )
+    page.wait_for_function("() => window.__queueResolvers?.length >= 1")
+    _activate_chat_tab(page, sid_b)
+    page.evaluate("() => window.__queueResolvers[0]()")
+    page.wait_for_function(
+        """([sid]) => document.querySelector('#app')._x_dataStack[0]
+          .tabState[sid]?.draft.input === 'queued-a'""",
+        arg=[sid_a],
+    )
+    state = page.evaluate(
+        """([a, b]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            current: app.currentId,
+            visibleInput: app.input,
+            aInput: app.tabState[a].draft.input,
+            aImages: app.tabState[a].draft.pendingImages.map(x => x.id),
+            aDocs: app.tabState[a].draft.pendingDocs.map(x => x.id),
+            bInput: app.tabState[b].draft.input,
+          };
+        }""",
+        arg=[sid_a, sid_b],
+    )
+    assert state == {
+        "current": sid_b,
+        "visibleInput": "draft-b",
+        "aInput": "queued-a",
+        "aImages": ["img-a"],
+        "aDocs": ["doc-a"],
+        "bInput": "draft-b",
+    }
+
+
+def test_workspace_picker_switches_conversation_and_keeps_archive_surface(
         page: Page, backend_url, auth_token, tmp_path):
-    """A workspace switch restores its files, preview and conversation."""
+    """A workspace switch changes chat cwd without moving the archive root."""
     _login(page, backend_url, auth_token)
     primary = page.evaluate(
         "() => document.querySelector('#app')._x_dataStack[0].currentWorkspacePath()")
@@ -158,23 +391,16 @@ def test_workspace_picker_switches_files_previews_and_sessions_together(
               app.sessions.find(item => item.id === id)?.cwd),
           };
         }""")
-    assert "WORKSPACE_ONLY.md" in state["visible"]
-    assert "README.md" not in state["visible"]
-    assert state["selected"] == ""
+    assert "WORKSPACE_ONLY.md" not in state["visible"]
+    assert "README.md" in state["visible"]
+    assert state["selected"] == "README.md"
     assert state["tabCwds"] and set(state["tabCwds"]) == {str(other)}
     secondary_id = state["currentId"]
 
-    page.locator('.filelist li[data-path="WORKSPACE_ONLY.md"]').click()
-    page.wait_for_function(
-        """() => {
-          const app = document.querySelector('#app')._x_dataStack[0];
-          return app.selected === 'WORKSPACE_ONLY.md'
-            && app.rawText.includes('workspace-isolated-preview');
-        }""")
-
     page.locator(".workspace-picker-btn").click()
-    page.locator(
-        f'.workspace-picker-row[title="{primary}"] .workspace-picker-select').click()
+    page.locator(".workspace-picker-row").filter(
+        has=page.get_by_text(primary, exact=True)).locator(
+        ".workspace-picker-select").click()
     page.wait_for_function(
         """([path, sid]) => {
           const app = document.querySelector('#app')._x_dataStack[0];
@@ -187,14 +413,15 @@ def test_workspace_picker_switches_files_previews_and_sessions_together(
     )
 
     page.locator(".workspace-picker-btn").click()
-    page.locator(
-        f'.workspace-picker-row[title="{other}"] .workspace-picker-select').click()
+    page.locator(".workspace-picker-row").filter(
+        has=page.get_by_text(str(other), exact=True)).locator(
+        ".workspace-picker-select").click()
     page.wait_for_function(
         """([path, sid]) => {
           const app = document.querySelector('#app')._x_dataStack[0];
           return app.currentWorkspacePath() === path && app.currentId === sid
-            && app.selected === 'WORKSPACE_ONLY.md'
-            && app.rawText.includes('workspace-isolated-preview')
+            && app.selected === 'README.md'
+            && app.rawText.includes('muselab e2e')
             && !app.workspaceSwitching;
         }""",
         arg=[str(other), secondary_id],
@@ -203,15 +430,17 @@ def test_workspace_picker_switches_files_previews_and_sessions_together(
 
     # Remove the registry entry through the UI; project files remain untouched.
     page.locator(".workspace-picker-btn").click()
-    page.locator(
-        f'.workspace-picker-row[title="{primary}"] .workspace-picker-select').click()
+    page.locator(".workspace-picker-row").filter(
+        has=page.get_by_text(primary, exact=True)).locator(
+        ".workspace-picker-select").click()
     page.wait_for_function(
         "([path]) => document.querySelector('#app')._x_dataStack[0].currentWorkspacePath() === path",
         arg=[primary],
     )
     page.locator(".workspace-picker-btn").click()
-    page.locator(
-        f'.workspace-picker-row[title="{other}"] .workspace-picker-remove').click()
+    page.locator(".workspace-picker-row").filter(
+        has=page.get_by_text(str(other), exact=True)).locator(
+        ".workspace-picker-remove").click()
     expect(page.locator(".confirm-modal")).to_be_visible()
     page.locator(".confirm-modal .btn-danger").click()
     page.wait_for_function(

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -4,7 +4,12 @@ These hit the FastAPI routes through TestClient with the pool pre-seeded
 with fake clients, so the route logic (3-tuple key handling, disconnect
 fan-out, response shape) runs for real without spawning a CLI.
 """
+import asyncio
+import os
+from types import SimpleNamespace
+
 import pytest
+from claude_agent_sdk import ResultMessage
 
 from tests.conftest import TEST_TOKEN
 
@@ -141,7 +146,58 @@ def test_interrupt_swallows_sdk_error_but_still_marks_pending(chat_mod, client):
     assert "sid-boom" in chat_mod._pending_interrupts
 
 
+def test_interrupt_pauses_nonempty_queue_before_sdk_call(chat_mod, client):
+    """The current turn may finish while interrupt() awaits the SDK. Queue
+    state must already be paused then, otherwise its finally block can dequeue
+    and start the next turn after the user pressed Stop."""
+    from backend import sessions as sess
+
+    sid = "sid-queued-stop"
+    c = _seed(chat_mod, (sid, "claude-sonnet-4-6", ""))
+    sess.enqueue_message(sid, "do not auto-run")
+    observed = []
+
+    async def inspect_interrupt():
+        observed.append(sess.get_queue(sid))
+        c.interrupted = True
+
+    c.interrupt = inspect_interrupt
+    response = client.post(
+        f"/api/chat/interrupt?session_id={sid}&token={TEST_TOKEN}")
+
+    assert response.status_code == 200, response.text
+    assert observed and observed[0]["paused"] is True
+    assert observed[0]["items"][0]["text"] == "do not auto-run"
+
+
 # ====== force-stop watchdog (interrupt that the SDK refuses to honor) ======
+
+@pytest.mark.asyncio
+async def test_session_runtime_cleanup_invalidates_continuation_owner(chat_mod):
+    sid = "sid-delete-continuation"
+    watcher = asyncio.create_task(asyncio.sleep(60))
+    pump = asyncio.create_task(asyncio.sleep(60))
+    broadcast = chat_mod.TurnBroadcast(sid)
+    broadcast.task = pump
+    chat_mod._task_watchers[sid] = watcher
+    chat_mod._continuation_generations[sid] = 3
+    chat_mod._active_turns[sid] = broadcast
+    chat_mod._recent_turns[sid] = broadcast
+    chat_mod._sessions_with_inflight_tasks[sid] = {"task-1"}
+    chat_mod._bg_task_descriptions["task-1"] = "background work"
+
+    chat_mod._clear_session_runtime_state(sid)
+    await asyncio.gather(watcher, pump, return_exceptions=True)
+
+    assert chat_mod._continuation_generations[sid] == 4
+    assert sid not in chat_mod._task_watchers
+    assert sid not in chat_mod._active_turns
+    assert sid not in chat_mod._recent_turns
+    assert sid not in chat_mod._sessions_with_inflight_tasks
+    assert "task-1" not in chat_mod._bg_task_descriptions
+    assert broadcast.cancelled is True
+    assert broadcast.done is True
+
 
 @pytest.mark.asyncio
 async def test_force_stop_tears_down_stuck_turn(chat_mod):
@@ -248,3 +304,116 @@ def test_probe_hits_vendor_endpoint_with_fake_httpx(client, auth, monkeypatch, c
     # The request carried the api key header + ping body.
     assert posted["headers"]["x-api-key"] == "sk-deepseek-abcd1234efgh5678"
     assert posted["json"]["messages"][0]["content"] == "ping"
+
+
+class _FakeCompactClient:
+    def __init__(self, result, totals=(190_000, 190_000)):
+        self.result = result
+        self.totals = iter(totals)
+        self.queries = []
+        self.restored_permission = None
+
+    async def query(self, prompt):
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        yield self.result
+
+    async def get_context_usage(self):
+        return {"totalTokens": next(self.totals), "maxTokens": 200_000}
+
+    async def set_permission_mode(self, permission):
+        self.restored_permission = permission
+
+
+def _make_compact_session(client):
+    r = client.post(
+        "/api/chat/sessions",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "compact endpoint", "model": "claude-sonnet-4-6"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+def test_native_compact_rejects_in_band_context_error(chat_mod, client, monkeypatch):
+    sid = _make_compact_session(client)
+    result = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id=sid,
+        result="Your input exceeds the context window of this model",
+        api_error_status=400,
+    )
+    fake = _FakeCompactClient(result, totals=(190_000,))
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    key = (sid, "claude-sonnet-4-6", "")
+    chat_mod._client_permission[key] = "default"
+
+    r = client.post(
+        f"/api/chat/sessions/{sid}/native-compact",
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert r.status_code == 409, r.text
+    assert "context window" in r.json()["detail"]
+    assert fake.queries == ["/compact"]
+    assert fake.restored_permission == "default"
+
+
+def test_vendor_fork_uses_vendor_session_store_and_restores_env(
+    chat_mod, client, monkeypatch, tmp_path,
+):
+    from backend import endpoints
+
+    r = client.post(
+        "/api/chat/sessions",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "vendor fork", "model": "codex:gpt-5.6-sol"},
+    )
+    assert r.status_code == 200, r.text
+    sid = r.json()["id"]
+    # Test fixture availability filtering can canonicalize the requested model
+    # to Claude; pin the metadata to the vendor model this regression targets.
+    chat_mod.sess.update_model(sid, "codex:gpt-5.6-sol")
+    vendor_dir = tmp_path / "vendor-config"
+    monkeypatch.setattr(endpoints, "_VENDOR_CONFIG_DIR", vendor_dir)
+    observed = {}
+
+    def fake_fork(*_args, **_kwargs):
+        observed["config_dir"] = os.environ.get("CLAUDE_CONFIG_DIR")
+        return SimpleNamespace(session_id="11111111-2222-4333-8444-555555555555")
+
+    monkeypatch.setattr(chat_mod, "sdk_fork_session", fake_fork)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "original-config")
+    response = client.post(
+        f"/api/chat/sessions/{sid}/fork",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"title": "vendor recovery"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert observed["config_dir"] == str(vendor_dir)
+    assert os.environ["CLAUDE_CONFIG_DIR"] == "original-config"
+
+
+def test_native_compact_rejects_success_without_token_drop(chat_mod, client, monkeypatch):
+    sid = _make_compact_session(client)
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1,
+        is_error=False, num_turns=1, session_id=sid,
+    )
+    fake = _FakeCompactClient(result, totals=(190_000, 190_000))
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.post(
+        f"/api/chat/sessions/{sid}/native-compact",
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert r.status_code == 500, r.text
+    assert "did not decrease" in r.json()["detail"]

--- a/tests/test_chat_options.py
+++ b/tests/test_chat_options.py
@@ -37,6 +37,8 @@ def test_third_party_provider_enables_sdk_skills(app_module, monkeypatch, tmp_pa
     assert client is not None
     assert captured["skills"] == "all"
     assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-test"
+    for tier in ("OPUS", "SONNET", "HAIKU", "FABLE"):
+        assert captured["env"][f"ANTHROPIC_DEFAULT_{tier}_MODEL"] == "deepseek-v4-pro"
 
 
 def test_codex_gateway_effort_reaches_sdk_options(app_module, monkeypatch, tmp_path):
@@ -74,6 +76,8 @@ def test_codex_gateway_effort_reaches_sdk_options(app_module, monkeypatch, tmp_p
     # Claude CLI must use the same effective window as the meter and native
     # compact preflight instead of its unrelated built-in 200K default.
     assert captured["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "258400"
+    for tier in ("OPUS", "SONNET", "HAIKU", "FABLE"):
+        assert captured["env"][f"ANTHROPIC_DEFAULT_{tier}_MODEL"] == "gpt-5.5"
 
 
 def test_disable_skills_env_still_opts_out(app_module, monkeypatch, tmp_path):

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -8,6 +8,7 @@ assert the SSE frames the frontend depends on (text → tool_use → tool_result
 
 No real network, no real CLI subprocess, no Anthropic API.
 """
+import asyncio
 import base64
 import json
 from types import SimpleNamespace
@@ -282,6 +283,54 @@ def test_stream_drops_prior_turn_replay_but_keeps_late_task_lifecycle(
     assert sid not in chat_mod._active_turns
 
 
+def test_sdk_error_extractors_keep_result_and_assistant_detail(stream_env):
+    chat_mod = stream_env
+    assistant = AssistantMessage(
+        content=[TextBlock(text="API Error: input exceeds the context window")],
+        model="<synthetic>", error="invalid_request",
+    )
+    result = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id="sid",
+        result="502 unknown provider for model claude-opus-4-8",
+        errors=["502 unknown provider for model claude-opus-4-8"],
+        api_error_status=502,
+    )
+
+    a = chat_mod._sdk_assistant_error(assistant)
+    r = chat_mod._sdk_result_error(result)
+    merged = chat_mod._merge_sdk_errors([a, r])
+
+    assert "context window" in a["message"]
+    assert merged["message"].count("502 unknown provider") == 1
+    assert merged["api_error_status"] == 502
+
+
+def test_run_sdk_command_checked_rejects_in_band_result_error(stream_env):
+    chat_mod = stream_env
+    result = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id="sid",
+        result="Your input exceeds the context window of this model",
+        api_error_status=400,
+    )
+
+    class FakeClient:
+        def __init__(self):
+            self.queries = []
+
+        async def query(self, prompt):
+            self.queries.append(prompt)
+
+        async def receive_response(self):
+            yield result
+
+    fake = FakeClient()
+    with pytest.raises(chat_mod._SDKCommandError, match="context window"):
+        asyncio.run(chat_mod._run_sdk_command_checked(fake, "/compact"))
+    assert fake.queries == ["/compact"]
+
+
 def test_turn_response_boundary_accepts_lifecycle_and_uuid_less_error(stream_env):
     chat_mod = stream_env
     boundary = chat_mod._TurnResponseBoundary({"old"})
@@ -298,6 +347,74 @@ def test_turn_response_boundary_accepts_lifecycle_and_uuid_less_error(stream_env
     assert boundary.classify(lifecycle) == "forward"
     assert boundary.classify(old_result) == "stale_result"
     assert boundary.classify(error_result) == "current_result"
+
+
+def test_preflight_compact_failure_blocks_original_prompt(stream_env, client, monkeypatch):
+    chat_mod = stream_env
+    sid = _make_session(client)
+    compact_error = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id=sid,
+        result="Your input exceeds the context window of this model",
+        api_error_status=400,
+    )
+    fake = _FakeStreamClient([compact_error])
+
+    async def near_limit_context():
+        return {
+            "maxTokens": 200_000,
+            "rawMaxTokens": 200_000,
+            "autoCompactThreshold": 160_000,
+            "totalTokens": 190_000,
+        }
+
+    fake.get_context_usage = near_limit_context
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=must-not-send&model=claude-sonnet-4-6")
+    events = _parse_sse(r.text)
+    error = next(json.loads(d) for e, d in events if e == "error")
+
+    assert fake.queried == ["/compact"]
+    assert error["kind"] == "context_window"
+    assert error["retryable"] is False
+
+
+def test_stream_done_classifies_synthetic_context_error(stream_env, client, monkeypatch):
+    chat_mod = stream_env
+    sid = _make_session(client)
+    messages = [
+        AssistantMessage(
+            content=[TextBlock(text="API Error: Your input exceeds the context window")],
+            model="<synthetic>", error="invalid_request",
+        ),
+        ResultMessage(
+            subtype="error", duration_ms=1, duration_api_ms=1,
+            is_error=True, num_turns=1, session_id=sid,
+            result="API Error: Your input exceeds the context window of this model",
+            api_error_status=400,
+        ),
+    ]
+    fake = _FakeStreamClient(messages)
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=continue&model=claude-sonnet-4-6")
+    events = _parse_sse(r.text)
+    assert not [d for e, d in events if e == "text"], "synthetic error is not assistant text"
+    done = next(json.loads(d) for e, d in events if e == "done")
+    assert done["is_error"] is True
+    assert done["kind"] == "context_window"
+    assert done["cta"] == "compact_or_fork"
+    assert done["retryable"] is False
+    assert "context window" in done["error"]
 
 
 def test_stream_pdf_attachment_persists_path_fallback(stream_env, client, monkeypatch):
@@ -781,6 +898,76 @@ def test_subscribe_broadcast_marks_continuation_consumed(stream_env):
     plain.finish()
     asyncio.run(drain(plain))
     assert plain.continuation_consumed is False
+
+
+def test_broadcast_replay_binary_compaction_handles_100k_deltas(stream_env):
+    """Replay stays exact and O(log n) in envelopes on pathological streams."""
+    import json
+
+    chat_mod = stream_env
+    bc = chat_mod.TurnBroadcast(
+        session_id="stress-replay",
+        replay_max_events=128,
+        replay_max_bytes=512_000,
+    )
+    for _ in range(100_000):
+        bc.publish({"event": "text", "data": '{"text":"x"}'})
+
+    assert len(bc.events) <= 20
+    assert sum(
+        len(json.loads(event["data"])["text"])
+        for event in bc.events
+    ) == 100_000
+    assert bc._replay_bytes <= 512_000
+
+
+def test_broadcast_bounds_replay_and_isolates_slow_subscriber(stream_env):
+    import asyncio
+
+    chat_mod = stream_env
+
+    async def exercise():
+        bc = chat_mod.TurnBroadcast(
+            session_id="stress-subscribers",
+            replay_max_events=1,
+            replay_max_bytes=4096,
+            subscriber_max_events=8,
+            subscriber_max_bytes=4096,
+        )
+        slow = bc.subscribe()
+        fast = bc.subscribe()
+        received = []
+
+        async def consume_fast():
+            while True:
+                event = await fast.get()
+                if event is None:
+                    return
+                received.append(event)
+
+        consumer = asyncio.create_task(consume_fast())
+        for i in range(2_000):
+            bc.publish({
+                "event": "tool_result",
+                "data": '{"id":"%d"}' % i,
+            })
+            await asyncio.sleep(0)
+        bc.finish()
+        await consumer
+
+        slow_first = await slow.get()
+        assert slow_first["event"] == "resync"
+        assert json.loads(slow_first["data"])["reason"] == "slow_subscriber"
+        assert len(received) == 2_000
+        assert bc.events == []
+
+        replay = bc.subscribe()
+        replay_first = await replay.get()
+        assert replay_first["event"] == "resync"
+        assert json.loads(replay_first["data"])["reason"] == "replay_truncated"
+
+    import json
+    asyncio.run(exercise())
 
 
 def test_stream_error_path_classifies_auth_error(stream_env, client, monkeypatch):

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -269,6 +269,28 @@ def test_session_poll_and_revision_reconciliation_are_resilient():
     assert "this._sessionsInitialized = true" in app
 
 
+def test_optimistic_session_is_registered_before_first_turn():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    helper_start = app.index("_registerOptimisticSession(meta)")
+    helper_end = app.index("\n    newSession(options = {})", helper_start)
+    helpers = app[helper_start:helper_end]
+    send_start = app.index("async send(opts = {})")
+    send_end = app.index("\n    async stop()", send_start)
+    send = app[send_start:send_end]
+
+    assert "_sessionRegistrationPromises: {}" in app
+    assert "this._sessionRegistrationPromises[id]" in helpers
+    assert "async _ensureSessionRegistered(id)" in helpers
+    assert helpers.count("this._registerOptimisticSession(meta)") >= 2
+    ensure_at = send.index("await this._ensureSessionRegistered(sendSid)")
+    push_at = send.index("this._appendLiveMessage(sendState")
+    ticket_at = send.index('fetch("/api/chat/stream/start"')
+    clear_at = send.index("clearSubmittedComposer();")
+    assert ensure_at < push_at < ticket_at
+    assert ensure_at < clear_at
+    assert "新会话未能保存" in send
+
+
 def test_silent_stream_recovers_without_manual_refresh():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     start = app.index("async _recoverStalledStream(sid = this.currentId)")
@@ -376,10 +398,11 @@ def test_history_jump_keeps_the_session_that_owned_the_click():
     assert "const sid = ownerSid" in jump
     assert "body && body.querySelector" in jump
     assert "document.querySelector(" not in jump
-    assert "this._scrollToUserMsg(m, sid)" in jump
+    assert "await this._loadAroundMessage(sid, uuid)" in jump
     assert "this.tabState[sid] !== st || sid !== this.currentId" in jump
     assert "if (this.currentId !== sid) return" in palette_jump
     assert "body && body.querySelector" in palette_jump
+    assert "await this._loadAroundMessage(sid, uuid)" in palette_jump
 
 
 def test_failed_transcript_refresh_preserves_last_good_messages():
@@ -420,3 +443,315 @@ def test_activity_center_uses_two_compact_numberless_status_dots():
     assert "width:10px" in unread and "height:10px" in unread
     assert "min-width" not in unread and "padding" not in unread
     assert "background:var(--c-success)" in unread
+
+
+def test_bounded_stream_resync_waits_for_canonical_history_without_retry_loop():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    handler_start = app.index('es.addEventListener("resync"')
+    handler_end = app.index('es.addEventListener("error"', handler_start)
+    handler = app[handler_start:handler_end]
+    error_end = app.index('es.addEventListener("cancelled"', handler_end)
+    error = app[handler_end:error_end]
+    helper_start = app.index("_scheduleCanonicalStreamReload(sid, st")
+    helper_end = app.index("\n    _retireStaleSessionStream", helper_start)
+    helper = app[helper_start:helper_end]
+
+    assert '"cancelled", "resync"' in app
+    assert "streamState._canonicalResyncPending = true" in handler
+    assert "this._scheduleCanonicalStreamReload(streamSid, streamState)" in handler
+    assert "if (streamState._canonicalResyncPending) return" in error
+    assert "/active" in helper
+    assert "this.loadSession(sid" in helper
+    assert "31 * 60_000" in helper
+
+
+def test_stream_done_errors_share_failed_message_state_and_actions():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    helper_start = app.index("const markUserFailed = (errorText, kind, cta, retryable)")
+    done_start = app.index('es.addEventListener("done"', helper_start)
+    error_start = app.index('es.addEventListener("error"', done_start)
+    done = app[done_start:error_start]
+    error = app[error_start:app.index('es.addEventListener("cancelled"', error_start)]
+
+    assert "markUserFailed(_detail, d.kind, d.cta, d.retryable)" in done
+    assert "if (d.is_error)" in done
+    assert "_drainPendingQueue(streamSid)" in done
+    assert "markUserFailed(serverError, errKind, errCta, errRetryable)" in error
+
+
+def test_frontend_recognizes_model_route_and_full_context_window_errors():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("_humanizeStreamError(raw)")
+    humanizer = app[start:app.index("copyMsg(m)", start)]
+    hint_start = app.index("errorFixHint(m)")
+    hints = app[hint_start:app.index("findToolUseFor", hint_start)]
+
+    assert "unknown provider" in humanizer
+    assert "context window" in humanizer
+    assert "input exceeds" in humanizer
+    assert "unknown provider" in hints
+    assert "context window" in hints
+
+
+def test_compact_http_failure_parses_detail_and_never_shows_success():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("async runCompact")
+    compact = app[start:app.index("onChatArrowUp", start)]
+    failure = compact[compact.index("if (!r.ok)"):compact.index("// Reload the compacted", compact.index("if (!r.ok)"))]
+
+    assert "JSON.parse(raw)" in failure
+    assert "body.detail" in failure
+    assert "_humanizeStreamError(detail)" in failure
+    assert "压缩完成" not in failure
+
+
+def test_workspace_switch_disables_composer_and_gates_programmatic_user_send():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    start = app.index("async send(opts = {})")
+    send = app[start:app.index("// ====== ask_user_question", start)]
+
+    assert "if (this.workspaceSwitching && !opts.reconnect && !opts.resumedItem) return" in send
+    assert ':disabled="!availableModels.length || workspaceSwitching"' in html
+    assert 'multiple style="display:none" :disabled="workspaceSwitching"' in html
+    assert ':disabled="workspaceSwitching || !availableModels.length' in html
+    assert ':disabled="workspaceSwitching || !!(tabState[currentId]' in html
+
+
+def test_stop_control_interrupts_session_and_never_removes_queue_items():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    start = app.index("async stop() {")
+    stop = app[start:app.index("// ====== ask_user_question", start)]
+
+    assert 'x-show="isTabStreaming(currentId)"' in html
+    assert "chat-toolbar-stop" in html
+    assert ':title="_isBusy(currentId) ? t(\'queue.button_hint\')' in html
+    assert "撤回队尾" not in html
+    assert "removePendingQueueItem" not in stop
+    assert "if (st._stopping) return" in stop
+    assert "const r = await fetch(" in stop
+    assert "if (!r.ok) throw" in stop
+    assert 'String(item).startsWith(sid + "@")' in stop
+    assert "const timeout = setTimeout(() => controller.abort(), 15000)" in stop
+    assert "this._retireStaleSessionStream(sid, st)" in stop
+    assert "if (st._renderStreamingHtml) st._renderStreamingHtml()" in stop
+    assert "if (!didInterrupt)" in stop
+    assert "this.isTabStreaming(this.currentId)" in app
+
+
+def test_attachment_uploads_have_deadlines_and_never_log_filenames():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    assert app.count("() => uploadController.abort(), 5 * 60 * 1000") == 2
+    assert app.count("signal: uploadController.signal") == 2
+    assert app.count("clearTimeout(uploadTimeout)") == 2
+    assert "[muselab][upload]" not in app
+
+
+def test_send_pins_owner_waits_before_enqueue_and_blocks_failed_attachments():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("async send(opts = {})")
+    send = app[start:app.index("// ====== ask_user_question", start)]
+
+    assert "const sendSid = opts.sessionId || this.currentId" in send
+    assert "const sendState = this._ensureTabState(sendSid)" in send
+    assert "const sendMeta = (this.sessions || []).find(s => s.id === sendSid)" in send
+    assert "sendSid === this.currentId" in send
+    assert "const sendDraft = sendState.draft" in send
+    assert "const composerImages = sendDraft.pendingImages.slice()" in send
+    assert "const composerDocs = sendDraft.pendingDocs.slice()" in send
+    assert "const clearSubmittedComposer = () =>" in send
+    assert "removeOwned(sendDraft.pendingImages" in send
+    busy_branch = "await this._confirmSessionBusy(sendSid, sendState)"
+    assert send.index("while (ownsSendDraft() && stillUploading())") < send.rindex(busy_branch)
+    assert send.index("failedAttachments.length") < send.rindex(busy_branch)
+    assert "this._enqueueMessage(sendSid" in send
+    assert "async _confirmSessionBusy(sid" in app
+    assert "failed and were skipped" not in send
+
+
+def test_composer_draft_is_per_session_and_async_actions_pin_owner():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    blank_start = app.index("_blankTabState()")
+    blank = app[blank_start:app.index("_ensureTabState(id)", blank_start)]
+    attach_start = app.index("async _attachFile(file)")
+    attach = app[attach_start:app.index("async onAttachPicked", attach_start)]
+    editor_start = app.index("async openImageEditor(i)")
+    editor = app[editor_start:app.index("openImageGen()", editor_start)]
+    image_gen_start = app.index("async attachGeneratedImage")
+    image_gen = app[image_gen_start:app.index("imageGenStatusLabel", image_gen_start)]
+
+    assert 'draft: {' in blank
+    assert 'input: ""' in blank
+    assert 'pendingImages: []' in blank
+    assert 'pendingDocs: []' in blank
+    assert '_sendWaitingForUpload: false' in blank
+    assert "_captureComposerState(id = this.currentId)" in app
+    assert "_activateComposerState(id)" in app
+    assert "this._activateComposerState(id)" in app
+    assert attach.index("const ownerSid = this.currentId") < attach.index(
+        "await this._maybeCompressImage")
+    assert "ownerDraft.pendingImages.push(raw)" in attach
+    assert "ownerDraft.pendingDocs.push(raw)" in attach
+    assert "this.tabState[ownerSid] === ownerState" in attach
+    assert "ownerSid" in editor and "ownerEntry" in editor
+    assert "ownerState.draft.pendingImages.includes(entry)" in editor
+    assert "ownerState.draft.pendingImages.push(entry)" in image_gen
+    assert "this.tabState[ownerSid] !== ownerState" in image_gen
+
+
+def test_queue_edit_and_prompt_menu_do_not_borrow_active_composer():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    queue_start = app.index("async editPendingQueueItem")
+    queue_edit = app[queue_start:app.index("async resumeQueueDrain", queue_start)]
+    menu_start = app.index("async menuEditPrompt")
+    menu_edit = app[menu_start:app.index("async menuClose", menu_start)]
+
+    assert "draft.input = text" in queue_edit
+    assert "draft.pendingImages.splice" in queue_edit
+    assert "draft.pendingDocs.splice" in queue_edit
+    assert "if (sid !== this.currentId) return" not in queue_edit
+    assert "await this.editSessionPrompt(id)" in menu_edit
+    assert "this.currentId =" not in menu_edit
+
+
+def test_tab_disposal_aborts_uploads_and_drops_memory_only_draft():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("_disposeTabRuntime(id)")
+    dispose = app[start:app.index("async removeWorkspace", start)]
+
+    assert "draft._uploadControllers" in dispose
+    assert "controller.abort()" in dispose
+    assert 'draft.input = ""' in dispose
+    assert "draft.pendingImages.splice(0)" in dispose
+    assert "draft.pendingDocs.splice(0)" in dispose
+    assert "delete this.tabState[id]" in dispose
+
+
+def test_active_stream_owns_messages_and_continuation_reconciles_canonical_history():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    load_start = app.index("async loadSession(sid, opts = {})")
+    load = app[load_start:app.index("// Warm OPEN-but-inactive tabs", load_start)]
+    send_start = app.index("async send(opts = {})")
+    send = app[send_start:app.index("async stop()", send_start)]
+
+    assert "if (st.streaming || st.es) return false" in load
+    assert "this.tabState[sid] !== st || st.streaming || st.es" in load
+    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible)")
+    reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
+    assert "this.tabState[sid] !== st || st.streaming || st.es" in reveal
+    assert "const ownsCurBubble = () =>" in send
+    assert "this._containsPaneMessage(streamState, curBubble)" in send
+    assert "if (ownsCurBubble()) curBubble.error" in send
+    assert "this._reconcileCompletedContinuation(" in send
+    assert "streamSid, streamState, continuationFinalText" in send
+    assert "const loaded = await this.loadSession(sid, { quiet: true })" in app
+    assert "expectedText" in app
+    assert "const stillOwned = () => this.tabState[sid] === ownerState" in app
+    assert "if (!isContinuation)" in send
+
+
+def test_workspace_gate_does_not_destroy_retry_or_edit_before_send_rejects():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    retry_start = app.index("retryFailedMessage(m)")
+    retry = app[retry_start:app.index("onUserBubbleClick", retry_start)]
+    edit_start = app.index("commitEditMessage(m)")
+    edit = app[edit_start:app.index("_humanizeStreamError", edit_start)]
+
+    assert retry.index("if (this.workspaceSwitching) return") < retry.index(
+        "this.messages.splice")
+    assert edit.index("this.workspaceSwitching") < edit.index("msgs.splice")
+
+
+def test_queue_sync_keeps_older_success_when_newer_read_fails():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("async _syncQueueFromServer(sid)")
+    sync = app[start:app.index("_currentQueueLen", start)]
+
+    assert "_queueAppliedSeq: 0" in app
+    assert "seq < st._queueAppliedSeq" in sync
+    assert "st._queueAppliedSeq = seq" in sync
+    assert "st._queueSyncSeq !== seq" not in sync
+
+
+def test_long_chat_state_is_per_tab_bounded_and_generation_safe():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    blank = app[app.index("_blankTabState()"):
+                app.index("_ensureTabState(id)", app.index("_blankTabState()"))]
+    assert "messagesReady: true" in blank
+    assert "messagesLoading: false" in blank
+    assert 'historyGeneration: ""' in blank
+    assert '_historyOrder: "normal"' in blank
+    assert "_hasServerLater: false" in blank
+    assert "_laterMessages: []" in blank
+    assert "_nextLiveKey: 1" in blank
+    assert "_mountedMessageCap() { return this._isMobileLayout() ? 60 : 120; }" in app
+    assert "_historyCacheCap() { return this._isMobileLayout() ? 120 : 240; }" in app
+    assert "const budget = this._isMobileLayout() ? 1 : 2" in app
+    assert "if (cst && cst.streaming) continue" not in app
+    assert '"&history_generation="' in app
+    assert "if (r.status === 409)" in app
+    assert '"?around_uuid="' in app
+    assert "full: true" not in app
+
+    around_start = app.index("async _loadAroundMessage(sid, uuid")
+    around_end = app.index("// Outline click", around_start)
+    around = app[around_start:around_end]
+    assert "return this._loadAroundMessage(sid, uuid, false)" in around
+    assert 'this._capMountedWindow(st, "around", uuid)' in around
+    assert "st._hasServerLater = !!data.has_later" in around
+    assert 'st._historyOrder = data.history_order === "normal" ? "normal" : "full"' in around
+
+    older_start = app.index("async _fetchOlderWindow(sid)")
+    older_end = app.index("async _fetchLaterWindow(sid)", older_start)
+    older = app[older_start:older_end]
+    later_end = app.index("// Per-message placeholder height", older_end)
+    newer = app[older_end:later_end]
+    assert 'st._historyOrder === "full" ? "&full=1" : ""' in older
+    assert 'st._historyOrder === "full" ? "&full=1" : ""' in newer
+    assert "st._loadedOffset + this._allPaneMessages(st).length" in newer
+    assert "< st._total" in newer
+
+    cap_start = app.index("_capMountedWindow(st, direction")
+    cap_end = app.index("// Pop the next batch", cap_start)
+    cap = app[cap_start:cap_end]
+    assert 'direction === "around"' in cap
+    assert 'direction === "older"' in cap
+    assert "st._laterMessages.splice(st._laterMessages.length - drop, drop)" in cap
+    assert "_captureMessageAnchor(scrollEl, m)" in cap
+    assert "_restoreMessageAnchor(scrollEl, anchor)" in cap
+    assert "return st._loadedOffset > 0" in app
+    assert "historyTruncated(sid)" in app and "return false" in app[
+        app.index("historyTruncated(sid)"):app.index("async renameSession()")]
+
+    pane_start = html.index('<div class="msg-pane"')
+    pane_end = html.index("<!-- /P1 per-tab message panes", pane_start)
+    pane = html[pane_start:pane_end]
+    assert ':data-tid="tid"' in pane
+    assert 'x-for="(m, i) in paneMsgs" :key="m._k"' in pane
+    assert "pane.streaming" in pane
+    assert "pane.streamElapsed" in pane
+    assert "fmtStreamElapsed((pane && pane.streamElapsed) || 0)" in pane
+    assert 'x-text="fmtStreamElapsed(pane.streamElapsed)"' not in pane
+    assert "messages.length" not in re.sub(r"<!--.*?-->", "", pane, flags=re.S)
+    assert "streaming &&" not in re.sub(r"<!--.*?-->", "", pane, flags=re.S).replace(
+        "pane.streaming &&", "")
+
+
+def test_long_stream_switches_to_plain_preview_and_final_rich_render():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    assert "acc.length > 32 * 1024" in app
+    assert "curBubble._streamPlain = true" in app
+    assert "curBubble._streamPlain = false" in app
+    assert "_streamRichRenderCount" in app
+    assert "_streamPlainRenderCount" in app
+    assert "}, 1000);" in app
+    assert 'class="stream-plain" x-text="m.text || \'\'"' in html
+    assert 'x-show="!m._streamPlain" x-html="m.html || \'\'"' in html
+    assert "if (this.atBottom) this.scrollToBottom(false)" in app
+    assert "if (this.atBottom) this._capLiveMessages" not in app

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -781,6 +781,12 @@ def test_classify_stream_error_buckets():
         ("Request timed out", "network", "retry", True),
         ("thinking signature missing", "cross_vendor", "compact_or_fork", True),
         ("Session ID already in use", "session", "retry", True),
+        ("Your input exceeds the context window of this model", "context_window",
+         "compact_or_fork", False),
+        ("maximum context length exceeded", "context_window", "compact_or_fork", False),
+        ("502 unknown provider for model claude-opus-4-8", "model_route",
+         "switch_model", False),
+        ("HTTP 502 upstream temporarily unavailable", "unknown", "retry", True),
         ("something weird", "unknown", "retry", True),
     ]
     for msg, expected_kind, expected_cta, expected_retry in cases:

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from backend import transcript_index as ti
+
+
+def _entry(uid: str, typ: str, content, parent: str | None = None, **extra):
+    return {
+        "uuid": uid,
+        "parentUuid": parent,
+        "type": typ,
+        "sessionId": "00000000-0000-4000-8000-000000000001",
+        "message": {"content": content},
+        **extra,
+    }
+
+
+def _append(path: Path, *entries: dict, final_newline: bool = True) -> None:
+    text = "\n".join(json.dumps(e, ensure_ascii=False) for e in entries)
+    if final_newline:
+        text += "\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(text)
+
+
+def _describe(entry: dict) -> dict:
+    content = (entry.get("message") or {}).get("content")
+    if isinstance(content, str):
+        count = 0 if "<task-notification>" in content else int(bool(content.strip()))
+        preview = content[:80] if entry.get("type") == "user" and count else ""
+        notifications = []
+    else:
+        count = sum(1 for block in content or [] if block.get("type") in {
+            "text", "thinking", "tool_use", "tool_result",
+        })
+        preview = ""
+        notifications = []
+    tools = [
+        {"id": block.get("id", ""), "name": block.get("name", "")}
+        for block in content or []
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ] if isinstance(content, list) else []
+    return {
+        "bubble_count": count,
+        "user_preview": preview,
+        "tool_uses": tools,
+        "task_notifications": notifications,
+    }
+
+
+def test_incremental_append_partial_malformed_and_replace(tmp_path):
+    transcript = tmp_path / "s.jsonl"
+    index_path = tmp_path / "s.transcript-index.json"
+    _append(transcript, _entry("u1", "user", "one"))
+
+    first = ti.ensure_index("s", transcript, index_path, _describe)
+    assert len(first["records"]) == 1
+    assert first["source"]["scanned_bytes"] == transcript.stat().st_size
+    generation1 = first["history_generation"]
+
+    # A partial tail is not indexed and scanned_bytes stays at its beginning.
+    partial = json.dumps(_entry("a1", "assistant", "two"), ensure_ascii=False)
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write(partial[: len(partial) // 2])
+    partial_index = ti.ensure_index("s", transcript, index_path, _describe)
+    assert len(partial_index["records"]) == 1
+    partial_start = partial_index["source"]["scanned_bytes"]
+    assert partial_start < transcript.stat().st_size
+    assert partial_index["history_generation"] == generation1
+
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write(partial[len(partial) // 2:] + "\n{malformed}\n")
+    appended = ti.ensure_index("s", transcript, index_path, _describe)
+    assert [r["uuid"] for r in appended["records"]] == ["u1", "a1"]
+    assert appended["source"]["scanned_bytes"] == transcript.stat().st_size
+    assert appended["history_generation"] != generation1
+
+    # Atomic replacement changes inode and forces a clean rebuild.
+    replacement = tmp_path / "replacement"
+    _append(replacement, _entry("u9", "user", "replacement"))
+    os.replace(replacement, transcript)
+    rebuilt = ti.ensure_index("s", transcript, index_path, _describe)
+    assert [r["uuid"] for r in rebuilt["records"]] == ["u9"]
+
+    # A stale schema is rejected and rebuilt rather than trusted.
+    bad = json.loads(index_path.read_text())
+    bad["schema"] = 999
+    index_path.write_text(json.dumps(bad))
+    schema_rebuilt = ti.ensure_index("s", transcript, index_path, _describe)
+    assert schema_rebuilt["schema"] == ti.SCHEMA_VERSION
+    assert [r["uuid"] for r in schema_rebuilt["records"]] == ["u9"]
+
+
+def test_same_inode_growing_rewrite_rebuilds(tmp_path):
+    transcript = tmp_path / "rewrite.jsonl"
+    index_path = tmp_path / "rewrite.index.json"
+    _append(transcript, _entry("old", "user", "old"))
+    ti.ensure_index("rewrite", transcript, index_path, _describe)
+    inode = transcript.stat().st_ino
+
+    replacement_text = (
+        json.dumps(_entry("new1", "user", "new one")) + "\n"
+        + json.dumps(_entry("new2", "assistant", "new two", "new1")) + "\n"
+    )
+    transcript.write_text(replacement_text)
+    assert transcript.stat().st_ino == inode
+    rebuilt = ti.ensure_index("rewrite", transcript, index_path, _describe)
+    assert [record["uuid"] for record in rebuilt["records"]] == ["new1", "new2"]
+
+
+def test_same_inode_middle_rewrite_plus_growth_rebuilds(tmp_path):
+    """Changing only the indexed middle must invalidate append metadata."""
+    transcript = tmp_path / "middle-rewrite.jsonl"
+    index_path = tmp_path / "middle-rewrite.index.json"
+    entries = [
+        _entry(f"u{i:02d}", "user", f"marker-{i:02d}-" + (str(i) * 6000))
+        for i in range(9)
+    ]
+    _append(transcript, *entries)
+    first = ti.ensure_index("middle-rewrite", transcript, index_path, _describe)
+    generation = first["history_generation"]
+    inode = transcript.stat().st_ino
+
+    # Preserve the old first/last 4 KiB and total indexed length. The old
+    # sparse prefix fingerprint accepted this as a pure append.
+    rewritten = list(entries)
+    rewritten[4] = _entry("x04", "user", "change-04-" + ("4" * 6000))
+    old_line = json.dumps(entries[4], ensure_ascii=False)
+    new_line = json.dumps(rewritten[4], ensure_ascii=False)
+    assert len(old_line) == len(new_line)
+    transcript.write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in rewritten) + "\n",
+        encoding="utf-8",
+    )
+    _append(transcript, _entry("u09", "assistant", "appended", "x04"))
+    assert transcript.stat().st_ino == inode
+
+    rebuilt = ti.ensure_index(
+        "middle-rewrite", transcript, index_path, _describe)
+    uuids = [record["uuid"] for record in rebuilt["records"]]
+    assert "x04" in uuids
+    assert "u04" not in uuids
+    assert "u09" in uuids
+    assert rebuilt["history_generation"] != generation
+
+
+def test_normal_chain_matches_sdk_leaf_rules_and_full_keeps_file_order(tmp_path):
+    transcript = tmp_path / "branch.jsonl"
+    index_path = tmp_path / "branch.index.json"
+    _append(
+        transcript,
+        _entry("u1", "user", "root"),
+        _entry("a1", "assistant", "old", "u1"),
+        _entry("side", "assistant", "side", "u1", isSidechain=True),
+        _entry("u2", "user", "active", "a1"),
+        _entry("a2", "assistant", "leaf", "u2"),
+    )
+    index = ti.ensure_index("branch", transcript, index_path, _describe)
+    records = index["records"]
+    assert [records[i]["uuid"] for i in index["orders"]["normal"]] == [
+        "u1", "a1", "u2", "a2",
+    ]
+    assert [records[i]["uuid"] for i in index["orders"]["full"]] == [
+        "u1", "a1", "side", "u2", "a2",
+    ]
+    assert index["bubble_prefix"]["normal"][-1] == 4
+
+
+def test_same_sid_build_is_single_flight(tmp_path):
+    transcript = tmp_path / "concurrent.jsonl"
+    index_path = tmp_path / "concurrent.index.json"
+    _append(transcript, *[_entry(f"u{i}", "user", str(i)) for i in range(30)])
+    calls = 0
+
+    def describe(entry):
+        nonlocal calls
+        calls += 1
+        return _describe(entry)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(
+            lambda _: ti.ensure_index("same", transcript, index_path, describe),
+            range(8),
+        ))
+    assert calls == 30
+    assert all(len(result["records"]) == 30 for result in results)
+    assert "same" not in ti._locks
+
+
+def _make_endpoint_session(client, auth, chat_mod, tmp_path, entries):
+    response = client.post(
+        "/api/chat/sessions", headers=auth,
+        json={"name": "indexed", "model": "claude-sonnet-4-6"},
+    )
+    assert response.status_code == 200, response.text
+    sid = response.json()["id"]
+    transcript = tmp_path / f"{sid}.jsonl"
+    _append(transcript, *entries)
+    chat_mod._JSONL_PATH_CACHE[sid] = transcript
+    return sid, transcript
+
+
+def test_window_endpoint_matches_full_oracle_and_adds_stable_keys(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+    entries = [
+        _entry("u1", "user", "hello"),
+        _entry("a1", "assistant", [
+            {"type": "thinking", "thinking": "hmm"},
+            {"type": "text", "text": "before"},
+            {"type": "tool_use", "id": "toolu_1", "name": "Read",
+             "input": {"file_path": "/tmp/a"}},
+            {"type": "text", "text": "after"},
+        ], "u1"),
+        _entry("u2", "user", "next", "a1"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    oracle = chat_mod._sdk_messages_to_ui([
+        chat_mod._RawMsg(e["uuid"], e["type"], e["message"]) for e in entries
+    ], {})
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"offset": 1, "limit": 4},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [(m["role"], m.get("text"), m.get("id")) for m in body["messages"]] == [
+        (m["role"], m.get("text"), m.get("id")) for m in oracle[1:5]
+    ]
+    assert body["total"] == len(oracle)
+    assert body["has_more"] is True
+    assert body["has_later"] is True
+    assert body["history_generation"]
+    assert len({m["_key"] for m in body["messages"]}) == len(body["messages"])
+
+
+def test_cross_window_tool_context_task_status_generation_and_around(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+    notification = (
+        "<task-notification>\n"
+        "<tool-use-id>toolu_bg</tool-use-id>\n"
+        "<task-id>t1</task-id><status>completed</status>"
+        "<summary>done</summary><output-file>/tmp/t1.output</output-file>"
+        "</task-notification>"
+    )
+    entries = [
+        _entry("u1", "user", "start"),
+        _entry("a1", "assistant", [
+            {"type": "tool_use", "id": "toolu_bg", "name": "Bash",
+             "input": {"command": "printf hi", "run_in_background": True}},
+        ], "u1"),
+        _entry("u2", "user", [
+            {"type": "tool_result", "tool_use_id": "toolu_bg",
+             "content": "<stdout>hi</stdout><stderr></stderr><exit_code>0</exit_code>"},
+        ], "a1"),
+        _entry("u3", "user", notification, "u2"),
+        _entry("a2", "assistant", "finished", "u3"),
+    ]
+    sid, transcript = _make_endpoint_session(
+        client, auth, chat_mod, tmp_path, entries)
+
+    tool_result = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"offset": 2, "limit": 1},
+    ).json()
+    assert tool_result["messages"][0]["role"] == "tool_result"
+    assert tool_result["messages"][0]["tool_name"] == "Bash"
+    assert "bash" in tool_result["messages"][0]
+    generation = tool_result["history_generation"]
+    assert chat_mod.sess.get_session_meta(sid)["turn_count"] == 1
+
+    tool_card = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"offset": 1, "limit": 1},
+    ).json()["messages"][0]
+    assert tool_card["task_status"]["state"] == "completed"
+    assert tool_card["task_status"]["summary"] == "done"
+
+    around = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"around_uuid": "u2", "limit": 3},
+    )
+    assert around.status_code == 200, around.text
+    # limit is a UI-bubble budget.  The zero-bubble task notification between
+    # u2 and a2 does not consume it, so one visible bubble on either side of
+    # the target yields a1/u2/a2 and reaches the end of full-order history.
+    assert {m["uuid"] for m in around.json()["messages"]} == {"a1", "u2", "a2"}
+    assert around.json()["has_later"] is False
+
+    _append(transcript, _entry("u4", "user", "new", "a2"))
+    stale = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"tail": 2, "history_generation": generation},
+    )
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["error"] == "history_generation_mismatch"
+
+
+def test_around_uuid_limit_is_in_bubbles_and_keeps_target(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+
+    def rich(uid: str, parent: str) -> dict:
+        return _entry(uid, "assistant", [
+            {"type": "thinking", "thinking": f"think-{uid}"},
+            {"type": "text", "text": f"text-a-{uid}"},
+            {"type": "tool_use", "id": f"tool-{uid}", "name": "Read",
+             "input": {"file_path": "/tmp/x"}},
+            {"type": "text", "text": f"text-b-{uid}"},
+        ], parent)
+
+    entries = [_entry("u0", "user", "root")]
+    parent = "u0"
+    for i in range(8):
+        assistant = f"a{i}"
+        user = f"u{i + 1}"
+        entries.append(rich(assistant, parent))
+        entries.append(_entry(user, "user", f"prompt-{i + 1}", assistant))
+        parent = user
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"around_uuid": "u4", "limit": 5},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["messages"]) <= 5
+    assert any(item["uuid"] == "u4" for item in body["messages"])
+    assert body["history_order"] == "full"
+    assert body["has_more"] is True
+    assert body["has_later"] is True
+
+    # The returned offset is explicitly full-order. Continuing with full=1
+    # yields the immediately preceding bubbles instead of interpreting it in
+    # the compact/active normal coordinate space.
+    older_start = max(0, body["offset"] - 3)
+    older = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={
+            "full": 1,
+            "offset": older_start,
+            "limit": body["offset"] - older_start,
+            "history_generation": body["history_generation"],
+        },
+    )
+    assert older.status_code == 200, older.text
+    assert older.json()["history_order"] == "full"
+    assert older.json()["offset"] == older_start
+
+
+def test_tail_reconciles_pending_attachments_in_transcript_order(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+
+    image = {"type": "image", "source": {"media_type": "image/png"}}
+    entries = [
+        _entry("u1", "user", [image]),
+        _entry("a1", "assistant", "one", "u1"),
+        _entry("u2", "user", [image], "a1"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    chat_mod.sess.append_pending_attachments(
+        sid, images=[{"mime": "image/png", "thumb": "first"}])
+    chat_mod.sess.append_pending_attachments(
+        sid, images=[{"mime": "image/png", "thumb": "second"}])
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 1})
+    assert response.status_code == 200, response.text
+    assert response.json()["messages"][0]["images"][0]["thumb"] == "second"
+    annotations = chat_mod.sess.get_message_annotations(sid)
+    assert annotations["u1"]["images"][0]["thumb"] == "first"
+    assert annotations["u2"]["images"][0]["thumb"] == "second"
+
+
+def test_outline_uses_index_and_excludes_compact_summary(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+    entries = [
+        _entry("u1", "user", "# First prompt"),
+        _entry("c1", "user", "compacted", "u1", isCompactSummary=True),
+        _entry("a1", "assistant", "answer", "c1"),
+        _entry("u2", "user", [
+            {"type": "image", "source": {"media_type": "image/png"}},
+        ], "a1"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    response = client.get(f"/api/chat/sessions/{sid}/outline", headers=auth)
+    assert response.status_code == 200
+    assert response.json()["outline"] == [
+        {"preview": "First prompt", "uuid": "u1"},
+        {"preview": "(empty)", "uuid": "u2"},
+    ]
+    assert response.json()["history_generation"]

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -662,9 +662,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 变更类型\n- [x] 性能优化\n- [x] 修复\n- [x] 测试\n\n## 变更说明\n- 为超长会话增加转录索引和窗口化历史读取，降低移动端首次打开与切换成本\n- 限制驻留消息面板和流式缓冲，支持 generation 冲突与断流后的规范历史恢复\n- 修复子代理模型别名路由，覆盖 Explore 等子代理调用\n- 隔离多标签草稿、附件上传、队列编辑和流式状态，避免跨标签串写\n- 保持工作区切换只影响会话 cwd，不扩张文件归档面的语义\n\n## 测试情况\n- 单元测试按文件隔离执行：534 项通过\n- Chromium E2E：18 项通过\n- Ruff、JavaScript 语法与 git diff 检查通过\n- 真实约 29 MB 会话：冷加载约 1.10 秒，尾部 75 条约 0.014 秒\n- 真实 Explore 子代理调用成功\n\n## 审查检查项\n- [x] 代码符合规范\n- [x] 添加/更新了测试\n- [x] 自测通过\n- [x] 未包含私有文档或敏感信息