### PR TITLE
fix(agent): 收敛 Claude SDK 权限与会话运行时

### DIFF
--- a/backend/api_settings.py
+++ b/backend/api_settings.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from claude_agent_sdk.types import PermissionMode
 from pydantic import BaseModel, Field, model_validator
 
 from .auth import require_token
@@ -103,7 +104,7 @@ class SettingsIn(BaseModel):
     provider_keys: dict[str, str] | None = None
     # Defaults
     default_model: str | None = None
-    default_permission: str | None = None
+    default_permission: PermissionMode | None = None
     # (Removed 2026-05-28) notify_scheduled / notify_normal —
     # The 4-toggle notification panel collapsed to a single client-side
     # "notify me" switch. Subscription state IS the on/off; no per-class

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -64,9 +64,9 @@ from . import permission_request as perm
 # Valid permission modes, derived from the SDK's PermissionMode literal so
 # the whitelist tracks SDK upgrades automatically. External strings (query
 # params, queue items, tickets) flow into ClaudeAgentOptions / client
-# .set_permission_mode() — a typo'd or stale value would fail the SDK
-# connect (or worse, silently diverge UI state from the real gate), so
-# entry points must normalize through _validate_permission().
+# launch contract — a typo'd or stale value would fail the SDK connect (or
+# worse, silently diverge UI state from the real gate), so entry points must
+# normalize through _validate_permission().
 _VALID_PERMISSION_MODES: frozenset = frozenset(get_args(PermissionMode))
 
 
@@ -360,19 +360,11 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 # Clients keyed by (session_id, model, effort).
 _ClientKey = tuple[str, str, str]
 _clients: dict[_ClientKey, ClaudeSDKClient] = {}
-# Tracks the permission_mode currently active on each cached client. SDK
-# doesn't expose a getter, so we shadow what we asked for. Lets a cached
-# client whose mode no longer matches the request swap via
-# client.set_permission_mode() instead of needing a full rebuild.
+# Tracks the permission_mode the cached client was launched with. Permission
+# is launch-sensitive (notably default -> bypassPermissions cannot always be
+# enabled dynamically), so a mismatch rebuilds the runtime instead of trying
+# to mutate it in place.
 _client_permission: dict[_ClientKey, str] = {}
-# Per-client mutable bypass flag, shared by reference with the can_use_tool
-# closure built in permission_request. Switching permission mode on a pooled
-# client (set_permission_mode) must flip this flag so the closure stops/starts
-# auto-allowing tools — otherwise the bypass value baked in at build time
-# leaks across mode switches (2026-05-29 audit). Value is `{"bypass": bool}`;
-# the SAME dict object is captured by the closure, so mutating it here takes
-# effect on the next tool call without a rebuild.
-_bypass_state: dict[_ClientKey, dict] = {}
 
 
 _BROADCAST_REPLAY_MAX_EVENTS = env_int(
@@ -665,6 +657,20 @@ def _get_recent_turn(session_id: str) -> TurnBroadcast | None:
 _client_lru: list[_ClientKey] = []   # (session_id, model, effort)
 _CLIENT_POOL_CAP = env_int("MUSELAB_CLIENT_POOL_CAP", 3, min_value=1)
 _lock = asyncio.Lock()
+
+# Exactly one SDK operation may own a session's CLI stream at a time. The
+# interactive turn mutex only covers /stream turns; scheduler and /compact
+# also call query()/receive_response() and therefore share this lock.
+_session_runtime_locks: dict[str, asyncio.Lock] = {}
+# Session settings can change after a turn reserves `_active_turns[sid]` but
+# before its detached query task starts. Disconnecting in that gap kills the
+# freshly selected client. Mark rebuilds and consume them at the next safe SDK
+# boundary instead.
+_pending_runtime_rebuilds: set[str] = set()
+
+
+def _session_runtime_lock_for(session_id: str) -> asyncio.Lock:
+    return _session_runtime_locks.setdefault(session_id, asyncio.Lock())
 
 # ---------------------------------------------------------------------------
 # Cross-turn background tasks (SDK-native run_in_background)
@@ -1608,6 +1614,10 @@ async def _build_and_connect_client(
     env_ovr = endpoints.env_override(model)
     if env_ovr is not None:
         env_ovr = dict(env_ovr)
+        # Isolated vendor config prevents OAuth fallback, but starts with no
+        # project trust state. Without this marker the CLI silently ignores
+        # permissions.allow rules from the workspace settings.
+        endpoints.ensure_vendor_workspace_trusted(workspace_root)
         # Agent/Task's `model` field is intentionally an alias enum
         # (sonnet|opus|haiku|fable), not an arbitrary model ID. Without these
         # CLI-native alias overrides, a subagent launched inside a Codex or
@@ -1730,29 +1740,13 @@ async def _build_and_connect_client(
     # need not appear in _VALID_EFFORT.)
     if effort and effort in _VALID_EFFORT:
         opts_kwargs["effort"] = effort
-    # Wire the SDK's can_use_tool callback UNCONDITIONALLY (2026-05-23).
-    # Two responsibilities:
-    #   1. Per-tool permission prompts (only when permission != bypass).
-    #   2. Routing built-in AskUserQuestion calls to muselab's UI — needed
-    #      ALWAYS, even on bypassPermissions. Without this, when the model
-    #      calls SDK's built-in `AskUserQuestion` (the shorter name —
-    #      models often forget the longer `mcp__muselab__ask_user_question`
-    #      MCP alias), the SDK's default tool handler tries to surface a
-    #      terminal-style prompt that obviously can't render in the web
-    #      UI → user sees "no options to pick" and is stuck waiting.
-    # The `bypass` flag tells the callback to auto-allow everything except
-    # AskUserQuestion, preserving the no-prompts UX while still surfacing
-    # the model's questions.
-    # The bypass flag is a mutable dict captured by reference inside the
-    # can_use_tool closure, then registered under this (sid, model, effort)
-    # key so set_permission_mode can flip it on a cached client without a
-    # rebuild. Register BEFORE connect so the key is live the moment the
-    # client is usable.
-    key = (session_id, model, effort)
-    bypass_state = {"bypass": permission == "bypassPermissions"}
-    _bypass_state[key] = bypass_state
-    opts_kwargs["can_use_tool"] = perm.build_callback_for_session(
-        session_id, bypass_state=bypass_state)
+    # can_use_tool resolves SDK permission prompts; it is not a universal tool
+    # hook. In bypassPermissions the SDK approves tools before consulting the
+    # callback, so wiring it there only creates a false AskUserQuestion promise
+    # plus CanUseToolShadowedWarning noise. Interactive questions use the
+    # dedicated muselab MCP tool in every mode.
+    if permission != "bypassPermissions":
+        opts_kwargs["can_use_tool"] = perm.build_callback_for_session(session_id)
     try:
         client = ClaudeSDKClient(options=ClaudeAgentOptions(**opts_kwargs))
         await client.connect()
@@ -1976,6 +1970,12 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
 
     effort: "" (SDK adaptive) / "low" / "medium" / "high" / "xhigh" / "max".
     Anything else is ignored — invalid values fall back to the SDK default."""
+    if session_id in _pending_runtime_rebuilds:
+        # Callers that operate a session hold its runtime lock. Consuming the
+        # marker here closes the race where a new turn reserves the active slot
+        # just before the previous turn's cleanup tries to rebuild.
+        await disconnect_client(session_id)
+
     key = (session_id, model, effort)
 
     # Fast path: cache hit. Lock just long enough to read + touch LRU.
@@ -1988,26 +1988,15 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
         cached_perm = _client_permission.get(key) if cached is not None else None
 
     if cached is not None:
-        # set_permission_mode runs OUTSIDE _lock — it can take seconds and
-        # we never want sibling requests to wait on it. The cache key is
-        # (sid, model, effort), NOT permission, so swapping permission
-        # doesn't trigger a CLI subprocess rebuild.
+        # Permission is part of the runtime's launch contract even though it
+        # is not part of the storage key. In particular, a process launched in
+        # default mode may reject a later switch to bypassPermissions. Never
+        # return a stale client after a failed control request: replace the
+        # session runtime deterministically.
         if cached_perm != permission:
-            try:
-                await cached.set_permission_mode(permission)
-                _client_permission[key] = permission
-                # Flip the can_use_tool bypass flag to match the new mode.
-                # Without this the closure keeps the bypass value baked in at
-                # build time, so switching bypassPermissions → default would
-                # still auto-allow every tool (permission cards never show).
-                st = _bypass_state.get(key)
-                if st is not None:
-                    st["bypass"] = (permission == "bypassPermissions")
-            except Exception as e:
-                sys.stderr.write(
-                    f"[chat] set_permission_mode {cached_perm}→{permission} "
-                    f"failed for {key}: {type(e).__name__}: {e}\n")
-                sys.stderr.flush()
+            await disconnect_client(session_id)
+            return await get_client(
+                session_id, model, permission, effort=effort)
         return cached
 
     # Cache miss: build a new client OUTSIDE _lock. Per-key creation
@@ -2022,7 +2011,16 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
                 if key in _client_lru:
                     _client_lru.remove(key)
                 _client_lru.append(key)
+            cached_perm = (
+                _client_permission.get(key) if cached is not None else None)
+
+        # Two callers can race on the same storage key while requesting
+        # different launch modes. The creation lock coalesces them, but the
+        # waiter must still reject the runtime built with the other mode.
+        if cached is not None:
+            if cached_perm == permission:
                 return cached
+            await disconnect_client(session_id)
 
         # Slow path — no awaits hold _lock.
         client = await _build_and_connect_client(
@@ -2072,7 +2070,6 @@ async def get_client(session_id: str, model: str, permission: str = "bypassPermi
                 old_key = _client_lru.pop(candidate_idx)
                 old_client = _clients.pop(old_key, None)
                 _client_permission.pop(old_key, None)
-                _bypass_state.pop(old_key, None)
                 # Drop the per-key creation lock too — otherwise evicted
                 # keys leak Lock objects in _creation_locks forever
                 # (disconnect_client clears it, but LRU eviction didn't).
@@ -2097,12 +2094,12 @@ async def disconnect_client(session_id: str) -> None:
     exit; we pop dict entries under _lock but do the await OUTSIDE so
     other requests aren't blocked for seconds at a time."""
     to_disconnect: list[ClaudeSDKClient] = []
+    _pending_runtime_rebuilds.discard(session_id)
     async with _lock:
         keys = [k for k in _clients if k[0] == session_id]
         for k in keys:
             c = _clients.pop(k, None)
             _client_permission.pop(k, None)
-            _bypass_state.pop(k, None)
             _creation_locks.pop(k, None)
             if k in _client_lru:
                 _client_lru.remove(k)
@@ -2115,11 +2112,28 @@ async def disconnect_client(session_id: str) -> None:
             pass
 
 
+async def _rebuild_session_runtime(session_id: str) -> None:
+    """Disconnect now, or defer until the active turn reaches a safe boundary."""
+    active = _active_turns.get(session_id)
+    if active is not None and not active.done:
+        _pending_runtime_rebuilds.add(session_id)
+        return
+    async with _session_runtime_lock_for(session_id):
+        # A turn may reserve the session while this coroutine waits for the
+        # mutex. Its get_client() will consume the marker before querying.
+        active = _active_turns.get(session_id)
+        if active is not None and not active.done:
+            _pending_runtime_rebuilds.add(session_id)
+            return
+        await disconnect_client(session_id)
+
+
 # ====== sessions REST ======
 
 class CreateReq(BaseModel):
     name: str | None = None
     model: str | None = None
+    permission: str = ""
     cwd: str = ""
     # Optimistic-create (2026-06-07): the client mints the session UUID up
     # front so the new-chat tab opens with ZERO network wait, then POSTs here
@@ -2432,6 +2446,7 @@ def create_session_api(req: CreateReq) -> dict:
     # 401 forever; the frontend gates chat until a provider exists, and the
     # model is resolved on first send.
     resolved_model = _resolve_default_model(req.model, allow_fallback=False)
+    resolved_permission = _validate_permission(req.permission)
     client_id = (req.id or "").strip()
     if client_id:
         # Optimistic-create path: the client minted this UUID and already
@@ -2453,6 +2468,7 @@ def create_session_api(req: CreateReq) -> dict:
                 client_id,
                 name=req.name or "",
                 model=resolved_model,
+                permission=resolved_permission,
                 auto_named=True,
                 cwd=req.cwd or None,
             )
@@ -2463,6 +2479,7 @@ def create_session_api(req: CreateReq) -> dict:
             meta = sess.create_session(
                 name=req.name or "",
                 model=resolved_model,
+                permission=resolved_permission,
                 cwd=req.cwd or None,
             )
         except ValueError as exc:
@@ -3853,6 +3870,11 @@ def export_session_markdown(sid: str) -> Response:
 
 def _clear_session_runtime_state(sid: str) -> None:
     """Forget detached turn/continuation state owned by a deleted session."""
+    perm.clear_session_permissions(sid)
+    _pending_runtime_rebuilds.discard(sid)
+    runtime_lock = _session_runtime_locks.get(sid)
+    if runtime_lock is not None and not runtime_lock.locked():
+        _session_runtime_locks.pop(sid, None)
     _continuation_generations[sid] = _continuation_generations.get(sid, 0) + 1
     watcher = _task_watchers.pop(sid, None)
     if watcher is not None and not watcher.done():
@@ -4137,6 +4159,7 @@ class SessionPatchReq(BaseModel):
     name: str | None = None
     system_prompt: str | None = None
     model: str | None = None
+    permission: str | None = None
     # SDK-native session tag — written to CLI JSONL so other tools (and
     # manual `claude` CLI runs) see it. Pass empty string to clear.
     tag: str | None = None
@@ -4185,7 +4208,10 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
     if req.system_prompt is not None:
         ok = sess.update_system_prompt(sid, req.system_prompt) or ok
         # System prompt change invalidates cached SDK clients for this session.
-        await disconnect_client(sid)
+        await _rebuild_session_runtime(sid)
+    if req.permission is not None:
+        permission = _validate_permission(req.permission)
+        ok = sess.update_permission(sid, permission) or ok
     if req.effort is not None:
         # Validate against SDK literal set; empty string is a deliberate
         # "clear override" signal so the user can revert to adaptive.
@@ -4202,7 +4228,7 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
         if req.effort != cur_effort:
             sess.update_effort(sid, req.effort)
             # The next stream() call picks up the new value via get_session().
-            await disconnect_client(sid)
+            await _rebuild_session_runtime(sid)
         ok = True
     if req.thinking is not None:
         # No-op guard, same rationale as effort: toggling thinking forces a
@@ -4211,7 +4237,7 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
         cur_thinking = bool((sess.get_session(sid) or {}).get("thinking", True))
         if bool(req.thinking) != cur_thinking:
             sess.update_thinking(sid, bool(req.thinking))
-            await disconnect_client(sid)
+            await _rebuild_session_runtime(sid)
         ok = True
     if req.model is not None and req.model == ((sess.get_session(sid) or {}).get("model") or ""):
         # No-op: re-selecting the current model would otherwise interrupt a
@@ -4243,72 +4269,13 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
                         f"[chat] interrupt before model swap failed for "
                         f"{sid}: {type(_e).__name__}: {_e}\n")
         sess.update_model(sid, req.model)
-        # SDK-native swap if same provider — `client.set_model()` reuses the
-        # CLI subprocess (and its loaded CLAUDE.md / MCP / system prompt).
-        # Cross-provider switch (e.g. Claude → DeepSeek) needs full rebuild
-        # because env_override / base_url differ.
-        async with _lock:
-            live = [(k, c) for k, c in _clients.items() if k[0] == sid]
-        pa = endpoints.lookup(req.model)
-        same_provider = (
-            len(live) == 1
-            and ((pa is None and endpoints.lookup(live[0][0][1]) is None)
-                 or (pa is not None
-                     and endpoints.lookup(live[0][0][1]) is not None
-                     and endpoints.lookup(live[0][0][1]).prefix == pa.prefix)))
-        if same_provider:
-            (old_key, client) = live[0]
-            try:
-                await client.set_model(endpoints.normalize_model_id(req.model))
-                # Re-validate under _lock — between the snapshot above
-                # and now, another request could have evicted / replaced
-                # _clients[old_key] (eviction from a parallel get_client,
-                # an interrupt, or even a competing model swap). Without
-                # this check we'd silently pop whatever's there now and
-                # leak the original client OR clobber a fresh handle the
-                # next turn just created.
-                snapshot_still_valid = False
-                async with _lock:
-                    if _clients.get(old_key) is client:
-                        snapshot_still_valid = True
-                        _clients.pop(old_key, None)
-                        perm = _client_permission.pop(old_key, "bypassPermissions")
-                        # The client object (and its can_use_tool closure) is
-                        # reused under new_key, so move the shared bypass dict
-                        # too — otherwise a later set_permission_mode can't
-                        # find it to flip the flag.
-                        bstate = _bypass_state.pop(old_key, None)
-                        if old_key in _client_lru:
-                            _client_lru.remove(old_key)
-                        # Preserve the effort dimension when remapping under
-                        # the new model — set_model() keeps the SDK options
-                        # object, which still has the prior effort baked in.
-                        new_key = (sid, req.model, old_key[2], old_key[3])
-                        _clients[new_key] = client
-                        _client_permission[new_key] = perm
-                        if bstate is not None:
-                            _bypass_state[new_key] = bstate
-                        _client_lru.append(new_key)
-                if not snapshot_still_valid:
-                    # Our client is orphaned now (the cache entry was
-                    # replaced under us). Disconnect it so the CLI
-                    # subprocess goes away; next turn will rebuild.
-                    sys.stderr.write(
-                        f"[chat] set_model {old_key[1]}→{req.model} raced "
-                        f"with cache mutation; disconnecting orphan\n")
-                    try:
-                        await client.disconnect()
-                    except Exception:
-                        pass
-            except Exception as e:
-                sys.stderr.write(
-                    f"[chat] set_model {old_key[1]}→{req.model} failed: "
-                    f"{type(e).__name__}: {e}; rebuilding on next turn\n")
-                await disconnect_client(sid)
-        else:
-            # Cross-provider, or no/multiple live clients — disconnect; the
-            # next send() rebuilds with the new model.
-            await disconnect_client(sid)
+        # Model identity participates in several launch-time settings beyond
+        # the top-level --model flag: provider URL/auth, subagent aliases,
+        # context-window override, thinking support, and output limits. The
+        # SDK's set_model() control request updates only the top-level model,
+        # so even a same-provider swap must rebuild the runtime to keep those
+        # values coherent.
+        await _rebuild_session_runtime(sid)
         ok = True
     if not ok:
         raise HTTPException(404, "session not found or no changes")
@@ -5285,6 +5252,14 @@ async def context_breakdown(session_id: str, model: str = "") -> dict:
 
 @router.post("/sessions/{sid}/native-compact", dependencies=[Depends(require_token)])
 async def native_compact_session_api(sid: str) -> dict:
+    async with _session_runtime_lock_for(sid):
+        bc = _active_turns.get(sid)
+        if bc is not None and not bc.done:
+            raise HTTPException(409, "cannot compact while a turn is active")
+        return await _native_compact_session_locked(sid)
+
+
+async def _native_compact_session_locked(sid: str) -> dict:
     """Compact a session using the CLI's native /compact slash command via SDK.
     Lossless — CLI writes compact_boundary + isCompactSummary into the session
     JSONL. Subsequent get_session_messages() returns the summary in place of
@@ -5297,13 +5272,13 @@ async def native_compact_session_api(sid: str) -> dict:
         raise HTTPException(404, "session not found")
     model = (meta.get("model") or "").strip() or MODEL
     effort = (meta.get("effort") or "").strip()
-    # Remember the cached client's CURRENT permission mode (if any) so we can
-    # restore it after compact. Without this, forcing bypassPermissions for
-    # the /compact run permanently leaves a default/plan-mode client stuck in
-    # bypass until it's rebuilt — silently disabling the user's per-tool
-    # permission cards for every subsequent turn on this session.
+    # /compact is a CLI control command, not an agent tool call. Preserve the
+    # current runtime permission instead of escalating to bypassPermissions;
+    # a cold compact uses fail-closed default. This avoids a launch-sensitive
+    # permission transition for an operation that does not need one.
     prior_perm = _client_permission.get((sid, model, effort))
-    client = await get_client(sid, model, "bypassPermissions", effort=effort)
+    client = await get_client(
+        sid, model, prior_perm or "default", effort=effort)
     before_total = 0
     post_compact_usage: dict | None = None
     try:
@@ -5346,21 +5321,6 @@ async def native_compact_session_api(sid: str) -> dict:
                           f"{type(e).__name__}: {e}\n")
         sys.stderr.flush()
         raise HTTPException(500, "native /compact failed — see server log") from None
-    finally:
-        # Restore the pre-compact permission mode so the user's chosen
-        # default/plan/acceptEdits is not silently downgraded to bypass.
-        if prior_perm is not None and prior_perm != "bypassPermissions":
-            try:
-                await client.set_permission_mode(prior_perm)
-                _client_permission[(sid, model, effort)] = prior_perm
-                st = _bypass_state.get((sid, model, effort))
-                if st is not None:
-                    st["bypass"] = (prior_perm == "bypassPermissions")
-            except Exception as e:
-                sys.stderr.write(
-                    f"[chat] restore permission {prior_perm} after compact "
-                    f"failed for sid={sid[:8]}: {type(e).__name__}: {e}\n")
-                sys.stderr.flush()
     # Refresh the cached context-usage snapshot from the now-compacted live
     # client so the meter drops immediately and STAYS dropped. /usage reads
     # _session_usage first; on a miss it falls back to
@@ -5969,7 +5929,6 @@ async def reset(session_id: str | None = None) -> dict:
         for k in keys:
             c = _clients.pop(k, None)
             _client_permission.pop(k, None)
-            _bypass_state.pop(k, None)
             _creation_locks.pop(k, None)
             if k in _client_lru:
                 _client_lru.remove(k)
@@ -8228,6 +8187,7 @@ async def _start_turn(
     model: str = "",
     permission: str = "bypassPermissions",
     image_ids: str = "",
+    persist_permission: bool = True,
 ) -> "TurnBroadcast":
     """Reserve + launch a turn as a detached background task; return its
     TurnBroadcast (already inserted into _active_turns and pumping via
@@ -8319,6 +8279,13 @@ async def _start_turn(
         model_to_use = model or MODEL
         sess.update_model(session_id, model_to_use)
 
+    # Permission is a session setting, not a browser-global preference. A
+    # direct request remains authoritative and is persisted for legacy clients
+    # that do not use PATCH. Queue items deliberately replay their enqueue-time
+    # snapshot without rolling the session's newer selection back afterward.
+    if persist_permission:
+        sess.update_permission(session_id, permission)
+
     # Effort is per-session; read from metadata (settable via PATCH). Empty
     # string = SDK adaptive default, which is what the existing behavior was.
     effort_to_use = (s.get("effort") or "").strip()
@@ -8329,10 +8296,16 @@ async def _start_turn(
     # MODE, otherwise this session's slot stays "busy" forever and
     # subsequent sends get rejected.
     try:
-        client = await asyncio.wait_for(
-            get_client(session_id, model_to_use, permission, effort=effort_to_use),
-            timeout=60.0,
-        )
+        # Serialize client creation/replacement with scheduler and /compact.
+        # The active-turn reservation above is visible before we wait here, so
+        # those paths can fail cleanly instead of mutating this runtime.
+        async with _session_runtime_lock_for(session_id):
+            client = await asyncio.wait_for(
+                get_client(
+                    session_id, model_to_use, permission,
+                    effort=effort_to_use),
+                timeout=60.0,
+            )
     except asyncio.TimeoutError:
         async with _lock:
             if _active_turns.get(session_id) is broadcast:
@@ -8730,7 +8703,7 @@ async def _start_turn(
             but filter already-persisted response UUIDs and continue past their
             stale Result until the current query reaches its own terminal.
             """
-            try:
+            async def _run_query() -> None:
                 await _preflight_compact_if_needed()
                 # Snapshot AFTER preflight compact (which may write a new compact
                 # boundary) and immediately BEFORE this user query. A cache hit is
@@ -8786,6 +8759,9 @@ async def _start_turn(
                         f"[chat-stream] dropped stale replay sid={session_id[:8]} "
                         f"messages={replay_dropped}\n")
                     sys.stderr.flush()
+            try:
+                async with _session_runtime_lock_for(session_id):
+                    await _run_query()
             except Exception as e:
                 # Log the full exception type + message + traceback for diagnosis.
                 # SDK transport errors / vendor 401s land here. Without this we
@@ -9742,6 +9718,8 @@ async def _start_turn(
                 sys.stderr.write(f"[activity] finish failed sid={session_id}: {e}\n")
             broadcast.finish()
             _active_turns.pop(session_id, None)
+            if session_id in _pending_runtime_rebuilds:
+                await _rebuild_session_runtime(session_id)
             # Grace-keep: a fast (esp. server-drained) turn can finish + get
             # popped here BEFORE the browser's reconnect SSE attaches. Stash the
             # finished broadcast so a slightly-late reconnect still replays it
@@ -9861,6 +9839,7 @@ async def _maybe_drain_queue(session_id: str) -> None:
             item.get("text", ""),
             permission=perm,
             image_ids=item.get("image_ids", ""),
+            persist_permission=False,
         )
     except _TurnBusy:
         # A manual turn grabbed the slot between our check and the
@@ -10057,4 +10036,15 @@ def providers_list() -> dict:
     # frontend seeds each new chat from this instead of the currently-viewed
     # session's locked model — without it, a new session inherited whatever
     # old tab you happened to be on.
-    return {"models": flat, "default_model": _resolve_default_model("")}
+    try:
+        default_permission = _validate_permission(
+            os.environ.get("MUSELAB_DEFAULT_PERMISSION", "bypassPermissions"))
+    except HTTPException:
+        # A stale hand-edited env value must not leak invalid state into the
+        # selector or the SDK launch contract.
+        default_permission = "bypassPermissions"
+    return {
+        "models": flat,
+        "default_model": _resolve_default_model(""),
+        "default_permission": default_permission,
+    }

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -113,6 +113,7 @@ _VENDOR_CONFIG_DIR = (
     Path(tempfile.gettempdir())
     / f"muselab-vendor-cli-config-{os.getuid()}"
 )
+_VENDOR_CONFIG_LOCK = threading.Lock()
 
 
 def _vendor_config_dir() -> Path:
@@ -125,6 +126,41 @@ def _vendor_config_dir() -> Path:
     sessions."""
     _VENDOR_CONFIG_DIR.mkdir(exist_ok=True, mode=0o700)
     return _VENDOR_CONFIG_DIR
+
+
+def ensure_vendor_workspace_trusted(workspace: Path) -> None:
+    """Record trust in the isolated vendor CLI config.
+
+    Third-party sessions deliberately cannot reuse the real Claude config
+    because that could leak/fallback to OAuth. The isolation also means the
+    CLI has never seen the workspace trust dialog, so it otherwise ignores
+    project permission allow rules. Preserve every CLI-owned field and add
+    only the standard per-project trust bit.
+    """
+    from .settings import atomic_write_text
+
+    cfg_path = _vendor_config_dir() / ".claude.json"
+    workspace_key = str(workspace.resolve())
+    with _VENDOR_CONFIG_LOCK:
+        try:
+            raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+            data = raw if isinstance(raw, dict) else {}
+        except (FileNotFoundError, OSError, ValueError, TypeError):
+            data = {}
+        projects = data.get("projects")
+        if not isinstance(projects, dict):
+            projects = {}
+            data["projects"] = projects
+        current = projects.get(workspace_key)
+        project = dict(current) if isinstance(current, dict) else {}
+        if project.get("hasTrustDialogAccepted") is True:
+            return
+        project["hasTrustDialogAccepted"] = True
+        projects[workspace_key] = project
+        atomic_write_text(
+            cfg_path,
+            json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        )
 
 
 def _resolve_base_url(env_key: str, provider: Provider | None = None) -> str:

--- a/backend/permission_request.py
+++ b/backend/permission_request.py
@@ -7,12 +7,10 @@ Two responsibilities now share one callback (SDK 0.2.82 routes both through
 1. **Tool approval** (when permission_mode != bypassPermissions):
    surface a permission card, await Allow / Deny / Always.
 
-2. **AskUserQuestion** (always, regardless of permission_mode): SDK's
-   native multiple-choice tool. Detected by `tool_name == "AskUserQuestion"`.
-   We push a question to the SSE channel reusing `ask_user_question`'s
-   queue/Future registry (same UI rendering, same submit endpoint), then
-   return `PermissionResultAllow(updated_input={questions, answers})` per
-   the SDK contract.
+2. **AskUserQuestion** (only when the SDK actually asks): SDK's native
+   multiple-choice tool. In bypass mode the SDK auto-approves tools before
+   this callback, so muselab's reliable interactive surface is the dedicated
+   `mcp__muselab__ask_user_question` tool instead.
 
 "Always allow" works at the muselab session level (in-memory): subsequent calls
 to the same (tool, key) pair bypass the prompt for the rest of this session.
@@ -63,12 +61,21 @@ def register_session_queue(session_id: str) -> asyncio.Queue:
 
 def unregister_session_queue(session_id: str) -> None:
     _session_queues.pop(session_id, None)
-    _always_allow.pop(session_id, None)
     for key in list(_pending.keys()):
         if key[0] == session_id:
             fut = _pending.pop(key, None)
             if fut is not None and not fut.done():
                 fut.cancel()
+
+
+def clear_session_permissions(session_id: str) -> None:
+    """Forget session-scoped grants when the session itself is deleted.
+
+    Queue registration is turn-scoped, while an "always" decision is
+    session-scoped.  Keeping these lifetimes separate makes the UI promise
+    ("always allow for this session") true across multiple turns.
+    """
+    _always_allow.pop(session_id, None)
 
 
 def submit_decision(session_id: str, request_id: str, decision: str,
@@ -181,32 +188,14 @@ async def _handle_ask_user_question(
         updated_input={"questions": questions, "answers": answers})
 
 
-def build_callback_for_session(session_id: str,
-                                bypass_state: dict | None = None):
+def build_callback_for_session(session_id: str):
     """Return an async callable matching the SDK's can_use_tool signature.
 
-    Wired UNCONDITIONALLY now (2026-05-23) — not just when permission_mode
-    requires per-tool prompts. Reason: the SDK routes the built-in
-    `AskUserQuestion` tool calls through `can_use_tool`, so without a
-    callback the model's questions silently vanish on bypassPermissions
-    (the default). The MCP fallback `mcp__muselab__ask_user_question` is
-    great when the model remembers to use that name, but models often
-    forget and call the shorter built-in instead.
-
-    `bypass_state` is a MUTABLE dict `{"bypass": bool}` owned by the caller
-    (chat.get_client). The callback reads `bypass_state["bypass"]` at call
-    time — NOT baked in as a constant — so that switching permission mode on
-    a cached/pooled client (via set_permission_mode) takes effect without
-    rebuilding the closure. When `bypass` is True (permission_mode ==
-    bypassPermissions) every non-AskUserQuestion tool is auto-allowed
-    without showing a permission card; when False, full per-tool prompting.
-    AskUserQuestion is always forwarded to the UI regardless — it's
-    interactive by design. (2026-05-29: previously this captured a constant
-    `bypass`, so switching from bypassPermissions to default left the cached
-    closure unconditionally allowing every tool — permission cards silently
-    failed.)"""
-    if bypass_state is None:
-        bypass_state = {"bypass": False}
+    The callback is installed only for permission modes that can ask. The SDK
+    explicitly does not invoke it for calls already approved by bypass,
+    acceptEdits, allow rules, or whole-tool Skill grants. It is therefore a
+    prompt resolver, not a universal tool gate. Use a PreToolUse hook when an
+    operation must observe every tool call."""
 
     async def can_use_tool(
             tool_name: str, tool_input: dict[str, Any], context: Any
@@ -219,14 +208,6 @@ def build_callback_for_session(session_id: str,
         # for the SDK-contract details.
         if tool_name == "AskUserQuestion":
             return await _handle_ask_user_question(session_id, tool_input)
-
-        # Bypass: auto-allow everything else without prompting. This
-        # keeps the "no permission cards" UX promise of bypassPermissions
-        # while still letting AskUserQuestion above route through the UI.
-        # Read the flag LIVE (not a captured constant) so a mode switch on
-        # the pooled client takes effect immediately.
-        if bypass_state.get("bypass"):
-            return PermissionResultAllow(updated_input=tool_input)
 
         # Always-allow cache check. Empty set is falsy, so don't use `or`.
         key = _input_key(tool_name, tool_input)

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -561,6 +561,53 @@ def ack_unread() -> int:
 
 # ---------- task execution ----------
 
+
+async def _run_sdk_task_turn(
+    session_id: str, model: str, prompt: str,
+) -> tuple[str, str | None]:
+    """Run one unattended turn under the session-wide SDK mutex."""
+    from .chat import (
+        _active_turns,
+        _session_runtime_lock_for,
+        get_client,
+    )
+
+    reply_text = ""
+    error: str | None = None
+    async with _session_runtime_lock_for(session_id):
+        # Re-check after acquiring: an interactive request may have reserved
+        # the session while this scheduled run was waiting for the mutex.
+        active = _active_turns.get(session_id)
+        if active is not None and not active.done:
+            raise RuntimeError("session is busy with an interactive turn")
+
+        # Unattended runs intentionally use bypassPermissions: no UI is
+        # present to answer a prompt. This is not a sandbox; the process has
+        # the service user's OS authority. Deployments that schedule prompts
+        # over untrusted content must isolate the service account/container or
+        # introduce an explicit non-interactive allow policy.
+        client = await get_client(
+            session_id=session_id,
+            model=model,
+            permission="bypassPermissions",
+        )
+        await client.query(prompt)
+        async for msg in client.receive_response():
+            if isinstance(msg, AssistantMessage):
+                for block in getattr(msg, "content", []) or []:
+                    if isinstance(block, TextBlock):
+                        reply_text += getattr(block, "text", "") or ""
+            elif isinstance(msg, ResultMessage):
+                if getattr(msg, "is_error", False):
+                    subtype = getattr(msg, "subtype", None) or "error"
+                    errors = getattr(msg, "errors", None) or []
+                    detail = "; ".join(str(e) for e in errors)
+                    error = (f"SDK result error ({subtype})"
+                             + (f": {detail}" if detail else ""))
+                break
+    return reply_text, error
+
+
 async def run_task_now(tid: str) -> bool:
     """Fire-and-forget out-of-schedule run. Returns True if the task exists
     and got scheduled; False if not found. Does NOT advance next_run — this
@@ -596,7 +643,6 @@ async def _execute_task(task: dict) -> None:
         the regular session list. task["session_id"] is overwritten to
         point at the latest run — list_task_history(tid) is the full
         view via history entries."""
-    from .chat import get_client  # local import — avoids startup cycle
     from datetime import datetime
 
     tid = task["id"]
@@ -650,57 +696,12 @@ async def _execute_task(task: dict) -> None:
             # default when task.model is empty.
             from .settings import MODEL as _DEFAULT_MODEL
             model = task.get("model") or _DEFAULT_MODEL
-            # SECURITY — unattended runs use bypassPermissions BY DESIGN.
-            # A scheduled task fires with no human present, so there is no
-            # one to answer a permission prompt; any mode that can block on
-            # can_use_tool would hang the run forever. The cost is that the
-            # agent can run arbitrary Bash (mv / rm / write files) with no
-            # confirmation. The real escalation path is PROMPT INJECTION:
-            # if a scheduled prompt pulls in external content (e.g.
-            # "summarize my latest email / fetch this page"), injected
-            # instructions in that content execute unchecked. Mitigations
-            # already in place: the SDK disallowed_tools blocklist (chat.py)
-            # and the archive-root sandbox. Self-hosters who schedule tasks
-            # that read untrusted external content should keep those prompts
-            # narrow. Do NOT "fix" this by switching to default/acceptEdits
-            # without also giving unattended runs a non-interactive
-            # permission resolver — otherwise scheduled tasks will silently
-            # hang. (See audit E/247.)
-            client = await get_client(
-                session_id=sid,
-                model=model,
-                permission="bypassPermissions",
-            )
-            # SDK 0.2.x AssistantMessage.content is a list of dataclass
-            # blocks (TextBlock / ToolUseBlock / ThinkingBlock / …), NOT
-            # plain dicts — so `block.type` doesn't exist as a string. The
-            # original implementation was checking that string and silently
-            # never matching, which left reply_text empty and made every
-            # push notification say "(no reply)". isinstance check is what
-            # chat.py uses too — mirror it here.
-            await client.query(task["prompt"])
-            async for msg in client.receive_response():
-                if isinstance(msg, AssistantMessage):
-                    for block in getattr(msg, "content", []) or []:
-                        if isinstance(block, TextBlock):
-                            reply_text += getattr(block, "text", "") or ""
-                elif isinstance(msg, ResultMessage):
-                    # The SDK reports turn-level failures (max turns, budget
-                    # exceeded, permission denied, API errors) THROUGH a
-                    # normal ResultMessage with is_error=True — not as an
-                    # exception. Without this check the run was recorded as
-                    # ok and the user saw a "success" entry with whatever
-                    # partial text had streamed.
-                    if getattr(msg, "is_error", False):
-                        _subtype = getattr(msg, "subtype", None) or "error"
-                        _errs = getattr(msg, "errors", None) or []
-                        _detail = "; ".join(str(e) for e in _errs)
-                        error = (f"SDK result error ({_subtype})"
-                                 + (f": {_detail}" if _detail else ""))
-                        sys.stderr.write(
-                            f"[scheduler] task {tid} ({task['name']}) "
-                            f"result is_error: {error}\n")
-                    break
+            reply_text, error = await _run_sdk_task_turn(
+                sid, model, task["prompt"])
+            if error:
+                sys.stderr.write(
+                    f"[scheduler] task {tid} ({task['name']}) "
+                    f"result is_error: {error}\n")
         except Exception as e:
             error = f"{type(e).__name__}: {e}"
             sys.stderr.write(f"[scheduler] task {tid} ({task['name']}) failed: {error}\n")

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -287,6 +287,7 @@ def _merge_sdk_with_index(
         "id": info.session_id,
         "name": name,
         "model": m.get("model", ""),
+        "permission": m.get("permission", ""),
         "system_prompt": m.get("system_prompt", ""),
         # Auto-named flag stays True only if neither SDK custom_title nor
         # an explicit muselab rename has happened yet.
@@ -467,13 +468,16 @@ def create_session(
     model: str = "",
     system_prompt: str = "",
     cwd: str | Path | None = None,
+    permission: str = "",
 ) -> dict:
     return register_session(str(uuid.uuid4()), name=name, model=model,
+                            permission=permission,
                             system_prompt=system_prompt, auto_named=True,
                             cwd=cwd)
 
 
 def register_session(sid: str, *, name: str = "", model: str = "",
+                     permission: str = "",
                      system_prompt: str = "", auto_named: bool = True,
                      message_count: int = 0,
                      cwd: str | Path | None = None) -> dict:
@@ -486,6 +490,7 @@ def register_session(sid: str, *, name: str = "", model: str = "",
         "id": sid,
         "name": name or _default_session_name(),
         "model": model,
+        "permission": permission,
         "system_prompt": system_prompt,
         "created_at": now,
         "updated_at": now,
@@ -712,6 +717,18 @@ def update_model(sid: str, model: str) -> None:
                 s["model"] = model
                 _save_index(idx)
                 return
+
+
+def update_permission(sid: str, permission: str) -> bool:
+    """Persist the permission selected for subsequent turns in this session."""
+    with _INDEX_LOCK:
+        idx = _load_index()
+        for s in idx:
+            if s["id"] == sid:
+                s["permission"] = permission
+                _save_index(idx)
+                return True
+        return False
 
 
 # effort is one of: "" (auto/SDK default) | "low" | "medium" | "high" | "xhigh" | "max"

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -68,9 +68,11 @@ A session that has run at least one turn is never re-resolved
 
 Each `ClaudeSDKClient` is keyed by `(session_id, model, effort)`
 ([`chat.py:L303`](../backend/chat.py#L303),
-[`chat.py:L1317`](../backend/chat.py#L1317)). **Permission mode is not part of
-the key** — it can be updated in-place via `set_permission_mode()` without
-spawning a new subprocess.
+[`chat.py:L1317`](../backend/chat.py#L1317)). Permission mode is a
+**process-launch contract**, not a dynamic Codex-style policy overlay. It is
+stored separately for the cached runtime; when it changes, muselab drains the
+current SDK operation, disconnects that session's client, and starts a fresh
+Claude Agent SDK runtime with the requested mode.
 
 The pool cap defaults to **3** clients and is configurable via
 `MUSELAB_CLIENT_POOL_CAP`
@@ -82,9 +84,9 @@ sessions.
 
 Under `_lock` (an `asyncio.Lock`), the pool checks `_clients[key]`
 ([`chat.py:L1318-L1349`](../backend/chat.py#L1318-L1349)). On a hit the LRU
-list is updated. If the cached client's permission mode differs from the
-request, `set_permission_mode()` is called **outside** `_lock` (it can take
-seconds) and the shared `_bypass_state` dict is flipped to match.
+list is updated. If the cached client's launch mode differs from the request,
+the cached runtime is discarded and rebuilt. A stale client is never returned
+after a failed in-place permission switch.
 
 ### Cache miss (slow path)
 

--- a/docs/routing_zh.md
+++ b/docs/routing_zh.md
@@ -42,13 +42,13 @@
 
 ### 缓存键与容量
 
-每个 `ClaudeSDKClient` 的缓存键为 `(session_id, model, effort)`（[`chat.py:L303`](../backend/chat.py#L303)、[`chat.py:L1317`](../backend/chat.py#L1317)）。**权限模式不纳入缓存键** —— 它可以通过 `set_permission_mode()` 原地更新，无需派生新的子进程（fork）。
+每个 `ClaudeSDKClient` 的缓存键为 `(session_id, model, effort)`（[`chat.py:L303`](../backend/chat.py#L303)、[`chat.py:L1317`](../backend/chat.py#L1317)）。权限模式是 **SDK 进程启动契约**，而不是 Codex 风格的动态策略覆盖。权限会单独记录在缓存运行时上；发生变更时，muselab 会等待当前 SDK 操作结束，断开该会话的客户端，再以新模式启动 Claude Agent SDK 运行时。
 
 客户端池（client pool）默认上限为 **3** 个，可通过 `MUSELAB_CLIENT_POOL_CAP` 配置（[`chat.py:L473`](../backend/chat.py#L473)）。每个 CLI 子进程约占 30–50 MB RSS；该上限防止随着用户打开更多会话而无限制地增长内存。
 
 ### 缓存命中（快速路径）
 
-在 `_lock`（一个 `asyncio.Lock`）保护下，客户端池检查 `_clients[key]`（[`chat.py:L1318-L1349`](../backend/chat.py#L1318-L1349)）。命中时更新 LRU 列表。若缓存客户端的权限模式与请求不符，则在 `_lock` **之外**调用 `set_permission_mode()`（可能耗时数秒），并翻转共享的 `_bypass_state` 字典以使之匹配。
+在 `_lock`（一个 `asyncio.Lock`）保护下，客户端池检查 `_clients[key]`（[`chat.py:L1318-L1349`](../backend/chat.py#L1318-L1349)）。命中时更新 LRU 列表。若缓存客户端的启动权限与请求不符，则直接丢弃并重建运行时；系统不会在原地切换权限失败后返回旧客户端。
 
 ### 缓存未命中（慢速路径）
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -521,6 +521,9 @@ function portal() {
     // not whatever old session you were just looking at. Loaded from the
     // /providers response at boot (and persisted in prefs for instant restore).
     defaultModel: "",
+    // Configured default for NEW sessions. Kept separate from `permission`,
+    // which always mirrors the currently viewed session.
+    defaultPermission: "bypassPermissions",
     permission: "bypassPermissions",
     // Mobile-only: collapses the per-session settings (permission / effort)
     // behind a gear in the composer toolbar so the row stays single-line on
@@ -4582,7 +4585,8 @@ function portal() {
       // behavior via openTabIds.
       this._setLS("muselab_prefs", JSON.stringify({
         schema: 4,          // v4 decouples conversation cwd from the archive surface
-        model: this.model, defaultModel: this.defaultModel, permission: this.permission,
+        model: this.model, defaultModel: this.defaultModel,
+        permission: this.permission, defaultPermission: this.defaultPermission,
         currentId: this.currentId,
         openTabIds: this.openTabIds,
         previewTabs: this.tabs.map(t => this._previewTabSnapshot(t)),
@@ -4633,6 +4637,11 @@ function portal() {
         if (p.model) this.model = p.model;
         if (p.defaultModel) this.defaultModel = p.defaultModel;
         if (p.permission) this.permission = p.permission;
+        // Older prefs used `permission` for both roles. Preserve that value as
+        // the new-session default on migration, while session load will still
+        // replace the current selector with the server-authoritative value.
+        if (p.defaultPermission) this.defaultPermission = p.defaultPermission;
+        else if (p.permission) this.defaultPermission = p.permission;
         if (typeof p.activeWorkspace === "string") this.activeWorkspace = p.activeWorkspace;
         if (p.workspaceLastSession && typeof p.workspaceLastSession === "object"
             && !Array.isArray(p.workspaceLastSession)) {
@@ -4722,6 +4731,10 @@ function portal() {
           const d = await r.json();
           this.availableModels = d.models || [];
           if (d.default_model) { this.defaultModel = d.default_model; this.savePrefs(); }
+          if (d.default_permission) {
+            this.defaultPermission = d.default_permission;
+            this.savePrefs();
+          }
           this._ensureValidModel();
           await this._rebindModelSelect();
         }
@@ -5108,6 +5121,57 @@ function portal() {
         if (st[tailKey] === run) st[tailKey] = null;
       }
     },
+    async onPermissionChange() {
+      if (!this.currentId) return false;
+      const sid = this.currentId;
+      const st = this._ensureTabState(sid);
+      const seq = ++st._permissionPatchSeq;
+      const value = this.permission || "default";
+      const session = this.sessions.find(s => s.id === sid);
+      const previous = (session && session.permission) || "default";
+      const priorExpected = st._permissionExpected;
+      const expected = {
+        seq, value,
+        fallback: priorExpected ? priorExpected.fallback : previous,
+      };
+      st._permissionExpected = expected;
+      try {
+        const r = await this._serializeTabSettingPatch(
+          st, "_permissionPatchTail", async () => {
+            if (this.tabState[sid] !== st || st._permissionPatchSeq !== seq) return null;
+            return fetch("/api/chat/sessions/" + encodeURIComponent(sid), {
+              method: "PATCH",
+              headers: { ...this.hdr(), "Content-Type": "application/json" },
+              body: JSON.stringify({ permission: value }),
+            });
+          },
+        );
+        if (!r) return false;
+        if (!r.ok) throw new Error(await r.text());
+        if (this.tabState[sid] !== st) return false;
+        const current = this.sessions.find(s => s.id === sid);
+        if (current) current.permission = value;
+        if (st._permissionExpected) {
+          st._permissionExpected.fallback = value;
+          if (st._permissionExpected.seq === seq && st._permissionExpected.echoed) {
+            st._permissionExpected = null;
+          }
+        }
+        if (st._permissionPatchSeq !== seq) return false;
+        if (this.currentId === sid) this.permission = value;
+        this.savePrefs();
+        return true;
+      } catch (_) {
+        if (this.tabState[sid] !== st || st._permissionPatchSeq !== seq) return false;
+        const fallback = expected.fallback;
+        if (st._permissionExpected === expected) st._permissionExpected = null;
+        const current = this.sessions.find(s => s.id === sid);
+        if (current) current.permission = fallback;
+        if (this.currentId === sid) this.permission = fallback;
+        this.toast(this.lang === "zh" ? "权限切换失败" : "Permission switch failed", "error");
+        return false;
+      }
+    },
     async onEffortChange() {
       if (!this.currentId) return false;
       const sid = this.currentId;
@@ -5284,13 +5348,16 @@ function portal() {
         _reconnectTimer: null,
         _canonicalResyncTimer: null,
         _canonicalResyncPending: false,
+        _permissionPatchSeq: 0,
         _effortPatchSeq: 0,
         _thinkingPatchSeq: 0,
         _queueSyncSeq: 0,
         _queueAppliedSeq: 0,
+        _permissionExpected: null,
         _effortExpected: null,
         _thinkingExpected: null,
         _effortPatchTail: null,
+        _permissionPatchTail: null,
         _thinkingPatchTail: null,
         _loaded: false,   // set true after first loadSession populates messages
         _seenUpdated: undefined,
@@ -6207,6 +6274,8 @@ function portal() {
       if (!st) return meta;
       let out = meta;
       const fields = [
+        ["_permissionExpected", "_permissionPatchTail", "permission",
+          value => value || "default"],
         ["_effortExpected", "_effortPatchTail", "effort",
           value => value || ""],
         ["_thinkingExpected", "_thinkingPatchTail", "thinking",
@@ -7022,6 +7091,7 @@ function portal() {
         st._serverActiveObserved = false;
         st._reconcileRetryTimer = null;
         st._reconcilePromise = null;
+        st._permissionPatchSeq = (Number(st._permissionPatchSeq) || 0) + 1;
         st._effortPatchSeq = (Number(st._effortPatchSeq) || 0) + 1;
         st._thinkingPatchSeq = (Number(st._thinkingPatchSeq) || 0) + 1;
         if (this.currentId === id && this.es === ownedEs) {
@@ -7101,6 +7171,7 @@ function portal() {
             keepalive: true,
             body: JSON.stringify({
               id, name: meta.name, model: meta.model || "", cwd: meta.cwd || "",
+              permission: meta.permission || this.defaultPermission || "bypassPermissions",
               open_ids: this.openTabIds || [],
             }),
           });
@@ -7174,6 +7245,7 @@ function portal() {
         id,
         name: prefix + stamp,
         model: seedModel,
+        permission: this.defaultPermission || "bypassPermissions",
         system_prompt: "",
         created_at: ts,
         updated_at: ts,
@@ -9772,6 +9844,9 @@ function portal() {
           // surface the state. The user can wait + reload to see more.
           this._checkActiveTurn(sid);
           if (s.model) this.model = s.model;
+          this.permission = st._permissionExpected
+            ? st._permissionExpected.value
+            : (s.permission || "default");
           // effort defaults to "" (adaptive); always assign so switching from
           // a high-effort tab to a fresh one doesn't leave the old value visible.
           this.effort = s.effort || "";
@@ -10658,6 +10733,10 @@ function portal() {
       );
       this.settings.providerNew = { show: false, base_url: "", prefix: "", models: "", api_key: "" };
       this.settings.draftDefaults = { ...d.defaults };
+      if (d.defaults && d.defaults.permission) {
+        this.defaultPermission = d.defaults.permission;
+        this.savePrefs();
+      }
       // `d.params` is empty since 2026-05-28 (kept as {} for FE back-compat).
       // Desktop: sidebar is always visible, so land on a default tab
       // (provider — the most-used section) and render only that pane.
@@ -11394,6 +11473,10 @@ function portal() {
           const d = await r.json();
           this.availableModels = d.models || [];
           if (d.default_model) { this.defaultModel = d.default_model; this.savePrefs(); }
+          if (d.default_permission) {
+            this.defaultPermission = d.default_permission;
+            this.savePrefs();
+          }
           this._ensureValidModel();
         }
       } catch (e) {
@@ -11692,14 +11775,11 @@ function portal() {
           // newSession() seeds from defaultModel — update it so the change
           // takes effect on the very next new chat without a providers refetch.
           this.defaultModel = newDefaultModel;
-          // Also move the active dropdown to the new default (the original
-          // behavior) so "I changed it" is immediately visible.
-          if (newDefaultModel !== this.model) this.model = newDefaultModel;
           this.savePrefs();
         }
         const newDefaultPerm = this.settings.draftDefaults.permission;
-        if (newDefaultPerm && newDefaultPerm !== this.permission) {
-          this.permission = newDefaultPerm;
+        if (newDefaultPerm && newDefaultPerm !== this.defaultPermission) {
+          this.defaultPermission = newDefaultPerm;
           this.savePrefs();
         }
         // 刷新可用 provider 列表

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2848,11 +2848,14 @@
               </template>
             </select>
             <!-- Permission mode -->
-            <select x-model="permission" class="chat-toolbar-select chat-toolbar-permission"
+            <select x-model="permission" @change="onPermissionChange()"
+                    class="chat-toolbar-select chat-toolbar-permission"
                     :title="t('set.label.default_permission')">
               <option value="bypassPermissions">bypass</option>
               <option value="acceptEdits">acceptEdits</option>
               <option value="default">default</option>
+              <option value="dontAsk">dontAsk</option>
+              <option value="auto">auto</option>
               <option value="plan">plan</option>
             </select>
             <!-- Reasoning effort. Empty = SDK adaptive default (Opus 4.7's
@@ -2893,10 +2896,12 @@
                    @click.outside="composerSettingsOpen = false">
                 <label class="chat-toolbar-more-field">
                   <span x-text="t('set.label.default_permission')"></span>
-                  <select x-model="permission">
+                  <select x-model="permission" @change="onPermissionChange()">
                     <option value="bypassPermissions">bypass</option>
                     <option value="acceptEdits">acceptEdits</option>
                     <option value="default">default</option>
+                    <option value="dontAsk">dontAsk</option>
+                    <option value="auto">auto</option>
                     <option value="plan">plan</option>
                   </select>
                 </label>
@@ -4049,6 +4054,8 @@
               <option value="bypassPermissions" x-text="lang==='zh' ? 'bypass（无提示）' : 'bypass (no prompts)'"></option>
               <option value="acceptEdits">acceptEdits</option>
               <option value="default">default</option>
+              <option value="dontAsk">dontAsk</option>
+              <option value="auto">auto</option>
               <option value="plan">plan</option>
             </select>
           </div>

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -28,30 +28,36 @@ class _FakeSDKClient:
             raise RuntimeError("interrupt boom")
         self.interrupted = True
 
+    async def set_model(self, _model):
+        raise AssertionError("model changes must rebuild, not call set_model")
+
 
 @pytest.fixture()
 def chat_mod(app_module):
     from backend import chat as chat_mod
     chat_mod._clients.clear()
     chat_mod._client_permission.clear()
-    chat_mod._bypass_state.clear()
     chat_mod._creation_locks.clear()
     chat_mod._client_lru.clear()
+    chat_mod._session_runtime_locks.clear()
+    chat_mod._pending_runtime_rebuilds.clear()
     chat_mod._pending_interrupts.clear()
+    chat_mod._active_turns.clear()
     yield chat_mod
     chat_mod._clients.clear()
     chat_mod._client_permission.clear()
-    chat_mod._bypass_state.clear()
     chat_mod._creation_locks.clear()
     chat_mod._client_lru.clear()
+    chat_mod._session_runtime_locks.clear()
+    chat_mod._pending_runtime_rebuilds.clear()
     chat_mod._pending_interrupts.clear()
+    chat_mod._active_turns.clear()
 
 
 def _seed(chat_mod, key, client=None):
     client = client or _FakeSDKClient()
     chat_mod._clients[key] = client
     chat_mod._client_permission[key] = "bypassPermissions"
-    chat_mod._bypass_state[key] = {"bypass": True}
     chat_mod._client_lru.append(key)
     return client
 
@@ -92,7 +98,6 @@ def test_reset_all_with_multiple_three_tuple_keys(chat_mod, client):
     assert all(c.disconnected for c in (c1, c2, c3))
     assert chat_mod._clients == {}
     assert chat_mod._client_lru == []
-    assert chat_mod._bypass_state == {}
     assert chat_mod._client_permission == {}
 
 
@@ -101,6 +106,44 @@ def test_reset_all_empty_pool(chat_mod, client):
     r = client.post(f"/api/chat/reset?token={TEST_TOKEN}")
     assert r.status_code == 200, r.text
     assert r.json() == {"ok": True, "reset": []}
+
+
+def test_same_provider_model_switch_rebuilds_client(chat_mod, client):
+    sid = _make_compact_session(client)
+    key = (sid, "claude-sonnet-4-6", "")
+    fake = _seed(chat_mod, key)
+
+    r = client.patch(
+        f"/api/chat/sessions/{sid}",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={"model": "claude-haiku-4-5"},
+    )
+
+    assert r.status_code == 200, r.text
+    assert fake.disconnected is True
+    assert key not in chat_mod._clients
+    assert chat_mod.sess.get_session(sid)["model"] == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_runtime_rebuild_defers_while_turn_is_reserved(chat_mod):
+    sid = "sid-deferred-rebuild"
+    key = (sid, "claude-sonnet-4-6", "")
+    fake = _seed(chat_mod, key)
+    active = chat_mod.TurnBroadcast(sid)
+    chat_mod._active_turns[sid] = active
+
+    await chat_mod._rebuild_session_runtime(sid)
+
+    assert fake.disconnected is False
+    assert sid in chat_mod._pending_runtime_rebuilds
+
+    active.finish()
+    chat_mod._active_turns.pop(sid, None)
+    await chat_mod._rebuild_session_runtime(sid)
+
+    assert fake.disconnected is True
+    assert sid not in chat_mod._pending_runtime_rebuilds
 
 
 # ====== interrupt ======
@@ -311,7 +354,6 @@ class _FakeCompactClient:
         self.result = result
         self.totals = iter(totals)
         self.queries = []
-        self.restored_permission = None
 
     async def query(self, prompt):
         self.queries.append(prompt)
@@ -321,10 +363,6 @@ class _FakeCompactClient:
 
     async def get_context_usage(self):
         return {"totalTokens": next(self.totals), "maxTokens": 200_000}
-
-    async def set_permission_mode(self, permission):
-        self.restored_permission = permission
-
 
 def _make_compact_session(client):
     r = client.post(
@@ -346,7 +384,10 @@ def test_native_compact_rejects_in_band_context_error(chat_mod, client, monkeypa
     )
     fake = _FakeCompactClient(result, totals=(190_000,))
 
-    async def fake_get_client(*_args, **_kwargs):
+    observed = {}
+
+    async def fake_get_client(*args, **kwargs):
+        observed["permission"] = args[2] if len(args) > 2 else kwargs.get("permission")
         return fake
 
     monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
@@ -360,7 +401,23 @@ def test_native_compact_rejects_in_band_context_error(chat_mod, client, monkeypa
     assert r.status_code == 409, r.text
     assert "context window" in r.json()["detail"]
     assert fake.queries == ["/compact"]
-    assert fake.restored_permission == "default"
+    assert observed["permission"] == "default"
+
+
+def test_native_compact_rejects_active_turn(chat_mod, client, monkeypatch):
+    sid = _make_compact_session(client)
+    chat_mod._active_turns[sid] = SimpleNamespace(done=False)
+
+    async def should_not_get_client(*_args, **_kwargs):
+        raise AssertionError("compact must stop before touching the SDK")
+
+    monkeypatch.setattr(chat_mod, "get_client", should_not_get_client)
+    r = client.post(
+        f"/api/chat/sessions/{sid}/native-compact",
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert r.status_code == 409, r.text
+    assert "turn is active" in r.json()["detail"]
 
 
 def test_vendor_fork_uses_vendor_session_store_and_restores_env(

--- a/tests/test_chat_options.py
+++ b/tests/test_chat_options.py
@@ -36,9 +36,26 @@ def test_third_party_provider_enables_sdk_skills(app_module, monkeypatch, tmp_pa
     assert captured["connected"] is True
     assert client is not None
     assert captured["skills"] == "all"
+    assert "can_use_tool" not in captured
     assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-test"
     for tier in ("OPUS", "SONNET", "HAIKU", "FABLE"):
         assert captured["env"][f"ANTHROPIC_DEFAULT_{tier}_MODEL"] == "deepseek-v4-pro"
+
+
+def test_non_bypass_runtime_installs_permission_resolver(
+    app_module, monkeypatch, tmp_path,
+):
+    from backend import chat as chat_mod
+    from backend import endpoints
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    monkeypatch.setattr(endpoints, "_VENDOR_CONFIG_DIR", tmp_path / "vendor-cfg")
+    captured = _capture_build_options(chat_mod, monkeypatch)
+
+    asyncio.run(chat_mod._build_and_connect_client(
+        "sid-default-permission", "deepseek-v4-pro", "default", ""))
+
+    assert callable(captured["can_use_tool"])
 
 
 def test_codex_gateway_effort_reaches_sdk_options(app_module, monkeypatch, tmp_path):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -7,11 +7,12 @@ Two levels:
   - endpoint round-trips against /api/chat/sessions/{sid}/queue
     (GET / POST / DELETE / pause / reorder).
 
-The drain dispatch (_maybe_drain_queue → _start_turn) needs the Claude SDK
-+ a live model, so it isn't unit-tested here — we only cover the queue STATE
-it reads/writes (mirrors how test_scheduler.py leaves _execute_task out).
+The drain dispatch is tested with its SDK turn launcher replaced by a narrow
+fake, keeping queue permission and rollback semantics hermetic.
 """
 from __future__ import annotations
+
+import pytest
 
 
 def _sess(app_module):
@@ -284,3 +285,26 @@ def test_queue_endpoint_requires_auth(client):
     """At least one route enforces the token — no header → 401."""
     r = client.get("/api/chat/sessions/whatever/queue")
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_drain_replays_snapshot_without_reverting_session_permission(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    meta = sess.create_session(permission="plan")
+    sid = meta["id"]
+    sess.enqueue_message(sid, "queued", permission="default")
+    observed = {}
+
+    async def fake_start_turn(session_id, prompt, **kwargs):
+        observed.update(session_id=session_id, prompt=prompt, **kwargs)
+
+    monkeypatch.setattr(chat, "_start_turn", fake_start_turn)
+    await chat._maybe_drain_queue(sid)
+
+    assert observed["permission"] == "default"
+    assert observed["persist_permission"] is False
+    assert sess.get_session(sid)["permission"] == "plan"

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -1,8 +1,8 @@
 """Client-pool behavior for chat.get_client / disconnect_client.
 
 These guard the long-lived state the rest of the chat surface depends on:
-the (sid, model, effort) -> ClaudeSDKClient cache plus its four side dicts
-(_client_permission / _bypass_state / _creation_locks / _client_lru).
+the (sid, model, effort) -> ClaudeSDKClient cache plus its side registries
+(_client_permission / _creation_locks / _client_lru).
 
 Production code spawns a real CLI subprocess in _build_and_connect_client;
 we monkeypatch THAT (not get_client) so the cache/LRU/eviction logic under
@@ -14,18 +14,13 @@ import pytest
 
 
 class _FakeSDKClient:
-    """Stands in for ClaudeSDKClient. Records permission-mode flips and
-    disconnects so tests can assert the pool drove them."""
+    """Stands in for ClaudeSDKClient and records disconnects."""
 
     def __init__(self, sid="s", model="m", effort=""):
         self.sid = sid
         self.model = model
         self.effort = effort
-        self.permission_modes: list[str] = []
         self.disconnected = False
-
-    async def set_permission_mode(self, mode):
-        self.permission_modes.append(mode)
 
     async def disconnect(self):
         self.disconnected = True
@@ -38,27 +33,24 @@ def chat_mod(app_module):
     from backend import chat as chat_mod
     chat_mod._clients.clear()
     chat_mod._client_permission.clear()
-    chat_mod._bypass_state.clear()
     chat_mod._creation_locks.clear()
     chat_mod._client_lru.clear()
+    chat_mod._session_runtime_locks.clear()
+    chat_mod._pending_runtime_rebuilds.clear()
     chat_mod._sessions_with_inflight_tasks.clear()
     yield chat_mod
     chat_mod._clients.clear()
     chat_mod._client_permission.clear()
-    chat_mod._bypass_state.clear()
     chat_mod._creation_locks.clear()
     chat_mod._client_lru.clear()
+    chat_mod._session_runtime_locks.clear()
+    chat_mod._pending_runtime_rebuilds.clear()
     chat_mod._sessions_with_inflight_tasks.clear()
 
 
 def _patch_builder(monkeypatch, chat_mod):
-    """Replace the slow CLI-spawning path with a fake-client factory that
-    ALSO registers the bypass_state dict the same way production does (so
-    the get_client permission-flip path has something to flip)."""
+    """Replace the slow CLI-spawning path with a fake-client factory."""
     async def fake_build(session_id, model, permission, effort):
-        key = (session_id, model, effort)
-        chat_mod._bypass_state[key] = {
-            "bypass": permission == "bypassPermissions"}
         return _FakeSDKClient(session_id, model, effort)
 
     monkeypatch.setattr(chat_mod, "_build_and_connect_client", fake_build)
@@ -102,7 +94,7 @@ def test_different_key_builds_new_client(chat_mod, monkeypatch):
 
 def test_disconnect_client_evicts_entry_and_all_side_dicts(chat_mod, monkeypatch):
     """disconnect_client must remove the pool entry AND _client_permission,
-    _bypass_state, _creation_locks, _client_lru — leaving zero residue."""
+    _creation_locks and _client_lru — leaving zero residue."""
     _patch_builder(monkeypatch, chat_mod)
 
     async def run():
@@ -112,7 +104,6 @@ def test_disconnect_client_evicts_entry_and_all_side_dicts(chat_mod, monkeypatch
         assert key in chat_mod._creation_locks
         assert key in chat_mod._clients
         assert key in chat_mod._client_permission
-        assert key in chat_mod._bypass_state
         assert key in chat_mod._client_lru
 
         await chat_mod.disconnect_client("sid-evict")
@@ -122,49 +113,33 @@ def test_disconnect_client_evicts_entry_and_all_side_dicts(chat_mod, monkeypatch
     assert c.disconnected is True, "evicted client never disconnected"
     assert key not in chat_mod._clients
     assert key not in chat_mod._client_permission
-    assert key not in chat_mod._bypass_state
     assert key not in chat_mod._creation_locks
     assert key not in chat_mod._client_lru
 
 
-def test_permission_switch_flips_shared_bypass_flag_live(chat_mod, monkeypatch):
-    """L244 regression: switching permission mode on a CACHED client via
-    get_client must flip the SAME _bypass_state[key] dict the can_use_tool
-    closure captured by reference — so a bypass→default switch starts
-    actually prompting, and default→bypass stops prompting, WITHOUT a
-    client rebuild."""
+def test_permission_switch_rebuilds_runtime(chat_mod, monkeypatch):
+    """Permission is launch-sensitive, so every mode change replaces the
+    runtime rather than risking a stale or partially-switched client."""
     _patch_builder(monkeypatch, chat_mod)
 
     async def run():
         key = ("sid-flip", "claude-sonnet-4-6", "")
-        # First call: bypassPermissions → bypass flag True.
         c1 = await chat_mod.get_client("sid-flip", "claude-sonnet-4-6", "bypassPermissions")
-        st = chat_mod._bypass_state[key]
-        assert st["bypass"] is True
-
-        # Switch to 'default' on the cached client. Same object back.
         c2 = await chat_mod.get_client("sid-flip", "claude-sonnet-4-6", "default")
-        assert c2 is c1, "permission switch must NOT rebuild the client"
-        # The closure's captured dict was mutated in place.
-        assert st["bypass"] is False, "bypass flag not flipped to False — closure stale"
+        assert c2 is not c1
+        assert c1.disconnected is True
         assert chat_mod._client_permission[key] == "default"
-        # SDK set_permission_mode was actually called with the new mode.
-        assert c1.permission_modes == ["default"]
-
-        # Switch back to bypass — flag flips live again.
         c3 = await chat_mod.get_client("sid-flip", "claude-sonnet-4-6", "bypassPermissions")
-        assert c3 is c1
-        assert st["bypass"] is True
-        assert c1.permission_modes == ["default", "bypassPermissions"]
-        return st
+        assert c3 is not c2
+        assert c2.disconnected is True
+        assert chat_mod._client_permission[key] == "bypassPermissions"
 
     asyncio.run(run())
 
 
 def test_eviction_at_pool_cap_drops_oldest_and_its_side_dicts(chat_mod, monkeypatch):
     """When the LRU exceeds _CLIENT_POOL_CAP, the oldest non-streaming entry
-    is evicted: removed from _clients/_client_permission/_bypass_state/
-    _client_lru and disconnected."""
+    is evicted and removed from every side registry."""
     _patch_builder(monkeypatch, chat_mod)
     monkeypatch.setattr(chat_mod, "_CLIENT_POOL_CAP", 2)
 
@@ -180,7 +155,6 @@ def test_eviction_at_pool_cap_drops_oldest_and_its_side_dicts(chat_mod, monkeypa
     assert a.disconnected is True, "oldest entry not disconnected on eviction"
     assert key_a not in chat_mod._clients
     assert key_a not in chat_mod._client_permission
-    assert key_a not in chat_mod._bypass_state
     assert key_a not in chat_mod._client_lru
     # B and C survive.
     assert ("B", "claude-sonnet-4-6", "") in chat_mod._clients

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,4 +1,5 @@
 """Third-party provider catalog: prefix→endpoint+key dispatch."""
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -213,6 +214,24 @@ def test_env_override_merges_with_os_environ(monkeypatch):
     assert env["PATH"] == "/usr/bin:/bin"
     assert env["HOME"] == "/home/test"
     assert env["ANTHROPIC_BASE_URL"].endswith("/anthropic")
+
+
+def test_vendor_workspace_trust_preserves_cli_config(monkeypatch, tmp_path):
+    ep = _reload_endpoints(monkeypatch, {})
+    vendor_dir = tmp_path / "vendor-config"
+    vendor_dir.mkdir()
+    monkeypatch.setattr(ep, "_VENDOR_CONFIG_DIR", vendor_dir)
+    cfg = vendor_dir / ".claude.json"
+    cfg.write_text(json.dumps({"feature": {"keep": True}, "projects": {}}))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    ep.ensure_vendor_workspace_trusted(workspace)
+
+    saved = json.loads(cfg.read_text())
+    assert saved["feature"] == {"keep": True}
+    assert saved["projects"][str(workspace.resolve())][
+        "hasTrustDialogAccepted"] is True
 
 
 def test_all_catalog_providers_have_valid_fields(monkeypatch):

--- a/tests/test_permission_request.py
+++ b/tests/test_permission_request.py
@@ -21,6 +21,8 @@ def test_register_and_unregister():
     assert "s1" in perm._always_allow
     perm.unregister_session_queue("s1")
     assert "s1" not in perm._session_queues
+    assert "s1" in perm._always_allow
+    perm.clear_session_permissions("s1")
     assert "s1" not in perm._always_allow
 
 
@@ -125,6 +127,14 @@ async def test_always_allow_caches_subsequent_calls():
     # Second call to same tool+key — should NOT prompt (queue stays empty)
     r2 = await cb("Bash", {"command": "ls /tmp"}, None)
     assert r2.behavior == "allow"
+    assert perm._session_queues[sid].empty()
+
+    # A turn boundary unregisters the prompt queue but the session-level
+    # grant survives and applies after the next turn registers its queue.
+    perm.unregister_session_queue(sid)
+    perm.register_session_queue(sid)
+    r3 = await cb("Bash", {"command": "ls /var/tmp"}, None)
+    assert r3.behavior == "allow"
     assert perm._session_queues[sid].empty()
 
 

--- a/tests/test_permission_ui.py
+++ b/tests/test_permission_ui.py
@@ -1,0 +1,31 @@
+"""Static contract tests for per-session Claude SDK permission controls."""
+from pathlib import Path
+import re
+from typing import get_args
+
+from claude_agent_sdk.types import PermissionMode
+
+
+FRONTEND = Path(__file__).resolve().parents[1] / "frontend"
+
+
+def test_session_permission_is_separate_from_new_session_default():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    assert 'defaultPermission: "bypassPermissions"' in app
+    assert 'permission: this.defaultPermission || "bypassPermissions"' in app
+    assert 'this.permission = s.permission || "default"' not in app
+    assert 'this.defaultPermission = newDefaultPerm' in app
+    assert 'this.permission = newDefaultPerm' not in app
+    assert 'this.model = newDefaultModel' not in app
+    assert '["_permissionExpected", "_permissionPatchTail", "permission"' in app
+
+
+def test_permission_selector_matches_installed_sdk_modes():
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    start = html.index("<!-- Permission mode -->")
+    end = html.index("<!-- Reasoning effort.", start)
+    toolbar = html[start:end]
+    rendered = set(re.findall(r'<option value="([^"]+)">', toolbar))
+
+    assert rendered == set(get_args(PermissionMode))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,8 @@ Claude SDK + a real model call); we cover the state-management surface
 that fresh mode introduced and the back-compat path for old tasks."""
 from __future__ import annotations
 
+import asyncio
+
 
 def _sched_mod(app_module):
     """Pull the scheduler module out of the reloaded backend.* tree.
@@ -89,6 +91,27 @@ def test_effective_session_mode_respects_explicit_value(app_module):
         {"session_mode": "fresh"}) == "fresh"
     assert sched._effective_session_mode(
         {"session_mode": "reuse"}) == "reuse"
+
+
+def test_sdk_turn_rejects_session_with_interactive_owner(
+    app_module, monkeypatch,
+):
+    sched = _sched_mod(app_module)
+    from backend import chat
+
+    sid = "busy-session"
+    chat._active_turns[sid] = type("Busy", (), {"done": False})()
+
+    async def should_not_get_client(*_args, **_kwargs):
+        raise AssertionError("scheduler must not touch an interactive runtime")
+
+    monkeypatch.setattr(chat, "get_client", should_not_get_client)
+    try:
+        with pytest.raises(RuntimeError, match="interactive turn"):
+            asyncio.run(sched._run_sdk_task_turn(sid, "model", "prompt"))
+    finally:
+        chat._active_turns.pop(sid, None)
+        chat._session_runtime_locks.pop(sid, None)
 
 
 # ---- delete_task ----

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -8,7 +8,10 @@ flows require a live SDK and are not unit-testable here.
 
 
 def test_session_lifecycle(client, auth):
-    r = client.post("/api/chat/sessions", headers=auth, json={"name": "t1"})
+    r = client.post(
+        "/api/chat/sessions", headers=auth,
+        json={"name": "t1", "permission": "default"},
+    )
     assert r.status_code == 200
     sid = r.json()["id"]
 
@@ -19,17 +22,31 @@ def test_session_lifecycle(client, auth):
     assert r.status_code == 200
     s = r.json()
     assert s["name"] == "t1"
+    assert s["permission"] == "default"
     # New session, no SDK turn yet → CLI JSONL doesn't exist → empty messages
     assert s["messages"] == []
 
-    r = client.patch(f"/api/chat/sessions/{sid}", headers=auth, json={"name": "t2"})
+    r = client.patch(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        json={"name": "t2", "permission": "dontAsk"},
+    )
     assert r.status_code == 200
     r = client.get(f"/api/chat/sessions/{sid}", headers=auth)
     assert r.json()["name"] == "t2"
+    assert r.json()["permission"] == "dontAsk"
 
     r = client.delete(f"/api/chat/sessions/{sid}", headers=auth)
     assert r.status_code == 200
     r = client.get(f"/api/chat/sessions/{sid}", headers=auth)
+    assert r.status_code == 404
+
+
+def test_permission_patch_unknown_session_is_404(client, auth):
+    r = client.patch(
+        "/api/chat/sessions/not-a-session",
+        headers=auth,
+        json={"permission": "default"},
+    )
     assert r.status_code == 404
 
 
@@ -185,7 +202,9 @@ def test_usage_endpoint(client, auth):
 def test_providers_endpoint(client, auth):
     r = client.get("/api/chat/providers", headers=auth)
     assert r.status_code == 200
-    models = r.json()["models"]
+    body = r.json()
+    models = body["models"]
+    assert body["default_permission"] == "bypassPermissions"
     # Conftest deletes ANTHROPIC_API_KEY; without claude OAuth either,
     # Claude group must be hidden (regression fix from ba00629).
     from backend import endpoints
@@ -193,6 +212,13 @@ def test_providers_endpoint(client, auth):
         assert not any(m["model"].startswith("claude-") for m in models)
     # DeepSeek hidden because key not set in test env
     assert not any(m["model"].startswith("deepseek-") for m in models)
+
+
+def test_providers_rejects_stale_default_permission(client, auth, monkeypatch):
+    monkeypatch.setenv("MUSELAB_DEFAULT_PERMISSION", "codex-full-access")
+    r = client.get("/api/chat/providers", headers=auth)
+    assert r.status_code == 200
+    assert r.json()["default_permission"] == "bypassPermissions"
 
 
 def test_providers_includes_deepseek_after_key_set(client, auth, monkeypatch):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -63,6 +63,15 @@ def test_put_settings_writes_env_and_refreshes(client, auth, monkeypatch, tmp_pa
     assert os.environ["MUSELAB_DEFAULT_MODEL"] == "claude-haiku-4-5-20251001"
 
 
+def test_put_settings_rejects_non_sdk_permission_mode(client, auth):
+    r = client.put(
+        "/api/settings",
+        headers=auth,
+        json={"default_permission": "codex-full-access"},
+    )
+    assert r.status_code == 422
+
+
 def test_put_settings_skips_empty_values(client, auth, monkeypatch, tmp_path):
     """Empty / None provider key = 'don't touch'; existing value preserved."""
     from backend import api_settings as api_s


### PR DESCRIPTION
## What this changes

将 Claude Agent SDK 确立为唯一 Agent 运行时权限标准；Codex Gateway 与其他 Anthropic-compatible provider 只负责提供基座模型，不再尝试映射 Codex 权限体系。

- 权限模式改为会话级启动契约，切换时安全重建 SDK client
- 为交互 turn、scheduler 与 native compact 增加会话级运行时互斥
- 持久化每个 session 的权限，并拆分当前会话权限与新会话默认权限
- 按 SDK 真实语义处理 can_use_tool、Always Allow 与 AskUserQuestion
- 补齐第三方隔离 CLI 的 workspace trust
- 同提供商模型切换也完整重建 launch-time 配置
- 明确无人值守 scheduler 的 bypassPermissions 边界，不再宣称具备文件沙箱

## Why

Claude Agent SDK 的权限不能完整映射为 Codex 权限。原实现动态调用 set_permission_mode，并用额外 bypass 状态模拟权限，存在切换失败后继续复用旧 client、callback 被 SDK shadow、队列与调度并发操作同一 stream 等问题。该 PR 让 muselab 直接遵循 SDK 契约，同时保留 GPT/Codex 作为基座模型的能力。

## Testing

- [x] 546 个非 E2E 测试通过（按文件分片运行，覆盖全部 tests/test_*.py）
- [x] uv run ruff check backend/ tests/ 通过
- [x] bash scripts/lint.sh 通过
- [x] frontend/app.js、sw.js、constants.js、i18n/index.js 均通过 node --check
- [x] Web manifest JSON 校验通过
- [x] 新增并更新权限、client pool、scheduler、queue、compact、vendor trust 与前端契约测试

## Frontend before / after

- Before：权限选择是浏览器全局状态，切换 session 时可能串值，且缺少 dontAsk 与 auto。
- After：权限跟随 session 持久化；新会话默认值单独维护；桌面、移动端和设置页覆盖 SDK 当前全部 PermissionMode。

## Checklist

- [x] No secrets committed
- [x] Docs updated for visible behavior
- [x] No runtime dependency added
