### PR TITLE
feat(workspace): 同步切换文件与预览区域

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4126,7 +4126,7 @@ function portal() {
     // ROOT-relative path whose full path ends with the clicked path (same
     // file, just a missing prefix). Caller decides: 0 → not-found toast,
     // 1 → open, >1 → disambiguation picker. Returns [{path,name}, ...].
-    async _findBySuffix(path, name, requestHeaders = this.hdr()) {
+    async _findBySuffix(path, name, requestHeaders = this.fileHdr()) {
       try {
         const r = await fetch("/api/files/search?q=" + encodeURIComponent(name) + "&limit=50",
           { headers: requestHeaders });
@@ -4162,7 +4162,7 @@ function portal() {
     // model output and may not exist — surface the failure as a toast.
     async openByPathToasted(path) {
       const ownerWorkspace = this.fileWorkspacePath();
-      const requestHeaders = this.hdr();
+      const requestHeaders = this.fileHdr();
       // HEAD-equivalent check via list on the parent dir is fragile (binary
       // files, images etc. don't go through /api/files/read). Just delegate
       // to openFile and let it set previewMode='unsupported' / pdf / img,
@@ -4325,8 +4325,8 @@ function portal() {
     },
 
     hdr() {
-      // Global/file requests intentionally omit a workspace header: backend
-      // file APIs then use their safe default, the primary MUSELAB_ROOT.
+      // Global requests are workspace-agnostic. File and conversation requests
+      // add their registered workspace through fileHdr()/conversationHdr().
       return { "X-Auth-Token": this.token };
     },
     conversationHdr(path = "") {
@@ -8765,7 +8765,7 @@ function portal() {
       fd.append("file", file);
       try {
         const r = await fetch("/api/files/upload", {
-          method: "POST", headers: this.hdr(), body: fd,
+          method: "POST", headers: this.fileHdr(), body: fd,
         });
         if (!r.ok) {
           console.warn("[upload]", file.name, "failed:", r.status);
@@ -12022,7 +12022,7 @@ function portal() {
       if (this._childFetches.has(pendingKey)) return this._childFetches.get(pendingKey);
       const url = "/api/files/list?path=" + encodeURIComponent(path)
         + (showHidden ? "&show_hidden=true" : "");
-      const requestHeaders = this.hdr();
+      const requestHeaders = this.fileHdr();
       const promise = (async () => {
         let r;
         try {
@@ -12399,7 +12399,7 @@ function portal() {
       try {
         r = await fetch("/api/files/write", {
           method: "PUT",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path, content: "" }),
         });
       } catch (e) {
@@ -12441,7 +12441,7 @@ function portal() {
       try {
         r = await fetch("/api/files/mkdir", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path }),
         });
       } catch (e) {
@@ -12489,7 +12489,7 @@ function portal() {
       try {
         r = await fetch("/api/files/rename", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ src: n.path, dst: newPath }),
         });
       } catch (e) {
@@ -12537,7 +12537,7 @@ function portal() {
       try {
         r = await fetch("/api/files/copy-bak", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
       } catch (e) {
@@ -12629,7 +12629,7 @@ function portal() {
       try {
         r = await fetch("/api/files/delete", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path: n.path }),
         });
       } catch (e) {
@@ -12697,7 +12697,7 @@ function portal() {
         && ownerWorkspace === this.fileWorkspacePath();
       this.trash.loading = true;
       try {
-        const r = await fetch("/api/files/trash/list", { headers: this.hdr() });
+        const r = await fetch("/api/files/trash/list", { headers: this.fileHdr() });
         if (!isOwner()) return;
         if (!r.ok) {
           const detail = await r.text();
@@ -12727,7 +12727,7 @@ function portal() {
       try {
         r = await fetch("/api/files/trash/restore", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ trash_id: tid }),
         });
       } catch (e) {
@@ -12777,7 +12777,7 @@ function portal() {
       try {
         r = await fetch("/api/files/trash/purge", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ trash_id: tid }),
         });
       } catch (e) {
@@ -12812,7 +12812,7 @@ function portal() {
       try {
         r = await fetch("/api/files/trash/empty", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
         });
       } catch (e) {
         if (this._workspaceIsCurrent(ownerWorkspace)) {
@@ -12877,7 +12877,7 @@ function portal() {
       const results = await Promise.allSettled(paths.map(p =>
         fetch("/api/files/delete", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path: p }),
           // 404 = already gone — count as done, not a failure.
         }).then(r => (r.ok || r.status === 404 ? p : Promise.reject(new Error(p))))
@@ -12909,7 +12909,7 @@ function portal() {
       try {
         r = await fetch("/api/files/delete", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path }),
         });
       } catch (e) {
@@ -13644,7 +13644,7 @@ function portal() {
         // the empty-file placeholder (previewMode==='md' && !rawText) during
         // the in-flight fetch. Failures route through _previewFail().
         const r = await fetch("/api/files/read?path=" + encodeURIComponent(n.path),
-                              { headers: this.hdr(), signal: controller.signal });
+                              { headers: this.fileHdr(), signal: controller.signal });
         if (_stale()) return false;
         if (r.ok) {
           const body = await r.text();
@@ -13691,7 +13691,7 @@ function portal() {
         // string matrices so the frontend just renders <table>s. No formula
         // evaluation; cells show the last-cached value.
         const r = await fetch("/api/files/xlsx?path=" + encodeURIComponent(n.path),
-                              { headers: this.hdr(), signal: controller.signal });
+                              { headers: this.fileHdr(), signal: controller.signal });
         if (_stale()) return false;
         if (r.ok) {
           const data = await r.json();
@@ -13740,7 +13740,7 @@ function portal() {
         // that the archive-scoped /api/files/read can't reach.
         const readUrl = opts.readUrl || ("/api/files/read?path=" + encodeURIComponent(n.path));
         const r = await fetch(readUrl, {
-          headers: this.hdr(), signal: controller.signal,
+          headers: this.fileHdr(), signal: controller.signal,
         });
         if (_stale()) return false;
         if (r.ok) {
@@ -13802,7 +13802,7 @@ function portal() {
       try {
         const url = `/api/files/csv?path=${encodeURIComponent(reqPath)}`
                     + `&offset=${reqOffset}&limit=${this.csvLimit}`;
-        const r = await fetch(url, { headers: this.hdr(), signal: controller.signal });
+        const r = await fetch(url, { headers: this.fileHdr(), signal: controller.signal });
         if (_csvStale()) return false;
         if (r.ok) {
           const data = await r.json();
@@ -14058,7 +14058,7 @@ function portal() {
       if (!path) { this.selectedMeta = null; return; }
       try {
         const r = await fetch("/api/files/stat?path=" + encodeURIComponent(path),
-                              { headers: this.hdr() });
+                              { headers: this.fileHdr() });
         if (!isOwner()) return;
         if (!r.ok) { this.selectedMeta = null; return; }
         const d = await r.json();
@@ -15083,7 +15083,7 @@ function portal() {
       const controller = new AbortController();
       this._fileSearchAbort = controller;
       const readJson = async (url) => {
-        const r = await fetch(url, { headers: this.hdr(), signal: controller.signal });
+        const r = await fetch(url, { headers: this.fileHdr(), signal: controller.signal });
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
       };
@@ -15198,7 +15198,7 @@ function portal() {
       fd.append("file", file);
       let r;
       try {
-        r = await fetch("/api/files/upload", { method: "POST", headers: this.hdr(), body: fd });
+        r = await fetch("/api/files/upload", { method: "POST", headers: this.fileHdr(), body: fd });
       } catch (e) {
         if (this._workspaceIsCurrent(ownerWorkspace)) {
           this.errToast("upload", String((e && e.message) || e));
@@ -15481,7 +15481,7 @@ function portal() {
       try {
         r = await fetch("/api/files/rename", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ src: srcPath, dst: newPath }),
         });
       } catch (e) {
@@ -15542,7 +15542,7 @@ function portal() {
       const results = await Promise.allSettled(plan.map(p =>
         fetch("/api/files/rename", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ src: p.src, dst: p.dst }),
         }).then(r => (r.ok ? p : Promise.reject(new Error(p.src))))
       ));
@@ -15603,7 +15603,7 @@ function portal() {
       const results = await Promise.allSettled(paths.map(p =>
         fetch("/api/files/delete", {
           method: "DELETE",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path: p }),
           // 404 = already gone (e.g. a child whose parent dir we just trashed
           // in the same batch) — count it as done, not a failure.
@@ -15744,7 +15744,7 @@ function portal() {
       try {
         r = await fetch("/api/files/mkdir", {
           method: "POST",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path: name }),
         });
       } catch (e) {
@@ -16113,7 +16113,7 @@ function portal() {
         let r;
         try {
           r = await fetch("/api/files/read?path=" + encodeURIComponent(targetPath),
-                          { headers: this.hdr() });
+                          { headers: this.fileHdr() });
         } catch (e) {
           if (this._workspaceIsCurrent(ownerWorkspace)
               && this.selected === targetPath) {
@@ -16187,7 +16187,7 @@ function portal() {
         try {
           r = await fetch("/api/files/write", {
             method: "PUT",
-            headers: { ...this.hdr(), "Content-Type": "application/json" },
+            headers: { ...this.fileHdr(), "Content-Type": "application/json" },
             body: JSON.stringify({ path: savePath, content: saveText }),
           });
         } catch (e) {
@@ -16733,7 +16733,7 @@ function portal() {
       try {
         r = await fetch("/api/files/write", {
           method: "PUT",
-          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          headers: { ...this.fileHdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ path: trimmed, content: "# " + trimmed.replace(/\.md$/, "") + "\n\n" }),
         });
       } catch (e) {
@@ -17092,7 +17092,7 @@ function portal() {
         let d = { entries: [] };
         try {
           const r = await fetch("/api/files/search?q=" + encodeURIComponent(q) + "&limit=15",
-                                { headers: this.hdr(), signal: controller.signal });
+                                { headers: this.fileHdr(), signal: controller.signal });
           if (r.ok) d = await r.json();
         } catch (e) {
           if ((e && e.name === "AbortError") || mentionSeq !== this._mentionSeq) return;
@@ -19275,7 +19275,7 @@ function portal() {
       try {
         const r = await fetch(
           "/api/files/search?q=" + encodeURIComponent(q) + "&limit=30",
-          { headers: this.hdr() });
+          { headers: this.fileHdr() });
         if (!isOwner()) return;
         if (!r.ok) { this.palette.fileResults = []; return; }
         const data = await r.json();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -470,7 +470,7 @@ function portal() {
       truncated: false, requestSeq: 0,
     },
     workspaceLastSession: {},
-    _loadedPrefsSchema: 4,
+    _loadedPrefsSchema: 5,
     workspaceSurfaces: {},
     _workspaceRuntimeCaches: new Map(),
     _workspaceTreeCacheTimers: new Map(),
@@ -4584,7 +4584,7 @@ function portal() {
       // the exact files the user was looking at — matches the chat-tab strip's
       // behavior via openTabIds.
       this._setLS("muselab_prefs", JSON.stringify({
-        schema: 4,          // v4 decouples conversation cwd from the archive surface
+        schema: 5,          // v5 persists one file/preview surface per workspace
         model: this.model, defaultModel: this.defaultModel,
         permission: this.permission, defaultPermission: this.defaultPermission,
         currentId: this.currentId,
@@ -4594,6 +4594,7 @@ function portal() {
         expanded: Array.from(this.expanded),
         activeWorkspace: this.activeWorkspace,
         workspaceLastSession: this.workspaceLastSession,
+        workspaceSurfaces: this.workspaceSurfaces,
         leftOpen: this.leftOpen, rightOpen: this.rightOpen,
         leftWidth: this.leftWidth, rightWidth: this.rightWidth,
         showHidden: this.showHidden,
@@ -6680,7 +6681,7 @@ function portal() {
       return ((this.sessionWorkspaces.find(w => w.primary) || {}).path || "");
     },
     fileWorkspacePath() {
-      return this.primaryWorkspacePath();
+      return this.currentWorkspacePath();
     },
     currentWorkspacePath() {
       if (this.activeWorkspace) return this.activeWorkspace;
@@ -6908,10 +6909,9 @@ function portal() {
       }
       this.workspaceSwitching = true;
       try {
-        // Workspace selection changes only the conversation cwd. The file tree,
-        // preview tabs and editor remain rooted at primary MUSELAB_ROOT.
-        this.activeWorkspace = path;
-        await this.fetchContextInfo();
+        // A workspace owns the conversation cwd, file tree, preview tabs, and
+        // editor together. Preserve the old surface and restore the target one.
+        await this._changeWorkspaceSurface(path);
         if (!this.workspaceSessions(path).length) await this._pullAllSessions();
         const remembered = this.workspaceLastSession[path];
         const target = this.sessions.find(s => s.id === remembered && s.cwd === path)
@@ -7123,10 +7123,7 @@ function portal() {
       try {
         if (this.activeWorkspace === path) {
           const primary = this.sessionWorkspaces.find(w => w.primary);
-          if (primary) {
-            this.activeWorkspace = primary.path;
-            await this.fetchContextInfo();
-          }
+          if (primary) await this._changeWorkspaceSurface(primary.path);
         }
         const response = await fetch(
           "/api/chat/workspaces?path=" + encodeURIComponent(path),
@@ -7345,8 +7342,7 @@ function portal() {
       const cwd = session && session.cwd;
       if (cwd && cwd !== this.currentWorkspacePath()
           && this.sessionWorkspaces.some(w => w.path === cwd)) {
-        this.activeWorkspace = cwd;
-        this.fetchContextInfo();
+        await this._changeWorkspaceSurface(cwd);
       }
       if (!this.openTabIds.includes(id)) {
         const MAX_TABS = 20;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -277,7 +277,49 @@
     <aside class="pane files" :class="{'pane-hidden': !leftOpen}">
       <header class="pane-head">
         <span class="pane-title"><span class="icon"><svg><use href="#i-folder"/></svg></span><span x-text="t('pane.files')"></span></span>
+        <div class="workspace-picker files-head-workspace" @click.outside="workspaceMenuOpen = false">
+          <button class="workspace-picker-btn" type="button"
+                  @click="workspaceMenuOpen = !workspaceMenuOpen"
+                  :disabled="workspaceSwitching" :title="currentWorkspacePath()"
+                  :aria-expanded="workspaceMenuOpen">
+            <svg><use href="#i-folder"/></svg>
+            <span class="workspace-picker-name" x-text="workspaceLabel()"></span>
+            <svg class="workspace-picker-caret"><use href="#i-chevron-down"/></svg>
+          </button>
+          <div class="workspace-picker-pop" x-show="workspaceMenuOpen" x-cloak>
+            <div class="workspace-picker-title">
+              <span x-text="t('workspace.title')"></span>
+              <button type="button" class="workspace-info-btn"
+                      @click.stop="toast(t('workspace.help'), 'info', 7000)"
+                      :title="t('workspace.help')"
+                      :aria-label="t('workspace.help')">
+                <svg><use href="#i-info"/></svg>
+              </button>
+            </div>
+            <template x-for="workspace in sessionWorkspaces" :key="workspace.path">
+              <div class="workspace-picker-row" :class="{ active: workspace.path === currentWorkspacePath() }">
+                <button class="workspace-picker-select" @click="switchWorkspace(workspace.path)">
+                  <span class="workspace-picker-check" x-text="workspace.path === currentWorkspacePath() ? '✓' : ''"></span>
+                  <span class="workspace-picker-meta"><strong x-text="workspace.name"></strong><small x-text="workspace.path"></small></span>
+                  <span class="workspace-activity-mini" x-show="workspaceActivity(workspace.path).running || workspaceActivity(workspace.path).unread">
+                    <span class="running" x-show="workspaceActivity(workspace.path).running" x-text="'◌ ' + workspaceActivity(workspace.path).running"></span>
+                    <span class="unread" x-show="workspaceActivity(workspace.path).unread" x-text="'✓ ' + workspaceActivity(workspace.path).unread"></span>
+                  </span>
+                </button>
+                <button class="workspace-picker-remove" x-show="!workspace.primary" @click.stop="removeWorkspace(workspace.path)"><svg><use href="#i-x"/></svg></button>
+              </div>
+            </template>
+            <button class="workspace-picker-add" @click="addWorkspace()"><svg><use href="#i-folder-plus"/></svg><span x-text="lang==='zh' ? '添加工作目录…' : 'Add workspace…'"></span></button>
+          </div>
+        </div>
         <span class="spacer"></span>
+        <button class="activity-center-btn" type="button" @click="openActivityCenter()"
+                :class="{ active: activity.summary.running || activity.summary.unread, danger: activity.summary.attention }"
+                :title="lang==='zh' ? '全局任务中心' : 'Global activity center'">
+          <svg><use href="#i-list"/></svg>
+          <span class="activity-running" x-show="activity.summary.running" aria-hidden="true"></span>
+          <span class="activity-unread" x-show="activity.summary.unread" aria-hidden="true"></span>
+        </button>
         <button @click="$refs.upload.click()" class="icon-btn files-keep-mobile" :title="t('btn.upload')"><svg><use href="#i-upload"/></svg></button>
         <button @click="mkdirPrompt()" class="icon-btn" :title="t('btn.new_dir')"><svg><use href="#i-folder-plus"/></svg></button>
         <button @click="toggleHidden()" class="icon-btn"
@@ -374,12 +416,12 @@
       <div class="filelist-wrap" x-show="!searchMode">
         <div class="filelist-sticky-root"
              :class="{ 'drag-over': dragOverRoot }"
-             :title="currentWorkspacePath() || contextInfo.archive_root || ''"
+             :title="fileWorkspacePath() || contextInfo.archive_root || ''"
              @dragover.prevent="onTreeRootDragOver($event)"
              @dragleave="dragOverRoot = false"
              @drop.prevent="onTreeRootDrop($event)">
           <span class="icon"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9M5 10v10h14V10"/></svg></span>
-          <span class="path" x-text="currentWorkspacePath() || contextInfo.archive_root || '—'"></span>
+          <span class="path" x-text="fileWorkspacePath() || contextInfo.archive_root || '—'"></span>
           <!-- Root-level quick actions. Same doNewFile/doNewDir the per-dir
                "+" and ctx menu use — both already handle path:'' (root), so
                these are pure entry points, no new write paths. @click.stop
@@ -1066,41 +1108,6 @@
           </span>
           <span x-text="t('pane.chat')"></span>
         </span>
-        <div class="workspace-picker chat-head-workspace" @click.outside="workspaceMenuOpen = false">
-          <button class="workspace-picker-btn" type="button"
-                  @click="workspaceMenuOpen = !workspaceMenuOpen"
-                  :disabled="workspaceSwitching" :title="currentWorkspacePath()"
-                  :aria-expanded="workspaceMenuOpen">
-            <svg><use href="#i-folder"/></svg>
-            <span class="workspace-picker-name" x-text="workspaceLabel()"></span>
-            <svg class="workspace-picker-caret"><use href="#i-chevron-down"/></svg>
-          </button>
-          <div class="workspace-picker-pop" x-show="workspaceMenuOpen" x-cloak>
-            <div class="workspace-picker-title">
-              <span x-text="t('workspace.title')"></span>
-              <button type="button" class="workspace-info-btn"
-                      @click.stop="toast(t('workspace.help'), 'info', 7000)"
-                      :title="t('workspace.help')"
-                      :aria-label="t('workspace.help')">
-                <svg><use href="#i-info"/></svg>
-              </button>
-            </div>
-            <template x-for="workspace in sessionWorkspaces" :key="workspace.path">
-              <div class="workspace-picker-row" :class="{ active: workspace.path === currentWorkspacePath() }">
-                <button class="workspace-picker-select" @click="switchWorkspace(workspace.path)">
-                  <span class="workspace-picker-check" x-text="workspace.path === currentWorkspacePath() ? '✓' : ''"></span>
-                  <span class="workspace-picker-meta"><strong x-text="workspace.name"></strong><small x-text="workspace.path"></small></span>
-                  <span class="workspace-activity-mini" x-show="workspaceActivity(workspace.path).running || workspaceActivity(workspace.path).unread">
-                    <span class="running" x-show="workspaceActivity(workspace.path).running" x-text="'◌ ' + workspaceActivity(workspace.path).running"></span>
-                    <span class="unread" x-show="workspaceActivity(workspace.path).unread" x-text="'✓ ' + workspaceActivity(workspace.path).unread"></span>
-                  </span>
-                </button>
-                <button class="workspace-picker-remove" x-show="!workspace.primary" @click.stop="removeWorkspace(workspace.path)"><svg><use href="#i-x"/></svg></button>
-              </div>
-            </template>
-            <button class="workspace-picker-add" @click="addWorkspace()"><svg><use href="#i-folder-plus"/></svg><span x-text="lang==='zh' ? '添加工作目录…' : 'Add workspace…'"></span></button>
-          </div>
-        </div>
         <span class="spacer"></span>
         <!-- CLAUDE.md status chip — only shown when MISSING (intake creates it
              by default, so the "present" state is implicit). When missing,
@@ -1112,14 +1119,6 @@
           <svg class="ctx-chip-icon"><use href="#i-alert-triangle"/></svg>
           <span x-text="lang==='zh' ? '未配档案' : 'no archive'"></span>
         </span>
-        <button class="activity-center-btn" type="button" @click="openActivityCenter()"
-                :class="{ active: activity.summary.running || activity.summary.unread, danger: activity.summary.attention }"
-                :title="lang==='zh' ? '全局任务中心' : 'Global activity center'">
-          <svg><use href="#i-list"/></svg>
-          <!-- Two compact state dots: blue = running, green = finished but unread. -->
-          <span class="activity-running" x-show="activity.summary.running" aria-hidden="true"></span>
-          <span class="activity-unread" x-show="activity.summary.unread" aria-hidden="true"></span>
-        </button>
         <!-- Skills + MCP drawer toggles. 2026-05-29: 从 chat-input 底 bar 移到
              顶 bar，与其它「能力 / 会话」入口（整理档案、定时任务、命令面板）
              并列；底 bar 只留 attach / 模型 / 权限 / effort / context ring 等

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2920,8 +2920,8 @@ pre.text {
    escapes the parent .chat-tabs overflow: auto clip. Just bump z-index. */
 .chat-tab-history .session-picker-pop { z-index: 1500; }
 
-/* Application-level workspace picker. It sits between history and the session
-   tabs so the selected directory clearly owns files, preview, and chat. */
+/* Application-level workspace picker. It lives in the files-pane header because
+   the selected directory owns the file tree, preview surface, and chat cwd. */
 .workspace-picker {
   position: relative;
   flex: 0 0 auto;
@@ -3061,7 +3061,14 @@ pre.text {
 @keyframes activity-running-pulse { 0% { transform:scale(.75); opacity:.8; } 75%,100% { transform:scale(1.4); opacity:0; } }
 .activity-center-btn .activity-unread { position:absolute; right:-2px; top:-2px; width:10px; height:10px; border:2px solid var(--c-bg-1); border-radius:var(--r-full); background:var(--c-success); box-sizing:border-box; pointer-events:none; }
 @media (prefers-reduced-motion:reduce) { .activity-center-btn .activity-running::after { animation:none; opacity:0; } }
-.chat-head-workspace { flex:0 1 220px; margin-left:8px; }
+.files-head-workspace {
+  flex: 1 1 120px;
+  min-width: 0;
+  max-width: 180px;
+  margin-left: 6px;
+  border-right: 0;
+}
+.files-head-workspace .workspace-picker-btn { width: 100%; max-width: none; border-radius: var(--r-sm); }
 .activity-modal { width:620px; max-width:calc(100vw - 32px); }
 .activity-summary { display:flex; align-items:center; gap:12px; padding:10px 16px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
 .activity-summary .running { color:var(--c-accent); }
@@ -3082,7 +3089,10 @@ pre.text {
 .activity-row-main strong,.activity-row-main small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .activity-row-main small,.activity-row-side small { color:var(--c-fg-3); font-size:var(--fs-xs); }
 .activity-row-side { flex:0 0 auto; display:flex; flex-direction:column; align-items:flex-end; gap:3px; color:var(--c-fg-2); font-size:var(--fs-xs); }
-@media (max-width:600px) { .chat-head-workspace { flex:1 1 auto; max-width:none; margin-left:2px; } .chat-head-workspace .workspace-picker-btn { width:100%; max-width:150px; } }
+@media (max-width:600px) {
+  .files-head-workspace { flex:1 1 auto; max-width:none; margin-left:2px; }
+  .files-head-workspace .workspace-picker-btn { width:100%; max-width:150px; }
+}
 
 @media (max-width: 600px) {
   .workspace-picker-btn { max-width: 112px; padding-inline: 7px; }

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -397,7 +397,11 @@ def test_workspace_picker_switches_files_preview_and_conversation_together(
     assert state["tabCwds"] and set(state["tabCwds"]) == {str(other)}
     secondary_id = state["currentId"]
 
-    page.locator('.filelist li[data-path="WORKSPACE_ONLY.md"]').click()
+    workspace_file = page.locator('.filelist li[data-path="WORKSPACE_ONLY.md"]')
+    if not workspace_file.is_visible():
+        page.locator(".mobile-tab-bar button").first.click()
+        expect(workspace_file).to_be_visible()
+    workspace_file.click()
     page.wait_for_function(
         """() => {
           const app = document.querySelector('#app')._x_dataStack[0];
@@ -472,6 +476,8 @@ def test_workspace_folder_browser_is_fullscreen_and_navigable_on_mobile(
     child.mkdir(parents=True)
     (child / "package.json").write_text('{"name":"nested"}\n', encoding="utf-8")
 
+    page.locator(".mobile-tab-bar button").first.click()
+    expect(page.locator(".workspace-picker-btn")).to_be_visible()
     page.locator(".workspace-picker-btn").click()
     page.locator(".workspace-picker-add").click()
     modal = page.locator(".workspace-browser-modal")

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -340,9 +340,9 @@ def test_queue_edit_restores_original_tab_during_switch(
     }
 
 
-def test_workspace_picker_switches_conversation_and_keeps_archive_surface(
+def test_workspace_picker_switches_files_preview_and_conversation_together(
         page: Page, backend_url, auth_token, tmp_path):
-    """A workspace switch changes chat cwd without moving the archive root."""
+    """A workspace switch moves chat, file tree, and preview as one surface."""
     _login(page, backend_url, auth_token)
     primary = page.evaluate(
         "() => document.querySelector('#app')._x_dataStack[0].currentWorkspacePath()")
@@ -391,11 +391,19 @@ def test_workspace_picker_switches_conversation_and_keeps_archive_surface(
               app.sessions.find(item => item.id === id)?.cwd),
           };
         }""")
-    assert "WORKSPACE_ONLY.md" not in state["visible"]
-    assert "README.md" in state["visible"]
-    assert state["selected"] == "README.md"
+    assert "WORKSPACE_ONLY.md" in state["visible"]
+    assert "README.md" not in state["visible"]
+    assert state["selected"] == ""
     assert state["tabCwds"] and set(state["tabCwds"]) == {str(other)}
     secondary_id = state["currentId"]
+
+    page.locator('.filelist li[data-path="WORKSPACE_ONLY.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.selected === 'WORKSPACE_ONLY.md'
+            && app.rawText.includes('workspace-isolated-preview');
+        }""")
 
     page.locator(".workspace-picker-btn").click()
     page.locator(".workspace-picker-row").filter(
@@ -420,8 +428,8 @@ def test_workspace_picker_switches_conversation_and_keeps_archive_surface(
         """([path, sid]) => {
           const app = document.querySelector('#app')._x_dataStack[0];
           return app.currentWorkspacePath() === path && app.currentId === sid
-            && app.selected === 'README.md'
-            && app.rawText.includes('muselab e2e')
+            && app.selected === 'WORKSPACE_ONLY.md'
+            && app.rawText.includes('workspace-isolated-preview')
             && !app.workspaceSwitching;
         }""",
         arg=[str(other), secondary_id],

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -179,19 +179,24 @@ def test_multi_workspace_ui_and_folder_browser_are_wired_end_to_end():
     assert "height: 100dvh" in mobile
 
 
-def test_workspace_switch_changes_conversation_only_and_keeps_archive_surface():
+def test_workspace_switch_moves_files_preview_and_conversation_together():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     start = app.index("async switchWorkspace(path)")
     end = app.index("\n    closeWorkspaceBrowser()", start)
     switch = app[start:end]
 
-    assert "this.activeWorkspace = path" in switch
-    assert "await this.fetchContextInfo()" in switch
-    assert "_changeWorkspaceSurface" not in switch
-    assert "_confirmLoseEdits" not in switch
-    assert "loadRoot()" not in switch
-    assert "loadTrash()" not in switch
-    assert "_clearPreviewState" not in switch
+    assert "await this._changeWorkspaceSurface(path)" in switch
+    assert "return this.currentWorkspacePath()" in app
+    assert "workspaceSurfaces: this.workspaceSurfaces" in app
+    files_start = html.index('<aside class="pane files"')
+    files_end = html.index("</aside>", files_start)
+    chat_start = html.index('<aside class="pane chat"')
+    chat_end = html.index("</aside>", chat_start)
+    assert "files-head-workspace" in html[files_start:files_end]
+    assert "activity-center-btn" in html[files_start:files_end]
+    assert "workspace-picker" not in html[chat_start:chat_end]
+    assert "activity-center-btn" not in html[chat_start:chat_end]
 
 
 def test_session_history_and_workspace_use_distinct_icons():


### PR DESCRIPTION
## What this changes

将工作目录选择器和全局任务中心移动到文件区顶栏，并让工作目录统一控制聊天、文件树、预览标签与编辑器。每个工作目录会独立保存预览标签、当前文件、目录展开状态和隐藏文件设置，切回时恢复原界面。

## Why

原来的工作目录只切换聊天 cwd，文件区和预览区始终固定在主目录，导致顶栏显示的目录与实际文件内容不一致。统一状态后，用户切换工作目录时看到和编辑的文件会同步切换，不再发生跨目录错位。

## Testing

- [ ] `uv run pytest tests/` passes（由 PR CI 执行）
- [x] `uv run pytest tests/test_frontend_lint.py -q`：36 passed
- [x] `uv run ruff check backend/ tests/` passes
- [x] `bash scripts/lint.sh` passes
- [x] `node --check frontend/app.js` passes
- [x] 在生产服务通过 Playwright 验证：控件位于文件区顶栏；切换工作目录后文件根路径同步变化；切回后恢复原目录

## Frontend before / after

- Before：工作目录和全局任务中心位于聊天顶栏；切换工作目录只改变聊天 cwd，文件区和预览区仍停留在主目录。
- After：两个入口位于文件区顶栏；工作目录同时驱动聊天、文件区和预览区，并按目录恢复各自状态。

## Checklist

- [x] No secrets committed
- [x] Visible behavior and regression tests updated
- [x] No runtime dependency added
