### PR TITLE
fix(chat): 修复输入历史、终止状态与弹窗层级

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1404,6 +1404,18 @@ def _rough_prompt_tokens(text: str) -> int:
     return max(1, len(text) // 3)
 
 
+_CLI_INTERRUPT_MESSAGE_RE = re.compile(
+    r"^\[Request interrupted by user(?: for tool use)?\]$",
+    re.IGNORECASE,
+)
+
+
+def _is_cli_interrupt_message(text: Any) -> bool:
+    """Return True only for Claude CLI's synthetic interrupt transcript row."""
+    return isinstance(text, str) and bool(
+        _CLI_INTERRUPT_MESSAGE_RE.fullmatch(text.strip()))
+
+
 async def _detect_gateway_context_limit(model: str) -> int:
     """Compatibility wrapper returning only the effective integer limit."""
     capability = await _detect_gateway_context_capability(model)
@@ -1432,12 +1444,18 @@ def _is_real_user_prompt(sm: Any) -> bool:
     msg = getattr(sm, "message", None)
     content = msg.get("content") if isinstance(msg, dict) else None
     if isinstance(content, str):
-        return bool(content.strip())
+        return bool(content.strip()) and not _is_cli_interrupt_message(content)
     if isinstance(content, list):
-        # If any block is non-tool_result (text / image / etc.) → real prompt.
+        # If any meaningful block is non-tool_result (text / image / etc.) →
+        # real prompt. Claude CLI persists Stop as a synthetic user text row;
+        # it is transport metadata, not a human turn.
         for b in content:
-            if isinstance(b, dict) and b.get("type") != "tool_result":
-                return True
+            if not isinstance(b, dict) or b.get("type") == "tool_result":
+                continue
+            if (b.get("type") == "text"
+                    and _is_cli_interrupt_message(b.get("text"))):
+                continue
+            return True
         return False
     # Unknown shape — default to "real" so we don't under-count.
     return True
@@ -2862,6 +2880,11 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
 
         # Simple shape: content is a single string.
         if isinstance(content, str):
+            # Claude CLI persists an explicit Stop as a synthetic user record.
+            # It is not a message the human sent and must not split the visible
+            # assistant/tool run or appear as an English user bubble.
+            if _is_cli_interrupt_message(content):
+                continue
             # Background-task completion record → stamp the launching tool_use
             # card's terminal task_status (durable ✅ across reloads) and DROP
             # the raw XML bubble. The card was emitted by an earlier assistant
@@ -2910,6 +2933,8 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
             # render. Pure-wrapper messages produce empty text + no images
             # → drop the bubble entirely.
             cleaned = _strip_cli_slash_wrapper(text_buf)
+            if _is_cli_interrupt_message(cleaned):
+                cleaned = ""
             if not cleaned and not image_refs:
                 text_buf = ""
                 image_refs = []

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4606,7 +4606,23 @@ function portal() {
       finally { this.dismissToast(t.id); }
     },
 
+    // Enter pressed while a CJK IME is composing confirms the highlighted
+    // candidate; it must not also submit the surrounding prompt or rename.
+    // `isComposing` is the standard signal, while keyCode/which 229 and
+    // key="Process" cover older Safari/WebView and Windows IME variants.
+    _claimNonImeEnter(ev) {
+      if (!ev || ev.isComposing || ev.keyCode === 229 || ev.which === 229
+          || ev.key === "Process") return false;
+      ev.preventDefault();
+      ev.stopPropagation();
+      return true;
+    },
+
     // ===== modal =====
+    confirmModalOnEnter(ev) {
+      if (!this._claimNonImeEnter(ev)) return;
+      if (this.modal.confirm) this.modal.confirm();
+    },
     confirm({ title, body = "", okText, cancelText, danger = false }) {
       // Don't depend on this.t() for default labels — in some call paths
       // (observed 2026-05-28 from deleteSchedTask) `this.t` evaluates to
@@ -7657,6 +7673,10 @@ function portal() {
         if (el) { el.focus(); el.select(); }
       });
     },
+    commitRenameTabOnEnter(ev) {
+      if (!this._claimNonImeEnter(ev)) return;
+      this.commitRenameTab();
+    },
     async commitRenameTab() {
       const id = this.renamingTabId;
       const name = (this.renameDraft || "").trim();
@@ -9342,6 +9362,10 @@ function portal() {
       const el = document.querySelector(
         `.session-picker-rename-input[data-sid="${CSS.escape(sid)}"]`);
       if (el) { el.focus(); el.select(); }
+    },
+    pickerCommitInlineRenameOnEnter(ev) {
+      if (!this._claimNonImeEnter(ev)) return;
+      this.pickerCommitInlineRename();
     },
     async pickerCommitInlineRename() {
       const sid = this.renamingPickerSid;
@@ -18011,9 +18035,10 @@ function portal() {
 
     // ===== chat =====
     onEnter(ev) {
-      // 中文 / 日文 输入法在选词阶段也会触发 Enter (keyCode=229 / isComposing=true)。
-      // 那时不应该当成"发送"，让 IME 自己处理。
-      if (ev.isComposing || ev.keyCode === 229) return;
+      // Leave candidate-confirming Enter entirely to the IME. For a regular
+      // Enter, claim the event here instead of using Alpine's `.prevent`
+      // modifier, which would preventDefault even during composition.
+      if (!this._claimNonImeEnter(ev)) return;
       if (this.mentionShow) { this.pickMention(); return; }
       // Newline-at-cursor for: Shift+Enter, Ctrl+Enter, Meta+Enter, and
       // touch devices (where bare Enter is a newline because send is via

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4610,9 +4610,12 @@ function portal() {
     // candidate; it must not also submit the surrounding prompt or rename.
     // `isComposing` is the standard signal, while keyCode/which 229 and
     // key="Process" cover older Safari/WebView and Windows IME variants.
+    _isImeComposingEvent(ev) {
+      return !!(ev && (ev.isComposing || ev.keyCode === 229 || ev.which === 229
+        || ev.key === "Process"));
+    },
     _claimNonImeEnter(ev) {
-      if (!ev || ev.isComposing || ev.keyCode === 229 || ev.which === 229
-          || ev.key === "Process") return false;
+      if (!ev || this._isImeComposingEvent(ev)) return false;
       ev.preventDefault();
       ev.stopPropagation();
       return true;
@@ -5452,6 +5455,8 @@ function portal() {
           input: "",
           pendingImages: [],
           pendingDocs: [],
+          _historyIndex: -1,
+          _historyDraft: "",
           _sendWaitingForUpload: false,
           _uploadControllers: new Set(),
         },
@@ -17881,37 +17886,90 @@ function portal() {
       }
     },
 
+    _chatInputHistory() {
+      const st = this.currentId && this.tabState && this.tabState[this.currentId];
+      const messages = st
+        ? [
+            ...(st._earlierMessages || []),
+            ...(st.messages || []),
+            ...(st._laterMessages || []),
+          ]
+        : (this.messages || []);
+      return messages
+        .filter(m => m && m.role === "user" && typeof m.text === "string"
+          && m.text.length)
+        .map(m => m.text);
+    },
+    _resetChatInputHistory(draft = null) {
+      draft = draft || (this.currentId && this.tabState
+        && this.tabState[this.currentId] && this.tabState[this.currentId].draft);
+      if (!draft) return;
+      draft._historyIndex = -1;
+      draft._historyDraft = "";
+    },
+    _showChatHistoryInput(text, ev) {
+      this.input = text;
+      ev.preventDefault();
+      this.$nextTick(() => {
+        const ta = this.$refs.chatInput;
+        if (!ta) return;
+        ta.focus();
+        const len = this.input.length;
+        ta.setSelectionRange(len, len);
+        this.autoGrow(ta);
+      });
+    },
     onChatArrowUp(ev) {
-      // 1. If a mention/slash popup is open, ↑ navigates it (preserves
-      //    the prior keymap).
+      // Candidate lists own their arrow keys while a CJK IME is composing.
+      if (this._isImeComposingEvent(ev)) return;
+      // 1. If a mention/slash popup is open, ↑ navigates it.
       if (this.mentionShow || this.slashShow) {
         this._navPop(-1);
         ev.preventDefault();
         return;
       }
-      // 2. Empty input → recall the most recent user message so the user
-      //    can edit + re-send (Slack/Cursor/iTerm/zsh style).
-      if (!this.input.trim()) {
-        const msgs = this.messages || [];
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const m = msgs[i];
-          if (m && m.role === "user" && m.text) {
-            this.input = m.text;
-            ev.preventDefault();
-            this.$nextTick(() => {
-              const ta = this.$refs.chatInput;
-              if (ta) {
-                ta.focus();
-                const len = this.input.length;
-                ta.setSelectionRange(len, len);
-                this.autoGrow(ta);
-              }
-            });
-            return;
-          }
-        }
+      const st = this.currentId && this.tabState && this.tabState[this.currentId];
+      const draft = st && st.draft;
+      const history = this._chatInputHistory();
+      if (!draft || !history.length) return;
+      let index = Number.isInteger(draft._historyIndex)
+        ? draft._historyIndex : -1;
+      // Preserve native caret movement for multiline drafts until history
+      // navigation has explicitly started. Single-line input follows shell
+      // semantics and is restored after the user walks forward with ↓.
+      if (index < 0) {
+        if (this.input.includes("\n")) return;
+        draft._historyDraft = this.input;
+        index = history.length;
       }
-      // Otherwise let the browser handle ↑ (cursor up inside textarea).
+      if (index <= 0) {
+        ev.preventDefault();
+        return;
+      }
+      draft._historyIndex = index - 1;
+      this._showChatHistoryInput(history[draft._historyIndex], ev);
+    },
+    onChatArrowDown(ev) {
+      if (this._isImeComposingEvent(ev)) return;
+      if (this.mentionShow || this.slashShow) {
+        this._navPop(1);
+        ev.preventDefault();
+        return;
+      }
+      const st = this.currentId && this.tabState && this.tabState[this.currentId];
+      const draft = st && st.draft;
+      const index = draft && Number.isInteger(draft._historyIndex)
+        ? draft._historyIndex : -1;
+      if (!draft || index < 0) return;
+      const history = this._chatInputHistory();
+      if (index < history.length - 1) {
+        draft._historyIndex = index + 1;
+        this._showChatHistoryInput(history[draft._historyIndex], ev);
+        return;
+      }
+      const originalDraft = draft._historyDraft || "";
+      this._resetChatInputHistory(draft);
+      this._showChatHistoryInput(originalDraft, ev);
     },
 
     _cancelMentionLookup() {
@@ -17921,6 +17979,9 @@ function portal() {
       this.mentionShow = false;
     },
     onChatInput(ev) {
+      // A real edit forks away from the recalled entry. Programmatic history
+      // navigation updates x-model directly and does not emit an input event.
+      this._resetChatInputHistory();
       const ta = ev.target;
       const pos = ta.selectionStart;
       const text = this.input.slice(0, pos);
@@ -18368,6 +18429,7 @@ function portal() {
       const clearSubmittedComposer = () => {
         if (!ownsSendDraft()) return;
         if (sendDraft.input === composerText) sendDraft.input = "";
+        this._resetChatInputHistory(sendDraft);
         const removeOwned = (items, sent) => {
           for (let i = items.length - 1; i >= 0; i--) {
             if (sent.has(items[i])) items.splice(i, 1);
@@ -18443,6 +18505,7 @@ function portal() {
           }
           if (ownsSendDraft() && sendDraft.input === composerText) {
             sendDraft.input = "";
+            this._resetChatInputHistory(sendDraft);
             if (this.currentId === sendSid) this.input = "";
           }
           this.$nextTick(() => { if (this.currentId === sendSid && this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
@@ -19275,6 +19338,7 @@ function portal() {
       const _markDone = (cancelled = false) => {
         streamState.streaming = false;
         streamState.es = null;
+        streamState._stopping = false;
         streamState._serverActiveObserved = false;
         // If the user is on a different tab when this turn lands, flag
         // unread so the tab strip can show a green dot. Doing it inside
@@ -19674,7 +19738,7 @@ function portal() {
       es.addEventListener("cancelled", () => {
         flushRender();
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
-        es.close(); _markDone(); _stopTimer();
+        es.close(); _markDone(true); _stopTimer();
         // User explicitly stopped — pause the queue too. Auto-draining
         // here would be surprising (they cancelled for a reason, almost
         // never "just this one but please send the rest"). The paused
@@ -19710,6 +19774,7 @@ function portal() {
       if (st.pendingQueue && st.pendingQueue.length > 0) st._queuePaused = true;
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 15000);
+      let waitForTerminalEvent = false;
       try {
         const r = await fetch(
           "/api/chat/interrupt?session_id=" + encodeURIComponent(sid),
@@ -19725,6 +19790,12 @@ function portal() {
           item => item === sid || String(item).startsWith(sid + "@"),
         );
         if (this.tabState[sid] !== st) return;
+        // The HTTP response only acknowledges the control request. Keep the
+        // EventSource alive until its cancelled/done event flushes the final
+        // markdown/tool boundary and performs the one authoritative cleanup.
+        // Closing it here used to strand partially rendered blocks and race a
+        // subsequent history reload.
+        waitForTerminalEvent = !!st.streaming;
         if (!didInterrupt) {
           // An empty interrupted list means the SDK client was detached or its
           // best-effort interrupt failed. The backend watchdog is now forcing the
@@ -19735,32 +19806,11 @@ function portal() {
                      "warn", 2500);
           return;
         }
-
-        // Flush selection-deferred text before retiring the EventSource, then use
-        // the shared lifecycle cleanup so reconnect counters/timers cannot leak
-        // into the next turn.
-        if (st._renderStreamingHtml) st._renderStreamingHtml();
-        const now = Date.now();
-        const clockElapsed = st._streamStartedAt
-          ? (now - st._streamStartedAt) / 1000 : 0;
-        const elapsed = Math.max(0, Number(st.streamElapsed) || 0,
-          Number.isFinite(clockElapsed) ? clockElapsed : 0);
-        this._retireStaleSessionStream(sid, st);
-        st._renderStreamingHtml = null;
-        st._pendingHtmlRender = null;
-        for (let i = st.messages.length - 1; i >= 0; i--) {
-          const message = st.messages[i];
-          if (!message) continue;
-          if (message.role === "user") break;
-          if (message.role !== "assistant") continue;
-          if (!message.ts) message.ts = now;
-          if (!message.elapsed && elapsed >= 1) message.elapsed = elapsed;
-          break;
+        if (waitForTerminalEvent) {
+          this.toast(this.lang === "zh" ? "正在中断当前会话…"
+                                        : "Interrupting the current session…",
+                     "warn", 2000);
         }
-        const session = (this.sessions || []).find(s => s.id === sid);
-        if (session) session.active = false;
-        this.toast(this.lang === "zh" ? "已中断当前会话" : "Session interrupted",
-                   "warn", 2000);
       } catch (_e) {
         this.toast(this.lang === "zh"
                     ? "停止失败，当前会话仍在运行"
@@ -19769,7 +19819,9 @@ function portal() {
       } finally {
         clearTimeout(timeout);
         if (this.tabState[sid] === st) {
-          st._stopping = false;
+          // A successfully accepted interrupt stays deduplicated until the
+          // stream's terminal event clears _stopping in _markDone().
+          if (!waitForTerminalEvent || !st.streaming) st._stopping = false;
           this._syncQueueFromServer(sid);
         }
         setTimeout(() => this.refreshSessions(), 800);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2987,7 +2987,7 @@
                     @keydown.ctrl.x="onCutLine($event)"
                     @keydown.meta.x="onCutLine($event)"
                     @keydown.up="onChatArrowUp($event)"
-                    @keydown.down="(mentionShow || slashShow) && _navPop(1) && $event.preventDefault()"
+                    @keydown.down="onChatArrowDown($event)"
                     @input="onChatInput($event); autoGrow($event.target)"
                     @paste="onImagePaste($event)"
                     @focus="onChatInputFocus($event)"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -276,7 +276,11 @@
        :data-mobile-tab="mobileTab" :data-desktop-full="desktopFullPane">
 
     <!-- ============ 左：文件树 ============ -->
-    <aside class="pane files" :class="{'pane-hidden': !leftOpen}">
+    <aside class="pane files"
+           :class="{
+             'pane-hidden': !leftOpen,
+             'pane-floating-layer': workspaceMenuOpen
+           }">
       <header class="pane-head">
         <span class="pane-title"><span class="icon"><svg><use href="#i-file-text"/></svg></span><span x-text="t('pane.files')"></span></span>
         <div class="workspace-picker files-head-workspace" @click.outside="workspaceMenuOpen = false">
@@ -595,7 +599,11 @@
     <div class="resizer" :class="{'pane-hidden': !leftOpen}" @mousedown="startResize('left', $event)"></div>
 
     <!-- ============ 中：预览 ============ -->
-    <section class="pane preview">
+    <section class="pane preview"
+             :class="{
+               'pane-floating-layer': terminalManagerOpen
+                 || editorTabPickerOpen || !!previewTabCtxMenu
+             }">
       <header class="pane-head">
         <button @click="toggleFilesPane()" class="icon-btn"
                 :title="desktopFullPane === 'preview'
@@ -1280,7 +1288,13 @@
     <div class="resizer" :class="{'pane-hidden': !rightOpen}" @mousedown="startResize('right', $event)"></div>
 
     <!-- ============ 右：chat ============ -->
-    <aside class="pane chat" :class="{'pane-hidden': !rightOpen}">
+    <aside class="pane chat"
+           :class="{
+             'pane-hidden': !rightOpen,
+             'pane-floating-layer': sessionPickerOpen || !!tabCtxMenu
+               || ctxBreakdown.show || composerSettingsOpen
+               || mentionShow || slashShow
+           }">
       <header class="pane-head">
         <span class="pane-title">
           <span class="muse-mascot sm" :class="{'greet': mascotGreet, 'is-streaming': streaming}"
@@ -1553,7 +1567,7 @@
                            :data-sid="s.id"
                            x-model="pickerRenameDraft"
                            @click.stop
-                           @keydown.enter.prevent="pickerCommitInlineRename()"
+                           @keydown.enter="pickerCommitInlineRenameOnEnter($event)"
                            @keydown.escape.prevent="pickerCancelInlineRename()"
                            @blur="pickerCommitInlineRename()" />
                     <button class="session-picker-rename-ok"
@@ -1634,7 +1648,7 @@
                      x-show="renamingTabId === tid"
                      @click.stop @dblclick.stop
                      @blur="commitRenameTab()"
-                     @keydown.enter.prevent="commitRenameTab()"
+                     @keydown.enter="commitRenameTabOnEnter($event)"
                      @keydown.escape.prevent="cancelRenameTab()" />
               <!-- Kebab menu — only shown on mobile (CSS @media). Desktop uses
                    right-click which mobile browsers don't reliably synthesize. -->
@@ -2968,7 +2982,7 @@
                     autocapitalize="sentences" spellcheck="false"
                     enterkeyhint="enter"
                     data-1p-ignore="" data-lpignore="true" data-form-type="other"
-                    @keydown.enter.prevent.stop="onEnter($event)"
+                    @keydown.enter="onEnter($event)"
                     @keydown.escape="mentionShow=false; slashShow=false"
                     @keydown.ctrl.x="onCutLine($event)"
                     @keydown.meta.x="onCutLine($event)"
@@ -4791,7 +4805,7 @@
         <div x-show="modal.body" x-text="modal.body"></div>
         <input x-show="modal.input !== null" x-model="modal.input"
                :placeholder="modal.placeholder || ''"
-               x-ref="modalInput" @keydown.enter="modal.confirm?.()" />
+               x-ref="modalInput" @keydown.enter="confirmModalOnEnter($event)" />
         <div x-show="modal.choices && modal.choices.length" class="modal-choices">
           <template x-for="(c, ci) in (modal.choices || [])" :key="ci">
             <button type="button" class="modal-choice" @click="modal.pick && modal.pick(c.value)">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -9991,6 +9991,20 @@ html[data-theme="eyecare"] .tool-error-hint {
   box-shadow: 0 0 0 2px color-mix(in srgb, #4fbd78 18%, transparent);
 }
 .terminal-status-dot.exited { background: var(--c-fg-4); }
+/* `.pane` normally clips descendants so content cannot spill into neighbouring
+   columns. Dropdowns and context sheets are the exception. Their own z-index
+   cannot escape that clipping, so the owning pane temporarily becomes a
+   stacking context with visible overflow while one is open.
+
+   Keep this at 150: it clears resizers (10) and the mobile tab bar (100), but
+   stays below every application-level overlay (drawers/palette start at 200,
+   context menus at 800, modals at 900). This avoids fixing one pane popup by
+   accidentally placing the whole pane above a real modal. */
+.pane.pane-floating-layer {
+  position: relative;
+  z-index: 150;
+  overflow: visible;
+}
 .terminal-manager { position: relative; flex-shrink: 0; }
 .terminal-manager-btn { position: relative; gap: 3px; width: auto; min-width: 28px; }
 .chat-terminal-btn { display: none; position: relative; gap: 3px; width: auto; min-width: 28px; }

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -1300,6 +1300,28 @@ def test_rebuild_failed_status_maps_through():
     assert card["task_status"]["state"] == "failed"
 
 
+def test_rebuild_hides_only_cli_interrupt_user_messages():
+    from backend import chat as chat_mod
+
+    marker_string = _sm(
+        "interrupt-string", "user", "[Request interrupted by user]")
+    marker_list = _sm("interrupt-list", "user", [
+        {"type": "text", "text": "[Request interrupted by user for tool use]"},
+    ])
+    real_user = _sm("real-user", "user", [
+        {"type": "text", "text": "Please explain user interruption handling"},
+    ])
+
+    out = chat_mod._sdk_messages_to_ui(
+        [marker_string, marker_list, real_user], {})
+    assert [m["text"] for m in out if m.get("role") == "user"] == [
+        "Please explain user interruption handling",
+    ]
+    assert chat_mod._is_real_user_prompt(marker_string) is False
+    assert chat_mod._is_real_user_prompt(marker_list) is False
+    assert chat_mod._is_real_user_prompt(real_user) is True
+
+
 # --- GET /api/chat/task-output (serve bg-task .output from /tmp) ---------
 
 def _make_task_output(tmp_path, sid, name="abc.output", body="task stdout\n"):

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -173,10 +173,13 @@ def test_enter_submission_waits_for_ime_composition():
     helper_start = app.index("_claimNonImeEnter(ev)")
     helper_end = app.index("\n    },", helper_start)
     helper = app[helper_start:helper_end]
-    assert "ev.isComposing" in helper
-    assert "ev.keyCode === 229" in helper
-    assert "ev.which === 229" in helper
-    assert 'ev.key === "Process"' in helper
+    ime_start = app.index("_isImeComposingEvent(ev)")
+    ime_end = app.index("\n    },", ime_start)
+    ime = app[ime_start:ime_end]
+    assert "ev.isComposing" in ime
+    assert "ev.keyCode === 229" in ime
+    assert "ev.which === 229" in ime
+    assert 'ev.key === "Process"' in ime
     assert helper.index("return false") < helper.index("ev.preventDefault()")
 
     assert '@keydown.enter="confirmModalOnEnter($event)"' in html
@@ -186,6 +189,27 @@ def test_enter_submission_waits_for_ime_composition():
     assert '@keydown.enter.prevent="commitRenameTab()"' not in html
     assert '@keydown.enter.prevent="pickerCommitInlineRename()"' not in html
     assert '@keydown.enter.prevent.stop="onEnter($event)"' not in html
+
+
+def test_chat_arrow_keys_walk_user_input_history_and_restore_draft():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    start = app.index("_chatInputHistory()")
+    end = app.index("\n    _cancelMentionLookup()", start)
+    history = app[start:end]
+
+    assert "st._earlierMessages" in history
+    assert "st._laterMessages" in history
+    assert 'm.role === "user"' in history
+    assert "draft._historyIndex = index - 1" in history
+    assert "draft._historyIndex = index + 1" in history
+    assert "draft._historyDraft = this.input" in history
+    assert "const originalDraft = draft._historyDraft" in history
+    assert "this._resetChatInputHistory(draft)" in history
+    assert 'this.input.includes("\\n")' in history
+    assert "this._isImeComposingEvent(ev)" in history
+    assert '@keydown.up="onChatArrowUp($event)"' in html
+    assert '@keydown.down="onChatArrowDown($event)"' in html
 
 
 def test_pane_popups_escape_clipping_but_stay_below_global_overlays():
@@ -643,9 +667,18 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     assert "if (!r.ok) throw" in stop
     assert 'String(item).startsWith(sid + "@")' in stop
     assert "const timeout = setTimeout(() => controller.abort(), 15000)" in stop
-    assert "this._retireStaleSessionStream(sid, st)" in stop
-    assert "if (st._renderStreamingHtml) st._renderStreamingHtml()" in stop
+    assert "waitForTerminalEvent = !!st.streaming" in stop
+    assert "this._retireStaleSessionStream(sid, st)" not in stop
+    assert "if (st._renderStreamingHtml) st._renderStreamingHtml()" not in stop
     assert "if (!didInterrupt)" in stop
+    assert "if (!waitForTerminalEvent || !st.streaming)" in stop
+    cancelled_start = app.index('es.addEventListener("cancelled"')
+    cancelled_end = app.index("\n      });", cancelled_start)
+    assert "_markDone(true)" in app[cancelled_start:cancelled_end]
+    mark_done_start = app.index("const _markDone = (cancelled = false)")
+    mark_done_end = app.index("\n      };", mark_done_start)
+    assert "streamState._stopping = false" in app[
+        mark_done_start:mark_done_end]
     assert "this.isTabStreaming(this.currentId)" in app
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -166,6 +166,65 @@ def test_primary_mobile_surfaces_keep_native_touch_scrolling():
     assert "touch-action: pan-y" not in contract
 
 
+def test_enter_submission_waits_for_ime_composition():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    helper_start = app.index("_claimNonImeEnter(ev)")
+    helper_end = app.index("\n    },", helper_start)
+    helper = app[helper_start:helper_end]
+    assert "ev.isComposing" in helper
+    assert "ev.keyCode === 229" in helper
+    assert "ev.which === 229" in helper
+    assert 'ev.key === "Process"' in helper
+    assert helper.index("return false") < helper.index("ev.preventDefault()")
+
+    assert '@keydown.enter="confirmModalOnEnter($event)"' in html
+    assert '@keydown.enter="commitRenameTabOnEnter($event)"' in html
+    assert '@keydown.enter="pickerCommitInlineRenameOnEnter($event)"' in html
+    assert '@keydown.enter="onEnter($event)"' in html
+    assert '@keydown.enter.prevent="commitRenameTab()"' not in html
+    assert '@keydown.enter.prevent="pickerCommitInlineRename()"' not in html
+    assert '@keydown.enter.prevent.stop="onEnter($event)"' not in html
+
+
+def test_pane_popups_escape_clipping_but_stay_below_global_overlays():
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    files_start = html.index('<aside class="pane files"')
+    files_end = html.index("<header", files_start)
+    files = html[files_start:files_end]
+    assert "'pane-floating-layer': workspaceMenuOpen" in files
+
+    preview_start = html.index('<section class="pane preview"')
+    preview_end = html.index("<header", preview_start)
+    preview = html[preview_start:preview_end]
+    for state in ("terminalManagerOpen", "editorTabPickerOpen",
+                  "previewTabCtxMenu"):
+        assert state in preview
+
+    chat_start = html.index('<aside class="pane chat"')
+    chat_end = html.index("<header", chat_start)
+    chat = html[chat_start:chat_end]
+    for state in ("sessionPickerOpen", "tabCtxMenu", "ctxBreakdown.show",
+                  "composerSettingsOpen", "mentionShow", "slashShow"):
+        assert state in chat
+
+    layer_start = css.index(".pane.pane-floating-layer")
+    layer_end = css.index("}", layer_start)
+    layer = css[layer_start:layer_end]
+    assert "z-index: 150" in layer
+    assert "overflow: visible" in layer
+
+    # Pane-local floating content must clear navigation, while every true
+    # application overlay remains above it.
+    assert "height: 48px !important; z-index: 100" in css
+    assert "position: fixed; inset: 0; z-index: 200" in css
+    assert "position: fixed; z-index: 800" in css
+    assert "position: fixed; inset: 0; z-index: 900" in css
+
+
 def test_multi_workspace_ui_and_folder_browser_are_wired_end_to_end():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
@@ -877,6 +936,7 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "terminal-manager-pop" in html
     assert 'class="terminal-manager-backdrop"' in html
     assert 'class="terminal-manager-dismiss"' in html
+    assert "'pane-floating-layer': terminalManagerOpen" in html
     assert 'class="icon-btn chat-terminal-btn"' in html
     assert 'class="icon-btn terminal-manager-btn preview-keep-mobile"' in html
     assert 'data-terminal-key="backslash"' in html
@@ -884,6 +944,11 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert ".pane.chat .pane-head .chat-terminal-btn { display: inline-flex; }" in css
     assert ".pane.preview > .pane-head > .btn-primary { display: none; }" in css
     assert ".pane.preview .pane-head .btn-primary { display: none; }" not in css
+    layer_start = css.index(".pane.pane-floating-layer")
+    layer_end = css.index("}", layer_start)
+    layer = css[layer_start:layer_end]
+    assert "z-index: 150" in layer
+    assert "overflow: visible" in layer
     assert ".terminal-host .xterm-viewport { touch-action: none; }" in css
     mobile_sheet = css[css.index(".terminal-manager-backdrop {",
                                  css.index("@media", css.index("Real PTY terminal preview"))):]
@@ -900,8 +965,9 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert '@click="createTerminal($refs.terminalProfileSelect.value)"' in html
     assert 'class="terminal-manager-profile"' in html
     assert 'x-model="terminalProfileEditor.command"' in html
-    preview_head = html[html.index('<section class="pane preview">'):
-                        html.index('<div class="tab-bar"', html.index('<section class="pane preview">'))]
+    preview_start = html.index('<section class="pane preview"')
+    preview_head = html[preview_start:
+                        html.index('<div class="tab-bar"', preview_start)]
     assert preview_head.index('href="#i-search"') < preview_head.index(
         'class="terminal-manager"') < preview_head.index('@click="reloadPreview()"')
     assert "lang==='zh'?'已连接':'Connected'" not in preview_head


### PR DESCRIPTION
## What this changes

本 PR 集中修复会话输入与三栏浮层体验：

- 中文／日文输入法组合态下，Enter 只确认候选，不再误触发新建、重命名或发送。
- 对话输入框支持按 ↑／↓ 连续遍历当前会话的历史用户输入，并在回到最新位置时恢复原草稿；多行输入与 IME 候选仍保留原生方向键行为。
- 终止对话改为等待 SSE 的 cancelled/done 事件统一 flush 和收尾，不再提前关闭流导致 Markdown／tool block 边界错乱。
- 精确过滤 Claude CLI 写入 transcript 的 [Request interrupted by user] 两类合成记录，不再渲染成英文用户气泡或计入真实用户轮次。
- 为文件、预览和会话三栏的主要浮层建立统一层叠上下文，使工作目录、终端、Tab 与会话相关弹窗可跨栏显示，同时保持在全局抽屉、命令面板和模态框之下。

## Why

中文输入法确认候选会同时提交操作；输入历史只能取回最近一条；停止对话后会出现英文 user interrupt 气泡并打乱流式内容渲染；工作目录和终端等栏内弹窗还会被相邻区域覆盖或被父级 overflow: hidden 裁剪。

## Testing

- [ ] uv run pytest tests/ passes（本地 2 GB 内存环境在 71% 进入持续换页，主动终止；以本 PR CI 全量结果为合入门槛）
- [x] 输入历史／终止流／transcript／会话相关专项测试：180 passed
- [x] uv run ruff check backend/ tests/
- [x] bash scripts/lint.sh
- [x] 全部 frontend JS node --check，manifest JSON 校验通过
- [x] git diff --check
- [x] If backend: 已在 tests/test_chat_stream.py 增加 CLI 中断合成记录过滤测试
- [x] If frontend visual: 已检查层级链路；栏内浮层层级 150，高于 resizer/mobile tab bar，低于全局 overlay 200+ 与 modal 900+

## Checklist

- [x] No secrets committed
- [x] Docs updated if behavior visible to users（无需更新用户文档；已增加回归测试与代码内说明）
- [x] If adds runtime dep: install scripts updated（未新增依赖）