### PR TITLE
feat(files): 添加文件树实时刷新与软链接支持

### DIFF
--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -1,0 +1,208 @@
+"""On-demand filesystem change events for the active workspace.
+
+One native watcher is shared by every browser subscribed to the same root.
+The watcher only exists while at least one SSE client is connected, so an
+idle muselab process does not retain recursive OS watches indefinitely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from sse_starlette.sse import EventSourceResponse, ServerSentEvent
+from watchfiles import Change, DefaultFilter, awatch
+
+from .auth import require_token_query
+from .files import TRASH_DIR_NAME
+from .workspaces import resolve_workspace_root
+
+
+router = APIRouter(prefix="/api/files", tags=["files"])
+
+_QUEUE_LIMIT = 8
+_WATCH_DEBOUNCE_MS = 350
+_WATCH_STEP_MS = 100
+_IGNORED_DIRS = tuple(DefaultFilter.ignore_dirs) + (
+    TRASH_DIR_NAME,
+    ".muselab",
+)
+
+
+@dataclass
+class _WatchState:
+    root: Path
+    subscribers: set[asyncio.Queue[dict[str, Any]]] = field(default_factory=set)
+    task: asyncio.Task[None] | None = None
+
+
+def _normalise_changes(
+    root: Path,
+    changes: set[tuple[Change, str]],
+) -> list[dict[str, str]]:
+    """Convert native absolute paths to a stable, non-leaking wire format."""
+    root = root.resolve()
+    rows: dict[tuple[str, str], dict[str, str]] = {}
+    for change, raw_path in changes:
+        try:
+            relative = Path(raw_path).relative_to(root)
+        except ValueError:
+            # A symlink/backend quirk must never leak an absolute path outside
+            # the registered workspace to the browser.
+            continue
+        path = relative.as_posix()
+        if not path or path == ".":
+            continue
+        kind = {
+            Change.added: "added",
+            Change.modified: "modified",
+            Change.deleted: "deleted",
+        }.get(change)
+        if not kind:
+            continue
+        rows[(kind, path)] = {"type": kind, "path": path}
+    return sorted(rows.values(), key=lambda row: (row["path"], row["type"]))
+
+
+class FileWatchManager:
+    """Share one recursive watchfiles task per registered workspace."""
+
+    def __init__(self) -> None:
+        self._states: dict[Path, _WatchState] = {}
+        self._lock = asyncio.Lock()
+        self._filter = DefaultFilter(ignore_dirs=_IGNORED_DIRS)
+
+    @contextlib.asynccontextmanager
+    async def subscribe(
+        self,
+        root: Path,
+    ) -> AsyncIterator[asyncio.Queue[dict[str, Any]]]:
+        root = root.resolve()
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_QUEUE_LIMIT)
+        async with self._lock:
+            state = self._states.get(root)
+            if state is None:
+                state = _WatchState(root=root)
+                self._states[root] = state
+            state.subscribers.add(queue)
+            if state.task is None or state.task.done():
+                state.task = asyncio.create_task(
+                    self._watch(state),
+                    name=f"muselab-files:{root.name or 'root'}",
+                )
+        try:
+            yield queue
+        finally:
+            await self._unsubscribe(root, queue)
+
+    async def _unsubscribe(
+        self,
+        root: Path,
+        queue: asyncio.Queue[dict[str, Any]],
+    ) -> None:
+        task: asyncio.Task[None] | None = None
+        async with self._lock:
+            state = self._states.get(root)
+            if state is None:
+                return
+            state.subscribers.discard(queue)
+            if not state.subscribers:
+                self._states.pop(root, None)
+                task = state.task
+                state.task = None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _watch(self, state: _WatchState) -> None:
+        while True:
+            try:
+                async for changes in awatch(
+                    state.root,
+                    watch_filter=self._filter,
+                    debounce=_WATCH_DEBOUNCE_MS,
+                    step=_WATCH_STEP_MS,
+                    recursive=True,
+                    ignore_permission_denied=True,
+                ):
+                    rows = _normalise_changes(state.root, changes)
+                    if rows:
+                        self._broadcast(state, {"changes": rows})
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A native watcher can fail transiently when a mount is
+                # replaced. Tell clients to re-baseline, then retry while the
+                # workspace still has subscribers.
+                self._broadcast(state, {"resync": True, "changes": []})
+                await asyncio.sleep(1.5)
+
+    @staticmethod
+    def _broadcast(state: _WatchState, payload: dict[str, Any]) -> None:
+        for queue in tuple(state.subscribers):
+            if queue.full():
+                # Once a slow client misses even one structural event, a full
+                # refresh is cheaper and more correct than replaying a partial
+                # tail. Collapse the entire backlog into one resync marker.
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    while True:
+                        queue.get_nowait()
+                payload_for_queue = {"resync": True, "changes": []}
+            else:
+                payload_for_queue = payload
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait(payload_for_queue)
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            states = list(self._states.values())
+            self._states.clear()
+            tasks = [state.task for state in states if state.task is not None]
+            for state in states:
+                state.subscribers.clear()
+                state.task = None
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+manager = FileWatchManager()
+
+
+@router.get("/events", dependencies=[Depends(require_token_query)])
+async def file_events(
+    root: Path = Depends(resolve_workspace_root),
+) -> EventSourceResponse:
+    """Stream coalesced relative-path changes for one registered workspace."""
+
+    async def events() -> AsyncIterator[ServerSentEvent]:
+        async with manager.subscribe(root) as queue:
+            yield ServerSentEvent(
+                event="ready",
+                data=json.dumps({"ready": True}, separators=(",", ":")),
+            )
+            while True:
+                payload = await queue.get()
+                event = "resync" if payload.get("resync") else "changes"
+                yield ServerSentEvent(
+                    event=event,
+                    data=json.dumps(payload, separators=(",", ":")),
+                )
+
+    return EventSourceResponse(
+        events(),
+        ping=20,
+        headers={
+            "Cache-Control": "no-cache, no-store",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/files.py
+++ b/backend/files.py
@@ -393,6 +393,14 @@ def list_dir(
         raise HTTPException(status_code=400, detail="not a directory")
     entries: list[dict] = []
     truncated = False
+    # Keep the caller's logical path when `path` traverses a directory
+    # symlink. `target` is the resolved real directory (required for the
+    # containment check), but DirEntry.path therefore points at that real
+    # location too. Returning it made a tree row such as `vendor -> shared`
+    # yield children named `shared/x` instead of `vendor/x`; Alpine then
+    # filtered them as duplicates when the real directory was also visible,
+    # making the symlink look impossible to expand.
+    logical_parent = Path((path or "").strip("/"))
     # Trash dir is always hidden from the file tree (even when
     # show_hidden=true) — it has its own dedicated UI surface; mixing it
     # back into the tree would surface deleted files in a confusing
@@ -428,7 +436,7 @@ def list_dir(
             continue
         entries.append(Entry(
             name=child.name,
-            path=str(Path(child.path).relative_to(root)),
+            path=(logical_parent / child.name).as_posix(),
             is_dir=is_dir,
             size=stat.st_size if not is_dir else 0,
             mtime=stat.st_mtime,

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from .api_push import router as push_router
 from .workspaces import router as workspaces_router
 from .activity_api import router as activity_router
 from .terminal import router as terminal_router
+from .file_events import router as file_events_router
 from .settings import ROOT, PORT, HOST
 
 
@@ -228,10 +229,12 @@ async def _lifespan(app: FastAPI):
     # are cheap; first run can take a few seconds on archives with
     # hundreds of sessions.
     from .terminal import manager as _terminal_manager
+    from .file_events import manager as _file_watch_manager
     await _terminal_manager.start()
     try:
         yield
     finally:
+        await _file_watch_manager.shutdown()
         # PTY workers outlive individual WebSocket connections so refreshes
         # can reattach. They must not outlive the muselab service itself.
         await _terminal_manager.shutdown()
@@ -349,6 +352,7 @@ async def _security_headers(request: Request, call_next):
 
 
 app.include_router(files_router)
+app.include_router(file_events_router)
 app.include_router(chat_router)
 app.include_router(settings_router)
 app.include_router(scheduler_router)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -258,6 +258,17 @@ function portal() {
     treeFocusPath: "",
     _treeLoadSeq: 0,
     _childFetches: null,
+    // On-demand filesystem events. The backend shares one native watcher per
+    // active workspace; this page keeps one SSE subscription for its current
+    // workspace and coalesces structural changes before touching Alpine state.
+    _fileEvents: null,
+    _fileEventsWorkspace: "",
+    _fileEventsSeq: 0,
+    _fileEventsTimer: null,
+    _fileEventsPending: null,
+    _fileTreeDirty: false,
+    _fileTreeRefreshBusy: false,
+    _fileEventsVisibilityBound: false,
     dragOver: "",
     // Highlight flag for the sticky root bar while a tree node / OS file is
     // dragged over it (drop = move/upload to archive root).
@@ -1286,6 +1297,7 @@ function portal() {
           this.previewImmersive = false;
           document.body.classList.remove("preview-immersive");
         }
+        if (t === "files") this.$nextTick(() => this._flushFileTreeDirty());
         this.savePrefs();
       });
 
@@ -1844,6 +1856,7 @@ function portal() {
       this._startHeartbeat();
       this._startPresence();
       this._startSessionsSync();
+      this._startFileEvents();
       this.fetchActivity();
       // Restoring a saved current session means the user is already looking at
       // it; clear any completion that landed before this page loaded.
@@ -6988,6 +7001,7 @@ function portal() {
       if (!path || path === this.activeWorkspace) return true;
       const previous = this.activeWorkspace;
       if (previous) this._captureWorkspaceSurface(previous);
+      this._stopFileEvents(false);
       this._teardownTerminalView();
       this.terminals = [];
 
@@ -7063,6 +7077,9 @@ function portal() {
         );
       }
       this.setMobileTab(keepMobileTab);
+      this._fileTreeDirty = false;
+      this._fileEventsPending = new Map();
+      this._startFileEvents();
       this.savePrefs();
       return true;
     },
@@ -12032,6 +12049,178 @@ function portal() {
     },
 
     // ===== file tree =====
+    _fileTreeIsVisible() {
+      if (typeof document !== "undefined"
+          && document.visibilityState !== "visible") return false;
+      if (this._isMobileLayout()) return this.mobileTab === "files";
+      return !!this.leftOpen && !this.desktopFullPane;
+    },
+    _stopFileEvents(markDirty = false) {
+      ++this._fileEventsSeq;
+      if (this._fileEvents) {
+        try { this._fileEvents.close(); } catch (_) {}
+      }
+      this._fileEvents = null;
+      this._fileEventsWorkspace = "";
+      if (this._fileEventsTimer) clearTimeout(this._fileEventsTimer);
+      this._fileEventsTimer = null;
+      if (markDirty) this._fileTreeDirty = true;
+    },
+    _startFileEvents() {
+      const workspace = this.fileWorkspacePath();
+      if (!this.token || !workspace || typeof EventSource === "undefined") return;
+      if (typeof document !== "undefined"
+          && document.visibilityState !== "visible") {
+        this._fileTreeDirty = true;
+        return;
+      }
+      if (this._fileEvents && this._fileEventsWorkspace === workspace) return;
+      this._stopFileEvents(false);
+      const seq = ++this._fileEventsSeq;
+      const params = new URLSearchParams({ token: this.token, workspace });
+      const es = new EventSource(`/api/files/events?${params.toString()}`);
+      this._fileEvents = es;
+      this._fileEventsWorkspace = workspace;
+      this._fileEventsPending = this._fileEventsPending || new Map();
+      const owns = () => seq === this._fileEventsSeq
+        && this._fileEvents === es
+        && this._workspaceIsCurrent(workspace);
+      es.addEventListener("ready", () => {
+        if (!owns()) return;
+        if (this._fileTreeDirty) this._flushFileTreeDirty();
+      });
+      es.addEventListener("changes", (ev) => {
+        if (!owns()) return;
+        let payload;
+        try { payload = JSON.parse(ev.data); } catch (_) { return; }
+        this._queueFileChanges(payload.changes, workspace);
+      });
+      es.addEventListener("resync", () => {
+        if (!owns()) return;
+        this._fileTreeDirty = true;
+        this._flushFileTreeDirty();
+      });
+      es.onerror = () => {
+        if (!owns()) return;
+        // EventSource reconnects itself. Mark the tree dirty because changes
+        // can land in the disconnect gap; the next `ready` re-baselines once.
+        this._fileTreeDirty = true;
+      };
+      if (!this._fileEventsVisibilityBound) {
+        this._fileEventsVisibilityBound = true;
+        document.addEventListener("visibilitychange", () => {
+          if (document.visibilityState !== "visible") {
+            this._stopFileEvents(true);
+          } else {
+            this._startFileEvents();
+          }
+        });
+        window.addEventListener("pagehide", () => this._stopFileEvents(false));
+      }
+    },
+    _queueFileChanges(changes, ownerWorkspace) {
+      if (!this._workspaceIsCurrent(ownerWorkspace) || !Array.isArray(changes)) return;
+      this._fileEventsPending = this._fileEventsPending || new Map();
+      for (const row of changes) {
+        if (!row || typeof row.path !== "string") continue;
+        if (!["added", "modified", "deleted"].includes(row.type)) continue;
+        const path = row.path.replace(/^\/+/, "");
+        if (!path) continue;
+        // External writes should not leave a stale body in the preview cache.
+        // Avoid re-rendering a hidden mobile preview; opening it later will
+        // naturally fetch fresh content after this invalidation.
+        if (row.type === "modified" && path === this.selected) {
+          this._previewCacheDel(path);
+          if (this.editing) {
+            this._previewNeedsReload = path;
+            this.loadSelectedMeta(path);
+          } else if (this.previewSurface === "file"
+              && (!this._isMobileLayout() || this.mobileTab === "preview")) {
+            this._maybeReloadPreview(path, ownerWorkspace);
+          }
+        }
+        if (row.type !== "modified") {
+          this._fileEventsPending.set(`${row.type}\0${path}`, {
+            type: row.type, path,
+          });
+        }
+      }
+      const hasStructural = changes.some(row =>
+        row && (row.type === "added" || row.type === "deleted"));
+      if (!hasStructural) return;
+      if (!this._fileTreeIsVisible()) {
+        this._fileTreeDirty = true;
+        return;
+      }
+      if (this._fileEventsTimer) clearTimeout(this._fileEventsTimer);
+      // Mobile receives the same batched server event but gets a longer UI
+      // debounce so git/npm bursts cost one render, not many small splices.
+      const delay = this._isMobileLayout() ? 650 : 250;
+      this._fileEventsTimer = setTimeout(() => {
+        this._fileEventsTimer = null;
+        this._flushFileChanges(ownerWorkspace);
+      }, delay);
+    },
+    async _flushFileChanges(ownerWorkspace = this.fileWorkspacePath()) {
+      if (!this._workspaceIsCurrent(ownerWorkspace)) return false;
+      if (!this._fileTreeIsVisible()) {
+        this._fileTreeDirty = true;
+        return false;
+      }
+      if (this._fileTreeRefreshBusy) {
+        this._fileTreeDirty = true;
+        return false;
+      }
+      const pending = Array.from((this._fileEventsPending || new Map()).values());
+      this._fileEventsPending = new Map();
+      const structural = pending.filter(row =>
+        row.type === "added" || row.type === "deleted");
+      if (!structural.length) return true;
+      const representativeByParent = new Map();
+      for (const row of structural) {
+        const parent = row.path.split("/").slice(0, -1).join("/");
+        if (!representativeByParent.has(parent)) {
+          representativeByParent.set(parent, row.path);
+        }
+      }
+      this._fileTreeRefreshBusy = true;
+      let ok = true;
+      try {
+        // Root changes require rebuilding the root slice; a large multi-dir
+        // burst is also cheaper as one transactional reload than N subtree
+        // refreshes. loadRoot preserves expanded paths and last-good content.
+        if (representativeByParent.has("") || representativeByParent.size > 6) {
+          ok = await this.reloadTree();
+        } else {
+          const rows = Array.from(representativeByParent.entries())
+            .sort((a, b) => a[0].split("/").length - b[0].split("/").length);
+          for (const [, path] of rows) {
+            const refreshed = await this._refreshParentInTree(path, ownerWorkspace);
+            if (!this._workspaceIsCurrent(ownerWorkspace)) return false;
+            if (refreshed === false) ok = false;
+          }
+        }
+      } finally {
+        this._fileTreeRefreshBusy = false;
+      }
+      this._fileTreeDirty = !ok;
+      return ok;
+    },
+    async _flushFileTreeDirty() {
+      if (!this._fileTreeDirty || !this._fileTreeIsVisible()) return false;
+      if (this._fileTreeRefreshBusy) return false;
+      const ownerWorkspace = this.fileWorkspacePath();
+      this._fileTreeRefreshBusy = true;
+      this._fileEventsPending = new Map();
+      let ok = false;
+      try {
+        ok = await this.reloadTree();
+      } finally {
+        this._fileTreeRefreshBusy = false;
+      }
+      if (this._workspaceIsCurrent(ownerWorkspace)) this._fileTreeDirty = !ok;
+      return ok;
+    },
     async loadRoot() {
       const treeSeq = ++this._treeLoadSeq;
       this.treeLoading = true;
@@ -16700,6 +16889,7 @@ function portal() {
       } else {
         this.leftOpen = !this.leftOpen;
       }
+      if (this.leftOpen) this.$nextTick(() => this._flushFileTreeDirty());
       this.savePrefs();
     },
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3175,8 +3175,9 @@
             <button @click="send()"
                     :disabled="workspaceSwitching || !availableModels.length || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingImages.length && !pendingDocs.length)"
                     class="btn-primary chat-toolbar-send chat-toolbar-queue"
+                    :aria-label="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')"
                     :title="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')">
-              <span class="icon"><svg><use href="#i-send"/></svg></span><span x-text="t('btn.send')"></span>
+              <span class="icon"><svg><use href="#i-send"/></svg></span>
               <span class="chat-toolbar-queue-badge"
                     x-show="_currentQueueLen() > 0"
                     x-text="_currentQueueLen()"></span>
@@ -3184,8 +3185,9 @@
             <button x-show="isTabStreaming(currentId)" @click="stop()"
                     class="btn-danger chat-toolbar-send chat-toolbar-stop"
                     :disabled="workspaceSwitching || !!(tabState[currentId] && tabState[currentId]._stopping)"
+                    :aria-label="t('btn.stop')"
                     :title="t('btn.stop') + ' (Esc)'">
-              <span class="icon"><svg><use href="#i-square"/></svg></span><span x-text="t('btn.stop')"></span>
+              <span class="icon"><svg><use href="#i-square"/></svg></span>
             </button>
           </div>
         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1498,25 +1498,8 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
     height: 44px;
     min-width: 44px;
   }
-  .chat-toolbar-send { width: auto; padding: 0 12px; }
+  .chat-toolbar-send { width: 44px; padding: 0; }
   .chat-toolbar-send svg { width: 16px; height: 16px; }
-  /* Show the send label on touch — gives the user a clearer target than
-     a tiny icon. */
-  .chat-toolbar .chat-toolbar-send > span:nth-child(2) {
-    display: inline; margin-left: 6px;
-    font-size: var(--fs-xs); font-weight: var(--fw-medium);
-  }
-  /* During a stream the queue/send action and Stop share one row. Preserve
-     the more important Stop label and collapse only queue/send back to an
-     icon, preventing the model selector from being squeezed to one glyph. */
-  .chat-toolbar.has-stop .chat-toolbar-queue {
-    width: 44px;
-    padding: 0;
-  }
-  .chat-toolbar.has-stop .chat-toolbar-queue > span:nth-child(2) {
-    display: none;
-    margin-left: 0;
-  }
   /* Textarea on touch: no min-height override here. The tighter
      line-height that prevents single-line input from inflating the
      box is set at the END of this file (alongside the iOS anti-zoom
@@ -1534,10 +1517,6 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   .chat-toolbar.has-stop .chat-toolbar-stop {
     width: 44px;
     padding: 0;
-  }
-  .chat-toolbar.has-stop .chat-toolbar-stop > span:nth-child(2) {
-    display: none;
-    margin-left: 0;
   }
 }
 
@@ -6133,10 +6112,6 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
 .chat-toolbar-send svg { width: 14px; height: 14px; }
 .chat-toolbar-send.btn-danger { background: var(--c-danger); }
 .chat-toolbar-send.btn-danger:hover { background: #b91c2c; }
-/* The Send / Stop label inside the button — hidden by default
-   (icon-only). Use nth-child(2) instead of :last-child because the
-   queue badge is a 3rd <span> sibling that must stay visible. */
-.chat-toolbar-send > span:nth-child(2) { display: none; }
 /* Queue button: full sizing inherits from .chat-toolbar-send +
    .neutral above. This class only carries the position context for
    the absolute-positioned badge below. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "python-multipart>=0.0.32",
     "uvicorn[standard]>=0.49.0",
+    # Live file-tree refresh for Agent / terminal / external-editor changes.
+    # One native watcher is shared per active workspace and released when the
+    # last browser disconnects.
+    "watchfiles>=1.1.1",
     # xlsx preview — read-only, used by /api/files/xlsx. Pure-Python, no
     # native deps; safe to ship in the muselab Docker image.
     "openpyxl>=3.1.5",

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -1246,15 +1246,24 @@ def test_mobile_composer_footer_is_compact_and_never_overflows(
                     return {top: r.top, bottom: r.bottom, width: r.width, height: r.height};
                   };
                   const toolbar = pick(".chat-toolbar");
-                  const sendLabel = pick(
-                    ".chat-toolbar-queue > span:nth-child(2)");
+                  const send = pick(".chat-toolbar-queue");
+                  const stop = pick(".chat-toolbar-stop");
+                  const textLabelCount = button => Array.from(button.children)
+                    .filter(child => !child.classList.contains("icon")
+                      && !child.classList.contains("chat-toolbar-queue-badge"))
+                    .length;
                   return {
                     composer: box(".chat-input"),
                     wrapPadding: getComputedStyle(pick(".chat-input-wrap")).paddingTop,
                     flexShrink: getComputedStyle(pick(".chat-input")).flexShrink,
                     toolbarOverflow: toolbar.scrollWidth - toolbar.clientWidth,
                     nav: box(".mobile-tab-bar"),
-                    sendLabelDisplay: getComputedStyle(sendLabel).display,
+                    sendWidth: send.getBoundingClientRect().width,
+                    sendLabelCount: textLabelCount(send),
+                    sendAria: send.getAttribute("aria-label") || "",
+                    stopWidth: stop.getBoundingClientRect().width,
+                    stopLabelCount: textLabelCount(stop),
+                    stopAria: stop.getAttribute("aria-label") || "",
                   };
                 }"""
             )
@@ -1263,7 +1272,9 @@ def test_mobile_composer_footer_is_compact_and_never_overflows(
         assert idle["wrapPadding"] == "0px"
         assert idle["flexShrink"] == "0"
         assert idle["toolbarOverflow"] <= 1
-        assert idle["sendLabelDisplay"] != "none"
+        assert idle["sendWidth"] == 44
+        assert idle["sendLabelCount"] == 0
+        assert idle["sendAria"]
         assert idle["composer"]["height"] <= 120
         assert idle["composer"]["bottom"] <= idle["nav"]["top"] + 1
 
@@ -1282,6 +1293,9 @@ def test_mobile_composer_footer_is_compact_and_never_overflows(
         )
         busy = composer_metrics()
         assert busy["toolbarOverflow"] <= 1
+        assert busy["stopWidth"] == 44
+        assert busy["stopLabelCount"] == 0
+        assert busy["stopAria"]
         assert busy["composer"]["bottom"] <= busy["nav"]["top"] + 1
 
         page.set_viewport_size({"width": 320, "height": 700})

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -376,7 +376,20 @@ def test_mobile_html_restore_overrides_report_smooth_scroll(
           return app.selected === 'smooth-preview.html' && app.previewMode === 'html';
         }"""
     )
-    frame = page.frame(url=lambda url: "smooth-preview.html" in url)
+    iframe = page.locator(
+        'iframe[data-preview-html-path="smooth-preview.html"]',
+    )
+    expect(iframe).to_be_visible(timeout=5000)
+    page.wait_for_function(
+        """() => {
+          const frame = document.querySelector(
+            'iframe[data-preview-html-path="smooth-preview.html"]');
+          return frame && frame.src.includes('smooth-preview.html');
+        }""",
+        timeout=5000,
+    )
+    handle = iframe.element_handle()
+    frame = handle.content_frame() if handle else None
     assert frame is not None
     frame.wait_for_load_state("domcontentloaded")
     page.wait_for_timeout(300)

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -30,6 +30,54 @@ def _login(page: Page, base: str, token: str) -> None:
     )
 
 
+def test_external_file_changes_refresh_tree_without_manual_reload(
+        page: Page, backend_url, auth_token):
+    """Direct API mutations stand in for Agent/terminal writes and deletes."""
+    _login(page, backend_url, auth_token)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app._fileEvents && app._fileEvents.readyState === EventSource.OPEN;
+        }""",
+        timeout=5000,
+    )
+    created = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const response = await fetch('/api/files/write', {
+            method: 'PUT',
+            headers: {...app.fileHdr(), 'Content-Type': 'application/json'},
+            body: JSON.stringify({path: 'watch-live.txt', content: 'live\\n'}),
+          });
+          return response.ok;
+        }"""
+    )
+    assert created
+    page.wait_for_function(
+        """() => document.querySelector('#app')._x_dataStack[0]
+          .visible.some(node => node.path === 'watch-live.txt')""",
+        timeout=5000,
+    )
+
+    deleted = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const response = await fetch('/api/files/delete', {
+            method: 'DELETE',
+            headers: {...app.fileHdr(), 'Content-Type': 'application/json'},
+            body: JSON.stringify({path: 'watch-live.txt'}),
+          });
+          return response.ok;
+        }"""
+    )
+    assert deleted
+    page.wait_for_function(
+        """() => !document.querySelector('#app')._x_dataStack[0]
+          .visible.some(node => node.path === 'watch-live.txt')""",
+        timeout=5000,
+    )
+
+
 def test_latest_file_open_owns_preview_and_network_failure_exits_loading(
         page: Page, backend_url, auth_token):
     _login(page, backend_url, auth_token)

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -1,0 +1,82 @@
+"""Shared filesystem watcher and SSE endpoint regressions."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from watchfiles import Change
+
+
+def test_file_events_require_query_token(client):
+    response = client.get("/api/files/events")
+    assert response.status_code == 401
+
+
+def test_normalise_changes_keeps_paths_relative_and_deduplicated(app_module, temp_root):
+    from backend.file_events import _normalise_changes
+
+    changes = {
+        (Change.added, str(temp_root / "notes" / "new.md")),
+        (Change.added, str(temp_root / "notes" / "new.md")),
+        (Change.deleted, str(temp_root / "old.txt")),
+        (Change.modified, str(temp_root.parent / "outside.txt")),
+    }
+    assert _normalise_changes(temp_root, changes) == [
+        {"type": "added", "path": "notes/new.md"},
+        {"type": "deleted", "path": "old.txt"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manager_shares_one_native_watcher_per_workspace(
+    app_module,
+    temp_root: Path,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_awatch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        yield {(Change.added, str(temp_root / "fresh.txt"))}
+        await asyncio.Future()
+
+    monkeypatch.setattr(file_events, "awatch", fake_awatch)
+    manager = file_events.FileWatchManager()
+    async with manager.subscribe(temp_root) as first:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        async with manager.subscribe(temp_root) as second:
+            assert calls == 1
+            release.set()
+            first_payload, second_payload = await asyncio.gather(
+                asyncio.wait_for(first.get(), timeout=1),
+                asyncio.wait_for(second.get(), timeout=1),
+            )
+            expected = {
+                "changes": [{"type": "added", "path": "fresh.txt"}],
+            }
+            assert first_payload == expected
+            assert second_payload == expected
+    assert manager._states == {}
+
+
+def test_slow_subscriber_is_collapsed_to_resync(app_module, temp_root):
+    from backend.file_events import FileWatchManager, _WatchState
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    state = _WatchState(root=temp_root, subscribers={queue})
+    FileWatchManager._broadcast(
+        state,
+        {"changes": [{"type": "added", "path": "first"}]},
+    )
+    FileWatchManager._broadcast(
+        state,
+        {"changes": [{"type": "added", "path": "second"}]},
+    )
+    assert queue.get_nowait() == {"resync": True, "changes": []}

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -28,6 +28,29 @@ def test_list_subdir(client, auth):
     assert names == {"a.md", "b.txt", "deep"}
 
 
+def test_list_internal_directory_symlink_preserves_logical_paths(
+    client,
+    auth,
+    temp_root,
+):
+    (temp_root / "notes-link").symlink_to(temp_root / "notes", target_is_directory=True)
+
+    response = client.get("/api/files/list?path=notes-link", headers=auth)
+    assert response.status_code == 200
+    paths = {entry["path"] for entry in response.json()["entries"]}
+    assert paths == {
+        "notes-link/a.md",
+        "notes-link/b.txt",
+        "notes-link/deep",
+    }
+
+    nested = client.get("/api/files/list?path=notes-link/deep", headers=auth)
+    assert nested.status_code == 200
+    assert [entry["path"] for entry in nested.json()["entries"]] == [
+        "notes-link/deep/c.py",
+    ]
+
+
 def test_read_markdown(client, auth):
     r = client.get("/api/files/read?path=README.md", headers=auth)
     assert r.status_code == 200

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -908,7 +908,7 @@ def test_long_stream_switches_to_plain_preview_and_final_rich_render():
     chat_input = css[composer_start:css.index("}", composer_start)]
     assert "flex-shrink: 0" in chat_input
     assert ".chat-input-wrap { padding: 0; }" in css
-    assert ".chat-toolbar.has-stop .chat-toolbar-queue" in css
+    assert ".chat-toolbar.has-stop .chat-toolbar-ring" in css
     assert ".chat-toolbar-rl { display: none !important; }" in css
     assert ":class=\"{ 'has-stop': isTabStreaming(currentId) }\"" in html
 
@@ -1147,3 +1147,44 @@ def test_diff_surfaces_use_theme_tokens_and_readable_edges():
     assert theme_switch.index("highlight-theme.css") < (
         theme_switch.index("highlight-theme-light.css")
     )
+
+
+def test_file_tree_live_events_are_workspace_scoped_and_mobile_batched():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    assert "new EventSource(`/api/files/events?${params.toString()}`)" in app
+    assert "this._fileEventsWorkspace === workspace" in app
+    assert 'es.addEventListener("changes"' in app
+    assert 'es.addEventListener("resync"' in app
+    assert "this._workspaceIsCurrent(ownerWorkspace)" in app
+    assert "this._refreshParentInTree(path, ownerWorkspace)" in app
+    assert "const delay = this._isMobileLayout() ? 650 : 250" in app
+    assert 'document.visibilityState !== "visible"' in app
+    assert "this._stopFileEvents(true)" in app
+    assert 'if (t === "files") this.$nextTick(() => this._flushFileTreeDirty())' in app
+
+
+def test_chat_code_blocks_have_copy_button_with_clipboard_fallback():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    assert "this._attachCopyBtn(el);" in app
+    assert 'btn.className = "code-copy-btn"' in app
+    assert "await navigator.clipboard.writeText(raw)" in app
+    assert 'document.execCommand("copy")' in app
+    assert "pre.has-copy-btn .code-copy-btn" in css
+    assert "@media (hover: none)" in css
+
+
+def test_chat_send_and_stop_buttons_are_icon_only_but_accessible():
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    toolbar_start = html.index('class="btn-primary chat-toolbar-send chat-toolbar-queue"')
+    toolbar_end = html.index("</button>", html.index(
+        'class="btn-danger chat-toolbar-send chat-toolbar-stop"', toolbar_start,
+    )) + len("</button>")
+    buttons = html[toolbar_start:toolbar_end]
+    assert 'x-text="t(\'btn.send\')"' not in buttons
+    assert 'x-text="t(\'btn.stop\')"' not in buttons
+    assert ':aria-label="_isBusy(currentId) ? t(\'queue.button_hint\') : t(\'btn.send\')"' in buttons
+    assert ':aria-label="t(\'btn.stop\')"' in buttons
+    assert ".chat-toolbar-send { width: 44px; padding: 0; }" in css
+    assert ".chat-toolbar-send > span:nth-child(2)" not in css

--- a/uv.lock
+++ b/uv.lock
@@ -855,6 +855,7 @@ dependencies = [
     { name = "pywebpush" },
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.dev-dependencies]
@@ -878,6 +879,7 @@ requires-dist = [
     { name = "pywebpush", specifier = ">=2.0.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
+    { name = "watchfiles", specifier = ">=1.1.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## 变更类型
- [x] 新功能 (feature)
- [x] 修复 (bugfix)
- [ ] 重构 (refactor)
- [ ] 文档 (docs)
- [ ] 其他 (other)

## 变更说明
- 为当前工作区增加按需共享的 `watchfiles` 监听，通过 SSE 推送新增、删除、重命名与修改事件
- 桌面端 250ms、移动端 650ms 合并刷新；优先局部更新，断线或积压时整树校准
- 页面隐藏或最后一个客户端断开时释放 watcher，忽略 `.git`、`node_modules`、`.venv` 与内部目录
- 修复工作区内部目录软链接展开后子节点丢失别名路径的问题，保持工作区外软链接阻断策略
- 将会话区发送与停止按钮统一为纯图标，保留动态 title、aria-label 与队列角标

## 关联 Issue
无

## 测试情况
- `uv run pytest tests/test_file_events.py tests/test_frontend_lint.py tests/test_files.py -q`：99 passed
- `uv run pytest tests/test_files.py tests/test_security.py -q`：72 passed
- `RUN_E2E=1 uv run pytest tests/e2e/test_files_preview.py -q`：13 passed（新增实时刷新场景另行验证 1 passed）
- 原生 watcher smoke：通过
- `node --check frontend/app.js`：通过
- `uv run ruff check ...`：通过
- `bash scripts/lint.sh`：通过
- `git diff --check`：通过

## 截图（如适用）
无

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 未提交敏感信息