### PR TITLE
feat(chat): 长回合可见性、会话简洁模式，并修复 /compact 假阴性

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2371,6 +2371,24 @@ class _SessionStream:
         if self._turn is q:
             self._turn = None
 
+    def park_unconsumed(self, q: asyncio.Queue) -> None:
+        """Hand a detached consumer's leftovers back to the orphan park.
+
+        A slash-command consumer (`_run_sdk_command_checked`) stops at ITS
+        ResultMessage, but the pump may already have routed later messages into
+        the same queue — a background task's notification, an auto-continuation.
+        Letting the queue fall out of scope would drop them silently, so they go
+        back to `_orphans` for whoever attaches next.
+        """
+        while True:
+            try:
+                msg = q.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if msg is _STREAM_EOF:
+                continue
+            self._orphans.append(msg)
+
     def attach_background(self) -> asyncio.Queue:
         """Register the task watcher as the sink for messages nobody owns.
 
@@ -5647,14 +5665,28 @@ class _SDKCommandError(RuntimeError):
 async def _run_sdk_command_checked(client: ClaudeSDKClient, command: str) -> ResultMessage:
     """Run a CLI slash command and require an explicitly successful Result.
 
+    Reads through the session's pump (`_SessionStream`) rather than opening
+    `client.receive_response()`. The SDK gives a client exactly ONE message
+    stream and the pump has owned it since client creation, so a second iterator
+    here lost every race — the command's ResultMessage went to the pump's
+    `_orphans` park and this function waited on a stream nobody was feeding.
+    The turn loop was migrated to `attach_turn()` when the pump landed; this
+    call site was missed. Symptom (2026-07-26): two auto-compacts reported
+    failure after 600s (TimeoutError) and 9m19s ("ended without a
+    ResultMessage") while the transcript shows both compactions had finished in
+    ~150s. Both were FALSE NEGATIVES — `query()` is a pure transport write, so
+    the command itself always ran.
+
     Assistant/API errors are in-band SDK messages, not Python exceptions. Drain
     through the terminal Result before raising so a failed command cannot leave
     a stale Result in the pooled client's receive queue for the next turn.
     """
-    await client.query(command)
     errors: list[dict] = []
     result: ResultMessage | None = None
-    async for msg in client.receive_response():
+
+    def _note(msg) -> bool:
+        """Record one message; True once the terminal Result has been seen."""
+        nonlocal result
         if isinstance(msg, AssistantMessage):
             if info := _sdk_assistant_error(msg):
                 errors.append(info)
@@ -5662,7 +5694,33 @@ async def _run_sdk_command_checked(client: ClaudeSDKClient, command: str) -> Res
             result = msg
             if info := _sdk_result_error(msg):
                 errors.append(info)
-            break
+            return True
+        return False
+
+    stream = _stream_for(client)
+    if stream is not None:
+        # Attach BEFORE query(): anything the pump routes between the write and
+        # the attach would be parked as an orphan, and attach_turn deliberately
+        # does not adopt orphans, so a late attach could miss its own Result.
+        q = stream.attach_turn()
+        try:
+            await client.query(command)
+            while True:
+                msg = await q.get()
+                if msg is _STREAM_EOF:
+                    break
+                if _note(msg):
+                    break
+        finally:
+            stream.detach_turn(q)
+            stream.park_unconsumed(q)
+    else:
+        # No pump — a client built outside the pool (unit tests). The SDK's own
+        # bounded reader is then the only reader, so it is safe to use.
+        await client.query(command)
+        async for msg in client.receive_response():
+            if _note(msg):
+                break
     if result is None:
         errors.append({
             "message": f"{command} ended without a ResultMessage",
@@ -5783,7 +5841,9 @@ async def _native_compact_session_locked(sid: str) -> dict:
             pass
         # Bound the wait: a hung CLI /compact would otherwise leave this HTTP
         # request open forever (the main turn loop has its own 1800s guard).
-        async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 600, min_value=1)):
+        # 300s is ~2x the observed worst case (~150s at 190K tokens) now that
+        # the command reads through the pump instead of racing it.
+        async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)):
             await _run_sdk_command_checked(client, "/compact")
         post_compact_usage = dict(await client.get_context_usage())
         after_total = _positive_int(post_compact_usage.get("totalTokens"))
@@ -9418,32 +9478,47 @@ async def _start_turn(
         # 📦 bubble since 2026-05-22; this reuses it for the automatic one.
         await _emit_compact(emit, "start", used=total, limit=limit,
                             threshold=threshold)
+        # How the command REPORTS itself is a hint; whether the context actually
+        # shrank is the fact. Keep the command's verdict aside and let the token
+        # count adjudicate, so a compaction that succeeded but failed to
+        # acknowledge itself cannot kill the turn it just made room for.
+        cmd_error: Exception | None = None
         try:
-            async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 600, min_value=1)):
+            async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)):
                 await _run_sdk_command_checked(client, "/compact")
+        except Exception as e:
+            cmd_error = e
+            sys.stderr.write(
+                f"[chat-preflight] native compact reported failure sid={session_id[:8]} "
+                f"model={model_to_use}: {type(e).__name__}: {e} — verifying\n")
+            sys.stderr.flush()
+        try:
             cu2 = await client.get_context_usage()
         except Exception as e:
-            # Once the SDK says compaction is required, failure is terminal for
-            # this turn. Sending the original prompt anyway only produces a
-            # second context-window error and trains the UI to offer a useless
-            # retry loop.
+            # Can't observe the outcome, so the command's verdict is all we
+            # have. No reading also means no evidence of success.
+            await _emit_compact(emit, "end", ok=False,
+                                error=f"{type(e).__name__}: {e}")
+            raise cmd_error or e
+        real_total = _positive_int(cu2.get("totalTokens"))
+        if not (total and real_total and real_total < total):
+            # Genuinely no room made. Once the SDK says compaction is required,
+            # that is terminal for this turn — sending the original prompt
+            # anyway only produces a second context-window error and trains the
+            # UI to offer a useless retry loop.
+            reason = (f"{type(cmd_error).__name__}: {cmd_error}" if cmd_error
+                      else f"context did not shrink ({total} -> {real_total})")
             sys.stderr.write(
                 f"[chat-preflight] native compact failed sid={session_id[:8]} "
-                f"model={model_to_use}: {type(e).__name__}: {e}\n")
+                f"model={model_to_use}: {reason}\n")
             sys.stderr.flush()
             # The `error` SSE that follows tears the stream down, and the FE
             # clears `compacting` on stream teardown regardless — but emit the
             # terminal phase anyway so the bubble's reason is the compact's,
             # not a generic transport failure.
-            await _emit_compact(emit, "end", ok=False,
-                                error=f"{type(e).__name__}: {e}")
-            raise
-        real_total = _positive_int(cu2.get("totalTokens"))
-        if total and real_total and real_total >= total:
-            # Outside the try/except above, so it needs its own terminal emit.
-            await _emit_compact(
-                emit, "end", ok=False,
-                error=f"context did not shrink ({total} -> {real_total})")
+            await _emit_compact(emit, "end", ok=False, error=reason)
+            if cmd_error is not None:
+                raise cmd_error
             raise _SDKCommandError({
                 "message": (
                     "native /compact reported success but context usage did not decrease "
@@ -9452,6 +9527,12 @@ async def _start_turn(
                 "source": "verification",
                 "api_error_status": None,
             })
+        if cmd_error is not None:
+            sys.stderr.write(
+                f"[chat-preflight] native compact recovered sid={session_id[:8]}: "
+                f"command reported {type(cmd_error).__name__} but context shrank "
+                f"{total} -> {real_total}; continuing\n")
+            sys.stderr.flush()
         real_max = _positive_int(cu2.get("maxTokens"))
         real_raw = _positive_int(cu2.get("rawMaxTokens"))
         refreshed_details = _context_limit_details(

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -220,17 +220,40 @@ def _get_session_msgs(sid: str, model: str = "") -> list:
             sid, directory=str(sess.session_workspace(sid)))
 
 
+def _transcript_ts_ms(entry: dict) -> int | None:
+    """Epoch-ms of a raw transcript entry's ``timestamp`` (ISO-8601, UTC).
+
+    Every CLI JSONL record carries one; the SDK's SessionMessage does not
+    expose it, which is why per-message times were unavailable to the UI even
+    though the data was on disk the whole time. Returns None for missing or
+    unparseable values — a message with no time simply doesn't show one."""
+    raw = entry.get("timestamp") or ""
+    if not raw:
+        return None
+    try:
+        import datetime as _dt
+        return int(_dt.datetime.fromisoformat(
+            str(raw).replace("Z", "+00:00")).timestamp() * 1000)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
 class _RawMsg:
     """Minimal stand-in for the SDK's SessionMessage, exposing just the
     .uuid / .type / .message surface that _sdk_messages_to_ui consumes. Lets
     the full-history reader reuse the exact same UI-shaping logic as the
-    normal path, so the two views can't drift."""
-    __slots__ = ("uuid", "type", "message")
+    normal path, so the two views can't drift.
 
-    def __init__(self, uuid: str, type_: str, message: dict):
+    `mts` is the extra field the real SessionMessage lacks — see
+    _transcript_ts_ms. Optional so existing construction sites keep working."""
+    __slots__ = ("uuid", "type", "message", "mts")
+
+    def __init__(self, uuid: str, type_: str, message: dict,
+                 mts: int | None = None):
         self.uuid = uuid
         self.type = type_
         self.message = message
+        self.mts = mts
 
 
 def _full_session_msgs(sid: str) -> list:
@@ -276,7 +299,8 @@ def _full_session_msgs(sid: str) -> list:
                 if not u or u in seen:
                     continue
                 seen.add(u)
-                out.append(_RawMsg(u, e.get("type"), e.get("message") or {}))
+                out.append(_RawMsg(u, e.get("type"), e.get("message") or {},
+                                   _transcript_ts_ms(e)))
     except Exception:
         return []
     return out
@@ -611,8 +635,9 @@ class TurnBroadcast:
     endpoint is just a SUBSCRIBER — it replays the existing buffer +
     streams new events. A reconnecting browser becomes a new subscriber
     and gets the full reply via replay + live tail, with no extra logic
-    on the SDK side. Up to 30 min per turn (asyncio.wait_for at the
-    background-task level). Removed from `_active_turns` when finished.
+    on the SDK side. A turn runs unbounded by default; set
+    MUSELAB_TURN_TIMEOUT_S to arm a wall-clock cap at the background-task
+    level. Removed from `_active_turns` when finished.
     """
     def __init__(
         self,
@@ -2518,6 +2543,93 @@ def _attachments_base() -> Path:
     return ROOT / ".muselab-attach"
 
 
+# Longest filename component we'll write. Keeps `{aid}-{name}` (32 hex + dash
+# + this) comfortably under the 255-byte limit ext4/APFS enforce PER COMPONENT
+# — and that limit is in BYTES, so a CJK name at 3 bytes/char hits it ~3x
+# sooner than a Latin one. Truncation is applied to the stem so the extension
+# always survives; the extension is what tells the agent (and our MIME map)
+# what the file actually is.
+_ATTACH_NAME_MAX = 60
+
+
+def _safe_attach_name(name: str) -> str:
+    """Turn a client-supplied filename into a safe single path component.
+
+    Keeps the original name legible (CJK included) because it lands in the
+    prompt as a path the agent reads back — `a3f2…-季度报表.xlsx` tells the
+    model what it's looking at, `a3f2….bin` does not. Everything that could
+    escape the directory or confuse a shell is replaced:
+      - any directory part is dropped (`Path.name`)
+      - path separators, NUL, control chars, quotes, and whitespace runs → `_`
+      - leading dots are stripped so nothing lands as a hidden file
+    Falls back to "file" if the input sanitises down to nothing.
+    """
+    base = Path(str(name or "")).name
+    # Reject separators explicitly first — Path.name already drops POSIX dirs,
+    # but a Windows-style "..\\..\\evil" arriving on Linux keeps its
+    # backslashes, so the replace below has to see them.
+    base = base.replace("\\", "_").replace("/", "_")
+    base = re.sub(r"[\x00-\x1f\x7f]", "", base)
+    base = re.sub(r'[\s"\'`$;|&<>*?]+', "_", base)
+    # Strip dots and underscores together, in one pass. Doing it as two
+    # separate steps (lstrip(".") then strip("_")) leaves debris when they
+    # interleave: "..\\..\\windows" sanitises to ".._.._windows", the lstrip
+    # eats the leading dots, the strip eats one underscore, and the SECOND
+    # ".." is left stranded at the front.
+    base = base.strip("._") or "file"
+    if len(base.encode("utf-8")) > _ATTACH_NAME_MAX:
+        stem, dot, ext = base.rpartition(".")
+        if not dot or len(ext) > 8:
+            stem, dot, ext = base, "", ""
+        budget = _ATTACH_NAME_MAX - len((dot + ext).encode("utf-8"))
+        trimmed = stem.encode("utf-8")[:max(1, budget)]
+        # A byte-slice can land mid-codepoint; drop the partial tail.
+        stem = trimmed.decode("utf-8", "ignore") or "file"
+        base = stem + dot + ext
+    return base
+
+
+def _persist_attachment(session_id: str, aid: str, name: str,
+                        data: bytes) -> tuple[str, str] | None:
+    """Write one attachment to `.muselab-attach/{sid}/{aid}-{safe name}`.
+
+    Returns (absolute path, browser URL), or None if the write failed — a
+    failed attachment must not abort the turn, the user still gets their
+    prompt through, just without that file. Callers log nothing extra; the
+    stderr line here is the single record.
+
+    The `{aid}-` prefix is what makes the name collision-proof: two messages
+    can each attach a `report.csv` and neither overwrites the other, while the
+    human-readable half still tells the agent (and the user browsing the
+    folder) what the file is.
+    """
+    safe = _safe_attach_name(name)
+    attach_dir = _attachments_base() / session_id
+    try:
+        attach_dir.mkdir(parents=True, exist_ok=True)
+        path = attach_dir / f"{aid}-{safe}"
+        path.write_bytes(data)
+    except Exception as e:
+        sys.stderr.write(
+            f"[attach] persist failed sid={session_id} aid={aid} "
+            f"name={safe!r} err={type(e).__name__}: {e}\n")
+        sys.stderr.flush()
+        return None
+    url = (f"/api/chat/attachments/{session_id}/"
+           f"{urllib.parse.quote(f'{aid}-{safe}')}")
+    return str(path), url
+
+
+def _doc_item(name: str, kind: str, saved: tuple[str, str] | None) -> dict:
+    """Bubble metadata for one non-image attachment. `url` is present only
+    when the file actually made it to disk, so the frontend can render a
+    dead-end chip rather than a link that 404s."""
+    item = {"name": name, "kind": kind}
+    if saved:
+        item["url"] = saved[1]
+    return item
+
+
 def _migrate_legacy_attachments() -> None:
     """One-shot migration: sessions/attachments/* → ROOT/.muselab-attach/*.
     Runs at module import. Idempotent — only moves dirs that don't yet
@@ -3415,6 +3527,19 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
     # under whichever entry is the turn tail; making sure all of them
     # carry ts means whatever block ends up at the tail can display
     # the time. Cheap O(N) — annotations is already a dict lookup.
+    # Per-message wall-clock, distinct from `ts`. `ts` is the TURN-completion
+    # stamp deliberately fanned across the tail uuid only; `mts` is when this
+    # individual record was written. Keeping them separate matters: the FE's
+    # _markDone walks backwards looking for a bubble that already has `ts` to
+    # decide it has left the current turn, so populating `ts` everywhere would
+    # abort that walk on the first block it saw. Absent on the pure-SDK loader
+    # (SessionMessage carries no timestamp) — consumers must treat it as
+    # optional.
+    mts_by_uuid: dict[str, int] = {}
+    for sm in sm_list:
+        val = getattr(sm, "mts", None)
+        if val:
+            mts_by_uuid[sm.uuid] = val
     key_ordinals: dict[str, int] = {}
     for entry in out:
         u = entry.get("uuid")
@@ -3423,6 +3548,8 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
         ordinal = key_ordinals.get(u, 0)
         key_ordinals[u] = ordinal + 1
         entry["_key"] = f"{u}:{ordinal}"
+        if u in mts_by_uuid:
+            entry["mts"] = mts_by_uuid[u]
         ann = annotations.get(u, {})
         ts = ann.get("ts")
         if ts is not None and "ts" not in entry:
@@ -3509,7 +3636,7 @@ def _indexed_ui_records(
     entries = transcript_idx.read_records(transcript_path, index, record_indices)
     raw = [
         _RawMsg(str(e.get("uuid") or ""), str(e.get("type") or ""),
-                e.get("message") or {})
+                e.get("message") or {}, _transcript_ts_ms(e))
         for e in entries
     ]
     compact = {str(e.get("uuid")) for e in entries if e.get("isCompactSummary")}
@@ -3913,6 +4040,7 @@ def get_session_api(
     uses_index = bool(around_uuid or tail > 0 or offset >= 0)
     generation = ""
     has_later = False
+    pre_total = 0
     history_order = "full" if (full or around_uuid) else "normal"
 
     if uses_index:
@@ -3925,6 +4053,11 @@ def get_session_api(
         else:
             transcript_path, index = indexed
             generation = str(index.get("history_generation") or "")
+            # Bubbles stranded before the visible chain's root (post-/compact,
+            # or a fork). Reported in FULL-order units in every response so the
+            # client can offer "Load earlier" even when the normal-order window
+            # is sitting at offset 0 with nothing apparently behind it.
+            pre_total = transcript_idx.pre_chain_bubbles(index)
             if history_generation and history_generation != generation:
                 raise HTTPException(409, detail={
                     "error": "history_generation_mismatch",
@@ -4013,8 +4146,10 @@ def get_session_api(
             indexed = _ensure_transcript_index(sid)
             if indexed is not None:
                 generation = str(indexed[1].get("history_generation") or "")
+                pre_total = transcript_idx.pre_chain_bubbles(indexed[1])
         except Exception:
             generation = ""
+            pre_total = 0
         if not full and total > 0 and meta.get("message_count", 0) != total:
             try:
                 turns = sum(1 for item in messages if item.get("role") == "user")
@@ -4029,6 +4164,10 @@ def get_session_api(
         "offset": win_offset,
         "has_more": win_offset > 0,
         "has_later": has_later,
+        # Only meaningful while the client is reading normal order: once it has
+        # switched to full order those bubbles are inside `total` already, and
+        # plain `offset > 0` paging reaches them.
+        "pre_total": pre_total if history_order == "normal" else 0,
         "history_generation": generation,
         "history_order": history_order,
     }
@@ -6645,7 +6784,11 @@ _TEXT_EXTS = {
 # frontend" contract — frontend's _classifyFile maps these to "text"
 # too so the chip is consistent.
 _XLSX_EXTS = {".xlsx", ".xlsm", ".xltx", ".xltm"}
-_TEXT_MAX_BYTES = 200 * 1024            # inline at most 200 KB as text
+# Was a hard 413 ceiling back when text attachments were pasted into the
+# prompt verbatim. Attachments now go to disk and are referenced by path, so
+# this is only the threshold above which we log "this one was big" — the real
+# limit is _IMAGE_MAX_BYTES, same as every other upload.
+_TEXT_MAX_BYTES = 200 * 1024
 # Caps for xlsx inlining — same shape as the /api/files/xlsx preview
 # endpoint, kept smaller because we're shoving this into the prompt
 # context, not just rendering a table.
@@ -6665,8 +6808,12 @@ def _gc_images() -> None:
 
 def _image_entry_bytes(entry: dict) -> int:
     """Approximate retained size of a staged-upload entry. The base64 payload
-    (images / PDF) dominates; inlined text is already bounded but counted too."""
+    (images / PDF) dominates; text and the raw bytes we hold for disk
+    persistence are counted too — `raw` in particular is un-capped now that
+    text attachments are no longer inlined, so leaving it out of the budget
+    would let the eviction logic under-count by the full file size."""
     return (len(entry.get("b64", ""))
+            + len(entry.get("raw", b""))
             + len(entry.get("text", ""))
             + len(entry.get("name", "")))
 
@@ -7739,7 +7886,14 @@ def get_attachment(session_id: str, filename: str):
         raise HTTPException(400, "bad session_id")
     if "/" in filename or ".." in filename or "\\" in filename:
         raise HTTPException(400, "bad filename")
-    if not _re.fullmatch(r"[A-Za-z0-9_\-]+\.[A-Za-z0-9]{1,8}", filename):
+    # Was `[A-Za-z0-9_\-]+\.[A-Za-z0-9]{1,8}`, which predates this endpoint
+    # serving anything but images named `{aid}.{ext}`. Now that every
+    # attachment persists as `{aid}-{原文件名}`, an ASCII-only pattern 400s
+    # every Chinese filename — i.e. most of them. Widened to "one path
+    # component, no control chars", which combined with the traversal guard
+    # above and the resolve()/relative_to() check below is the actual
+    # security boundary. The `{aid}-` prefix still has to match a real file.
+    if not _re.fullmatch(r"[^/\\\x00-\x1f\x7f]{1,200}", filename):
         raise HTTPException(400, "bad filename format")
     path = _attachments_base() / session_id / filename
     if not path.exists() or not path.is_file():
@@ -7756,6 +7910,18 @@ def get_attachment(session_id: str, filename: str):
     mime = {
         "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg",
         "gif": "image/gif", "webp": "image/webp",
+        # Non-image attachments now live here too. Text types get an explicit
+        # charset so the browser doesn't mojibake a UTF-8 Chinese .md/.csv,
+        # and PDF gets its real type so the tab renders inline instead of
+        # forcing a download.
+        "pdf": "application/pdf",
+        "txt": "text/plain; charset=utf-8",
+        "md": "text/plain; charset=utf-8",
+        "csv": "text/plain; charset=utf-8",
+        "json": "application/json; charset=utf-8",
+        "yaml": "text/plain; charset=utf-8", "yml": "text/plain; charset=utf-8",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
     }.get(ext, "application/octet-stream")
     from fastapi.responses import FileResponse
     return FileResponse(
@@ -7788,36 +7954,36 @@ async def upload_image(file: UploadFile = File(...)) -> dict:
     aid = uuid.uuid4().hex
     entry: dict = {"kind": kind, "mime": mime, "name": name, "ts": time.time()}
     if kind == "text":
-        if len(body) > _TEXT_MAX_BYTES:
-            raise HTTPException(
-                413,
-                f"text file too large: {len(body)} bytes. Max "
-                f"{_TEXT_MAX_BYTES} (~200 KB). Trim it or send as PDF.",
-            )
+        # `raw` is what actually lands on disk at send-time. The decoded
+        # `text` is kept only as a validity check + for anything that still
+        # wants a preview — it is NO LONGER pasted into the prompt.
         try:
             entry["text"] = body.decode("utf-8")
         except UnicodeDecodeError:
             raise HTTPException(400, "text file is not valid UTF-8 — "
                                       "convert to UTF-8 or send as PDF") from None
+        # The old 200 KB ceiling existed because the whole file was inlined
+        # into the prompt, where it burned context 1:1. Attachments now go to
+        # disk and the agent Reads only what it needs, so the cap can be the
+        # generic upload limit. Kept as a named constant so the error message
+        # stays honest about which limit was hit.
+        if len(body) > _TEXT_MAX_BYTES:
+            sys.stderr.write(
+                f"[upload] large text attachment: {len(body)} bytes "
+                f"name={Path(name).name!r} — persisted to disk, not inlined\n")
+        entry["raw"] = body
     elif kind == "xlsx":
-        # Convert to text up front; downstream chat code only inlines
-        # entries whose kind is "text", so flip it before storing.
+        # Store the ORIGINAL workbook (the user asked for the real file to
+        # survive) AND a plain-text transcription. Neither alone is enough:
+        # `Read` can't parse the zip container, and a transcription throws
+        # away formulas / multiple sheets / exact cell values the user may
+        # want a script to open later. Both paths go into the prompt.
         # openpyxl load_workbook + full-sheet walk is CPU-heavy and fully
         # synchronous — off-load so a multi-MB xlsx upload doesn't freeze the
         # event loop (and every concurrent SSE stream) mid-parse. (perf: RED —
         # chat.py upload_image xlsx parse)
+        entry["raw"] = body
         entry["text"] = await asyncio.to_thread(_xlsx_to_text, body, name)
-        entry["kind"] = "text"
-        if len(entry["text"].encode("utf-8")) > _TEXT_MAX_BYTES * 2:
-            # Higher cap for converted spreadsheets — the per-cell + row
-            # ceilings already bound output size, this is just a hard
-            # safety rail. 400 KB ≈ 10k rows of 8 short cols.
-            raise HTTPException(
-                413,
-                "spreadsheet too large after conversion. Reduce rows / "
-                "cols and re-upload, or send a CSV of just the slice "
-                "you need.",
-            )
     else:
         # base64-encoding a ~10MB image is tens of ms of pure CPU on the loop
         # — off-load it so the upload doesn't stall concurrent streams.
@@ -8969,8 +9135,12 @@ async def _start_turn(
     # SDK. Consume them — same attachment won't be re-sent on retry.
     img_blocks: list[dict] = []
     pdf_blocks: list[dict] = []
-    text_attachments: list[tuple[str, str]] = []   # (name, content)
-    pdf_path_attachments: list[tuple[str, str]] = []   # (name, local path)
+    # Every non-image attachment lands here as (display name, on-disk path,
+    # optional note). Nothing is pasted into the prompt any more — the user's
+    # call, and the right one: a 200 KB CSV used to cost 200 KB of context on
+    # EVERY subsequent turn because it lived in the transcript forever, while
+    # the agent usually only needed three columns of it.
+    disk_attachments: list[tuple[str, str, str]] = []
     persisted_imgs: list[dict] = []
     persisted_docs: list[dict] = []
     if image_ids:
@@ -9061,56 +9231,55 @@ async def _start_turn(
                 # silently ignore PDF document blocks; the path fallback lets
                 # Claude Code/Agent tools inspect the same PDF via Read.
                 doc_name = entry.get("name", "doc.pdf")
-                attach_dir = _attachments_base() / session_id
-                try:
-                    attach_dir.mkdir(parents=True, exist_ok=True)
-                    attach_path = attach_dir / f"{aid}.pdf"
-                    attach_path.write_bytes(base64.b64decode(entry["b64"]))
-                    pdf_path_attachments.append((doc_name, str(attach_path)))
-                except Exception as _e:
-                    sys.stderr.write(
-                        f"[attach] pdf persist failed sid={session_id} aid={aid} "
-                        f"path={attach_dir} err={type(_e).__name__}: {_e}\n")
-                    sys.stderr.flush()
-                persisted_docs.append({"name": doc_name, "kind": "pdf"})
+                saved = _persist_attachment(
+                    session_id, aid, doc_name,
+                    base64.b64decode(entry["b64"]))
+                if saved:
+                    disk_attachments.append((doc_name, saved[0], ""))
+                persisted_docs.append(_doc_item(doc_name, "pdf", saved))
             elif kind == "text":
-                text_attachments.append((entry.get("name", "file.txt"),
-                                          entry["text"]))
-                persisted_docs.append({"name": entry.get("name", "file.txt"),
-                                        "kind": "text"})
+                doc_name = entry.get("name", "file.txt")
+                saved = _persist_attachment(
+                    session_id, aid, doc_name,
+                    entry.get("raw") or (entry.get("text") or "").encode("utf-8"))
+                if saved:
+                    disk_attachments.append((doc_name, saved[0], ""))
+                persisted_docs.append(_doc_item(doc_name, "text", saved))
+            elif kind == "xlsx":
+                # Original workbook + plain-text transcription, both on disk.
+                doc_name = entry.get("name", "book.xlsx")
+                saved = _persist_attachment(
+                    session_id, aid, doc_name, entry.get("raw") or b"")
+                txt_name = Path(doc_name).stem + ".txt"
+                txt_saved = _persist_attachment(
+                    session_id, aid + "-txt", txt_name,
+                    (entry.get("text") or "").encode("utf-8"))
+                if saved:
+                    note = (f"plain-text transcription: {txt_saved[0]}"
+                            if txt_saved else "")
+                    disk_attachments.append((doc_name, saved[0], note))
+                elif txt_saved:
+                    disk_attachments.append((txt_name, txt_saved[0], ""))
+                persisted_docs.append(_doc_item(doc_name, "xlsx", saved))
 
-    # Prepend inline text attachments to the prompt (any model can consume).
-    if text_attachments:
-        parts = [prompt] if prompt else []
-        for name, body in text_attachments:
-            # Pick a fence longer than the longest backtick run in the body so
-            # an attachment that itself contains ``` can't prematurely close the
-            # code block and let its content bleed into / spoof the prompt.
-            longest_run = cur = 0
-            for ch in body:
-                if ch == "`":
-                    cur += 1
-                    longest_run = max(longest_run, cur)
-                else:
-                    cur = 0
-            fence = "`" * max(3, longest_run + 1)
-            parts.append(
-                f"\n\n--- Attached file: {name} ---\n{fence}\n{body}\n{fence}\n--- end {name} ---"
-            )
-        prompt = "\n".join(parts).lstrip()
-
-    # PDF document blocks are not reliably supported by every
-    # Anthropic-compatible backend. Tell the agent where the same PDF lives on
-    # disk so it can call Read if the native document block is unavailable.
-    if pdf_path_attachments:
+    # Attachments are referenced BY PATH, never inlined. The prompt gets a
+    # manifest; the agent Reads what it needs. Two things this buys:
+    #   - context: a big CSV no longer sits in the transcript forever, re-sent
+    #     on every subsequent turn of the session
+    #   - fidelity: the agent sees the real file (exact bytes, full length),
+    #     not a truncated / fenced copy of it
+    # The old inline path also needed backtick-fence-length arithmetic to stop
+    # an attachment containing ``` from breaking out of its code block and
+    # spoofing prompt text. Referencing by path removes that class of bug.
+    if disk_attachments:
         parts = [prompt] if prompt else []
         lines = [
-            "\n\n--- Attached PDF files available on disk ---",
-            "If you cannot access the PDF document block directly, use the Read tool on these local paths:",
+            "\n\n--- Files attached to this message (on disk) ---",
+            "Use the Read tool on these paths. Do not guess at their contents.",
         ]
-        for name, path in pdf_path_attachments:
-            lines.append(f"- {name}: {path}")
-        lines.append("--- end attached PDF files ---")
+        for name, path, note in disk_attachments:
+            lines.append(f"- {name}: {path}" + (f"  ({note})" if note else ""))
+        lines.append("--- end attached files ---")
         parts.append("\n".join(lines))
         prompt = "\n".join(parts).lstrip()
 
@@ -9154,7 +9323,26 @@ async def _start_turn(
     # marked failed even when ResultMessage itself omits the detail.
     turn_sdk_errors: list[dict] = []
 
-    async def _preflight_compact_if_needed() -> None:
+    async def _emit_compact(emit, phase: str, **fields) -> None:
+        """Push one `compact_progress` SSE event, best-effort.
+
+        A UI cue must never be able to kill the turn it is describing, so every
+        failure here is swallowed. `emit` is None on the paths that have no
+        stream to write to (tests, the post-turn compact) — also a no-op.
+        """
+        if emit is None:
+            return
+        try:
+            payload = {"phase": phase, "source": "auto", **fields}
+            await emit({"event": "compact_progress",
+                        "data": json.dumps(payload)})
+        except Exception as e:
+            sys.stderr.write(
+                f"[chat-preflight] compact_progress emit failed "
+                f"sid={session_id[:8]} phase={phase}: {type(e).__name__}: {e}\n")
+            sys.stderr.flush()
+
+    async def _preflight_compact_if_needed(emit=None) -> None:
         """Use Claude Code's native context accounting before sending a turn.
 
         The previous auto-compact path only ran after a successful `done` event,
@@ -9221,6 +9409,15 @@ async def _start_turn(
             f"[chat-preflight] native compact sid={session_id[:8]} model={model_to_use} "
             f"total={total} next~={next_est} threshold={threshold} limit={limit}\n")
         sys.stderr.flush()
+        # Tell the UI. Without this the auto-compact is indistinguishable from a
+        # slow turn: the FE shows the generic "Muse 正在思考…" bubble for the
+        # entire compact, which on a long session runs MINUTES (2026-07-25: a
+        # 186229/200000 session sat on that bubble for 9m19s and then died on
+        # "/compact ended without a ResultMessage" — the user's read was
+        # "这是在运行啥呢"). The manual compact path has had a dedicated
+        # 📦 bubble since 2026-05-22; this reuses it for the automatic one.
+        await _emit_compact(emit, "start", used=total, limit=limit,
+                            threshold=threshold)
         try:
             async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 600, min_value=1)):
                 await _run_sdk_command_checked(client, "/compact")
@@ -9234,9 +9431,19 @@ async def _start_turn(
                 f"[chat-preflight] native compact failed sid={session_id[:8]} "
                 f"model={model_to_use}: {type(e).__name__}: {e}\n")
             sys.stderr.flush()
+            # The `error` SSE that follows tears the stream down, and the FE
+            # clears `compacting` on stream teardown regardless — but emit the
+            # terminal phase anyway so the bubble's reason is the compact's,
+            # not a generic transport failure.
+            await _emit_compact(emit, "end", ok=False,
+                                error=f"{type(e).__name__}: {e}")
             raise
         real_total = _positive_int(cu2.get("totalTokens"))
         if total and real_total and real_total >= total:
+            # Outside the try/except above, so it needs its own terminal emit.
+            await _emit_compact(
+                emit, "end", ok=False,
+                error=f"context did not shrink ({total} -> {real_total})")
             raise _SDKCommandError({
                 "message": (
                     "native /compact reported success but context usage did not decrease "
@@ -9282,6 +9489,9 @@ async def _start_turn(
             sess_u["auto_compact_threshold"] = th
         if real_total and lim:
             sess_u["context_used_pct"] = round(real_total / lim * 100, 1)
+        # Success. The turn's real query starts immediately after this returns,
+        # so the FE swaps the 📦 bubble back for the normal streaming one.
+        await _emit_compact(emit, "end", ok=True, used=real_total, limit=lim)
 
     async def event_gen():
         nonlocal assistant_acc, streamed_in_bubble
@@ -9319,7 +9529,14 @@ async def _start_turn(
             stale Result until the current query reaches its own terminal.
             """
             async def _run_query() -> None:
-                await _preflight_compact_if_needed()
+                # `merge_q` lives in event_gen's scope, one level deeper than
+                # _preflight_compact_if_needed's — hence the injected emitter
+                # rather than a closure reference. Events ride the same "side"
+                # lane as ask_user_question / permission_request: already
+                # shaped as {"event", "data"} and passed straight through.
+                async def _emit_side(evt: dict) -> None:
+                    await merge_q.put(("side", evt))
+                await _preflight_compact_if_needed(_emit_side)
                 # Snapshot AFTER preflight compact (which may write a new compact
                 # boundary) and immediately BEFORE this user query. A cache hit is
                 # cheap; to_thread keeps a long-session parse off the event loop.
@@ -10284,8 +10501,8 @@ async def _start_turn(
             raise
         finally:
             # event_gen runs as part of a detached background task now;
-            # cleanup here runs after the task finishes naturally (or
-            # the 30-min outer timeout fires and cancels us).
+            # cleanup here runs after the task finishes naturally (or an
+            # explicit interrupt / an armed MUSELAB_TURN_TIMEOUT_S cancels us).
             side_task.cancel()
             perm_task.cancel()
             claude_task.cancel()
@@ -10302,10 +10519,26 @@ async def _start_turn(
     # every event it would have yielded into a per-session TurnBroadcast.
     # The HTTP response is just a subscriber that replays the buffer +
     # streams new events. A user closing their browser doesn't affect
-    # the background task — it runs to completion (or 30-min timeout).
+    # the background task — it runs to completion (or until interrupted).
     # A second SSE request to the same session (reconnect) becomes
     # another subscriber and sees the full reply via replay + live tail.
-    BG_TIMEOUT_S = 1800   # 30 minutes — see PR thread for rationale
+    # Wall-clock cap on a whole turn. 0 (the default) disables it.
+    #
+    # This used to be a hard 1800s. A wall-clock cap is the wrong shape for an
+    # agentic workspace: it can't tell "wedged" from "busy", so it kills turns
+    # that are actively producing output. A full test suite, a migration or a
+    # deep tool loop legitimately runs past 30 minutes, and the kill is total
+    # loss — the SDK CLI only writes the JSONL on completion, so an aborted
+    # turn leaves NO transcript record of its work or of why it stopped
+    # (`_error_event` is live-only SSE; miss the moment and the reason is gone).
+    #
+    # Nothing depends on it as a safety net: POST /interrupt marks the turn
+    # cancelled and schedules _force_stop_after_grace independently of this
+    # timeout, so a genuinely wedged turn already has an escape hatch that
+    # works whether or not a cap exists.
+    #
+    # Set MUSELAB_TURN_TIMEOUT_S to a positive number to re-arm it.
+    BG_TIMEOUT_S = env_int("MUSELAB_TURN_TIMEOUT_S", 0, min_value=0)
 
     # `broadcast` was already reserved under _lock at the top of NEW-TURN
     # MODE to close the check+insert race. Fill its remaining fields now
@@ -10324,7 +10557,8 @@ async def _start_turn(
     async def _pump_gen_to_broadcast():
         turn_errored = False
         try:
-            async with asyncio.timeout(BG_TIMEOUT_S):
+            # None → asyncio.timeout is a no-op wrapper (no deadline armed).
+            async with asyncio.timeout(BG_TIMEOUT_S or None):
                 async for ev in event_gen():
                     # Track in-band errors too (merge_q "error" → an SSE error
                     # event flows through event_gen without raising). The queue
@@ -10346,10 +10580,11 @@ async def _start_turn(
         except asyncio.TimeoutError:
             turn_errored = True
             sys.stderr.write(
-                f"[chat] turn exceeded {BG_TIMEOUT_S}s (30min), aborting "
-                f"sid={session_id}\n")
+                f"[chat] turn exceeded MUSELAB_TURN_TIMEOUT_S={BG_TIMEOUT_S}s, "
+                f"aborting sid={session_id}\n")
             sys.stderr.flush()
-            broadcast.publish(_error_event("turn exceeded 30min"))
+            broadcast.publish(
+                _error_event(f"turn exceeded {BG_TIMEOUT_S}s"))
         except Exception as e:
             turn_errored = True
             import traceback as _tb

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1158,10 +1158,23 @@ def requeue_head(sid: str, item: dict) -> dict:
 
 
 def remove_queue_item(sid: str, item_id: str) -> dict:
-    """Remove one item by id. Returns the updated queue snapshot."""
+    """Remove one item by id. Returns the updated queue snapshot.
+
+    Emptying the queue also clears ``paused``. The flag means "there is queued
+    work that stopped auto-draining because a turn errored" — with no items
+    left it has no referent, and leaving it set is a silent trap: the next
+    enqueue lands in a queue whose ``dequeue_message`` returns None forever, so
+    the message sits there through every subsequent completed turn with no
+    banner and no error. Observed 2026-07-25: a 30-min-cap abort paused a queue
+    of 2, the user deleted both stale items, enqueued 2 fresh ones, and they
+    never sent. It also unblocks _save_queue's empty-file cleanup, which skips
+    deletion while ``paused`` is true — sessions/ had zombie
+    ``{items: [], paused: true}`` files dating back a week."""
     with _QUEUE_LOCK:
         data = _load_queue(sid)
         data["items"] = [it for it in data["items"] if it.get("id") != item_id]
+        if not data["items"]:
+            data["paused"] = False
         _save_queue(sid, data)
         return data
 

--- a/backend/transcript_index.py
+++ b/backend/transcript_index.py
@@ -394,6 +394,46 @@ def record_indices_for_bubble_window(
     return order_ids[first:last], start - prefix[first], total
 
 
+def pre_chain_bubbles(index: dict[str, Any]) -> int:
+    """Full-order bubbles sitting BEFORE the start of the normal chain.
+
+    After a `/compact`, compaction writes a fresh root: the summary's parent is
+    a `system` record with parentUuid=None, so the pre-compact turns live on a
+    genuinely disconnected branch. The normal order (parentUuid walk back from
+    the leaf) therefore *starts* at the summary, `total` collapses to the
+    post-compact slice, `offset` is 0 — and the client's "Load earlier" button,
+    which keys off `offset > 0`, never appears. The older turns are still on
+    disk and still in `orders["full"]`; they're just unreachable from the chat
+    pane.
+
+    This returns how many full-order bubbles are stranded that way, which the
+    client uses both as the "is there anything back there" predicate and as the
+    count it shows on the button.
+
+    Deliberately NOT `full_total - normal_total`: `full` keeps sidechain /
+    team / meta records that `normal` filters out, so the two orders are not a
+    simple translation of each other — the difference is non-zero for any
+    session that merely used a subagent, and the arithmetic would mis-seat the
+    window. Anchoring on where the visible chain actually begins is exact, and
+    falls out to 0 for an uncompacted session (`normal[0] is full[0]`). Forked
+    sessions, whose rewired parentUuid chain also bypasses earlier records,
+    get the correct non-zero answer for free.
+    """
+    normal = index["orders"]["normal"]
+    if not normal:
+        return 0
+    full = index["orders"]["full"]
+    prefix = index["bubble_prefix"]["full"]
+    try:
+        pos = full.index(normal[0])
+    except ValueError:
+        # normal[0] absent from full only if duplicate-uuid dedup kept a
+        # different occurrence (full keeps the first, normal resolves the
+        # last). Degrade to "nothing stranded" rather than guess an offset.
+        return 0
+    return prefix[pos]
+
+
 def record_indices_around_uuid(
     index: dict[str, Any],
     uuid_value: str,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -415,6 +415,11 @@ function portal() {
     PREVIEW_ZOOM_MIN: 0.5,
     PREVIEW_ZOOM_MAX: 3,
     PREVIEW_ZOOM_STEP: 0.1,
+    // Concise chat mode — declared here (not just assigned in init) so Alpine
+    // owns it from the first render and the x-if gates that read it don't
+    // evaluate against undefined on the initial paint. Restored from
+    // localStorage in init(); see conciseHidesToolUse().
+    conciseChat: false,
     // Compact orchestration: the per-tab `compacting` flag (see
     // _blankTabState) marks the window where the CLI is busy summarising
     // *that session's* history. User messages typed during compact go into
@@ -1479,6 +1484,12 @@ function portal() {
         const z = parseFloat(localStorage.getItem("muselab_preview_zoom"));
         if (!Number.isNaN(z)) this.previewZoom = this._clampPreviewZoom(z);
       }
+      // Concise chat mode. Per-DEVICE (localStorage, like preview zoom), not
+      // per-session: the problem it solves is "the phone screen is small", so
+      // the same session read from a desktop should stay fully detailed.
+      // Default off — it removes the only surface on which you can catch the
+      // agent touching a file you didn't expect.
+      this.conciseChat = localStorage.getItem("muselab_concise_chat") === "1";
       // Vibration / push prefs come from localStorage (per-device) so a
       // shared muselab between a desktop + phone keeps independent
       // settings — your phone can vibrate; the desktop tab silently
@@ -8391,9 +8402,39 @@ function portal() {
     // "Task #N created successfully" similarly. Failed cases (is_error
     // true) are NEVER hidden — the user needs to see what broke + the
     // errorFixHint banner attached to the same result.
+    // Concise chat mode: drop the file-plumbing cards, keep the conversation.
+    // Exactly three classes go (user-selected 2026-07-26, by pointing at them
+    // in a screenshot): the generic tool bubble (Read / Bash / Grep / Edit…),
+    // its 改动预览 diff strip, and the tool_result. Everything that carries
+    // content or needs an action stays — TodoWrite, Task/Agent, the Task* log
+    // lines, ExitPlanMode's plan card, ask_user_question, permission_request.
+    //
+    // Failures are never hidden. That is not a new rule for this mode; it is
+    // shouldHideToolResult's existing invariant, and it is what keeps concise
+    // mode from turning a broken turn into an unexplained silence.
+    toggleConciseChat() {
+      this.conciseChat = !this.conciseChat;
+      try {
+        localStorage.setItem("muselab_concise_chat",
+                             this.conciseChat ? "1" : "0");
+      } catch {}
+      // The hidden cards were occupying real height; without this the viewport
+      // lands somewhere arbitrary in the middle of the now-shorter transcript.
+      this.$nextTick(() => this.scrollToBottom(true));
+    },
+    conciseHidesToolUse(m) {
+      if (!this.conciseChat || !m || m.role !== "tool_use") return false;
+      if (m.is_error) return false;
+      if (["TodoWrite", "Task", "Agent", "ExitPlanMode"].includes(m.name)) {
+        return false;
+      }
+      if (this.isTaskTool(m)) return false;
+      return true;
+    },
     shouldHideToolResult(m) {
       if (!m) return false;
       if (m.is_error) return false;  // never hide failures
+      if (this.conciseChat) return true;
       const kind = this.toolResultKind(m);
       if (kind === "task") return true;
       const name = m.tool_name || "";
@@ -8452,6 +8493,10 @@ function portal() {
         case "ask_user_question":
           return true;
         case "tool_use": {
+          // Concise mode first: this mirrors the x-if gates in index.html, and
+          // a wrapper left visible around a body that no longer renders is the
+          // 30-40px blank-gap bug this whole method exists to prevent.
+          if (this.conciseHidesToolUse(m)) return false;
           // TodoWrite / Task|Agent / ExitPlanMode always render their own card.
           if (m.name === "TodoWrite" || m.name === "Task" || m.name === "Agent"
               || m.name === "ExitPlanMode") return true;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -257,6 +257,9 @@ function portal() {
     // window plus a small overscan buffer.
     fileTreeViewport: { start: 0, end: 80 },
     _fileTreeScrollRAF: null,
+    // Measured row height for the virtual scroller. 0 = "remeasure on next
+    // read"; see _fileTreeRowHeight / _invalidateFileTreeRowHeight.
+    _fileTreeRowHeightCache: 0,
     selected: "",
     // The row that owns keyboard/copy/paste focus in the file tree. Keep this
     // separate from `selected`, which is the file whose body is rendered in
@@ -422,7 +425,10 @@ function portal() {
     // SDK get_context_usage() breakdown popup. Shows per-category token
     // counts (system prompt / tools / memory files / messages / mcp / skills)
     // so the user can see which slice is using their context window.
-    ctxBreakdown: { show: false, loading: false, data: null, error: "" },
+    // `data` is the raw SDK get_context_usage() payload; `view` is the
+    // normalised render model built by _ctxBuildView (see there for the SDK
+    // quirks it exists to absorb). Templates read `view`, never `data`.
+    ctxBreakdown: { show: false, loading: false, data: null, view: null, error: "" },
     // Per-category expansion state inside the breakdown popup. Keyed by
     // category name from SDK; only categories that map to a sub-list
     // (memoryFiles / mcpTools / agents) actually expand.
@@ -504,6 +510,10 @@ function portal() {
     activity: {
       show: false, loading: false, events: [],
       summary: { running: 0, unread: 0, attention: 0, workspaces: [] },
+      // group key -> true when the user asked to see past the row cap.
+      expanded: {},
+      // Selected group keys. Empty array = no filter = show every group.
+      filter: [],
     },
     _activityEtags: {},
     _activityFetchPromises: {},
@@ -1661,7 +1671,12 @@ function portal() {
         vv.addEventListener("resize", () => this._syncMobileKeyboardViewport());
         vv.addEventListener("scroll", () => this._syncMobileKeyboardViewport());
       }
-      window.addEventListener("resize", () => this._reconcileMobileViewport());
+      window.addEventListener("resize", () => {
+        // A resize can flip the (pointer: coarse) / width breakpoints that
+        // decide row padding, so the cached row height is no longer trusted.
+        this._invalidateFileTreeRowHeight();
+        this._reconcileMobileViewport();
+      });
       document.addEventListener("focusout", () => this._reconcileMobileViewport());
       window.addEventListener("focus", () => this._reconcileMobileViewport());
       window.addEventListener("pageshow", () => this._reconcileMobileViewport());
@@ -3570,6 +3585,7 @@ function portal() {
       st._laterMessages = [];
       st._loadedOffset = Number.isInteger(data.offset) ? data.offset : 0;
       st._total = Number.isInteger(data.total) ? data.total : win.length;
+      st._preTotal = Number.isInteger(data.pre_total) ? data.pre_total : 0;
       st.historyGeneration = data.history_generation || st.historyGeneration || "";
       st._historyOrder = data.history_order === "normal" ? "normal" : "full";
       st._hasServerLater = !!data.has_later;
@@ -5312,6 +5328,29 @@ function portal() {
         .filter(level => this._effortAllowed(level, model))
         .map(level => ({ value: level, labelKey: "effort." + (level || "auto") }));
     },
+    // Label for the 📦 compact-in-progress bubble. An auto-compact rides the
+    // turn's own stream, so streamElapsed (already ticking once a second) is
+    // its elapsed time to within a second — and showing it is the whole point:
+    // the silent version of this bubble ran 9m19s before failing. The manual
+    // compact has no stream and no ticker, so it stays a bare label.
+    compactPendingLabel() {
+      const zh = this.lang === "zh";
+      const base = zh ? "压缩对话中…" : "Compacting conversation…";
+      const st = this.tabState[this.currentId];
+      if (!st || !st._compactStartedAt) return base;
+      const secs = st.streamElapsed || 0;
+      if (secs < 2) return base;
+      return base + " · " + this.fmtStreamElapsed(secs);
+    },
+    // The i18n option labels are self-describing ("Effort · high") because the
+    // DESKTOP control is a bare inline select with no field label next to it.
+    // Inside the mobile settings panel the field IS labelled "Effort", so the
+    // prefix printed the word twice in adjacent lines. Strip it at render
+    // rather than forking six keys × two languages — the separator is fixed
+    // and generated in one place above, so this can't drift out of sync.
+    effortOptLabel(opt) {
+      return String(this.t(opt.labelKey) || "").replace(/^Effort\s·\s/, "");
+    },
     async _serializeTabSettingPatch(st, tailKey, work) {
       const prior = st[tailKey] || Promise.resolve();
       const run = Promise.resolve(prior).catch(() => {}).then(work);
@@ -5635,6 +5674,14 @@ function portal() {
         // so earlierMessageCount() can show how many older messages exist
         // beyond what's in memory.
         _total: 0,
+        // Server `pre_total`: bubbles stranded BEFORE the root of the chain we
+        // are reading — i.e. everything from before a `/compact` (or a fork).
+        // They are not counted in `_total` and not reachable by decrementing
+        // `_loadedOffset`, because they sit in a different order (full) whose
+        // coordinates don't line up with normal's. Non-zero here is the only
+        // signal that "Load earlier" still has somewhere to go once
+        // `_loadedOffset` hits 0; _switchToFullOrder() does the crossing.
+        _preTotal: 0,
         // True while an async backend older-window fetch is in flight, so
         // rapid "Load earlier" clicks don't fire duplicate requests.
         _fetchingOlder: false,
@@ -8048,6 +8095,13 @@ function portal() {
       if (!m) return true;
       const k = this._msgKey(i, m);
       if (k in this._expandedMsgs) return this._expandedMsgs[k];
+      // A compact summary opts out of every default-open rule below. It is a
+      // static artifact, not a live block — but it DOES sit last in the pane
+      // from the moment the compact lands until the first muse-side msg of the
+      // next turn arrives, so the "streaming last block" rule would unfurl
+      // 10-20k chars over the running turn. Only an explicit tap (handled
+      // above) opens it.
+      if (m._is_compact_summary) return false;
       // Explicit caller hint (e.g. diff strip wants to be open by default)
       // overrides the default-collapsed behavior. Caller still respects
       // user's explicit toggle (the _expandedMsgs check above).
@@ -8057,14 +8111,30 @@ function portal() {
       const streaming = paneState ? !!paneState.streaming : !!this.streaming;
       return streaming && i === msgs.length - 1;
     },
-    toggleMsgExpanded(m, i) {
+    // `defaultOpen` MUST mirror whatever the caller passed to isMsgExpanded()
+    // for the same message. Without it the toggle reads the wrong "current"
+    // state for anything that renders open by default (the compact summary),
+    // computes !false === true, writes "expanded" over an already-expanded
+    // block — and the first tap visibly does nothing.
+    toggleMsgExpanded(m, i, defaultOpen = false) {
       if (!m) return;
       const idx = (i ?? (this.messages || []).indexOf(m));
       const k = this._msgKey(idx, m);
-      const cur = this.isMsgExpanded(idx, m);
+      const cur = this.isMsgExpanded(idx, m, defaultOpen);
       const newState = !cur;
       // Spread-assign so Alpine sees the replacement and re-evaluates.
       this._expandedMsgs = { ...this._expandedMsgs, [k]: newState };
+    },
+    // Rendered markdown for a /compact summary body. Cached onto the message
+    // because the summary runs 10-20k chars and x-html re-evaluates on every
+    // Alpine tick — re-parsing that on each keystroke in the composer was not
+    // an option. It can't be filled by loadSession's render pass either: that
+    // pass only touches `role === "assistant"` bubbles, and the compact
+    // summary arrives from the CLI JSONL with role "user".
+    compactSummaryHtml(m) {
+      if (!m) return "";
+      if (!m._compactHtml) m._compactHtml = this.mdRender(m.text || "");
+      return m._compactHtml;
     },
     toolResultClass(i, m, paneState = null, paneMsgs = null) {
       let cls = "tool-result";
@@ -8908,13 +8978,17 @@ function portal() {
 
     async showCtxBreakdown() {
       if (!this.currentId) return;
-      this.ctxBreakdown = { show: true, loading: true, data: null, error: "" };
+      this.ctxBreakdown = { show: true, loading: true, data: null, view: null, error: "" };
       this.ctxExpanded = {};
       const { ok, data, error, status } = await this.api(
         `/api/chat/context-breakdown/${this.currentId}`);
       this.ctxBreakdown.loading = false;
       if (ok && data) {
         this.ctxBreakdown.data = data;
+        // Normalise ONCE per response rather than on every Alpine re-render:
+        // the view splits categories and pre-sorts every drill-down list, and
+        // x-for would otherwise rebuild those arrays on each reactive pass.
+        this.ctxBreakdown.view = this._ctxBuildView(data);
       } else {
         // 409 = no live client yet (session hasn't streamed a turn).
         this.ctxBreakdown.error = status === 409
@@ -8924,22 +8998,153 @@ function portal() {
           : (error || (this.lang === "zh" ? "查询失败" : "Fetch failed"));
       }
     },
-    // % of maxTokens used by this category — drives both the stacked bar
-    // at the top of the popup and the per-row inline bar.
+    // % of maxTokens used by this category — drives the stacked bar at the
+    // top of the popup and the per-row % column.
     ctxCategoryPct(cat) {
       const max = (this.ctxBreakdown.data && this.ctxBreakdown.data.maxTokens) || 0;
       if (!max || !cat || !cat.tokens) return 0;
       return Math.min(100, (cat.tokens / max) * 100);
     },
-    // Pick a category color. SDK populates cat.color for known categories;
-    // fall back to a stable hash-based hue for everything else so the bar
-    // segments stay distinct.
+    // Share-of-window as text, replacing the per-row bar. Variable precision
+    // because the categories span four orders of magnitude: rounding the
+    // whole column to integers would print "0%" for Skills (79 tokens) and
+    // "0%" for System tools (10.3K) alike, which is exactly the flattening
+    // the bars already did. Sub-0.1% collapses to "<0.1%" rather than
+    // "0.04%" — at that size the only fact worth conveying is "negligible".
+    ctxPctLabel(cat) {
+      const p = this.ctxCategoryPct(cat);
+      if (!p) return "0%";
+      if (p < 0.1) return "<0.1%";
+      if (p < 10) return p.toFixed(1) + "%";
+      return Math.round(p) + "%";
+    },
+    // get_context_usage() returns `color` as a Claude Code THEME TOKEN NAME
+    // ("promptBorder", "inactive", "claude", "warning",
+    // "purple_FOR_SUBAGENTS_ONLY"), NOT a CSS color. The old code returned it
+    // verbatim, so every swatch and every bar got `background: promptBorder`
+    // — an invalid declaration the browser silently drops. Net effect: the
+    // stacked bar and all six row bars rendered completely blank, and the
+    // hashed-hue fallback below could never fire because `cat.color` is
+    // always truthy. Map the tokens onto our own themed palette instead.
+    ctxColorTokens: {
+      promptBorder: "var(--c-accent)",
+      inactive: "var(--c-fg-3)",
+      claude: "#d97757",
+      warning: "var(--c-warn)",
+      // The SDK really does ship this name. Purple is right for Messages;
+      // the shouty suffix is theirs, not a signal to skip the mapping.
+      purple_FOR_SUBAGENTS_ONLY: "#a78bfa",
+      success: "var(--c-success)",
+      error: "var(--c-danger)",
+      text: "var(--c-fg-1)",
+      secondaryText: "var(--c-fg-2)",
+    },
+    // Pick a category color: known SDK theme token → our palette; a literal
+    // CSS color (should the SDK ever start sending one) passes through; and
+    // anything unrecognised gets a stable hash-based hue so new categories
+    // still render as distinct segments instead of disappearing.
     ctxCategoryColor(cat) {
-      if (cat && cat.color) return cat.color;
+      const raw = (cat && cat.color) || "";
+      if (raw && this.ctxColorTokens[raw]) return this.ctxColorTokens[raw];
+      if (raw && this._isCssColor(raw)) return raw;
       const n = (cat && cat.name) || "?";
       let h = 0;
       for (let i = 0; i < n.length; i++) h = (h * 31 + n.charCodeAt(i)) >>> 0;
       return `hsl(${h % 360}, 55%, 55%)`;
+    },
+    _isCssColor(v) {
+      try {
+        if (window.CSS && CSS.supports) return CSS.supports("color", v);
+      } catch (_e) {}
+      // No CSS.supports → only trust shapes that can't be a bare token name.
+      return /^(#|rgba?\(|hsla?\(|var\()/.test(v);
+    },
+    // Split the SDK's flat `categories` array into what the popup can honestly
+    // render. Three quirks it absorbs, each verified against a live response
+    // (totalTokens 84835, maxTokens 200000):
+    //
+    //  1. "Free space" is in `categories`, but it is the REMAINDER, not usage.
+    //     Rendering it as a peer made it the single largest bar (57% of the
+    //     window), flattening every real category — while restating what the
+    //     "84.8K / 200K" header already says. It becomes the unfilled part of
+    //     the stack instead, plus one footer row.
+    //  2. "(deferred)" rows (MCP tools 4.3K, System tools 3.9K) are NOT part
+    //     of totalTokens. Summing all categories gave 208,235 against a
+    //     200,000 window — the 8,235 overflow is exactly those two, so the
+    //     stack overflowed its track by 4%. The SDK's own `gridRows` (the data
+    //     behind the CLI's /context square grid) omits them: its 100 cells
+    //     cover only System prompt / System tools / Memory files / Skills /
+    //     Messages / Free space. They stay visible — deferred tool schemas are
+    //     budget we SAVED and worth seeing — but in their own section, out of
+    //     the stack, and labelled as uncounted.
+    //  3. Drill-down arrays use inconsistent shapes: memoryFiles keys the name
+    //     as `path` (not `name`), and skills is an OBJECT wrapping
+    //     `skillFrontmatter`. The template read `item.name` for all of them,
+    //     so expanding Memory files — the 2nd largest real row — produced 14
+    //     rows of blank labels. Normalised to {label, title, meta, tokens}.
+    _ctxBuildView(data) {
+      const cats = Array.isArray(data && data.categories) ? data.categories : [];
+      const used = [], deferred = [];
+      let freeTokens = 0;
+      for (const c of cats) {
+        const name = String((c && c.name) || "");
+        if (/free\s*space/i.test(name)) { freeTokens += Number(c.tokens) || 0; continue; }
+        if (/\(\s*deferred\s*\)/i.test(name)) { deferred.push(c); continue; }
+        used.push(c);
+      }
+      const sum = list => list.reduce((a, c) => a + (Number(c.tokens) || 0), 0);
+      const children = {};
+      for (const c of used.concat(deferred)) {
+        const kids = this._ctxChildrenFor(data, c.name);
+        if (kids.length) children[c.name] = kids;
+      }
+      return {
+        used, deferred, freeTokens,
+        usedTotal: sum(used),
+        deferredTotal: sum(deferred),
+        children,
+      };
+    },
+    // Map a category name to its normalised drill-down list. Match is fuzzy
+    // (lowercased, separators stripped) because the SDK may localise labels.
+    // Sorted big-first: a 50-entry skill list is only useful if the rows that
+    // actually cost something are at the top.
+    _ctxChildrenFor(data, name) {
+      const key = String(name || "").toLowerCase().replace(/[\s_()-]/g, "");
+      let raw = [];
+      if (key.includes("memory")) {
+        raw = (data.memoryFiles || []).map(f => {
+          const path = String(f.path || f.name || "");
+          const parts = path.split("/").filter(Boolean);
+          return {
+            label: parts.slice(-2).join("/") || path,
+            title: path,
+            meta: f.type || "",
+            tokens: Number(f.tokens) || 0,
+          };
+        });
+      } else if (key.includes("mcp")) {
+        raw = (data.mcpTools || []).map(t => ({
+          // Strip the mcp__<server>__ prefix — it's already in `meta`, and on
+          // a phone the prefix eats the whole column.
+          label: String(t.name || "").replace(/^mcp__[^_]+__/, "") || String(t.name || ""),
+          title: t.name || "",
+          meta: t.serverName || "",
+          tokens: Number(t.tokens) || 0,
+        }));
+      } else if (key.includes("skill")) {
+        const sk = data.skills || {};
+        raw = (sk.skillFrontmatter || []).map(s => ({
+          label: s.name || "", title: s.name || "",
+          meta: s.source || "", tokens: Number(s.tokens) || 0,
+        }));
+      } else if (key.includes("agent")) {
+        raw = (data.agents || []).map(a => ({
+          label: a.name || "", title: a.name || "",
+          meta: a.source || "", tokens: Number(a.tokens) || 0,
+        }));
+      }
+      return raw.filter(x => x.label).sort((a, b) => b.tokens - a.tokens);
     },
     ctxFormatTokens(n) {
       if (!n) return "0";
@@ -8962,18 +9167,13 @@ function portal() {
         ? (this.lang === "zh" ? "（估算）" : " (estimate)") : "";
       return `${used} · ${this.lang === "zh" ? "窗口" : "window"}：${limitSource}${estimated}`;
     },
-    // Map a category name to its detailed sub-list. SDK returns
-    // memoryFiles / mcpTools / agents as separate top-level arrays; we
-    // surface them under whichever category row carries the same totals.
-    // Match is fuzzy (lowercased + stripped of separators) since the SDK
-    // labels may localize the category name.
+    // Drill-down rows for a category. Prebuilt by _ctxBuildView so repeated
+    // Alpine passes reuse one array (a fresh array per render would defeat
+    // x-for keying and re-sort 50 skills on every reactive tick).
     ctxRowChildren(name) {
-      const data = this.ctxBreakdown.data || {};
-      const key = String(name || "").toLowerCase().replace(/[\s_-]/g, "");
-      if (key.includes("memory")) return data.memoryFiles || [];
-      if (key.includes("mcp")) return data.mcpTools || [];
-      if (key.includes("agent")) return data.agents || [];
-      return [];
+      const view = (this.ctxBreakdown && this.ctxBreakdown.view) || null;
+      if (!view) return [];
+      return view.children[name] || [];
     },
     ctxToggleRow(name) {
       if (!this.ctxRowChildren(name).length) return;
@@ -9025,8 +9225,8 @@ function portal() {
         windowMeta.push(`${this.lang === "zh" ? "可配置上限" : "configurable max"} ${this.ctxFormatTokens(ceiling)}`);
       }
       const hint = this.lang === "zh"
-        ? "（点击压缩 · 右键看拆分）"
-        : "(click to compact · right-click for breakdown)";
+        ? "（点击查看拆分，压缩入口在弹层里）"
+        : "(click for breakdown — Compact lives in that popup)";
       const meta = windowMeta.length ? ` · ${windowMeta.join(" · ")}` : "";
       return `${used_s} / ${limit_s} (${pct}%) · ${modelLabel}\n${usedSource} · ${limitSource}${meta}\n${hint}`;
     },
@@ -10439,6 +10639,7 @@ function portal() {
         // no-window responses report offset 0 (whole chain in hand).
         st._loadedOffset = Number.isInteger(s.offset) ? s.offset : 0;
         st._total = Number.isInteger(s.total) ? s.total : all.length;
+        st._preTotal = Number.isInteger(s.pre_total) ? s.pre_total : 0;
         // Trimming may evict the oldest cached bubbles and advance the cursor,
         // so it must run after the response coordinate has been installed.
         // A canonical load is anchored at the newest end. If the selected
@@ -10946,7 +11147,13 @@ function portal() {
       ownerState._laterMessages = [];
       ownerState._loadedOffset = 0;
       ownerState.historyGeneration = "";
+      // Conflict recovery drops back to normal order by design: the chain was
+      // rewritten under us, so a full-order cursor is stale. A reader who had
+      // crossed into pre-compact history gets returned to the live tail and
+      // has to cross again — loadSession() repopulates _preTotal so the
+      // button is there waiting.
       ownerState._historyOrder = "normal";
+      ownerState._preTotal = 0;
       ownerState._hasServerLater = false;
       return this.loadSession(sid, { quiet: sid === this.currentId });
     },
@@ -10996,6 +11203,7 @@ function portal() {
         st._earlierMessages = win.concat(st._earlierMessages || []);
         st._loadedOffset = Number.isInteger(data.offset) ? data.offset : newOffset;
         if (Number.isInteger(data.total)) st._total = data.total;
+        if (Number.isInteger(data.pre_total)) st._preTotal = data.pre_total;
         st.historyGeneration = data.history_generation || st.historyGeneration || "";
         st._historyOrder = data.history_order === "full" ? "full" : "normal";
         if (sid === this.currentId) this.historyGeneration = st.historyGeneration;
@@ -11047,6 +11255,7 @@ function portal() {
         const win = this._historyEnvelopes(sid, data.messages || []);
         st._laterMessages = (st._laterMessages || []).concat(win);
         if (Number.isInteger(data.total)) st._total = data.total;
+        if (Number.isInteger(data.pre_total)) st._preTotal = data.pre_total;
         st.historyGeneration = data.history_generation || st.historyGeneration || "";
         st._historyOrder = data.history_order === "full" ? "full" : "normal";
         if (sid === this.currentId) this.historyGeneration = st.historyGeneration;
@@ -11085,6 +11294,42 @@ function portal() {
       // Clamp so a pathological estimate can't itself become a big jump.
       return Math.max(64, Math.min(h, 4000));
     },
+    // Cross from the post-/compact chain (normal order) into the transcript's
+    // real beginning (full order), landing at the coordinate the reader is
+    // already looking at.
+    //
+    // Deliberately NOT `_loadedOffset += pre_total` with `&full=1`: full order
+    // keeps the sidechain / team / meta records that normal filters out, so
+    // the two orders interleave rather than translate — any arithmetic across
+    // them mis-seats the window by however many subagent turns happen to sit
+    // in the range. Instead we hand the server a uuid and let it report the
+    // exact full-order offset back, reusing the same around_uuid path the
+    // outline's jump-to-pre-compact-prompt has been driving all along.
+    async _switchToFullOrder(sid) {
+      sid = sid || this.currentId;
+      if (!sid) return false;
+      const st = this._ensureTabState(sid);
+      if (!this._preCompactReachable(st)) return false;
+      // Anchor on the OLDEST bubble we hold: after the swap everything newly
+      // revealed lands above it, which is what "load earlier" should feel like.
+      const anchor = (this._allPaneMessages(st) || []).find(m => m && m.uuid);
+      if (!anchor) return false;
+      const anchorUuid = anchor.uuid;
+      const ok = await this._loadAroundMessage(sid, anchorUuid);
+      if (!ok || this.tabState[sid] !== st) return false;
+      // _loadAroundMessage replaces the mounted window, so without re-anchoring
+      // the viewport the reader gets teleported mid-transcript. Jump-to-start
+      // (not centred, no highlight flash) keeps the message they were reading
+      // at the fold with the recovered history stacked above it.
+      this.$nextTick(() => {
+        if (this.tabState[sid] !== st || sid !== this.currentId) return;
+        const body = this.$refs && this.$refs.chatBody;
+        const el = body && body.querySelector(
+          `.msg[data-uuid="${CSS.escape(anchorUuid)}"]`);
+        if (el) el.scrollIntoView({ block: "start" });
+      });
+      return true;
+    },
     async loadEarlierMessages(sid) {
       sid = sid || this.currentId;
       if (!sid) return;
@@ -11099,6 +11344,16 @@ function portal() {
       if (st._loadingEarlier) return;
       st._loadingEarlier = true;
       try {
+      // Exhausted this order (nothing stashed, offset at 0) but the chain we
+      // are reading isn't the transcript's start — cross orders instead of
+      // reporting "no more". One click = one crossing; the swap itself brings
+      // the older window in, so we're done for this press.
+      if ((!st._earlierMessages || !st._earlierMessages.length)
+          && !(st._loadedOffset > 0)
+          && this._preCompactReachable(st)) {
+        await this._switchToFullOrder(sid);
+        return;
+      }
       // Stash empty but server holds older history → page a window in first.
       if ((!st._earlierMessages || !st._earlierMessages.length)
           && st._loadedOffset > 0) {
@@ -11106,8 +11361,9 @@ function portal() {
       }
       if (!st._earlierMessages || !st._earlierMessages.length) {
         // Nothing local and nothing (more) on the server: recompute flags
-        // so the button hides itself.
-        st._hasMoreHistory = st._loadedOffset > 0;
+        // so the button hides itself. Pre-chain history counts as "more" —
+        // hiding the button here would strand it behind an unreachable state.
+        st._hasMoreHistory = st._loadedOffset > 0 || this._preCompactReachable(st);
         return;
       }
       // Take from the END of the earlier stash (those are the messages
@@ -11264,7 +11520,19 @@ function portal() {
       // The bounded cache is a sliding window: reaching its size cap no longer
       // blocks older paging because the far-future side is evicted on demand.
       if (st._earlierMessages && st._earlierMessages.length) return true;
-      return st._loadedOffset > 0;
+      if (st._loadedOffset > 0) return true;
+      // Sitting at offset 0 of a chain that itself starts partway into the
+      // transcript (post-/compact). Nothing is "earlier" in THIS order, but
+      // _switchToFullOrder can cross into the order where there is.
+      return this._preCompactReachable(st);
+    },
+    // True iff stranded pre-chain history exists and we haven't crossed into
+    // it yet. Once _historyOrder is "full" those bubbles are inside _total and
+    // ordinary offset paging owns them, so the predicate must go quiet or the
+    // button would never turn off at the true start of history.
+    _preCompactReachable(st) {
+      if (!st) return false;
+      return st._historyOrder !== "full" && (st._preTotal || 0) > 0;
     },
     earlierMessageCount(sid) {
       sid = sid || this.currentId;
@@ -11272,9 +11540,11 @@ function portal() {
       const st = this.tabState[sid];
       if (!st) return 0;
       // Older messages = those still on the server (before our window) plus
-      // those held in the in-memory stash.
+      // those held in the in-memory stash, plus anything stranded before this
+      // chain's root (pre-/compact) that we haven't crossed into yet.
       const stash = st._earlierMessages ? st._earlierMessages.length : 0;
-      return (st._loadedOffset || 0) + stash;
+      const pre = this._preCompactReachable(st) ? (st._preTotal || 0) : 0;
+      return (st._loadedOffset || 0) + stash + pre;
     },
     historyTruncated(sid) {
       sid = sid || this.currentId;
@@ -12582,10 +12852,28 @@ function portal() {
       return ok;
     },
     _fileTreeRowHeight() {
-      // Must match .filelist row min-height in styles.css. Coarse pointers use
-      // the larger touch target even when the viewport is desktop-sized.
+      // MEASURED from a live row, not hard-coded. The old constants (40 touch /
+      // 22 desktop) were the CSS `min-height`, but padding and line-height push
+      // the real box taller — a touch row measures ~48px, not 40. That 8px
+      // per-row error compounds through the virtual scroller: 100 rows of tree
+      // put the spacers 800px out of sync with reality, so scrolling landed on
+      // the wrong slice. Fall back to the CSS floor only before first paint.
+      if (this._fileTreeRowHeightCache > 0) return this._fileTreeRowHeightCache;
+      const list = this.$refs && this.$refs.fileList;
+      const row = list && list.querySelector(
+        "li:not(.filelist-virtual-spacer):not(.filelist-status)");
+      const measured = row ? row.getBoundingClientRect().height : 0;
+      if (measured > 0) {
+        this._fileTreeRowHeightCache = measured;
+        return measured;
+      }
       return window.matchMedia && window.matchMedia("(pointer: coarse)").matches
         ? 40 : 22;
+    },
+    // Invalidated on resize / zoom / font-size change — anything that can
+    // reflow a row. Cheap to recompute (one getBoundingClientRect).
+    _invalidateFileTreeRowHeight() {
+      this._fileTreeRowHeightCache = 0;
     },
     _syncFileTreeViewport(list = this.$refs && this.$refs.fileList) {
       if (!list) return;
@@ -14745,16 +15033,6 @@ function portal() {
       this._terminalSend(text);
       this.$nextTick(() => requestAnimationFrame(() => {
         if (this._terminal) this._terminal.focus();
-      }));
-    },
-    openTerminalManagerFromChat() {
-      if (!this.terminalEnabled) return;
-      this.setMobileTab("preview");
-      // Defer opening past the originating chat-header click. Otherwise the
-      // preview manager's @click.outside sees that same click and immediately
-      // closes the popup before the newly-visible pane paints.
-      this.$nextTick(() => requestAnimationFrame(() => {
-        if (this.mobileTab === "preview") this.terminalManagerOpen = true;
       }));
     },
     _attachTerminalSelectionCopy(host, term) {
@@ -20133,6 +20411,32 @@ function portal() {
         };
         this.rlBadge = this.rateLimitWorst();
       });
+      // Backend preflight auto-compact. Drives the SAME per-tab `compacting`
+      // flag the manual compact button sets, so the 📦 bubble, the ctx-meter
+      // shimmer and the "busy" checks all light up identically — the user
+      // shouldn't have to know whether a compact was their idea or the
+      // backend's. Written on streamState (not `this`) so a background tab's
+      // compact doesn't animate the tab you're looking at.
+      es.addEventListener("compact_progress", ev => {
+        let d;
+        try { d = JSON.parse(ev.data); } catch (_) { return; }
+        if (!streamState) return;
+        if (d.phase === "start") {
+          streamState.compacting = true;
+          streamState._compactStartedAt = Date.now();
+          if (streamSid === this.currentId) {
+            this.toast(this.lang === "zh"
+              ? `上下文 ${Math.round((d.used || 0) / 1000)}K，自动压缩中…`
+              : `Context ${Math.round((d.used || 0) / 1000)}K — auto-compacting…`,
+              "info", 4000);
+          }
+        } else if (d.phase === "end") {
+          streamState.compacting = false;
+          streamState._compactStartedAt = 0;
+          // Failure is terminal for the turn — the `error` event lands next
+          // and owns the toast. Don't double-report here.
+        }
+      });
       es.addEventListener("ask_user_question", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
@@ -20207,6 +20511,12 @@ function portal() {
         streamState.es = null;
         streamState._stopping = false;
         streamState._serverActiveObserved = false;
+        // Belt-and-braces for the auto-compact bubble: a turn that dies inside
+        // /compact (transport drop, 10-min timeout) may never deliver the
+        // phase:"end" event, and a 📦 bubble spinning forever on an idle tab
+        // would read as "still working" and block the queue's busy check.
+        streamState.compacting = false;
+        streamState._compactStartedAt = 0;
         if (!(Number(backgroundPending) > 0 && !cancelled)) {
           streamState.activeTurnId = "";
           streamState.parentTurnId = "";
@@ -21335,20 +21645,86 @@ function portal() {
     },
     activityGroups() {
       const zh = this.lang === "zh";
+      // Grouped strictly by STATE, in the order the user has to act on them.
+      // Read/unread deliberately no longer decides the group: it used to, and
+      // a finished task jumped from "results to review" into "recent" the
+      // moment you glanced at it — items moving under the cursor makes the
+      // list impossible to build any spatial memory of. Unread is shown
+      // in-row instead (see .activity-row.is-unread).
       return [
-        { key: "attention", label: zh ? "需要处理" : "Needs attention", states: ["waiting_approval", "paused"] },
-        { key: "unread", label: zh ? "待查看结果" : "Results to review", states: ["completed"], unreadOnly: true },
-        { key: "running", label: zh ? "进行中" : "Running", states: ["running"] },
-        { key: "recent", label: zh ? "最近完成" : "Recent", states: ["completed", "failed", "cancelled"], readOnly: true },
+        { key: "attention", label: zh ? "待决策" : "Awaiting decision", states: ["waiting_approval"] },
+        // Failure used to live under a heading that read "Recent" — a failed
+        // task is not a completed one, and burying it there is why the filter
+        // below needed a special case to keep unread failures visible at all.
+        { key: "failed", label: zh ? "运行失败" : "Failed", states: ["failed"] },
+        // Paused is an interrupted run, not an outcome, so it belongs here
+        // rather than under a heading that asks the user for a decision.
+        { key: "running", label: zh ? "进行中" : "Running", states: ["running", "paused"] },
+        { key: "done", label: zh ? "已结束" : "Finished", states: ["completed", "cancelled"] },
       ];
     },
-    activityEvents(group) {
+    // Rows shown per group before "show all". A durable cross-workspace
+    // ledger accumulates hundreds of finished tasks, and an uncapped list
+    // buries the two groups that need action under the one that does not.
+    ACTIVITY_GROUP_CAP: 5,
+    activityAllEvents(group) {
       const states = new Set(group.states || []);
-      return (this.activity.events || []).filter(item => {
-        const unread = !!item.needs_attention && !item.read;
-        return states.has(item.state) && (!group.unreadOnly || unread)
-          && (!group.readOnly || !unread || item.state === "failed");
-      });
+      return (this.activity.events || []).filter(item => states.has(item.state));
+    },
+    activityEvents(group) {
+      const all = this.activityAllEvents(group);
+      if (this.activity.expanded[group.key]) return all;
+      return all.slice(0, this.ACTIVITY_GROUP_CAP);
+    },
+    activityHiddenCount(group) {
+      return Math.max(
+        0, this.activityAllEvents(group).length - this.ACTIVITY_GROUP_CAP);
+    },
+    toggleActivityGroup(key) {
+      this.activity.expanded[key] = !this.activity.expanded[key];
+    },
+    // Header-chip count. Deliberately computed from the loaded events rather
+    // than from `activity.summary`: the backend summary only reports
+    // running/unread/attention, which is exactly why the header used to show
+    // two numbers while the body showed four groups. Counting client-side
+    // keeps the two in sync with no API change.
+    activityGroupCount(group) {
+      return this.activityAllEvents(group).length;
+    },
+    activityVisibleGroups() {
+      const groups = this.activityGroups();
+      const on = this.activity.filter || [];
+      if (!on.length) return groups;
+      return groups.filter(g => on.includes(g.key));
+    },
+    // Multi-select, not radio. The chips read as a filter bar, and a filter bar
+    // that silently drops your previous pick when you add a second one is the
+    // kind of thing you only notice after wondering where the failures went.
+    // Empty selection === show everything (no "all" chip needed).
+    isActivityFilterOn(key) {
+      return (this.activity.filter || []).includes(key);
+    },
+    toggleActivityFilter(key) {
+      const on = (this.activity.filter || []).slice();
+      const at = on.indexOf(key);
+      if (at >= 0) on.splice(at, 1);
+      else on.push(key);
+      // Replace the array rather than mutate: Alpine v3 doesn't deep-wrap
+      // array contents, so an in-place splice on the nested `activity.filter`
+      // wouldn't re-run the `:class` bindings.
+      this.activity.filter = on;
+    },
+    clearActivityFilter() {
+      this.activity.filter = [];
+    },
+    // Unread-in-this-group count. Drives the chip's colour: a group only earns
+    // its warning/danger tint while something in it is UNACKED. Opening an
+    // event acks it (openActivityEvent → POST /ack), so a failure you've
+    // already looked at stops shouting — previously the red dot was keyed to
+    // "group is non-empty", which meant it never went away.
+    activityGroupUnread(group) {
+      return this.activityAllEvents(group)
+        .filter(x => x && x.needs_attention && !x.read).length;
     },
     activityStateLabel(state) {
       const zh = this.lang === "zh";

--- a/frontend/i18n/index.js
+++ b/frontend/i18n/index.js
@@ -277,6 +277,11 @@ window.MUSELAB_STRINGS = {
     "rl.limited": "已限流",
     "rl.overage": "超额",
     "rl.resets": "{t}后重置",
+    // label = visible field caption, title = tooltip prose. Mirrors
+    // thinking.label / thinking.title below. Using `title` as a caption
+    // wrapped to 3 lines and blew the composer settings panel past its
+    // clip box.
+    "effort.label": "Effort",
     "effort.title": "Effort — Anthropic 官方术语，控制推理预算与 agentic loop 深度（不译）",
     "effort.auto": "Effort · auto",
     "effort.low": "Effort · low",
@@ -664,6 +669,7 @@ window.MUSELAB_STRINGS = {
     "rl.limited": "Rate-limited",
     "rl.overage": "Overage",
     "rl.resets": "resets in {t}",
+    "effort.label": "Effort",
     "effort.title": "Reasoning effort — thinking budget + agentic loop depth",
     "effort.auto": "Effort · auto",
     "effort.low": "Effort · low",

--- a/frontend/i18n/index.js
+++ b/frontend/i18n/index.js
@@ -281,6 +281,8 @@ window.MUSELAB_STRINGS = {
     // thinking.label / thinking.title below. Using `title` as a caption
     // wrapped to 3 lines and blew the composer settings panel past its
     // clip box.
+    "concise.label": "简洁模式",
+    "concise.title": "隐藏工具调用、改动预览与工具输出，只留对话气泡与思考块；失败的工具仍会显示。按设备记忆。",
     "effort.label": "Effort",
     "effort.title": "Effort — Anthropic 官方术语，控制推理预算与 agentic loop 深度（不译）",
     "effort.auto": "Effort · auto",
@@ -669,6 +671,8 @@ window.MUSELAB_STRINGS = {
     "rl.limited": "Rate-limited",
     "rl.overage": "Overage",
     "rl.resets": "resets in {t}",
+    "concise.label": "Concise",
+    "concise.title": "Hide tool calls, diff previews and tool output — keep the conversation and thinking blocks. Failed tools still show. Remembered per device.",
     "effort.label": "Effort",
     "effort.title": "Reasoning effort — thinking budget + agentic loop depth",
     "effort.auto": "Effort · auto",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2245,7 +2245,7 @@
               </template>
 
               <!-- default tool bubble -->
-              <template x-if="m.role === 'tool_use' && m.name !== 'TodoWrite' && m.name !== 'Task' && m.name !== 'Agent' && m.name !== 'ExitPlanMode' && !isTaskTool(m)">
+              <template x-if="m.role === 'tool_use' && m.name !== 'TodoWrite' && m.name !== 'Task' && m.name !== 'Agent' && m.name !== 'ExitPlanMode' && !isTaskTool(m) && !conciseHidesToolUse(m)">
                 <div class="msg-row">
                   <span class="msg-avatar assistant-avatar"
                         :class="{ 'is-streaming-avatar': isStreamingTurnAvatar(i, paneMsgs, pane && pane.streaming) }"
@@ -2329,7 +2329,10 @@
                    nesting two roots in one x-if silently drops the second.
                    The role guard here recovers what the parent x-if used to
                    filter for. -->
-              <template x-if="m.role === 'tool_use' && ['Edit','MultiEdit','Write'].includes(m.name) && m.input && (m.input.old_string || m.input.new_string || m.input.edits || m.input.content)">
+              <!-- The diff strip is a SECOND x-if on the same tool_use message,
+                   so it needs its own concise gate — the generic bubble's gate
+                   above does not cover it. -->
+              <template x-if="m.role === 'tool_use' && ['Edit','MultiEdit','Write'].includes(m.name) && m.input && (m.input.old_string || m.input.new_string || m.input.edits || m.input.content) && !conciseHidesToolUse(m)">
                 <div class="diff-strip diff-strip-cr"
                      :class="{ 'is-collapsed': !isMsgExpanded(i, m, isLatestEditTool(i, m, paneMsgs, tid), pane, paneMsgs) }">
                   <div class="diff-strip-head" @click.stop="toggleMsgExpanded(m, i)">
@@ -3020,6 +3023,18 @@
                 <option :value="opt.value" x-text="effortOptLabel(opt)"></option>
               </template>
             </select>
+          </label>
+          <!-- Concise mode. A device preference, not a session one — it sits
+               here rather than in Settings because the screen it fixes is the
+               one you're holding, and this panel is already the "how does this
+               chat behave" drawer within thumb reach. -->
+          <label class="chat-toolbar-more-field row">
+            <span x-text="t('concise.label')" :title="t('concise.title')"></span>
+            <span class="switch sm">
+              <input type="checkbox" :checked="conciseChat"
+                     @change="toggleConciseChat()">
+              <span class="switch-slider"></span>
+            </span>
           </label>
         </div>
         <!-- / slash command palette -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -166,7 +166,14 @@
   <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></symbol>
   <symbol id="i-msg" viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></symbol>
   <symbol id="i-at" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-4 8"/></symbol>
-  <symbol id="i-cog" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></symbol>
+  <!-- 2026-07-25: `i-cog` was deleted — its path was character-for-character
+       identical to `i-settings`, so one glyph was standing for two different
+       ideas. Real settings surfaces now use `i-settings`; the composer's
+       per-turn parameter popover uses `i-sliders` below, which is what it
+       actually does (adjust permission / effort for THIS turn, not configure
+       the app). -->
+  <!-- Lucide sliders-horizontal. Reads as "tune the knobs for this turn". -->
+  <symbol id="i-sliders" viewBox="0 0 24 24"><line x1="21" y1="4" x2="14" y2="4"/><line x1="10" y1="4" x2="3" y2="4"/><line x1="21" y1="12" x2="12" y2="12"/><line x1="8" y1="12" x2="3" y2="12"/><line x1="21" y1="20" x2="16" y2="20"/><line x1="12" y1="20" x2="3" y2="20"/><line x1="14" y1="2" x2="14" y2="6"/><line x1="8" y1="10" x2="8" y2="14"/><line x1="16" y1="18" x2="16" y2="22"/></symbol>
   <symbol id="i-inbox" viewBox="0 0 24 24"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></symbol>
   <symbol id="i-file-search" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="14 2 14 8 20 8"/><circle cx="11" cy="14" r="2"/><path d="m13 16 2 2"/></symbol>
   <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></symbol>
@@ -1326,19 +1333,18 @@
         <button class="activity-center-btn" type="button" @click="openActivityCenter()"
                 :class="{ active: activity.summary.running || activity.summary.unread, danger: activity.summary.attention }"
                 :title="lang==='zh' ? '全局任务中心' : 'Global activity center'">
-          <svg><use href="#i-list"/></svg>
+          <!-- Inbox, not the generic list glyph: `i-list` also marks the tab
+               picker and the scheduler section, so three unrelated surfaces
+               were sharing one shape. An inbox says "things arrived for you". -->
+          <svg><use href="#i-inbox"/></svg>
           <span class="activity-running" x-show="activity.summary.running" aria-hidden="true"></span>
           <span class="activity-unread" x-show="activity.summary.unread" aria-hidden="true"></span>
         </button>
-        <!-- Mobile chat-header shortcut. The terminal itself remains a preview
-             surface; this switches panes and opens the full terminal manager. -->
-        <button class="icon-btn chat-terminal-btn" x-show="terminalEnabled"
-                @click="openTerminalManagerFromChat()"
-                :title="lang==='zh' ? '终端' : 'Terminal'"
-                :aria-label="lang==='zh' ? '打开终端列表' : 'Open terminal list'">
-          <span class="terminal-glyph">&gt;_</span>
-          <span class="terminal-count" x-show="terminals.length" x-text="terminals.length"></span>
-        </button>
+        <!-- 2026-07-25: removed the mobile-only terminal shortcut that used to
+             sit here. The terminal is a preview-pane surface and the preview
+             header already carries `.terminal-manager-btn`, so this was a
+             second button for the same thing — competing for the scarcest row
+             in the mobile UI. Entry point is now the preview header only. -->
         <!-- Skills + MCP drawer toggles. 2026-05-29: 从 chat-input 底 bar 移到
              顶 bar，与其它「能力 / 会话」入口（定时任务、命令面板）
              并列；底 bar 只留 attach / 模型 / 权限 / effort / context ring 等
@@ -1434,54 +1440,124 @@
              x-text="lang==='zh' ? '查询中…' : 'Loading…'"></div>
         <div x-show="ctxBreakdown.error && !ctxBreakdown.loading"
              class="ctx-breakdown-body err" x-text="ctxBreakdown.error"></div>
-        <template x-if="ctxBreakdown.data && !ctxBreakdown.loading">
+        <template x-if="ctxBreakdown.view && !ctxBreakdown.loading">
           <div class="ctx-breakdown-body">
             <div class="ctx-breakdown-summary"
                  x-text="((ctxBreakdown.data.totalTokens||0)/1000).toFixed(1) + 'K / ' + ((ctxBreakdown.data.maxTokens||0)/1000).toFixed(0) + 'K (' + (ctxBreakdown.data.percentage||0).toFixed(1) + '%)'"></div>
             <div class="ctx-breakdown-summary"
                  x-text="ctxBreakdownAccuracyLabel()"></div>
-            <!-- Stacked bar — shows each category as a colored segment so the
-                 user can eyeball "where did 50K go" at a glance. -->
+            <!-- Stacked bar — one segment per OCCUPIED category, width relative
+                 to maxTokens. The unfilled remainder of the track IS the free
+                 space, so "Free space" is deliberately not a segment: as a peer
+                 it was the largest bar in the popup and squashed everything
+                 real. Deferred rows are excluded too — they aren't in
+                 totalTokens and used to overflow the track by 4%. -->
             <div class="ctx-breakdown-stack">
-              <template x-for="cat in (ctxBreakdown.data.categories || [])" :key="cat.name">
+              <template x-for="cat in ctxBreakdown.view.used" :key="cat.name">
                 <div class="ctx-breakdown-stack-seg"
                      :style="`width: ${ctxCategoryPct(cat)}%; background: ${ctxCategoryColor(cat)}`"
                      :title="cat.name + ' · ' + ctxFormatTokens(cat.tokens)"></div>
               </template>
             </div>
-            <template x-for="cat in (ctxBreakdown.data.categories || [])" :key="cat.name">
-              <div class="ctx-breakdown-row"
-                   :class="{ expandable: ctxRowChildren(cat.name).length, expanded: ctxExpanded[cat.name] }"
-                   @click="ctxToggleRow(cat.name)">
-                <span class="ctx-breakdown-swatch"
-                      :style="`background: ${ctxCategoryColor(cat)}`"></span>
-                <span class="ctx-breakdown-name" x-text="cat.name"></span>
-                <span class="ctx-breakdown-bar">
-                  <span class="ctx-breakdown-bar-fill"
-                        :style="`width: ${ctxCategoryPct(cat)}%; background: ${ctxCategoryColor(cat)}`"></span>
-                </span>
-                <span class="ctx-breakdown-tokens"
-                      x-text="ctxFormatTokens(cat.tokens)"></span>
-                <span class="ctx-breakdown-caret"
-                      x-show="ctxRowChildren(cat.name).length"
-                      x-text="ctxExpanded[cat.name] ? '▾' : '▸'"></span>
-              </div>
-              <template x-if="ctxExpanded[cat.name] && ctxRowChildren(cat.name).length">
-                <div class="ctx-breakdown-sub">
-                  <template x-for="item in ctxRowChildren(cat.name)" :key="item.name + '-' + item.tokens">
-                    <div class="ctx-breakdown-subrow">
-                      <span class="ctx-breakdown-subname" x-text="item.name"></span>
-                      <span class="ctx-breakdown-subtokens"
-                            x-text="ctxFormatTokens(item.tokens)"></span>
-                    </div>
-                  </template>
+            <template x-for="cat in ctxBreakdown.view.used" :key="cat.name">
+              <div>
+                <div class="ctx-breakdown-row"
+                     :class="{ expandable: ctxRowChildren(cat.name).length, expanded: ctxExpanded[cat.name] }"
+                     @click="ctxToggleRow(cat.name)">
+                  <span class="ctx-breakdown-swatch"
+                        :style="`background: ${ctxCategoryColor(cat)}`"></span>
+                  <span class="ctx-breakdown-name" :title="cat.name" x-text="cat.name"></span>
+                  <span class="ctx-breakdown-tokens"
+                        x-text="ctxFormatTokens(cat.tokens)"></span>
+                  <span class="ctx-breakdown-pct" x-text="ctxPctLabel(cat)"></span>
+                  <span class="ctx-breakdown-caret"
+                        x-show="ctxRowChildren(cat.name).length"
+                        x-text="ctxExpanded[cat.name] ? '▾' : '▸'"></span>
                 </div>
-              </template>
+                <template x-if="ctxExpanded[cat.name] && ctxRowChildren(cat.name).length">
+                  <div class="ctx-breakdown-sub">
+                    <template x-for="item in ctxRowChildren(cat.name)" :key="item.title + '-' + item.tokens">
+                      <div class="ctx-breakdown-subrow" :title="item.title">
+                        <span class="ctx-breakdown-subname" x-text="item.label"></span>
+                        <span class="ctx-breakdown-submeta" x-show="item.meta" x-text="item.meta"></span>
+                        <span class="ctx-breakdown-subtokens"
+                              x-text="ctxFormatTokens(item.tokens)"></span>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <!-- Remainder, stated once as a plain figure. No swatch —
+                 it isn't a slice of anything, it's what's left of the track
+                 above. -->
+            <div class="ctx-breakdown-row free">
+              <span class="ctx-breakdown-name"
+                    x-text="lang==='zh' ? '剩余' : 'Free space'"></span>
+              <span class="ctx-breakdown-tokens"
+                    x-text="ctxFormatTokens(ctxBreakdown.view.freeTokens)"></span>
+              <span class="ctx-breakdown-pct"
+                    x-text="ctxPctLabel({ tokens: ctxBreakdown.view.freeTokens })"></span>
+              <span class="ctx-breakdown-caret"></span>
+            </div>
+            <!-- Deferred tool schemas: real budget, but budget NOT spent —
+                 absent from totalTokens and from the SDK's own gridRows. Kept
+                 visible (it's what ToolSearch buys us) and kept clearly
+                 separate so it can't be read as occupancy. -->
+            <template x-if="ctxBreakdown.view.deferred.length">
+              <div class="ctx-breakdown-deferred">
+                <div class="ctx-breakdown-deferred-head"
+                     x-text="(lang==='zh' ? '未计入（按需加载，已省下 ' : 'Not counted (loaded on demand, saves ')
+                             + ctxFormatTokens(ctxBreakdown.view.deferredTotal)
+                             + (lang==='zh' ? '）' : ')')"></div>
+                <template x-for="cat in ctxBreakdown.view.deferred" :key="cat.name">
+                  <div>
+                    <div class="ctx-breakdown-row deferred"
+                         :class="{ expandable: ctxRowChildren(cat.name).length, expanded: ctxExpanded[cat.name] }"
+                         @click="ctxToggleRow(cat.name)">
+                      <span class="ctx-breakdown-swatch hollow"
+                            :style="`border-color: ${ctxCategoryColor(cat)}`"></span>
+                      <span class="ctx-breakdown-name" :title="cat.name" x-text="cat.name"></span>
+                      <span class="ctx-breakdown-tokens"
+                            x-text="ctxFormatTokens(cat.tokens)"></span>
+                      <!-- No % here on purpose: deferred tokens are not in
+                           totalTokens, so a share-of-window figure would be
+                           read as occupancy. Empty span keeps the column
+                           aligned with the counted rows above. -->
+                      <span class="ctx-breakdown-pct"></span>
+                      <span class="ctx-breakdown-caret"
+                            x-show="ctxRowChildren(cat.name).length"
+                            x-text="ctxExpanded[cat.name] ? '▾' : '▸'"></span>
+                    </div>
+                    <template x-if="ctxExpanded[cat.name] && ctxRowChildren(cat.name).length">
+                      <div class="ctx-breakdown-sub">
+                        <template x-for="item in ctxRowChildren(cat.name)" :key="item.title + '-' + item.tokens">
+                          <div class="ctx-breakdown-subrow" :title="item.title">
+                            <span class="ctx-breakdown-subname" x-text="item.label"></span>
+                            <span class="ctx-breakdown-submeta" x-show="item.meta" x-text="item.meta"></span>
+                            <span class="ctx-breakdown-subtokens"
+                                  x-text="ctxFormatTokens(item.tokens)"></span>
+                          </div>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
             </template>
             <div class="ctx-breakdown-hint"
                  x-text="lang==='zh' ? '说明：tools / system prompt 是 Claude Code CLI 内置；memoryFiles 是 CLAUDE.md union；messages 含所有历史 + tool_result' : 'Note: tools / system_prompt are CLI built-in; memoryFiles is CLAUDE.md union; messages include full history + tool results'"></div>
           </div>
         </template>
+        <!-- Compact lives here now that the ring itself opens this popup.
+             Outside the x-if so it stays reachable when the breakdown failed
+             to load — a 409 ("send a message first") is exactly the moment a
+             long session might still want compacting. -->
+        <div class="ctx-breakdown-actions">
+          <button class="btn-ghost sm"
+                  @click="ctxBreakdown.show = false; runCompact()"
+                  x-text="lang==='zh' ? '压缩对话…' : 'Compact session…'"></button>
+        </div>
       </div>
 
       <!-- Tab strip — like VS Code Claude. Each tab is an open session;
@@ -1823,10 +1899,56 @@
             <div :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i, paneMsgs) ? '' : ' is-hidden') + (m._noAnim ? ' no-anim' : '')"
                  :data-uuid="m.uuid || ''" :data-message-key="m._k"
                  :style="'contain-intrinsic-size: auto ' + estIntrinsicH(m) + 'px'">
-              <!-- compact-summary pill -->
+              <!-- Per-message wall-clock (`mts`, backend). Deliberately NOT on
+                   by default: an agentic turn is 30+ tool cards, and stamping
+                   every one of them costs more attention than it returns —
+                   the turn separator already answers "when" at the granularity
+                   anyone actually asks it. It appears only once you EXPAND a
+                   card, i.e. at the moment you're inspecting that specific
+                   step and its time is a real question. Live-streamed cards
+                   have no mts until the post-turn reconcile reloads canonical
+                   history; absent time simply renders nothing. -->
+              <div class="msg-time"
+                   x-show="m.mts
+                           && (m.role === 'tool_use' || m.role === 'tool_result'
+                               || m.role === 'thinking')
+                           && isMsgExpanded(i, m, false, pane, paneMsgs)"
+                   x-text="m.mts ? fmtTurnTime(m.mts) : ''"></div>
+              <!-- compact-summary pill + the summary itself.
+                   The pill used to be the ONLY thing rendered for this
+                   message — the summary body was dropped on the floor by
+                   both the user- and assistant-branch `!m._is_compact_summary`
+                   guards below. On a freshly-compacted session that is
+                   catastrophic: the SDK's post-compact view contains exactly
+                   ONE bubble (the summary), so the whole chat rendered as a
+                   lone pill over an empty screen while promising "摘要在下面".
+                   2026-07-25 user report: "啥也没有".
+                   That report was fixed by TWO changes at once — rendering the
+                   body at all, and defaulting it open while it was the pane's
+                   last bubble. The second one turned out to be the wrong half:
+                   a 10-20k-char summary unfurled on entry buries the actual
+                   conversation, and the "last bubble" test stays true through
+                   the whole next turn (nothing is appended until the first
+                   muse-side msg lands), so a running turn reads as a wall of
+                   summary. Collapsed by default now; the dead-end feel is
+                   handled by the state-tracking label below, which says
+                   "点击查看摘要" instead of promising a body that isn't there. -->
               <template x-if="m._is_compact_summary">
-                <div class="compact-summary-pill">
-                  <span x-text="lang==='zh' ? '📦 上方对话已压缩 · 以下为摘要' : '📦 Conversation compacted · summary below'"></span>
+                <div class="compact-summary-block">
+                  <button type="button" class="compact-summary-pill"
+                          @click="toggleMsgExpanded(m, i, false)"
+                          :aria-expanded="isMsgExpanded(i, m, false, pane, paneMsgs) ? 'true' : 'false'">
+                    <!-- Label tracks the open state: promising "摘要在下面" while
+                         collapsed is what made the old pill read as a dead end. -->
+                    <span x-text="isMsgExpanded(i, m, false, pane, paneMsgs)
+                                    ? (lang==='zh' ? '📦 上方对话已压缩 · 以下为摘要' : '📦 Conversation compacted · summary below')
+                                    : (lang==='zh' ? '📦 上方对话已压缩 · 点击查看摘要' : '📦 Conversation compacted · tap to read summary')"></span>
+                    <span class="compact-summary-caret"
+                          x-text="isMsgExpanded(i, m, false, pane, paneMsgs) ? '▾' : '▸'"></span>
+                  </button>
+                  <div class="compact-summary-body"
+                       x-show="isMsgExpanded(i, m, false, pane, paneMsgs)"
+                       x-html="compactSummaryHtml(m)"></div>
                 </div>
               </template>
 
@@ -2563,26 +2685,26 @@
                    tracks reactive deps (m.role / messages[i+1].role /
                    messages.length) directly — method calls aren't
                    guaranteed to wire up reactivity inside x-for. -->
+              <!-- Doubles as the TURN SEPARATOR. A session is otherwise one
+                   seamless stream of near-identical cards with no mark for
+                   "a turn ended here" — scrolling 300 messages on a phone,
+                   there is nothing to orient against. This row already sat at
+                   exactly the right place (the tail of every turn) and already
+                   carried the one fact worth anchoring to (the time), so it
+                   becomes the boundary rather than adding a second element.
+                   The streaming dots moved OUT of here to .turn-running-bar:
+                   they were only visible when you happened to be scrolled to
+                   the bottom, and keeping both would pulse two sets of dots
+                   ~20px apart. -->
               <div class="turn-footer"
                    x-show="m.role !== 'user'
                      && (i === paneMsgs.length - 1 || (paneMsgs[i + 1] && paneMsgs[i + 1].role === 'user'))
                      && (
-                       (pane && pane.streaming && i === paneMsgs.length - 1)
-                       || m.ts
+                       m.ts
                        || m.elapsed
-                       || (m.role === 'assistant' && m.uuid)
+                       || (m.role === 'assistant' && m.uuid && !(pane && pane.streaming))
                      )">
-                <span x-show="pane && pane.streaming && i === paneMsgs.length - 1"
-                      class="thinking-dots">
-                  <span></span><span></span><span></span>
-                </span>
-                <!-- Elapsed counter next to the streaming dots — kicks in
-                     after 1s so fast replies don't flash a "0s" label.
-                     Format: 12s / 2m50s / 1h05m (see fmtStreamElapsed). -->
-                <span x-show="pane && pane.streaming && i === paneMsgs.length - 1 && pane.streamElapsed >= 1"
-                      class="stream-elapsed"
-                      x-text="fmtStreamElapsed((pane && pane.streamElapsed) || 0)"></span>
-                <span x-show="m.ts && !(pane && pane.streaming && i === paneMsgs.length - 1)"
+                <span x-show="m.ts"
                       class="msg-ts" :title="m.model || ''"
                       x-text="fmtTurnTime(m.ts)"></span>
                 <!-- Total elapsed kept after done so the user can
@@ -2590,7 +2712,7 @@
                      for long agentic runs). Stamped in _markDone next
                      to .ts; only shown when both exist and m.elapsed
                      >= 1s (sub-second replies don't need the noise). -->
-                <span x-show="m.elapsed && m.ts && !(pane && pane.streaming && i === paneMsgs.length - 1)"
+                <span x-show="m.elapsed && m.ts"
                       class="msg-elapsed"
                       x-text="'· ' + fmtStreamElapsed(m.elapsed)"></span>
                 <button class="turn-fork-btn"
@@ -2605,6 +2727,37 @@
               </div>
             </div>
           </template>
+          <!-- Running indicator, pinned to the bottom of the SCROLL VIEWPORT
+               rather than trailing the last message. An agentic turn can run
+               for dozens of blocks, and the only two "still working" cues used
+               to be (a) the pulsing avatar, which sits on the turn's FIRST
+               message and is long scrolled off-screen, and (b) the dots in the
+               turn-footer under the very last message, which you only see if
+               you happen to be scrolled to the bottom. Anywhere else in a long
+               turn the chat is an undifferentiated wall of tool cards with no
+               state and no time (2026-07-25 report). Sticky keeps the answer
+               on screen at every scroll position; it's inside the pane so each
+               resident tab carries its own. -->
+          <!-- Suppressed while the "Muse 正在思考…" pending bubble is up: that
+               bubble already carries dots + model + elapsed, and the sticky bar
+               parks itself ~20px under it, so the user sees the SAME three
+               facts twice (2026-07-25 screenshot: "运行中 · 9m27s · Opus 5" over
+               "Muse 正在思考… · Opus 5 · 9m27s"). The pending bubble's own
+               condition is "no muse-side msg yet" — mirror it inverted here so
+               exactly one of the two is ever visible. -->
+          <div class="turn-running-bar"
+               x-show="pane && pane.streaming
+                       && paneMsgs.length
+                       && paneMsgs[paneMsgs.length - 1].role !== 'user'"
+               x-cloak>
+            <span class="thinking-dots"><span></span><span></span><span></span></span>
+            <span class="turn-running-label"
+                  x-text="(lang==='zh' ? '运行中' : 'Running')
+                          + (pane && pane.streamElapsed >= 1
+                              ? ' · ' + fmtStreamElapsed((pane && pane.streamElapsed) || 0) : '')
+                          + (pane && pane.streamingModel
+                              ? ' · ' + modelLabel(pane.streamingModel) : '')"></span>
+          </div>
           </div>
           </template>
           <div x-show="messagesReady && hasLaterMessages()" class="load-later-wrap">
@@ -2632,8 +2785,13 @@
                the pending bubble's avatar duplicated next to those
                msgs' own avatars. Now: any non-user last msg already
                has its own avatar — suppress pending. -->
+          <!-- ...and NOT while an auto-compact is running: that fires at the
+               top of the turn, when the last msg is still the user's, so both
+               placeholders would qualify and stack. The 📦 one is strictly
+               more informative, so it wins. -->
           <div x-show="streaming && (!messages.length
-                                       || messages[messages.length-1].role === 'user')"
+                                       || messages[messages.length-1].role === 'user')
+                       && !(tabState[currentId] && tabState[currentId].compacting)"
                class="msg assistant">
             <div class="msg-row">
               <span class="msg-avatar assistant-avatar is-streaming-avatar" :title="mascotLabel()">
@@ -2681,6 +2839,16 @@
                     <span class="queued-label"
                           x-text="(lang==='zh' ? '已排队 ' : 'Queued ') + (qi+1) + ' / '
                                    + _currentQueueLen()"></span>
+                    <!-- "已排队 1/2" alone reads as "will send shortly", which
+                         is wrong while the queue is paused — the item will
+                         NEVER send until Resume. State the difference on the
+                         bubble, not just in the banner: the banner sits at the
+                         bottom of the chat and is easy to scroll past on a
+                         phone, and the bubble is what the user actually looks
+                         at when wondering why nothing happened. -->
+                    <span class="queued-paused-badge"
+                          x-show="tabState[currentId] && tabState[currentId]._queuePaused"
+                          x-text="lang==='zh' ? '已暂停' : 'paused'"></span>
                     <span style="flex:1"></span>
                     <button class="queued-act icon-btn sm"
                             @click="editPendingQueueItem(currentId, qi)"
@@ -2736,12 +2904,18 @@
                  2. Items left dormant after a process restart — the server
                     intentionally does NOT auto-resume draining on boot, so
                     they wait here for an explicit Resume.
-               While a turn is running, items just auto-drain server-side and
-               this banner stays hidden. -->
+               While a turn is running, items normally auto-drain server-side
+               and this banner stays hidden — EXCEPT when the queue is paused.
+               The old `!streaming` gate assumed running ⇒ will drain, which is
+               exactly false in the paused state: the user starts a new turn,
+               sees no banner, the turn ends, dequeue_message returns None
+               because of the flag, and nothing ever indicates why. Paused wins
+               over streaming (2026-07-25 report: 2 items sat through several
+               completed turns with no visible cause). -->
           <div x-show="tabState[currentId]
                         && tabState[currentId].pendingQueue
                         && tabState[currentId].pendingQueue.length
-                        && !streaming
+                        && (!streaming || tabState[currentId]._queuePaused)
                         && !(tabState[currentId].backgroundActive)
                         && !(tabState[currentId].compacting)
                         && !(tabState[currentId]._draining)"
@@ -2776,7 +2950,7 @@
               <div class="bubble pending">
                 <span class="compact-pending-icon"><svg><use href="#i-package"/></svg></span>
                 <span class="thinking-dots"><span></span><span></span><span></span></span>
-                <span class="thinking-label" x-text="lang==='zh' ? '压缩对话中…' : 'Compacting conversation…'"></span>
+                <span class="thinking-label" x-text="compactPendingLabel()"></span>
               </div>
             </div>
           </div>
@@ -2808,6 +2982,46 @@
       </div>
 
       <div class="chat-input">
+        <!-- Composer settings panel (mobile gear). Anchored HERE, not next to
+             its button: the button lives in .chat-toolbar inside
+             .chat-input-wrap, which sets `overflow: hidden` to clip the
+             textarea + toolbar to the rounded frame. A panel popping upward
+             from inside that box gets cut at the wrap's top edge — with the
+             41-char zh effort label wrapping to 3 lines the panel was ~176px
+             tall against ~46px of usable room, so all the user ever saw was
+             the bottom slice (one bare select). z-index could not help: this
+             is clipping, not stacking. Same escape hatch .mention-pop already
+             uses — .chat-input is position:relative with no overflow rule. -->
+        <div class="chat-toolbar-more-pop"
+             x-show="composerSettingsOpen"
+             x-cloak
+             @click.outside="composerSettingsOpen = false">
+          <label class="chat-toolbar-more-field">
+            <span x-text="t('set.label.default_permission')"></span>
+            <select x-model="permission" @change="onPermissionChange()">
+              <option value="bypassPermissions">bypass</option>
+              <option value="acceptEdits">acceptEdits</option>
+              <option value="default">default</option>
+              <option value="dontAsk">dontAsk</option>
+              <option value="auto">auto</option>
+              <option value="plan">plan</option>
+            </select>
+          </label>
+          <!-- `effort.label`, not `effort.title`: the latter is tooltip prose
+               ("Effort — Anthropic 官方术语，控制推理预算与…") and was being
+               rendered as a visible field label. -->
+          <label class="chat-toolbar-more-field" x-show="_supportsEffort(model)">
+            <span x-text="t('effort.label')" :title="t('effort.title')"></span>
+            <select x-model="effort" @change="onEffortChange()">
+              <!-- effortOptLabel, not t(): the raw labels carry an "Effort · "
+                   prefix for the unlabelled desktop select, which under this
+                   field's own "Effort" label printed the word twice. -->
+              <template x-for="opt in effortChoices(model)" :key="opt.value || 'auto'">
+                <option :value="opt.value" x-text="effortOptLabel(opt)"></option>
+              </template>
+            </select>
+          </label>
+        </div>
         <!-- / slash command palette -->
         <div class="mention-pop slash-pop" x-show="slashShow" x-transition.opacity>
           <div class="mention-hint" x-text="t('slash.hint')"></div>
@@ -3041,32 +3255,14 @@
                       :class="{ active: composerSettingsOpen }"
                       @click.stop="composerSettingsOpen = !composerSettingsOpen"
                       :title="lang==='zh' ? '会话设置（权限 / Effort）' : 'Session settings (permission / effort)'">
-                <svg><use href="#i-cog"/></svg>
+                <svg><use href="#i-sliders"/></svg>
               </button>
-              <div class="chat-toolbar-more-pop"
-                   x-show="composerSettingsOpen"
-                   x-cloak
-                   @click.outside="composerSettingsOpen = false">
-                <label class="chat-toolbar-more-field">
-                  <span x-text="t('set.label.default_permission')"></span>
-                  <select x-model="permission" @change="onPermissionChange()">
-                    <option value="bypassPermissions">bypass</option>
-                    <option value="acceptEdits">acceptEdits</option>
-                    <option value="default">default</option>
-                    <option value="dontAsk">dontAsk</option>
-                    <option value="auto">auto</option>
-                    <option value="plan">plan</option>
-                  </select>
-                </label>
-                <label class="chat-toolbar-more-field" x-show="_supportsEffort(model)">
-                  <span x-text="t('effort.title')"></span>
-                  <select x-model="effort" @change="onEffortChange()">
-                    <template x-for="opt in effortChoices(model)" :key="opt.value || 'auto'">
-                      <option :value="opt.value" x-text="t(opt.labelKey)"></option>
-                    </template>
-                  </select>
-                </label>
-              </div>
+              <!-- The panel itself is NOT here — see .chat-toolbar-more-pop
+                   further up, hoisted out to .chat-input. It has to live
+                   outside .chat-input-wrap, which is `overflow: hidden` and
+                   was slicing the panel down to its bottom ~46px. Only
+                   `composerSettingsOpen` ties the two together, so the split
+                   costs nothing. -->
             </div>
             <!-- Extended-thinking on/off. Default on. Turning it OFF is the
                  escape hatch for the CLI streaming-interleaving 400 ("thinking
@@ -3090,16 +3286,25 @@
               <input type="checkbox" x-model="thinkingEnabled" @change="onThinkingChange()">
               <span x-text="t('thinking.label')"></span>
             </label>
-            <!-- Context ring — % used. Click to compact. Right-click
-                 opens the SDK breakdown popup (the dedicated magnifier
-                 button was removed per user request). -->
+            <!-- Context ring — % used. Click (either button) opens the SDK
+                 breakdown popup, which carries the Compact action.
+
+                 2026-07-25: click used to fire compaction directly and the
+                 breakdown was bound to @contextmenu. On a phone that meant the
+                 ring's only reachable behaviour was "start a compact" — the
+                 number it displays was unreadable (title needs hover) and the
+                 breakdown was unreachable (no right-click). The ring is first
+                 and foremost a READOUT, so tapping it should explain itself;
+                 compaction is the decision you make after reading. `.stop` is
+                 required or the same click bubbles to the popup's
+                 @click.outside and closes it immediately. -->
             <button class="chat-toolbar-ring"
                     :class="{
                       warn: sessionUsage.context_used_pct >= 70 && sessionUsage.context_used_pct < 90,
                       danger: sessionUsage.context_used_pct >= 90,
                     }"
-                    @click="runCompact()"
-                    @contextmenu.prevent="showCtxBreakdown()"
+                    @click.stop="showCtxBreakdown()"
+                    @contextmenu.prevent.stop="showCtxBreakdown()"
                     :title="ctxRingTitle()">
               <svg viewBox="0 0 20 20" width="18" height="18">
                 <circle cx="10" cy="10" r="7" fill="none"
@@ -3449,7 +3654,7 @@
          role="dialog" aria-modal="true" :aria-label="t('set.title')">
       <div class="modal-head">
         <span class="modal-title">
-          <svg class="modal-title-icon"><use href="#i-cog"/></svg>
+          <svg class="modal-title-icon"><use href="#i-settings"/></svg>
           <span x-text="t('set.title')"></span>
         </span>
         <button class="modal-close" @click="settings.show=false"
@@ -3492,7 +3697,7 @@
           </li>
           <li class="settings-menu-item" @click="settings.activePage='defaults'"
               :class="{ active: settings.activePage==='defaults' }">
-            <span class="settings-menu-icon"><svg><use href="#i-cog"/></svg></span>
+            <span class="settings-menu-icon"><svg><use href="#i-settings"/></svg></span>
             <span class="settings-menu-title" x-text="t('set.sec.defaults')"></span>
             <span class="settings-menu-chevron">›</span>
           </li>
@@ -4864,17 +5069,42 @@
   <div class="modal-backdrop" x-show="activity.show" @click.self="activity.show=false" x-cloak>
     <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="activity.show=false">
       <div class="modal-head">
-        <span class="modal-title"><svg class="modal-title-icon"><use href="#i-list"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
+        <span class="modal-title"><svg class="modal-title-icon"><use href="#i-inbox"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
         <button class="modal-close" @click="activity.show=false" aria-label="Close">×</button>
       </div>
+      <!-- One chip per state group, in the SAME order as the groups below, so
+           the header and the body answer the same question. Chips keep their
+           slot at count 0 — "Failed 0" is information, and a chip that appears
+           and disappears can never be found by muscle memory. Tap to filter. -->
       <div class="activity-summary">
-        <span class="running" x-text="(lang==='zh'?'进行中 ':'Running ') + activity.summary.running"></span>
-        <span class="unread" x-text="(lang==='zh'?'待查看 ':'Unread ') + activity.summary.unread"></span>
+        <template x-for="group in activityGroups()" :key="group.key">
+          <!-- Multi-select filter chips. `has-unread` (NOT "group is
+               non-empty") is what turns on the colour, so a failure you've
+               opened goes quiet — opening an event acks it server-side. -->
+          <button class="activity-chip" type="button"
+                  :class="[group.key, activityGroupCount(group) ? '' : 'is-empty',
+                           activityGroupUnread(group) ? 'has-unread' : '',
+                           isActivityFilterOn(group.key) ? 'active' : '']"
+                  :aria-pressed="isActivityFilterOn(group.key)"
+                  :title="(lang==='zh' ? '筛选：' : 'Filter: ') + group.label
+                          + (activityGroupUnread(group)
+                              ? (lang==='zh' ? ' · ' + activityGroupUnread(group) + ' 条未读'
+                                             : ' · ' + activityGroupUnread(group) + ' unread')
+                              : '')"
+                  @click="toggleActivityFilter(group.key)">
+            <span class="activity-chip-dot"></span>
+            <span x-text="group.label"></span>
+            <b x-text="activityGroupCount(group)"></b>
+          </button>
+        </template>
+        <button class="btn-ghost sm" x-show="activity.filter.length"
+                @click="clearActivityFilter()"
+                x-text="lang==='zh' ? '清除筛选' : 'Clear filter'"></button>
         <button class="btn-ghost sm" x-show="activity.summary.unread" @click="ackAllActivity()" x-text="lang==='zh' ? '全部标为已读' : 'Mark all read'"></button>
       </div>
       <div class="modal-body activity-body">
         <div class="hint-row" x-show="activity.loading" x-text="lang==='zh' ? '加载中…' : 'Loading…'"></div>
-        <template x-for="group in activityGroups()" :key="group.key">
+        <template x-for="group in activityVisibleGroups()" :key="group.key">
           <section class="activity-group" x-show="activityEvents(group).length">
             <h3 x-text="group.label"></h3>
             <template x-for="item in activityEvents(group)" :key="item.id">
@@ -4887,9 +5117,23 @@
                 <span class="activity-row-side"><span x-text="activityStateLabel(item.state)"></span><small x-text="activityTime(item)"></small></span>
               </button>
             </template>
+            <button class="activity-group-more" type="button"
+                    x-show="activityHiddenCount(group) > 0"
+                    @click="toggleActivityGroup(group.key)"
+                    x-text="activity.expanded[group.key]
+                      ? (lang==='zh' ? '收起' : 'Show less')
+                      : (lang==='zh'
+                          ? '还有 ' + activityHiddenCount(group) + ' 条'
+                          : activityHiddenCount(group) + ' more')"></button>
           </section>
         </template>
         <div class="hint-row" x-show="!activity.loading && !activity.events.length" x-text="lang==='zh' ? '暂无任务记录' : 'No activity yet'"></div>
+        <!-- Filtering to an empty group must say so, or the body just goes
+             blank and reads as a loading failure. -->
+        <div class="hint-row"
+             x-show="!activity.loading && activity.events.length && activity.filter.length
+               && !activityVisibleGroups().some(g => activityEvents(g).length)"
+             x-text="lang==='zh' ? '该状态下暂无任务' : 'No tasks in this state'"></div>
       </div>
     </div>
   </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -865,9 +865,45 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
      buttons belong to popovers (notably Terminal → New terminal) and must
      remain visible on mobile. */
   .pane.preview > .pane-head > .btn-primary { display: none; }
-  /* Keep the path + mtime strip on mobile too (user wants it visible): the
-     two-line stacked layout + 10px font fits the cramped head, and min-width:0
-     ellipsis on the path keeps the action icons right-aligned. */
+  /* Path + mtime strip: keep it on mobile (the user wants it visible), but
+     give it its OWN ROW.
+
+     2026-07-25, measured at 390x844: the previous "stacked layout fits the
+     cramped head" assumption was simply false. Sharing one row with the zoom
+     control (87.5px) and four 34px action icons left `.pane-fileinfo` just
+     10.2px wide. The mtime then wrapped one character per line into a 50px
+     column, making the strip 63.5px tall inside a head fixed at 42px — so it
+     overflowed BOTH edges (top -11.3px, bottom 52.3px), painting the path
+     above the header and smearing the mtime across the tab bar below.
+
+     Wrapping to a second row gives the strip the full width and lets the
+     first row breathe (title now gets ~100px instead of fighting for it). */
+  .pane.preview .pane-head {
+    height: auto;
+    min-height: 42px;
+    flex-wrap: wrap;
+    align-content: center;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    row-gap: 2px;
+  }
+  /* `.pane-fileinfo` used to double as the flex spacer; once it wraps away,
+     the title has to take over or the icons collapse against it. */
+  .pane.preview .pane-head .pane-title { flex: 1; min-width: 0; }
+  .pane.preview .pane-head .pane-fileinfo {
+    order: 10;          /* after the action icons → forced onto row 2 */
+    flex: 0 0 100%;
+    align-self: auto;
+  }
+  /* Full row available, so path and mtime sit side by side instead of
+     stacking; mtime is pushed right and never wraps. */
+  .pane.preview .pane-head .pane-fileinfo-row {
+    flex-direction: row;
+    align-items: baseline;
+    gap: var(--sp-2);
+    width: 100%;
+  }
+  .pane.preview .pane-head .pane-fileinfo-mtime { margin-left: auto; }
 
   /* Chat toolbar: keep attach + model + permission + effort + ctx-ring + send.
      Permission restored on mobile (2026-05-28): the prior "low-frequency,
@@ -1550,11 +1586,19 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 /* Preview-header path + mtime strip. flex:1 + min-width:0 lets it both fill
    the gap (acting as the old spacer) and shrink/ellipsis a long path instead
    of shoving the action icons off-screen. */
-.pane-head .pane-fileinfo { flex: 1; min-width: 0; display: flex; align-items: center; overflow: hidden; }
+/* `align-self: stretch` + `max-height: 100%` are load-bearing: without them a
+   squeezed strip grows TALLER than the fixed-height head and spills out of
+   both edges (it did — see the mobile override for the measurements). The head
+   itself can't take `overflow: hidden` as a guard, because the terminal
+   manager popover is a child of it and would get clipped. */
+.pane-head .pane-fileinfo {
+  flex: 1; min-width: 0; display: flex; align-items: center;
+  align-self: stretch; max-height: 100%; overflow: hidden;
+}
 /* Stack path over mtime — quieter than a single inline row. */
 .pane-head .pane-fileinfo-row {
   display: flex; flex-direction: column; align-items: flex-start; gap: 1px;
-  min-width: 0; overflow: hidden; line-height: 1.25;
+  min-width: 0; max-height: 100%; overflow: hidden; line-height: 1.25;
 }
 .pane-head .pane-fileinfo-path {
   color: var(--c-fg-4); font-size: var(--fs-2xs); font-weight: var(--fw-normal);
@@ -1566,6 +1610,9 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 .pane-head .pane-fileinfo-mtime {
   color: var(--c-fg-4); font-size: var(--fs-2xs); opacity: 0.8;
   flex-shrink: 0; font-variant-numeric: tabular-nums;
+  /* Never wrap. "上次修改 2026-06-05 15:28" folding one glyph per line is what
+     turned a 12px strip into a 50px tower and broke the header. */
+  white-space: nowrap;
 }
 .pane-head .pane-fileinfo-mtime-label { opacity: 0.75; }
 
@@ -3132,10 +3179,14 @@ pre.text {
 .workspace-activity-mini { display:inline-flex; gap:5px; margin-left:auto; font:10px var(--font-mono); }
 .workspace-activity-mini .running { color:var(--c-accent); }
 .workspace-activity-mini .unread { color:var(--c-success); }
-.activity-center-btn { position:relative; width:34px; height:34px; flex:0 0 34px; display:inline-flex; align-items:center; justify-content:center; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-2); cursor:pointer; }
+/* Sized to match `.icon-btn` (28px box / 15px glyph). It used to be 34/16,
+   which made it visibly the odd one out in a row of seven 28px siblings. */
+.activity-center-btn { position:relative; width:28px; height:28px; flex:0 0 28px; display:inline-flex; align-items:center; justify-content:center; border:0; border-radius:var(--r-md); background:transparent; color:var(--c-fg-2); cursor:pointer; }
 .activity-center-btn:hover,.activity-center-btn.active { background:var(--c-bg-2); color:var(--c-accent); }
 .activity-center-btn.danger { color:var(--c-danger); }
-.activity-center-btn svg { width:16px; height:16px; }
+/* `flex-shrink:0` is load-bearing: as a flex item the svg was being squeezed
+   to 14x16, i.e. rendered non-uniformly scaled. */
+.activity-center-btn svg { width:15px; height:15px; flex:0 0 15px; }
 .activity-center-btn .activity-running { position:absolute; right:-2px; bottom:-2px; width:10px; height:10px; border:2px solid var(--c-bg-1); border-radius:var(--r-full); background:var(--c-running); box-sizing:border-box; pointer-events:none; }
 .activity-center-btn .activity-running::after { content:""; position:absolute; inset:-2px; border:2px solid var(--c-running); border-radius:inherit; animation:activity-running-pulse 1.6s ease-out infinite; }
 @keyframes activity-running-pulse { 0% { transform:scale(.75); opacity:.8; } 75%,100% { transform:scale(1.4); opacity:0; } }
@@ -3150,12 +3201,40 @@ pre.text {
 }
 .files-head-workspace .workspace-picker-btn { width: 100%; max-width: none; border-radius: var(--r-sm); }
 .activity-modal { width:620px; max-width:calc(100vw - 32px); }
-.activity-summary { display:flex; align-items:center; gap:12px; padding:10px 16px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
-.activity-summary .running { color:var(--c-accent); }
-.activity-summary .unread { color:var(--c-success); }
-.activity-summary button { margin-left:auto; }
+.activity-summary { display:flex; align-items:center; flex-wrap:wrap; gap:6px; padding:10px 14px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
+.activity-summary .btn-ghost { margin-left:auto; }
+/* Status chips. One per group below, always all four, always in the same
+   order — a chip that vanishes at count 0 can't be found by muscle memory,
+   and "Failed 0" is worth stating. Non-zero danger states colour themselves. */
+.activity-chip { display:inline-flex; align-items:center; gap:6px; padding:5px 10px; border:1px solid var(--c-border); border-radius:var(--r-full); background:transparent; color:var(--c-fg-2); font:inherit; font-size:var(--fs-xs); line-height:1.2; cursor:pointer; transition:background var(--t-fast), border-color var(--t-fast), color var(--t-fast), opacity var(--t-fast); }
+.activity-chip b { font-weight:var(--fw-medium); color:var(--c-fg-1); font-variant-numeric:tabular-nums; }
+.activity-chip-dot { width:7px; height:7px; flex:0 0 7px; border-radius:50%; background:var(--c-fg-3); }
+/* Dot colour is keyed to UNREAD, not to "the group has rows". A failure you
+   already opened is history, not an alarm — opening an event acks it, and the
+   chip must go quiet in response or the red dot is permanent furniture.
+   Colour split: 待决策 is a prompt (amber, "you need to do something"),
+   运行失败 is an outcome (red, "something broke"). Both were red before,
+   which flattened a question and a failure into the same signal. */
+.activity-chip.attention.has-unread .activity-chip-dot { background:var(--c-warn); }
+.activity-chip.failed.has-unread .activity-chip-dot { background:var(--c-danger); }
+.activity-chip.running .activity-chip-dot { background:var(--c-running); }
+.activity-chip.done .activity-chip-dot { background:var(--c-fg-4); }
+.activity-chip.running:not(.is-empty) .activity-chip-dot { animation:muse-breath 1.8s ease-in-out infinite; }
+.activity-chip.attention.has-unread { border-color:color-mix(in srgb, var(--c-warn) 45%, transparent); color:var(--c-warn); }
+.activity-chip.attention.has-unread b { color:var(--c-warn); }
+.activity-chip.failed.has-unread { border-color:color-mix(in srgb, var(--c-danger) 42%, transparent); color:var(--c-danger); }
+.activity-chip.failed.has-unread b { color:var(--c-danger); }
+.activity-chip:hover { background:var(--c-bg-2); }
+.activity-chip.active { background:var(--c-accent-soft); border-color:var(--c-accent); color:var(--c-fg-0); }
+.activity-chip.active b { color:var(--c-accent); }
+/* Count 0 keeps its slot but recedes. */
+.activity-chip.is-empty { opacity:0.42; }
+.activity-chip.is-empty:hover { opacity:0.85; }
+@media (prefers-reduced-motion:reduce) { .activity-chip .activity-chip-dot { animation:none; } }
 .activity-body { max-height:min(70vh,680px); overflow:auto; padding:10px 14px 18px; }
 .activity-group h3 { margin:10px 4px 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
+.activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
+.activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
 .activity-row { width:100%; display:flex; align-items:center; gap:10px; padding:10px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); text-align:left; cursor:pointer; }
 .activity-row:hover { background:var(--c-bg-2); }
 .activity-row.is-unread { background:var(--c-accent-soft); box-shadow:inset 3px 0 0 var(--c-accent); }
@@ -3644,9 +3723,13 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
    isCompactSummary content returned by SDK after /compact. Centered, dashed
    border, accent color. Lets the user understand "what they see is the
    summary, not the original history that's been compacted." */
+.compact-summary-block {
+  display: flex; flex-direction: column; align-items: center;
+  width: 100%; min-width: 0;
+}
 .compact-summary-pill {
   align-self: center;
-  display: inline-block;
+  display: inline-flex; align-items: center; gap: 6px;
   padding: 4px 14px;
   margin-bottom: 6px;
   background: var(--c-accent-soft); color: var(--c-accent-fg);
@@ -3654,7 +3737,29 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
   border-radius: var(--r-full);
   font-size: var(--fs-xs); font-weight: var(--fw-semibold);
   letter-spacing: 0.2px;
+  /* It's a <button> now — reset the UA defaults it would otherwise inherit. */
+  font-family: inherit; cursor: pointer;
 }
+.compact-summary-caret { font-size: 10px; opacity: 0.75; }
+/* The summary body. `max-height` + inner scroll is deliberate: the summary is
+   10-20k chars, and letting it flow at full height would push a freshly
+   compacted session's composer thousands of pixels below the fold — the user
+   would have to scroll the whole summary just to reach the input. */
+.compact-summary-body {
+  width: 100%; min-width: 0;
+  margin-bottom: 6px;
+  padding: 10px 14px;
+  background: var(--c-bg-1);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  color: var(--c-fg-1);
+  font-size: var(--fs-sm); line-height: 1.65;
+  max-height: 46vh; overflow-y: auto; overscroll-behavior: contain;
+  word-break: break-word;
+}
+.compact-summary-body > :first-child { margin-top: 0; }
+.compact-summary-body > :last-child { margin-bottom: 0; }
+.compact-summary-body pre { max-width: 100%; overflow-x: auto; }
 
 .msg.assistant .bubble {
   background: var(--c-assistant-bg); color: var(--c-fg-0);
@@ -3779,12 +3884,25 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
    how many blocks (thinking / tool_use / tool_result / assistant)
    are in the turn. Aligned to the muse-side content column (avatar
    width 32px + gap 8px = 40px gutter). */
+/* Now also the turn SEPARATOR: two hairlines bracket the stamp so the row
+   reads as a boundary rather than a caption hanging off the last card. The
+   40px content-column indent is gone with them — a boundary should span the
+   full width, and there is no longer an avatar-aligned run of dots to line up
+   with (those moved to .turn-running-bar). */
 .turn-footer {
-  padding: 4px 0 6px 40px;
+  padding: 0;
+  margin: 6px 0 2px;
   display: flex;
   align-items: center;
-  gap: var(--sp-2);
-  min-height: 18px;            /* avoid layout jitter when dots → time */
+  gap: 10px;
+  min-height: 16px;
+}
+.turn-footer::before,
+.turn-footer::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--c-border);
 }
 .turn-fork-btn {
   width: 22px;
@@ -3821,10 +3939,10 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
   opacity: 0.3;
 }
 @media (max-width: 480px) {
-  /* avatar shrinks to 26px on phones (see .msg-avatar @ media block),
-     keep the footer aligned by matching that gutter — 26 + 8 gap = 34. */
+  /* No avatar-gutter indent to match any more — the separator spans the full
+     width on every breakpoint. Just tighten the vertical rhythm. */
   .turn-footer {
-    padding: 2px 0 3px 34px;
+    margin: 4px 0 2px;
     min-height: 14px;
   }
   .turn-fork-btn {
@@ -3832,23 +3950,38 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
     height: 30px;
   }
 }
+/* Sticky "still running" row — see the comment on .turn-running-bar in
+   index.html for why this exists instead of the trailing dots it replaced.
+   Opaque bg-1 (the chat pane's own background) so message content scrolls
+   UNDER it cleanly; the hairline gives it an edge without a heavy shadow. */
+.turn-running-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-top: 4px;
+  padding: 6px 2px 4px;
+  background: var(--c-bg-1);
+  border-top: 1px solid var(--c-border);
+}
+.turn-running-label {
+  font-size: var(--fs-xs);
+  color: var(--c-fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: 0.3px;
+}
 
 .thinking-dots { display: inline-flex; gap: var(--sp-1); align-items: center; }
 .thinking-dots span {
   width: 6px; height: 6px; border-radius: 50%; background: var(--c-accent);
   animation: thinking-pulse 1.2s ease-in-out infinite;
 }
-/* Elapsed counter next to the dots in turn-footer. Mono so the digits
-   don't jitter as seconds tick. Muted color — supporting info, not
-   primary. Pending-bubble version is sibling-inline so it inherits the
-   .thinking-label parent's styling; this rule covers the standalone
-   turn-footer usage only. */
-.turn-footer .stream-elapsed {
-  font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  color: var(--c-fg-3);
-  letter-spacing: 0.3px;
-}
+/* `.turn-footer .stream-elapsed` removed: the footer became a turn separator
+   and its elapsed counter moved to .turn-running-bar. The only remaining
+   .stream-elapsed is inside the pending bubble, where it is sibling-inline
+   and inherits .thinking-label's styling — it never needed this rule. */
 .background-task-footer-label {
   color: var(--c-warn);
   font-size: var(--fs-xs);
@@ -5140,29 +5273,69 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   margin-bottom: 10px;
 }
 .ctx-breakdown-stack-seg { height: 100%; transition: width var(--t-fast); }
+/* Rows carry no rule of their own. The dashed border used to run under every
+   row, which at 6 rows read as a table grid and fought the stacked bar for
+   attention. Proportion is the stacked bar's job; these rows are a figure
+   list, so they only need vertical rhythm. */
 .ctx-breakdown-row {
   display: flex; align-items: center;
-  padding: 6px 0; gap: var(--sp-2);
-  border-bottom: 1px dashed var(--c-border);
+  padding: 5px 0; gap: var(--sp-2);
 }
-.ctx-breakdown-row:last-child { border-bottom: 0; }
 .ctx-breakdown-row.expandable { cursor: pointer; }
 .ctx-breakdown-row.expandable:hover { background: var(--c-bg-1); }
+/* Remainder row: a figure, not a slice. No swatch (the 18px keeps the name
+   column aligned with the real categories above). Separated by a hairline
+   because it's the one row that is NOT part of the stacked bar. */
+.ctx-breakdown-row.free {
+  color: var(--c-fg-3);
+  margin-top: 4px; padding-top: 7px;
+  border-top: 1px solid var(--c-border);
+}
+.ctx-breakdown-row.free .ctx-breakdown-name { margin-left: 18px; color: var(--c-fg-3); }
+.ctx-breakdown-row.free .ctx-breakdown-tokens { color: var(--c-fg-3); }
 .ctx-breakdown-swatch {
   width: 10px; height: 10px; border-radius: 50%;
   flex-shrink: 0;
 }
+/* Hollow ring = "this category is a schema budget we did NOT spend". Reads as
+   an outline of the same hue rather than a filled slice. */
+.ctx-breakdown-swatch.hollow {
+  background: none !important;
+  border: 1.5px solid var(--c-fg-4);
+}
+/* Name owns all the slack now that the per-row bar is gone, so long category
+   names ("System prompt (deferred)") stop ellipsing at 168px. */
 .ctx-breakdown-name {
-  color: var(--c-fg-2); flex-shrink: 0;
-  min-width: 80px; max-width: 130px;
+  color: var(--c-fg-2);
+  flex: 1 1 auto; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.ctx-breakdown-bar {
-  flex: 1; height: 6px; background: var(--c-bg-2);
-  border-radius: var(--r-sm); overflow: hidden;
-  min-width: 30px;
+/* The per-row bar is deliberately gone. Three reasons it never earned its
+   width: (1) the fill was a <span> with no `display`, and width/height do
+   not apply to non-replaced inline boxes (CSS 2.1 §10.3.1 / §10.6.1), so it
+   rendered as an empty track for its entire life; (2) even working, it
+   encoded the exact value already given by the swatch color + the numeral —
+   three encodings of one number; (3) scaled against maxTokens, 4 of 5 rows
+   sit under 10% and read as identically empty. The stacked bar at the top
+   carries proportion; this column carries the figure. */
+.ctx-breakdown-pct {
+  font-family: var(--font-mono);
+  color: var(--c-fg-3); flex-shrink: 0;
+  min-width: 44px; text-align: right;
+  font-size: var(--fs-xs);
 }
-.ctx-breakdown-bar-fill { height: 100%; transition: width var(--t-fast); }
+/* Uncounted section: separated by a rule and dimmed as a block, so no single
+   row here can be mistaken for window occupancy. */
+.ctx-breakdown-deferred {
+  margin-top: 8px; padding-top: 6px;
+  border-top: 1px solid var(--c-border);
+}
+.ctx-breakdown-deferred-head {
+  color: var(--c-fg-3); font-size: var(--fs-xs);
+  padding-bottom: 2px;
+}
+.ctx-breakdown-row.deferred .ctx-breakdown-name,
+.ctx-breakdown-row.deferred .ctx-breakdown-tokens { color: var(--c-fg-3); }
 .ctx-breakdown-tokens {
   font-family: var(--font-mono);
   color: var(--c-fg-1); flex-shrink: 0;
@@ -5173,18 +5346,30 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
 }
 /* Per-file / per-tool breakdown shown when a parent row is expanded. */
 .ctx-breakdown-sub {
-  padding: 2px 0 6px 22px;
-  border-bottom: 1px dashed var(--c-border);
+  margin: 0 0 4px 4px;
+  padding: 2px 0 2px 16px;
+  border-left: 1px solid var(--c-border);
 }
 .ctx-breakdown-subrow {
-  display: flex; justify-content: space-between; align-items: baseline;
-  padding: 3px 0; gap: var(--sp-3);
+  display: flex; align-items: baseline;
+  padding: 3px 0; gap: var(--sp-2);
   font-size: var(--fs-xs);
 }
 .ctx-breakdown-subname {
-  color: var(--c-fg-3);
+  color: var(--c-fg-3); flex: 1 1 auto; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-family: var(--font-mono);
+  /* Names are truncated head-first elsewhere, but here the distinguishing
+     part of a path/tool name is the TAIL, so keep direction default and rely
+     on the `title` attribute for the full value. */
+}
+/* Provenance tag (memory file type / MCP server / skill source). Muted and
+   shrink-proof so it never pushes the token column off the row. */
+.ctx-breakdown-submeta {
+  color: var(--c-fg-4); flex: 0 0 auto;
+  font-size: var(--fs-2xs);
+  max-width: 84px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .ctx-breakdown-subtokens {
   font-family: var(--font-mono); color: var(--c-fg-2); flex-shrink: 0;
@@ -5196,6 +5381,12 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   color: var(--c-fg-3);
   font-size: var(--fs-xs);
   line-height: 1.5;
+}
+/* Compact action, moved here from the ring's own click handler. */
+.ctx-breakdown-actions {
+  display: flex; justify-content: flex-end;
+  padding: 8px 12px 10px;
+  border-top: 1px solid var(--c-border);
 }
 
 /* While compact is running: indeterminate progress shimmer in the bar +
@@ -5895,6 +6086,19 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   background: var(--c-accent-soft); border-color: var(--c-accent);
 }
 
+/* Expanded-card timestamp. Absolute so it can't take part in the card's own
+   flex layout (every tool renderer has its own head row; a flowed element
+   would have to be threaded through all of them). Sits above the card's top
+   edge in the gutter between messages, mirroring .msg-actions. */
+.msg-time {
+  position: absolute; top: -2px; right: 6px;
+  font-size: var(--fs-2xs);
+  font-family: var(--font-mono);
+  color: var(--c-fg-4);
+  letter-spacing: 0.2px;
+  pointer-events: none;
+  z-index: 1;
+}
 .msg-actions {
   position: absolute; top: -8px; right: 8px;
   background: var(--c-bg-3); border: 1px solid var(--c-border-strong); border-radius: var(--r-md);
@@ -5924,9 +6128,12 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
    assistant message once the turn finishes — see fmtHM() in app.js. */
 .msg-ts {
   font-size: var(--fs-2xs); color: var(--c-fg-3);
-  margin-top: 2px; padding: 0 4px;
+  /* margin-top dropped: this now sits ON the separator rule, where a top
+     offset would push the text off the hairlines it's centered between. */
+  padding: 0 4px;
   font-family: var(--font-mono);
   letter-spacing: 0.2px;
+  flex-shrink: 0;
 }
 /* "· 2m50s" total-elapsed pill stamped next to .msg-ts after the turn
    finishes. Same mono / muted treatment as .msg-ts so they read as one
@@ -5936,6 +6143,7 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   font-size: var(--fs-2xs); color: var(--c-fg-3);
   font-family: var(--font-mono);
   letter-spacing: 0.2px;
+  flex-shrink: 0;
 }
 
 .jump-bottom {
@@ -6096,27 +6304,60 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
 
 /* Composer "more" group — gear that collapses permission/effort on mobile.
    Hidden on desktop (the inline selects stay); CSS in the pointer:coarse
-   block flips this on and hides the inline selects instead. */
-.chat-toolbar-more { display: none; position: relative; }
+   block flips this on and hides the inline selects instead.
+   No `position: relative` here on purpose: the panel is NOT anchored to this
+   button (see .chat-toolbar-more-pop). */
+.chat-toolbar-more { display: none; }
+/* Anchored to .chat-input, not to the gear. The gear sits inside
+   .chat-input-wrap, which is `overflow: hidden` to clip the textarea +
+   toolbar to the rounded frame — a panel popping upward from in there got
+   sliced at the wrap's top edge, leaving only its bottom ~46px (one bare
+   select). Stacking context was never the issue, so bumping z-index did
+   nothing; the fix is to escape the clip box entirely. .mention-pop solves
+   the same problem the same way, so the geometry below deliberately mirrors
+   it (bottom: calc(100% + 6px), z-index: 100). */
+/* Full composer width rather than a 190px box hugging the right edge. The
+   narrow version floated with no visual tie to the gear that opened it (the
+   gear sits mid-row, the panel was flush right), so it read as a stray card
+   dropped over the chat. Spanning the composer edge-to-edge makes it read as
+   a sheet lifted out of the input area — the same affordance the composer's
+   own rounded frame already establishes. */
 .chat-toolbar-more-pop {
   position: absolute;
-  bottom: calc(100% + 8px);   /* pop upward — composer sits at screen bottom */
-  right: 0;
-  z-index: 50;
-  display: flex; flex-direction: column; gap: var(--sp-2);
-  min-width: 190px;
-  padding: var(--sp-2) var(--sp-3);
+  bottom: calc(100% + 6px);   /* pop upward — composer sits at screen bottom */
+  /* 8px, matching .chat-input's `padding-inline: max(8px, …)` — offsets here
+     resolve against the padding BOX, so this lands the panel's edges exactly
+     on the composer frame's. The max() branch only bites above ~896px of pane
+     width, where this panel is display:none anyway (touch-only). */
+  left: var(--sp-2); right: var(--sp-2);
+  z-index: 100;
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 10px var(--sp-3) 12px;
   background: var(--c-bg-1);
   border: 1px solid var(--c-border);
   border-radius: var(--r-lg);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+  /* Opaque + a real border: the panel overlaps live message text, and a
+     shadow alone left the two layers visually interleaved. */
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.28);
+}
+/* Hoisting the panel out of .chat-toolbar-more also took it out of that
+   group's `display: none` on desktop, where the gear is unreachable and the
+   inline selects are shown instead. Re-gate it explicitly, or a phone→desktop
+   resize with the panel open would leave a duplicate control floating over the
+   chat. `!important` is required to beat the inline style x-show writes. */
+@media not all and (pointer: coarse) {
+  .chat-toolbar-more-pop { display: none !important; }
 }
 .chat-toolbar-more-field {
-  display: flex; flex-direction: column; gap: 4px;
-  font-size: var(--fs-xs); color: var(--c-fg-2);
+  display: flex; flex-direction: column; gap: 3px;
+  font-size: var(--fs-xs); color: var(--c-fg-3);
+  letter-spacing: 0.2px;
 }
+/* 34px, not 38: two native selects at 38 made the panel taller than the
+   composer it hangs off. Font stays at 16px — below that iOS Safari zooms the
+   whole page on focus, which is not negotiable for a phone-first surface. */
 .chat-toolbar-more-field select {
-  height: 38px; width: 100%;
+  height: 34px; width: 100%;
   padding: 0 10px;
   background: var(--c-bg-2);
   border: 1px solid var(--c-border);
@@ -6235,6 +6476,21 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
 }
 .queued-icon { font-size: var(--fs-sm); }
 .queued-label { white-space: nowrap; }
+/* Paused marker on a queued bubble. Warn-colored so it separates from the
+   neutral "已排队 1/2" counter beside it — this one is a blocked state, not
+   a position. */
+.queued-paused-badge {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: var(--r-sm);
+  /* No --c-warn-soft token exists; a translucent amber reads correctly on
+     every theme's bubble background without adding one. */
+  background: rgba(217, 119, 6, 0.15);
+  color: var(--c-warn);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-medium);
+  white-space: nowrap;
+}
 .queued-act {
   width: 18px; height: 18px;
   display: inline-flex; align-items: center; justify-content: center;
@@ -8698,7 +8954,14 @@ html[data-theme="dark"] .bubble :not(pre) > code:not(.has-file-link) * {
 /* Touch-first file/preview ergonomics. Desktop keeps the compact VSCode-like
    density; coarse pointers get real finger targets and wrapping toolbars. */
 @media (pointer: coarse) {
-  .filelist li:not(.filelist-status) {
+  /* `.filelist-virtual-spacer` MUST stay excluded. The spacer is a zero-or-N
+     pixel strut whose height is set inline by the virtual scroller; giving it
+     a 40px floor made an empty top spacer (height:0) render 40px tall, which
+     is the blank band that used to appear above the tree on touch devices.
+     The base rule at `.filelist li.filelist-virtual-spacer` sets min-height:0
+     but has the same specificity (0,0,2,1) as this one and comes EARLIER in
+     source order, so it loses. Excluding it here is the fix. */
+  .filelist li:not(.filelist-status):not(.filelist-virtual-spacer) {
     min-height: 40px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -10103,7 +10366,6 @@ html[data-theme="eyecare"] .tool-error-hint {
 }
 .terminal-manager { position: relative; flex-shrink: 0; }
 .terminal-manager-btn { position: relative; gap: 3px; width: auto; min-width: 28px; }
-.chat-terminal-btn { display: none; position: relative; gap: 3px; width: auto; min-width: 28px; }
 .terminal-manager-backdrop { display: none; }
 .terminal-count {
   min-width: 14px; height: 14px; padding: 0 3px;
@@ -10247,7 +10509,6 @@ html[data-theme="eyecare"] .tool-error-hint {
 .terminal-mobile-keys { display: none; }
 
 @media (max-width: 900px), (pointer: coarse) and (max-height: 500px) {
-  .pane.chat .pane-head .chat-terminal-btn { display: inline-flex; }
   .terminal-manager-backdrop {
     display: block; position: fixed; inset: 0; z-index: 1790;
     background: rgba(0, 0, 0, 0.46); touch-action: none;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -6353,6 +6353,13 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   font-size: var(--fs-xs); color: var(--c-fg-3);
   letter-spacing: 0.2px;
 }
+/* Switch rows read as label-on-the-left, control-on-the-right; the stacked
+   column layout above is for full-width selects only. min-height matches the
+   34px selects so the panel's rhythm doesn't break. */
+.chat-toolbar-more-field.row {
+  flex-direction: row; align-items: center; justify-content: space-between;
+  gap: var(--sp-2); min-height: 34px; cursor: pointer;
+}
 /* 34px, not 38: two native selects at 38 made the panel taller than the
    composer it hangs off. Font stays at 16px — below that iOS Safari zooms the
    whole page on focus, which is not negotiable for a phone-first surface. */

--- a/tests/e2e/test_terminal_mobile.py
+++ b/tests/e2e/test_terminal_mobile.py
@@ -271,7 +271,16 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
     try:
         _login(page, backend_url, auth_token)
 
-        terminal_entry = page.locator(".chat-terminal-btn")
+        # The terminal is a preview-pane surface, and since 2026-07-25 the
+        # preview header holds its ONLY entry point (the chat-header duplicate
+        # was removed). Switch panes the way the mobile tab bar would, then use
+        # that button.
+        page.evaluate(
+            """() => {
+              document.querySelector("#app")._x_dataStack[0].setMobileTab("preview");
+            }"""
+        )
+        terminal_entry = page.locator(".terminal-manager-btn")
         expect(terminal_entry).to_be_visible()
         terminal_entry.click()
 

--- a/tests/test_chat_image_upload.py
+++ b/tests/test_chat_image_upload.py
@@ -3,6 +3,8 @@ import base64
 import io
 from pathlib import Path
 
+import pytest
+
 from tests.conftest import TEST_TOKEN
 
 
@@ -54,13 +56,75 @@ def test_upload_accepts_pdf(client, auth):
     assert r.json()["kind"] == "pdf"
 
 
-def test_upload_text_too_large_returns_413(client, auth, monkeypatch):
+def test_upload_large_text_accepted_and_kept_raw(client, auth, monkeypatch):
+    """Text attachments are persisted to disk and referenced by path, never
+    pasted into the prompt — so the old 200 KB 413 (which existed purely to
+    protect the context window) is gone. Only _IMAGE_MAX_BYTES still applies.
+
+    The raw bytes must be retained on the store entry: that's what gets
+    written to disk at send-time, and re-encoding the decoded str would
+    silently normalise line endings / BOM."""
     from backend import chat
     monkeypatch.setattr(chat, "_TEXT_MAX_BYTES", 50)
     big = b"x" * 200
     files = {"file": ("big.txt", io.BytesIO(big), "text/plain")}
     r = client.post("/api/chat/upload-image", files=files, headers=auth)
-    assert r.status_code == 413
+    assert r.status_code == 200, r.text
+    entry = chat._image_store[r.json()["id"]]
+    assert entry["kind"] == "text"
+    assert entry["raw"] == big
+
+
+def test_upload_xlsx_keeps_original_bytes_and_kind(client, auth):
+    """xlsx must NOT be flipped to kind=text any more. The original workbook
+    is persisted alongside a plain-text transcription — Read can't open the
+    zip container, and the transcription loses formulas / sheet structure, so
+    the pair is what makes the attachment actually usable."""
+    openpyxl = pytest.importorskip("openpyxl")
+    wb = openpyxl.Workbook()
+    wb.active["A1"] = "hello"
+    buf = io.BytesIO()
+    wb.save(buf)
+    raw = buf.getvalue()
+    files = {"file": ("book.xlsx", io.BytesIO(raw),
+                      "application/vnd.openxmlformats-officedocument."
+                      "spreadsheetml.sheet")}
+    r = client.post("/api/chat/upload-image", files=files, headers=auth)
+    assert r.status_code == 200, r.text
+    assert r.json()["kind"] == "xlsx"
+    from backend import chat
+    entry = chat._image_store[r.json()["id"]]
+    assert entry["raw"] == raw
+    assert "hello" in entry["text"]
+
+
+@pytest.mark.parametrize("raw,expected", [
+    # POSIX traversal: Path.name already reduces this to the basename.
+    ("../../etc/passwd", "passwd"),
+    # Windows-style separators arriving on Linux survive Path.name, so they
+    # have to be replaced explicitly.
+    ("..\\..\\windows\\system32", "windows_system32"),
+    ("  spaced name.md ", "spaced_name.md"),
+    (".hidden", "hidden"),
+    # Shell metacharacters: everything before the last `/` is dropped as a
+    # directory part, the rest is neutralised.
+    ("rm -rf /; echo pwned.txt", "echo_pwned.txt"),
+    ("季度报表.xlsx", "季度报表.xlsx"),
+    ("", "file"),
+])
+def test_safe_attach_name(raw, expected):
+    """Filenames come straight from the client and become a path component."""
+    from backend import chat
+    assert chat._safe_attach_name(raw) == expected
+
+
+def test_safe_attach_name_truncates_on_bytes_not_chars():
+    """ext4/APFS cap each path component at 255 BYTES. A CJK name is 3
+    bytes/char, so a char-based truncation would still blow the limit."""
+    from backend import chat
+    out = chat._safe_attach_name("报" * 200 + ".txt")
+    assert len(out.encode("utf-8")) <= chat._ATTACH_NAME_MAX
+    assert out.endswith(".txt")
 
 
 def test_upload_text_rejects_non_utf8(client, auth):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -151,6 +151,39 @@ def test_remove_queue_item(app_module):
     assert [it["id"] for it in data2["items"]] == [b]
 
 
+def test_removing_the_last_item_also_clears_paused(app_module):
+    """`paused` must not outlive the items it was protecting.
+
+    Real failure, 2026-07-25: a wall-clock-capped turn aborted and paused a
+    2-item queue. The user deleted both stale items by hand, then sent two new
+    messages — which never went out. dequeue_message returns None while paused,
+    so every subsequent completed turn silently skipped the drain, and the
+    banner that would have explained it was gated on `!streaming`. The flag
+    describes "queued work stopped auto-draining"; with no work left it has no
+    referent and is purely a trap for the NEXT enqueue.
+    """
+    sess = _sess(app_module)
+    sid = "s-unpause-on-empty"
+    a = sess.enqueue_message(sid, "a")["item"]["id"]
+    b = sess.enqueue_message(sid, "b")["item"]["id"]
+    sess.set_queue_paused(sid, True)
+
+    # Removing one of two leaves the pause intact — there IS still work.
+    data = sess.remove_queue_item(sid, a)
+    assert data["paused"] is True
+
+    data = sess.remove_queue_item(sid, b)
+    assert data["items"] == []
+    assert data["paused"] is False
+    # A queue that is empty AND un-paused leaves no file behind; a stale
+    # `paused` used to block that cleanup too (sessions/ had zombie
+    # {items: [], paused: true} files up to a week old).
+    assert not sess._queue_path(sid).exists()
+    # And the next message drains normally instead of vanishing.
+    sess.enqueue_message(sid, "fresh")
+    assert sess.dequeue_message(sid)["text"] == "fresh"
+
+
 def test_clear_queue_empties_and_unpauses(app_module):
     sess = _sess(app_module)
     sid = "s-clear"

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -2015,3 +2015,148 @@ def test_preflight_compact_announces_itself_over_sse(stream_env, client, monkeyp
     kinds = [e for e, _ in events]
     assert kinds.index("compact_progress") < kinds.index("error")
     assert kinds.count("compact_progress") == 2
+
+
+def test_sdk_command_reads_through_the_session_pump(stream_env):
+    """A slash command must not open a SECOND iterator over the client stream.
+
+    Regression for 2026-07-26. `_SessionStream`'s pump has owned
+    `receive_messages()` since client creation, so the `receive_response()`
+    this helper used to open lost every race: /compact's ResultMessage was
+    routed to the pump and parked in `_orphans`, and the helper waited on a
+    stream nobody was feeding. Two auto-compacts reported failure after 600s
+    and 9m19s while the transcript shows both compactions had finished in
+    ~150s — `query()` is a pure transport write, so the command always ran.
+    """
+    chat_mod = stream_env
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1,
+        is_error=False, num_turns=1, session_id="sid", uuid="r1")
+
+    class PumpedClient:
+        """Only `receive_messages()` works — `receive_response()` is a trap."""
+
+        def __init__(self):
+            self.queries = []
+            self._q = asyncio.Queue()
+
+        async def query(self, prompt):
+            self.queries.append(prompt)
+            self._q.put_nowait(result)
+
+        async def receive_messages(self):
+            while True:
+                yield await self._q.get()
+
+        async def receive_response(self):
+            raise AssertionError(
+                "opened a second iterator instead of attaching to the pump")
+            yield  # pragma: no cover — keeps this an async generator
+
+    async def go():
+        fake = PumpedClient()
+        chat_mod._ensure_session_stream(("sid", "m", ""), fake)
+        try:
+            # The bug's signature was a hang, so the bound is the assertion.
+            got = await asyncio.wait_for(
+                chat_mod._run_sdk_command_checked(fake, "/compact"), 5)
+        finally:
+            await chat_mod._drop_session_streams("sid")
+        assert fake.queries == ["/compact"]
+        return got
+
+    assert asyncio.run(go()) is result
+
+
+def test_park_unconsumed_hands_leftovers_back_to_the_orphan_park(stream_env):
+    """Stopping at our own Result must not swallow what the pump queued after it.
+
+    A slash command breaks on its ResultMessage, but the pump routes
+    everything to the attached queue — a background task's notification can
+    already be sitting behind it. Letting the queue fall out of scope would
+    drop that message with no trace.
+    """
+    chat_mod = stream_env
+    later = TaskNotificationMessage(
+        subtype="task_notification", data={}, task_id="t", status="completed",
+        output_file="", summary="done", uuid="bg", session_id="sid")
+
+    class IdleClient:
+        async def receive_messages(self):
+            await asyncio.Event().wait()
+            yield  # pragma: no cover — never reached
+
+    async def go():
+        stream = chat_mod._SessionStream(("sid", "m", ""), IdleClient())
+        try:
+            q = stream.attach_turn()
+            q.put_nowait(later)
+            q.put_nowait(chat_mod._STREAM_EOF)
+            stream.detach_turn(q)
+            stream.park_unconsumed(q)
+        finally:
+            await stream.aclose()
+        return list(stream._orphans)
+
+    # EOF is a wake-up sentinel, not a message — it must not be re-parked.
+    assert asyncio.run(go()) == [later]
+
+
+def test_preflight_compact_trusts_the_token_count_over_the_verdict(
+        stream_env, client, monkeypatch):
+    """A compaction that succeeded must not lose the turn it made room for.
+
+    How the command REPORTS itself is a hint; whether the context shrank is
+    the fact. On 2026-07-26 the two were opposites — /compact finished in
+    ~150s and freed the window, then the read side timed out and the preflight
+    killed the user's prompt anyway. Belt and braces for the pump fix above:
+    even if the verdict is lost again, an observably smaller context wins.
+    """
+    chat_mod = stream_env
+    sid = _make_session(client)
+    compact_error = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id=sid,
+        result="/compact ended without a ResultMessage", api_error_status=None)
+    answer = [
+        AssistantMessage(
+            content=[TextBlock(text="room to think")],
+            model="claude-sonnet-4-6", uuid="a1",
+            usage={"input_tokens": 4, "output_tokens": 2}),
+        ResultMessage(
+            subtype="success", duration_ms=10, duration_api_ms=9,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.01, usage={"input_tokens": 4, "output_tokens": 2},
+            result="room to think", uuid="r1"),
+    ]
+    fake = _FakeBatchedStreamClient([[compact_error], answer])
+    reads = []
+
+    async def shrinking_context():
+        # First read is the preflight's trigger; every later read sees the
+        # compaction's effect, which is what the recovery hinges on.
+        reads.append(len(reads))
+        return {
+            "maxTokens": 200_000, "rawMaxTokens": 200_000,
+            "autoCompactThreshold": 160_000,
+            "totalTokens": 190_000 if len(reads) == 1 else 50_000,
+        }
+
+    fake.get_context_usage = shrinking_context
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=still-send-me&model=claude-sonnet-4-6")
+    events = _parse_sse(r.text)
+    kinds = [e for e, _ in events]
+    prog = [json.loads(d) for e, d in events if e == "compact_progress"]
+
+    assert "error" not in kinds
+    assert prog[-1]["phase"] == "end" and prog[-1]["ok"] is True
+    assert prog[-1]["used"] == 50_000
+    # The prompt survived the scare — it was sent after the compact, not dropped.
+    assert fake.queried[0] == "/compact"
+    assert len(fake.queried) == 2

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -451,7 +451,10 @@ def test_stream_pdf_attachment_persists_path_fallback(stream_env, client, monkey
                    f"&prompt=please read it&image_ids=pdf1&model=claude-sonnet-4-6")
     assert r.status_code == 200, r.text
 
-    attach_path = chat_mod._attachments_base() / sid / "pdf1.pdf"
+    # Filename is `{aid}-{sanitised original name}` — the aid keeps two
+    # same-named uploads from clobbering each other, the readable half tells
+    # the agent what it's about to Read.
+    attach_path = chat_mod._attachments_base() / sid / "pdf1-doc.pdf"
     assert attach_path.read_bytes() == pdf_bytes
 
     assert fake.queried, "stream handler never called client.query"
@@ -461,9 +464,67 @@ def test_stream_pdf_attachment_persists_path_fallback(stream_env, client, monkey
     assert content[0]["source"]["media_type"] == "application/pdf"
     text = content[1]["text"]
     assert "please read it" in text
-    assert "Attached PDF files available on disk" in text
+    assert "Files attached to this message (on disk)" in text
     assert "doc.pdf" in text
     assert str(attach_path) in text
+
+
+def test_stream_text_attachment_goes_to_disk_not_into_prompt(
+        stream_env, client, monkeypatch):
+    """The whole point of the 2026-07-25 change: a text attachment is written
+    to disk and referenced by PATH. Its contents must not appear in the
+    prompt — inlining put the file in the transcript forever, so every later
+    turn in the session re-sent it, and a 200 KB CSV quietly ate the context
+    window that the user actually wanted for the conversation."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    secret = "COLUMN_HEADER_THAT_MUST_NOT_BE_INLINED"
+    body = f"a,b,c\n1,2,{secret}\n".encode("utf-8")
+    chat_mod._image_store["txt1"] = {
+        "kind": "text",
+        "mime": "text/csv",
+        "name": "数据 表.csv",
+        "raw": body,
+        "text": body.decode("utf-8"),
+        "ts": 9999999999,
+    }
+
+    fake = _FakeStreamClient([
+        ResultMessage(
+            subtype="success", duration_ms=100, duration_api_ms=90,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0, usage={"input_tokens": 1, "output_tokens": 1},
+        ),
+    ])
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=summarise it&image_ids=txt1&model=claude-sonnet-4-6")
+    assert r.status_code == 200, r.text
+
+    # Whitespace in the original name is sanitised to `_`; CJK survives.
+    attach_path = chat_mod._attachments_base() / sid / "txt1-数据_表.csv"
+    assert attach_path.read_bytes() == body
+
+    # _FakeStreamClient.query records a bare string for a plain prompt and a
+    # LIST of message dicts for an async-generator payload. With no image/PDF
+    # blocks there's nothing to structure, so this turn is the string case —
+    # indexing [0][0] the way the PDF test does would grab one character.
+    call = fake.queried[0]
+    if isinstance(call, (list, tuple)):
+        content = call[0]["message"]["content"]
+        text = content if isinstance(content, str) else "".join(
+            b.get("text", "") for b in content if isinstance(b, dict))
+    else:
+        text = call
+    assert "summarise it" in text
+    assert str(attach_path) in text
+    assert "数据 表.csv" in text          # display name stays the original
+    assert secret not in text            # …but the CONTENTS never ship
 
 
 def test_stream_background_task_messages_flow_through(stream_env, client, monkeypatch):
@@ -1603,6 +1664,85 @@ def test_stream_early_get_client_failure_emits_error_frame(stream_env, client, m
     assert sid not in chat_mod._active_turns
 
 
+def _ok_turn(sid):
+    """Minimal successful SDK turn: one text block + a success result."""
+    return [
+        AssistantMessage(
+            content=[TextBlock(text="ok")],
+            model="claude-sonnet-4-6",
+            usage={"input_tokens": 1, "output_tokens": 1},
+        ),
+        ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0,
+            usage={"input_tokens": 1, "output_tokens": 1},
+        ),
+    ]
+
+
+def test_turn_has_no_wall_clock_cap_by_default(stream_env, client, monkeypatch):
+    """A turn must run unbounded unless an operator opts in.
+
+    The old hard 1800s cap couldn't tell "wedged" from "busy", so it killed
+    turns that were actively producing output — and the kill was total loss,
+    because the SDK only writes the JSONL on completion and the abort reason
+    only ever existed as a live SSE frame. Pin the absence of a deadline
+    directly: `asyncio.timeout(None)` arms nothing.
+    """
+    import asyncio as _asyncio
+    chat_mod = stream_env
+    sid = _make_session(client)
+    seen: list[object] = []
+    real_timeout = _asyncio.timeout
+
+    def spy(delay):
+        seen.append(delay)
+        return real_timeout(delay)
+
+    monkeypatch.setattr(_asyncio, "timeout", spy)
+    monkeypatch.delenv("MUSELAB_TURN_TIMEOUT_S", raising=False)
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return _FakeStreamClient(_ok_turn(sid))
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=hi&model=claude-sonnet-4-6")
+    assert r.status_code == 200, r.text
+    # The turn wrapper is the only asyncio.timeout on this path, and it must
+    # have been handed None. A number here means the cap got re-armed.
+    assert seen, "asyncio.timeout was never called on the turn path"
+    assert all(d is None for d in seen), f"a deadline was armed: {seen}"
+
+
+def test_turn_cap_is_opt_in_via_env(stream_env, client, monkeypatch):
+    """The escape hatch still works for anyone who wants a ceiling back."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    monkeypatch.setenv("MUSELAB_TURN_TIMEOUT_S", "1")
+
+    class _SlowClient(_FakeStreamClient):
+        async def receive_response(self):
+            import asyncio as _a
+            await _a.sleep(3)          # outlives the 1s cap
+            for m in self._messages:
+                yield m
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return _SlowClient(_ok_turn(sid))
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=hi&model=claude-sonnet-4-6")
+    assert r.status_code == 200, r.text
+    events = _parse_sse(r.text)
+    err = next((json.loads(d) for e, d in events if e == "error"), None)
+    assert err is not None, f"no error frame: {events}"
+    assert "turn exceeded" in err["error"]
+    assert sid not in chat_mod._active_turns
+
+
 def test_stream_reconnect_no_active_turn(stream_env, client):
     """Empty prompt + no in-flight turn = reconnect mode that finds nothing,
     yielding a single 'no active turn' error frame (not a 500)."""
@@ -1825,3 +1965,53 @@ def test_task_output_requires_token(client):
     r = client.get("/api/chat/task-output",
                    params={"session_id": sid, "path": p})
     assert r.status_code in (401, 403), r.text
+
+
+def test_preflight_compact_announces_itself_over_sse(stream_env, client, monkeypatch):
+    """The auto-compact must be visible while it runs, not only in the logs.
+
+    2026-07-25: a 186229/200000 session sat behind the generic "thinking"
+    bubble for 9m19s of /compact and then died. The FE has a dedicated 📦
+    placeholder driven by the per-tab `compacting` flag; these events are what
+    turn it on and off for a compact the user didn't ask for.
+    """
+    chat_mod = stream_env
+    sid = _make_session(client)
+    compact_error = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1,
+        is_error=True, num_turns=1, session_id=sid,
+        result="Your input exceeds the context window of this model",
+        api_error_status=400,
+    )
+    fake = _FakeStreamClient([compact_error])
+
+    async def near_limit_context():
+        return {
+            "maxTokens": 200_000,
+            "rawMaxTokens": 200_000,
+            "autoCompactThreshold": 160_000,
+            "totalTokens": 190_000,
+        }
+
+    fake.get_context_usage = near_limit_context
+
+    async def fake_get_client(session_id, model, permission="bypassPermissions", effort=""):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+                   f"&prompt=must-not-send&model=claude-sonnet-4-6")
+    events = _parse_sse(r.text)
+    prog = [json.loads(d) for e, d in events if e == "compact_progress"]
+
+    assert [p["phase"] for p in prog] == ["start", "end"]
+    # "start" carries the numbers that justify the wait — the FE toasts them.
+    assert prog[0]["source"] == "auto"
+    assert prog[0]["used"] == 190_000
+    assert prog[0]["limit"] == 200_000
+    # Terminal phase precedes the error event, so the bubble stops before the
+    # failure toast rather than spinning under it.
+    assert prog[1]["ok"] is False
+    kinds = [e for e, _ in events]
+    assert kinds.index("compact_progress") < kinds.index("error")
+    assert kinds.count("compact_progress") == 2

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1761,3 +1761,78 @@ def test_auto_compact_drives_the_same_ui_as_a_manual_one():
     # is still the user's, which is also the generic pending bubble's trigger.
     assert ("&& !(tabState[currentId] && tabState[currentId].compacting)\"\n"
             "               class=\"msg assistant\"") in html
+
+
+def test_concise_mode_hides_exactly_three_card_classes():
+    """Concise chat mode is a subtraction, and a narrow one.
+
+    2026-07-26, user-selected by circling them in a screenshot: the generic
+    tool bubble, its 改动预览 diff strip, and the tool_result. Everything that
+    carries content or needs an action stays visible — TodoWrite, Task/Agent,
+    the Task* log lines, ExitPlanMode's plan card, ask_user_question,
+    permission_request. Hiding that last pair would leave the backend awaiting
+    an answer the user cannot see, i.e. a silent deadlock.
+    """
+    js = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    fn = js[js.index("conciseHidesToolUse(m) {"):]
+    fn = fn[:fn.index("shouldHideToolResult(m) {")]
+    # Only tool_use is this predicate's business.
+    assert 'm.role !== "tool_use"' in fn
+    for keep in ("TodoWrite", "Task", "Agent", "ExitPlanMode"):
+        assert keep in fn
+    assert "isTaskTool(m)) return false" in fn
+    # Failures survive concise mode, on both the call and the result side.
+    assert "if (m.is_error) return false;" in fn
+    res = js[js.index("shouldHideToolResult(m) {"):]
+    res = res[:res.index("isMsgRenderable(")]
+    assert res.index("if (m.is_error) return false;") \
+        < res.index("if (this.conciseChat) return true;")
+
+    # BOTH x-if gates: the diff strip is a second template on the same message,
+    # so gating only the generic bubble would leave the red/green strip behind.
+    assert html.count("&& !conciseHidesToolUse(m)") == 2
+    assert "['Edit','MultiEdit','Write'].includes(m.name)" in html
+
+    # isMsgRenderable must agree with the x-if gates, or the wrapper survives
+    # around a body that no longer renders — the 30-40px blank-gap bug.
+    rend = js[js.index("isMsgRenderable(m, i, paneMsgs"):]
+    rend = rend[:rend.index("// True iff this Edit/Write/MultiEdit")]
+    assert "if (this.conciseHidesToolUse(m)) return false;" in rend
+    # ...but the turn-tail short-circuit still precedes it, so the turn
+    # separator survives on turns that end in a hidden tool card.
+    assert rend.index("if (isTurnTail) return true;") \
+        < rend.index("conciseHidesToolUse")
+
+
+def test_concise_mode_is_a_device_preference_and_defaults_off():
+    """Off by default, remembered per device.
+
+    The problem it solves is "the phone screen is small", so a desktop reading
+    the same session should still get the full detail — hence localStorage
+    rather than a per-session setting. Default off because the cards it removes
+    are the only surface on which you can notice the agent touching a file you
+    did not expect.
+    """
+    js = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    i18n = (FRONTEND / "i18n" / "index.js").read_text(encoding="utf-8")
+
+    # Declared on the data object, not merely assigned in init(): the x-if
+    # gates read it during the very first paint.
+    assert "\n    conciseChat: false," in js
+    assert 'localStorage.getItem("muselab_concise_chat") === "1"' in js
+    assert 'localStorage.setItem("muselab_concise_chat",' in js
+
+    # Toggle lives in the composer gear panel, inside the hoisted popover.
+    pop = html[html.index('class="chat-toolbar-more-pop"'):]
+    pop = pop[:pop.index("<!-- / slash command palette -->")]
+    assert 't(\'concise.label\')' in pop
+    assert '@change="toggleConciseChat()"' in pop
+
+    # Both languages, label + tooltip, and the tooltip states the exception.
+    assert i18n.count('"concise.label"') == 2
+    assert i18n.count('"concise.title"') == 2
+    assert "失败的工具仍会显示" in i18n
+    assert "Failed tools still show" in i18n

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 
 FRONTEND = Path(__file__).resolve().parents[1] / "frontend"
+# A few checks in here span the FE/BE seam (e.g. a field the backend must emit
+# for a binding to have anything to render), so the backend source is read the
+# same source-text way rather than importing it.
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
 
 
 # Match top-level method definitions inside the Alpine x-data object:
@@ -625,12 +629,27 @@ def test_failed_transcript_refresh_preserves_last_good_messages():
     assert "this.messages = st.messages" not in failed
 
 
-def test_activity_center_groups_failed_tasks_as_recent():
+def test_activity_center_groups_strictly_by_state():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
 
-    assert 'states: ["waiting_approval", "paused"]' in app
-    assert 'states: ["completed", "failed", "cancelled"], readOnly: true' in app
-    assert 'item.state === "failed"' in app
+    # Failure gets its own group. It used to sit under a heading that read
+    # "Recent" — a failed task is not a completed one — and burying it there
+    # is why the filter needed an `item.state === "failed"` special case to
+    # keep unread failures from being hidden by the read-only rule.
+    assert 'states: ["waiting_approval"]' in app
+    assert 'states: ["failed"]' in app
+    assert 'states: ["running", "paused"]' in app
+    assert 'states: ["completed", "cancelled"]' in app
+    assert "readOnly" not in app
+    assert 'item.state === "failed"' not in app
+
+    # Read state no longer decides the group, so a finished task cannot jump
+    # between sections the moment the user glances at it.
+    assert "unreadOnly" not in app
+
+    # Each group collapses past a fixed number of rows.
+    assert "ACTIVITY_GROUP_CAP: 5" in app
+    assert "activityHiddenCount(group)" in app
 
 
 def test_activity_center_uses_two_compact_numberless_status_dots():
@@ -802,7 +821,11 @@ def test_background_task_gap_keeps_footer_running_without_blocking_composer():
     assert "if (streamState.es === es) streamState.es = null" in app
     assert "d.background && d.attachable === false" in app
     assert "continuation: !!d.continuation" in app
-    assert "(m.role === 'assistant' && m.uuid)" in html
+    # An assistant tail with a uuid still earns a footer even without a `ts`
+    # (that's the fork affordance). The `!streaming` guard came with the
+    # separator restyle: the footer no longer hosts the streaming dots, so
+    # during a live turn this clause would otherwise render an empty rule.
+    assert "(m.role === 'assistant' && m.uuid && !(pane && pane.streaming))" in html
     assert 'x-show="m.role === \'assistant\' && m.uuid' in html
 
 
@@ -991,7 +1014,20 @@ def test_long_chat_state_is_per_tab_bounded_and_generation_safe():
     assert "st._laterMessages.splice(st._laterMessages.length - drop, drop)" in cap
     assert "_captureMessageAnchor(scrollEl, m)" in cap
     assert "_restoreMessageAnchor(scrollEl, anchor)" in cap
-    assert "return st._loadedOffset > 0" in app
+    # "Load earlier" keys off the server cursor first…
+    assert "if (st._loadedOffset > 0) return true;" in app
+    # …and, at cursor 0, off stranded pre-chain history (post-/compact), which
+    # is reached by crossing orders rather than by decrementing the cursor.
+    assert "return this._preCompactReachable(st);" in app
+    assert 'st._historyOrder !== "full" && (st._preTotal || 0) > 0' in app
+    switch_start = app.index("async _switchToFullOrder(sid)")
+    switch_end = app.index("async loadEarlierMessages(sid)", switch_start)
+    switch = app[switch_start:switch_end]
+    # The crossing must go through around_uuid; offset arithmetic across the
+    # two orders mis-seats the window (full keeps sidechains, normal doesn't).
+    assert "this._loadAroundMessage(sid, anchorUuid)" in switch
+    assert "&full=1" not in switch
+    assert "_preTotal" not in switch.split("_preCompactReachable")[-1]
     assert "historyTruncated(sid)" in app and "return false" in app[
         app.index("historyTruncated(sid)"):app.index("async renameSession()")]
 
@@ -1002,6 +1038,9 @@ def test_long_chat_state_is_per_tab_bounded_and_generation_safe():
     assert 'x-for="(m, i) in paneMsgs" :key="m._k"' in pane
     assert "pane.streaming" in pane
     assert "pane.streamElapsed" in pane
+    # Elapsed reads through a null-guarded pane. `pane` resolves to null while
+    # a closing tab's pane is torn down, and an unguarded property read there
+    # throws inside the Alpine effect.
     assert "fmtStreamElapsed((pane && pane.streamElapsed) || 0)" in pane
     assert 'x-text="fmtStreamElapsed(pane.streamElapsed)"' not in pane
     assert "messages.length" not in re.sub(r"<!--.*?-->", "", pane, flags=re.S)
@@ -1052,7 +1091,10 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "async terminateAllTerminals()" in app
     assert "async saveTerminalProfile()" in app
     assert "async deleteTerminalProfile()" in app
-    assert "openTerminalManagerFromChat()" in app
+    # The chat header must NOT grow a second terminal entry point. The preview
+    # header's terminal-manager button is the only one; a duplicate in the chat
+    # header competes for the most contested row in the mobile layout.
+    assert "openTerminalManagerFromChat()" not in app
     assert "terminalMobileKey(text)" in app
     assert "this._terminalSend(text)" in app
     assert "_terminalDataIsMouseReport(data)" in app
@@ -1103,11 +1145,11 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert 'class="terminal-manager-backdrop"' in html
     assert 'class="terminal-manager-dismiss"' in html
     assert "'pane-floating-layer': terminalManagerOpen" in html
-    assert 'class="icon-btn chat-terminal-btn"' in html
+    assert 'class="icon-btn chat-terminal-btn"' not in html
     assert 'class="icon-btn terminal-manager-btn preview-keep-mobile"' in html
     assert 'data-terminal-key="backslash"' in html
     assert "@click=\"terminalMobileKey('\\\\')\"" in html
-    assert ".pane.chat .pane-head .chat-terminal-btn { display: inline-flex; }" in css
+    assert "chat-terminal-btn" not in css
     assert ".pane.preview > .pane-head > .btn-primary { display: none; }" in css
     assert ".pane.preview .pane-head .btn-primary { display: none; }" not in css
     layer_start = css.index(".pane.pane-floating-layer")
@@ -1321,3 +1363,401 @@ def test_chat_send_and_stop_buttons_are_icon_only_but_accessible():
     assert ':aria-label="t(\'btn.stop\')"' in buttons
     assert ".chat-toolbar-send { width: 44px; padding: 0; }" in css
     assert ".chat-toolbar-send > span:nth-child(2)" not in css
+
+
+def test_ctx_breakdown_maps_sdk_theme_tokens_to_real_colors():
+    """SDK `color` is a THEME TOKEN NAME, not a CSS color.
+
+    Real bug, 2026-07-25: get_context_usage() returns colors like
+    "promptBorder" / "inactive" / "claude" / "warning" /
+    "purple_FOR_SUBAGENTS_ONLY". The old ctxCategoryColor() returned them
+    verbatim, so every swatch and bar got `background: promptBorder` — an
+    invalid declaration browsers drop. The whole visualisation rendered
+    blank, and the hashed-hue fallback was unreachable because `cat.color`
+    is always truthy.
+    """
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    for token in ("promptBorder", "inactive", "claude", "warning",
+                  "purple_FOR_SUBAGENTS_ONLY"):
+        assert f"{token}:" in app, f"theme token {token} left unmapped"
+    start = app.index("    ctxCategoryColor(cat) {")
+    body = app[start:app.index("\n    },", start)]
+    # The bug was returning cat.color unconditionally. Any passthrough must
+    # now be gated on it actually being a color.
+    assert "if (cat && cat.color) return cat.color;" not in body
+    assert "this.ctxColorTokens[raw]" in body
+    assert "this._isCssColor(raw)" in body
+    assert 'CSS.supports("color", v)' in app
+
+
+def test_ctx_breakdown_excludes_free_space_and_deferred_from_the_stack():
+    """Free space is the remainder, deferred rows aren't in totalTokens.
+
+    Real bug, 2026-07-25: `categories` was rendered raw. "Free space"
+    (114.8K = 57% of a 200K window) became the largest bar and flattened
+    every real category, and the two "(deferred)" rows pushed the sum to
+    208,235 against a 200,000 window — a stack overflowing its own track by
+    4%. The SDK's own gridRows (the CLI /context grid) omits both.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    # Nothing may iterate the raw category list any more.
+    assert "ctxBreakdown.data.categories" not in html
+    assert 'x-for="cat in ctxBreakdown.view.used"' in html
+    assert 'x-for="cat in ctxBreakdown.view.deferred"' in html
+    start = app.index("    _ctxBuildView(data) {")
+    body = app[start:app.index("\n    },", start)]
+    assert "/free\\s*space/i.test(name)" in body
+    assert "/\\(\\s*deferred\\s*\\)/i.test(name)" in body
+    # Deferred must be summed separately, never folded into usedTotal.
+    assert "deferredTotal: sum(deferred)" in body
+    assert "usedTotal: sum(used)" in body
+
+
+def test_ctx_breakdown_drilldown_uses_normalised_labels():
+    """memoryFiles keys its name as `path`, skills wraps skillFrontmatter.
+
+    Real bug, 2026-07-25: the template read `item.name` for every child
+    list, so expanding "Memory files" — the 2nd largest real category —
+    listed 14 rows with blank labels and `undefined-<tokens>` keys.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    assert 'x-text="item.name"' not in html
+    assert 'x-text="item.label"' in html
+    assert 'key="item.title + \'-\' + item.tokens"' in html
+    start = app.index("    _ctxChildrenFor(data, name) {")
+    body = app[start:app.index("\n    },", start)]
+    assert "f.path || f.name" in body          # memoryFiles: path, not name
+    assert "sk.skillFrontmatter" in body       # skills: object, not array
+    assert "data.mcpTools" in body
+    assert "sort((a, b) => b.tokens - a.tokens)" in body
+
+
+def test_ctx_breakdown_rows_survive_the_x_for_single_root_rule():
+    """Alpine x-for needs ONE root element per iteration.
+
+    The row <div> and its drill-down <template x-if> used to be siblings
+    inside the same x-for, which is not a single root. Each iteration now
+    wraps both in a container.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    assert ".ctx-breakdown-swatch.hollow" in css
+    assert ".ctx-breakdown-submeta" in css
+    # Both x-for bodies (counted + deferred) open a wrapper <div> immediately.
+    for marker in ('x-for="cat in ctxBreakdown.view.used"',
+                   'x-for="cat in ctxBreakdown.view.deferred"'):
+        # The stacked bar also iterates `.used`, and its body is a single
+        # <div class="ctx-breakdown-stack-seg"> — already one root.
+        for start in _all_indices(html, marker):
+            body = html[start:start + 400]
+            assert ("<div>" in body) or ("ctx-breakdown-stack-seg" in body), (
+                f"x-for at {start} must wrap its iteration in a single root")
+
+
+def _all_indices(hay: str, needle: str) -> list[int]:
+    out, i = [], hay.find(needle)
+    while i != -1:
+        out.append(i)
+        i = hay.find(needle, i + 1)
+    return out
+
+
+def test_ctx_breakdown_rows_show_a_percent_column_not_a_dead_inline_bar():
+    """The per-row bar was inert markup and is gone.
+
+    `.ctx-breakdown-bar-fill` was a <span> carrying only `height: 100%`, and
+    width/height do not apply to non-replaced inline boxes (CSS 2.1 §10.3.1,
+    §10.6.1) — so every row bar rendered as an empty grey track for its whole
+    life. The stacked bar at the top works because its segments are <div>s.
+    Rather than resurrect a control that triple-encoded one number (swatch +
+    bar + numeral) and flattened four of five rows into near-empty tracks, the
+    column is now the share-of-window figure.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    assert "ctx-breakdown-bar" not in html
+    assert "ctx-breakdown-bar-fill" not in css
+    assert ".ctx-breakdown-pct" in css
+    assert 'x-text="ctxPctLabel(cat)"' in html
+    # Variable precision, or Skills (79 tokens) and System tools (10.3K) both
+    # print "0%" — the exact flattening the bars already did.
+    assert 'if (p < 0.1) return "<0.1%";' in app
+    assert 'if (p < 10) return p.toFixed(1) + "%";' in app
+    # Deferred rows get an EMPTY pct cell: their tokens are not in totalTokens,
+    # so a share-of-window figure there would read as occupancy.
+    assert '<span class="ctx-breakdown-pct"></span>' in html
+    # Rows are a figure list now, not a table: no per-row rule.
+    assert "border-bottom: 1px dashed var(--c-border);\n}" not in css.split(
+        ".ctx-breakdown-row {")[1][:200]
+
+
+def test_composer_settings_panel_escapes_the_overflow_hidden_composer():
+    """The gear panel must not live inside .chat-input-wrap.
+
+    Real bug, 2026-07-25: the panel was a child of .chat-toolbar-more, which
+    sits inside .chat-input-wrap — and that wrap sets `overflow: hidden` to
+    clip the textarea + toolbar to its rounded frame. A panel popping upward
+    from in there is CLIPPED at the wrap's top edge, not merely stacked
+    under something, so its z-index was irrelevant. With the zh effort label
+    wrapping to 3 lines the panel ran ~176px against ~46px of room: the user
+    saw one bare select and nothing else.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    panel = html.index('class="chat-toolbar-more-pop"')
+    wrap = html.index('<div class="chat-input-wrap"')
+    chat_input = html.index('<div class="chat-input">')
+    assert chat_input < panel < wrap, (
+        "the settings panel must be anchored to .chat-input, before (and thus "
+        "outside) the overflow:hidden .chat-input-wrap"
+    )
+    # .chat-input-wrap keeps its clipping — the panel moved, the frame didn't.
+    # (There are several `.chat-input-wrap {` blocks; the media-query one only
+    # zeroes padding, so check every block rather than the first.)
+    blocks = [css[m.end():css.index("}", m.end())]
+              for m in re.finditer(r"\.chat-input-wrap \{", css)]
+    assert any("overflow: hidden;" in b for b in blocks), (
+        "the clip that made this bug is gone — if that was deliberate, this "
+        "test and the panel's hoisting should be revisited together"
+    )
+    # Anchor must no longer be the button's own box.
+    assert ".chat-toolbar-more { display: none; }" in css
+    # Desktop re-gate: hoisting it out of the group's display:none exposed it
+    # on viewports where the gear itself is hidden.
+    assert "@media not all and (pointer: coarse)" in css
+    assert ".chat-toolbar-more-pop { display: none !important; }" in css
+
+
+def test_effort_field_uses_a_short_label_not_the_tooltip_prose():
+    """`effort.title` is tooltip copy, not a field caption.
+
+    The zh string is 51 chars ("Effort — Anthropic 官方术语，控制推理预算与
+    agentic loop 深度（不译）"). Rendered as a visible <span> label it wrapped
+    to 3 lines and was the single largest contributor to the panel's height.
+    Mirrors the existing thinking.label / thinking.title split.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    i18n = (FRONTEND / "i18n" / "index.js").read_text(encoding="utf-8")
+    assert "x-text=\"t('effort.title')\"" not in html
+    assert "x-text=\"t('effort.label')\"" in html
+    # Present in BOTH dictionaries, and actually short.
+    assert i18n.count('"effort.label": "Effort",') == 2
+    for key in ("effort.label", "effort.title"):
+        assert i18n.count(f'"{key}":') == 2, f"{key} missing from a locale"
+
+
+def test_running_state_is_pinned_to_the_scroll_viewport_not_the_last_message():
+    """A long agentic turn must show "still running" at every scroll position.
+
+    2026-07-25 report ("这种界面很让人困惑啊 为什么没有footer？"): a screenful of
+    tool cards with no time, no state, no boundary. Three separately-reasonable
+    rules composed into that: (1) one footer per TURN, on its tail message;
+    (2) the HH:MM stamp only lands in the `done` handler, so a running turn has
+    no `ts` anywhere; (3) the pulsing avatar marks the turn's FIRST message,
+    which in a 40-block turn is far off-screen. Net: the only evidence of life
+    was the composer's stop button.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    pane_start = html.index('<div class="msg-pane"')
+    pane_end = html.index("<!-- /P1 per-tab message panes", pane_start)
+    pane = html[pane_start:pane_end]
+    # Lives INSIDE the pane: panes are resident per tab, and a single shared
+    # bar would report the active tab's state under every one of them.
+    assert 'class="turn-running-bar"' in pane
+    # The gate also excludes the pending-bubble case — see
+    # test_running_bar_and_pending_bubble_are_mutually_exclusive.
+    assert 'x-show="pane && pane.streaming' in pane
+
+    block = css[css.index(".turn-running-bar {"):]
+    block = block[:block.index("}")]
+    assert "position: sticky" in block
+    assert "bottom: 0" in block
+    # Opaque, or message text shows through as it scrolls underneath.
+    assert "background: var(--c-bg-1)" in block
+
+
+def test_turn_footer_is_a_separator_and_no_longer_hosts_streaming_dots():
+    """The footer became the turn boundary; the dots moved to the sticky bar.
+
+    Keeping both would pulse two sets of dots ~20px apart whenever the user
+    happened to be scrolled to the bottom.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    footer = html[html.index('<div class="turn-footer"'):]
+    footer = footer[:footer.index("</div>")]
+    assert "thinking-dots" not in footer
+    assert "stream-elapsed" not in footer
+    # Bracketing hairlines are what make it read as a boundary rather than a
+    # caption hanging off the last card.
+    assert ".turn-footer::before," in css
+    assert ".turn-footer::after {" in css
+    # The 40px avatar-column indent went with the dots — a boundary spans the
+    # full width.
+    assert "padding: 4px 0 6px 40px;" not in css
+    assert "padding: 2px 0 3px 34px;" not in css
+
+
+def test_per_message_timestamps_are_plumbed_but_only_shown_on_expand():
+    """`mts` is the transcript wall-clock, kept distinct from the turn `ts`.
+
+    Populating `ts` per message instead would break _markDone: it walks
+    backwards looking for a bubble that ALREADY has `ts` to decide it has left
+    the current turn, so it would abort on the first block it saw.
+    """
+    chat = (BACKEND / "chat.py").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    assert "def _transcript_ts_ms(entry: dict) -> int | None:" in chat
+    # Both raw-entry loaders stamp it; the pure-SDK loader can't (SessionMessage
+    # has no timestamp field) and consumers must tolerate its absence.
+    assert chat.count("_transcript_ts_ms(e)") == 2
+    assert 'entry["mts"] = mts_by_uuid[u]' in chat
+    assert '__slots__ = ("uuid", "type", "message", "mts")' in chat
+
+    # Shown only on an EXPANDED tool card — 30+ stamped cards per turn costs
+    # more attention than it returns, and the separator already answers "when".
+    assert 'class="msg-time"' in html
+    stamp = html[html.index('class="msg-time"'):]
+    stamp = stamp[:stamp.index("</div>")]
+    assert "isMsgExpanded(i, m, false, pane, paneMsgs)" in stamp
+    assert "m.role === 'tool_use'" in stamp
+
+
+def test_queue_paused_flag_cannot_outlive_its_items():
+    """An empty queue must never stay paused.
+
+    2026-07-25: a 30-min-cap abort paused a 2-item queue; the user deleted both
+    items; `paused` survived; two fresh messages then sat forever because
+    dequeue_message returns None while paused — through several completed
+    turns, with no banner (it was gated on `!streaming`) and no error. The
+    stale flag also blocks _save_queue's empty-file cleanup, so sessions/ had
+    zombie {items: [], paused: true} files up to a week old.
+    """
+    sessions = (BACKEND / "sessions.py").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    remove = sessions[sessions.index("def remove_queue_item("):]
+    remove = remove[:remove.index("def clear_queue(")]
+    assert 'if not data["items"]:' in remove
+    assert 'data["paused"] = False' in remove
+
+    # Paused beats streaming: "a turn is running" no longer implies "it will
+    # drain when the turn ends".
+    assert "(!streaming || tabState[currentId]._queuePaused)" in html
+    # And the bubble itself says so — the banner is easy to scroll past.
+    assert 'class="queued-paused-badge"' in html
+
+
+def test_compact_summary_stays_collapsed_until_tapped():
+    """A compact summary must never unfurl itself.
+
+    The original "啥也没有" fix (2026-07-25) bundled two changes: render the
+    summary body at all, and default it open while it was the pane's last
+    bubble. The second half backfired — a compact summary sits last from the
+    moment it lands until the first muse-side msg of the NEXT turn arrives, so
+    both the explicit `i === paneMsgs.length - 1` hint AND isMsgExpanded's
+    "streaming last block" fallback unfurled 10-20k chars on top of a turn the
+    user was trying to watch. Only an explicit tap opens it now; the pill's
+    state-tracking label carries the affordance instead.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    js = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    block = html[html.index('x-if="m._is_compact_summary"'):]
+    block = block[:block.index("</template>")]
+    # No default-open hint on any of the four call sites (pill click, aria,
+    # label, body).
+    assert "paneMsgs.length - 1" not in block
+    assert block.count("isMsgExpanded(i, m, false, pane, paneMsgs)") == 4
+    assert "toggleMsgExpanded(m, i, false)" in block
+    # toggleMsgExpanded's defaultOpen must mirror isMsgExpanded's, else the
+    # first tap computes the wrong "current" state and visibly does nothing.
+
+    # And the fallback rule opts compact summaries out before it can fire.
+    fn = js[js.index("isMsgExpanded(i, m, defaultOpen"):]
+    fn = fn[:fn.index("toggleMsgExpanded(")]
+    opt_out = fn.index("m._is_compact_summary")
+    assert opt_out < fn.index("if (defaultOpen) return true;")
+    assert opt_out < fn.index("streaming && i === msgs.length - 1")
+
+
+def test_running_bar_and_pending_bubble_are_mutually_exclusive():
+    """Only one live-state indicator at a time.
+
+    The sticky .turn-running-bar shows dots + elapsed + model. So does the
+    "Muse 正在思考…" pending bubble, and the bar pins itself a few px below it —
+    2026-07-25 screenshot showed "运行中 · 9m27s · Opus 5" stacked directly on
+    "Muse 正在思考… · Opus 5 · 9m27s". The pending bubble renders when there is
+    no muse-side msg yet; the bar must require the inverse.
+    """
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    bar = html[html.index('class="turn-running-bar"'):]
+    bar = bar[:bar.index("</div>")]
+    assert "paneMsgs[paneMsgs.length - 1].role !== 'user'" in bar
+    assert "paneMsgs.length" in bar
+
+    # The pending bubble's own gate, unchanged — the two conditions are
+    # complements, so exactly one renders.
+    assert ("streaming && (!messages.length\n"
+            "                                       || messages[messages.length-1]"
+            ".role === 'user')") in html
+
+
+def test_auto_compact_drives_the_same_ui_as_a_manual_one():
+    """A backend preflight compact must not masquerade as a slow turn.
+
+    2026-07-25: a 186229/200000 session auto-compacted for 9m19s behind the
+    generic "Muse 正在思考…" bubble and then died on "/compact ended without a
+    ResultMessage". The manual compact path has had a 📦 bubble + ctx-meter
+    shimmer since 2026-05-22, all driven by the per-tab `compacting` flag —
+    the automatic path now sets the same flag rather than growing a parallel
+    UI that would drift.
+    """
+    chat = (BACKEND / "chat.py").read_text(encoding="utf-8")
+    js = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    # Backend: both phases, on every exit path (ok, sdk failure, and the
+    # "context didn't shrink" verification failure).
+    pre = chat[chat.index("async def _preflight_compact_if_needed("):]
+    pre = pre[:pre.index("async def event_gen():")]
+    assert '_emit_compact(emit, "start"' in pre
+    assert pre.count('_emit_compact(\n                emit, "end"') \
+        + pre.count('_emit_compact(emit, "end"') == 3
+
+    # The emitter is injected, not closed over: merge_q is one scope deeper.
+    assert "async def _emit_side(evt: dict) -> None:" in chat
+    assert "await _preflight_compact_if_needed(_emit_side)" in chat
+    # A UI cue must never kill the turn it describes.
+    helper = chat[chat.index("async def _emit_compact("):]
+    helper = helper[:helper.index("async def _preflight_compact_if_needed(")]
+    assert "except Exception as e:" in helper
+    assert "if emit is None:" in helper
+
+    # Frontend: same flag, written per-tab (a background tab's compact must not
+    # animate the tab you're looking at).
+    h = js[js.index('es.addEventListener("compact_progress"'):]
+    h = h[:h.index('es.addEventListener("ask_user_question"')]
+    assert "streamState.compacting = true;" in h
+    assert "streamState.compacting = false;" in h
+    assert "this.compacting" not in h
+
+    # Cleared on stream teardown too — a turn that dies inside /compact may
+    # never deliver phase:"end", and a stuck flag also blocks queue drain.
+    done = js[js.index("const _markDone = ("):]
+    done = done[:done.index("this._setBackgroundTaskActive(")]
+    assert "streamState.compacting = false;" in done
+
+    # Exactly one placeholder bubble: the auto-compact fires while the last msg
+    # is still the user's, which is also the generic pending bubble's trigger.
+    assert ("&& !(tabState[currentId] && tabState[currentId].compacting)\"\n"
+            "               class=\"msg assistant\"") in html

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -170,6 +170,71 @@ def test_normal_chain_matches_sdk_leaf_rules_and_full_keeps_file_order(tmp_path)
     assert index["bubble_prefix"]["normal"][-1] == 4
 
 
+def _compacted_entries():
+    """Pre-compact turns, then the disconnected root /compact writes.
+
+    The summary's parent is a `system` record whose own parentUuid is None, so
+    walking parents back from the leaf stops AT the summary and never reaches
+    u1..a2 — which is exactly why they fall out of the normal order.
+    """
+    return [
+        _entry("u1", "user", "old one"),
+        _entry("a1", "assistant", "old reply", "u1"),
+        _entry("u2", "user", "old two"),
+        _entry("a2", "assistant", "old reply two", "u2"),
+        _entry("sys", "system", "boundary", None, subtype="compact_boundary"),
+        _entry("c1", "user", "summary", "sys", isCompactSummary=True),
+        _entry("u3", "user", "after compact", "c1"),
+        _entry("a3", "assistant", "after reply", "u3"),
+    ]
+
+
+def test_pre_chain_bubbles_counts_stranded_pre_compact_history(tmp_path):
+    transcript = tmp_path / "compacted.jsonl"
+    index_path = tmp_path / "compacted.index.json"
+    _append(transcript, *_compacted_entries())
+    index = ti.ensure_index("compacted", transcript, index_path, _describe)
+    records = index["records"]
+    # The visible chain starts at the summary; four bubbles precede it.
+    assert [records[i]["uuid"] for i in index["orders"]["normal"]] == [
+        "c1", "u3", "a3",
+    ]
+    assert index["bubble_prefix"]["normal"][-1] == 3
+    assert ti.pre_chain_bubbles(index) == 4
+
+
+def test_pre_chain_bubbles_ignores_sidechain_only_divergence(tmp_path):
+    """A subagent turn makes full longer than normal WITHOUT stranding history.
+
+    This is the case that kills the naive `full_total - normal_total`: the
+    difference is 1 here, but nothing is unreachable and the button must
+    stay hidden.
+    """
+    transcript = tmp_path / "sidechain.jsonl"
+    index_path = tmp_path / "sidechain.index.json"
+    _append(
+        transcript,
+        _entry("u1", "user", "root"),
+        _entry("a1", "assistant", "reply", "u1"),
+        _entry("side", "assistant", "subagent", "u1", isSidechain=True),
+        _entry("u2", "user", "next", "a1"),
+        _entry("a2", "assistant", "leaf", "u2"),
+    )
+    index = ti.ensure_index("sidechain", transcript, index_path, _describe)
+    full_total = index["bubble_prefix"]["full"][-1]
+    normal_total = index["bubble_prefix"]["normal"][-1]
+    assert full_total - normal_total == 1          # the trap
+    assert ti.pre_chain_bubbles(index) == 0        # the answer
+
+
+def test_pre_chain_bubbles_zero_on_empty_transcript(tmp_path):
+    transcript = tmp_path / "empty.jsonl"
+    index_path = tmp_path / "empty.index.json"
+    transcript.write_text("", encoding="utf-8")
+    index = ti.ensure_index("empty", transcript, index_path, _describe)
+    assert ti.pre_chain_bubbles(index) == 0
+
+
 def test_same_sid_build_is_single_flight(tmp_path):
     transcript = tmp_path / "concurrent.jsonl"
     index_path = tmp_path / "concurrent.index.json"
@@ -238,6 +303,40 @@ def test_window_endpoint_matches_full_oracle_and_adds_stable_keys(
     assert body["has_later"] is True
     assert body["history_generation"]
     assert len({m["_key"] for m in body["messages"]}) == len(body["messages"])
+
+
+def test_endpoint_reports_pre_total_and_zeroes_it_in_full_order(
+    client, auth, app_module, tmp_path,
+):
+    """`pre_total` is what makes "Load earlier" appear on a compacted session.
+
+    The normal-order tail reports offset 0 / total 3 — by every pre-existing
+    signal the client is looking at the whole conversation. `pre_total` is the
+    only thing that says otherwise. Once the client crosses into full order
+    those bubbles are inside `total`, so the field has to go quiet or the
+    button would never switch off at the real start.
+    """
+    from backend import chat as chat_mod
+    sid, _ = _make_endpoint_session(
+        client, auth, chat_mod, tmp_path, _compacted_entries())
+
+    normal = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 10})
+    assert normal.status_code == 200, normal.text
+    body = normal.json()
+    assert body["history_order"] == "normal"
+    assert body["offset"] == 0
+    assert body["has_more"] is False       # nothing earlier IN THIS ORDER…
+    assert body["pre_total"] == 4          # …but four bubbles are stranded
+
+    full = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth,
+        params={"tail": 10, "full": 1})
+    assert full.status_code == 200, full.text
+    full_body = full.json()
+    assert full_body["history_order"] == "full"
+    assert full_body["total"] == body["total"] + 4
+    assert full_body["pre_total"] == 0
 
 
 def test_cross_window_tool_context_task_status_generation_and_around(


### PR DESCRIPTION
## What this changes

三件事，都围绕「一轮对话在屏幕上到底看得见什么」：

1. **长回合可见性 + 附件落盘引用**（9718b59，已有）——回合分隔线、置顶运行条、
   自动压缩复用手动压缩的 📦 动画，附件从内联 base64 改为落盘引用。
2. **会话区简洁模式**（0243c22）——新增开关，只隐藏通用工具气泡、改动预览
   diff 条、tool_result 三类纯管道卡片；默认关，按设备记忆。
3. **修复 `/compact` 假阴性**（ff2e540）——slash 命令改从会话 pump 读取消息，
   不再自开第二个 iterator。

## Why

**简洁模式**：移动端一屏就那么大，一轮里的文件读写卡片能把真正的消息气泡挤出
视野。用减法解决——保留 TodoWrite / Task / ExitPlanMode / ask_user_question /
thinking / 消息气泡，只砍纯管道部分。失败的工具调用永远显示
（`shouldHideToolResult` 里既有的 invariant，不是新规则）。

**`/compact` 修复**：自动压缩连续两次报失败，实际两次都成功了。

```
00:33:41  [chat-preflight] native compact  total=172204
00:36:11  transcript compact_boundary  preTokens=173938 durationMs=150446
00:43:41  native compact failed: TimeoutError（600s 满）
```

压缩 150 秒就完成，后端又空等 7 分半才超时；前一次同样（147s 完成，9m19s 后报
`/compact ended without a ResultMessage`）。用户看到的是「等十分钟然后报错」，
而上下文其实已经压好了——重发一次就能跑通。

根因：`_SessionStream` 的 pump 自 client 创建起就独占 `receive_messages()`，
而 `_run_sdk_command_checked` 仍在自开 `receive_response()`，正是该类 docstring
里「two iterators competed for the same underlying queue」要根除的模式。主回合
循环当初迁到了 `attach_turn()`，**这个调用点漏迁了**。`/compact` 的
`ResultMessage` 被 pump 收走停进 `_orphans`，函数在等一条没人喂的流。
`query()` 是纯传输写操作，所以命令本身始终照常执行——两次失败都是假阴性。

## Testing

- [x] `uv run pytest tests/` passes — CI matrix 三条腿全绿
      （ubuntu py3.12 / py3.13、macos py3.12）。本地跑过
      `test_chat_stream.py` + `test_chat_queue.py` **79 passed** 与
      `test_frontend_lint.py` **70 passed**。
- [x] e2e：首轮 `test_120kb_mixed_sse_stream_renders_final_assistant_html[chromium-desktop]`
      挂了，已查证为抖动而非本分支回归——零改动重跑 CI 转绿；本地全量 e2e
      对照，main 与本分支挂的是**同一条**不相干用例
      （`test_external_file_changes_refresh_tree_without_manual_reload`），
      该用例单独跑本分支 3/3 通过。
- [x] `uv run ruff check backend/ tests/` passes
- [x] `bash scripts/lint.sh` passes
- [x] 后端改动已加测试

新增回归（`tests/test_chat_stream.py`，+3）：

- `test_sdk_command_reads_through_the_session_pump` — 假 client 的
  `receive_response()` 直接 `raise AssertionError`，只有 `receive_messages()`
  可用；原 bug 表现为挂死，所以断言是 `asyncio.wait_for(..., 5)`。
- `test_park_unconsumed_hands_leftovers_back_to_the_orphan_park`
- `test_preflight_compact_trusts_the_token_count_over_the_verdict` — 命令报错但
  context 从 190K 掉到 50K 时，原 prompt 照常发出、无 error 事件。

前端 lint（`tests/test_frontend_lint.py`，+2，共 70 passed）覆盖：三类卡片恰好
被隐藏、`conciseHidesToolUse` 在 index.html 中出现两次（改动预览是同一条
tool_use 上的**第二个** x-if，漏加门红绿条就会留在屏幕上）、开关默认关。

**前端视觉改动**，需要人工看的点：

- composer 齿轮面板底部新增「简洁模式」开关行，整行 label 可点。
- 打开后：Read / Bash 等工具气泡、红绿 diff 条、`> app.js · 8 行输出` 结果块
  消失；TodoWrite / 计划卡 / 思考块 / 消息气泡保留；工具**失败**时仍显示。
- 回合分隔线不能消失——`isMsgRenderable` 的回合尾短路排在简洁判断之前，
  即使一轮结束在被隐藏的工具卡上外壳仍渲染
  （2026-05-28「改动预览下方好像不会出现 footer 了」的回归保护）。

## Checklist

- [x] No secrets committed
- [x] Docs updated if behavior visible to users — 简洁模式的说明走 i18n
      `concise.title` tooltip（zh / en 均已加）
- [x] If adds runtime dep: install scripts updated — 无新增依赖

## Notes

- 隐藏走 `.msg` 外壳挂 `is-hidden` 类而非过滤数组，消息 index 不变
  （CSS-only `:has()` 方案在 iOS Safari 15.x 上会留 30-40px 空白带，已弃用）。
- `MUSELAB_COMPACT_TIMEOUT_S` 默认 600 → 300，两处统一。实测最坏约 150s，
  300 是两倍余量，且现在超时可恢复，快失败优于死等。
- 已知未完成（沿用 9718b59 commit message 的记录）：`_doc_item()` 仍会发一个
  没人消费的 `url` 字段，文档 chip 还是 `<span>`，附件暂不可下载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)