### PR TITLE
fix(activity): 重排全局任务中心

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -14,6 +14,61 @@ from . import sessions
 
 _MAX_EVENTS = 500
 _TERMINAL = {"completed", "failed", "cancelled"}
+_ACTIVE = {"running", "waiting_approval", "paused"}
+
+
+def _activity_at(item: dict[str, Any]) -> float:
+    """Return the latest task transition timestamp without letting ACK reorder rows."""
+    return float(item.get("updated_at") or item.get("finished_at")
+                 or item.get("started_at") or 0)
+
+
+def _is_unread_result(item: dict[str, Any]) -> bool:
+    return item.get("state") in {"completed", "failed"} and not item.get("read")
+
+
+def _requires_action(item: dict[str, Any]) -> bool:
+    return item.get("state") in {"waiting_approval", "paused"}
+
+
+def _summarize(events: list[dict[str, Any]]) -> dict[str, Any]:
+    groups = {
+        "review": sum(x.get("state") == "completed" and not x.get("read")
+                      for x in events),
+        "running": sum(x.get("state") in _ACTIVE for x in events),
+        "failed": sum(x.get("state") == "failed" for x in events),
+        "history": sum((x.get("state") == "completed" and bool(x.get("read")))
+                       or x.get("state") == "cancelled" for x in events),
+    }
+    group_unread = {
+        "review": groups["review"],
+        "running": sum(_requires_action(x) for x in events),
+        "failed": sum(x.get("state") == "failed" and not x.get("read")
+                      for x in events),
+        "history": 0,
+    }
+    workspaces: dict[str, dict[str, Any]] = {}
+    for item in events:
+        path = str(item.get("workspace") or "")
+        row = workspaces.setdefault(path, {"path": path,
+            "name": item.get("workspace_name") or Path(path).name or "Workspace",
+            "running": 0, "unread": 0, "attention": 0})
+        if item.get("state") in _ACTIVE:
+            row["running"] += 1
+        if _is_unread_result(item):
+            row["unread"] += 1
+        if _requires_action(item) or (item.get("state") == "failed" and not item.get("read")):
+            row["attention"] += 1
+    return {
+        "running": groups["running"],
+        "unread": sum(_is_unread_result(x) for x in events),
+        "attention": sum(_requires_action(x)
+                         or (x.get("state") == "failed" and not x.get("read"))
+                         for x in events),
+        "groups": groups,
+        "group_unread": group_unread,
+        "workspaces": list(workspaces.values()),
+    }
 
 
 class ActivityService:
@@ -25,9 +80,11 @@ class ActivityService:
         self._events = self._load()
         changed = self._collapse_sessions()
         for item in self._events:
-            if item.get("state") in {"running", "waiting_approval", "paused"}:
+            if item.get("state") in _ACTIVE:
+                now = time.time()
                 item.update(state="failed", status_detail="Interrupted by service restart",
-                            finished_at=time.time(), needs_attention=True, read=False)
+                            finished_at=now, updated_at=now,
+                            needs_attention=False, read=False)
                 changed = True
         if changed:
             self._save()
@@ -89,7 +146,7 @@ class ActivityService:
                 session_name=name, state="running",
                 task_summary=(summary or item.get("task_summary") or name)[:500],
                 status_detail="", started_at=now, finished_at=None,
-                needs_attention=False, read=True,
+                updated_at=now, needs_attention=False, read=True,
                 turn_count=int(item.get("turn_count") or 0) + 1,
             )
             self._events = self._events[-_MAX_EVENTS:]
@@ -97,7 +154,7 @@ class ActivityService:
             return dict(item)
 
     def set_state(self, sid: str, state: str, *, detail: str = "") -> dict[str, Any]:
-        if state not in {"running", "waiting_approval", "paused"}:
+        if state not in _ACTIVE:
             raise ValueError("invalid activity state")
         with self._lock:
             item = self._latest(sid)
@@ -107,9 +164,21 @@ class ActivityService:
             item = self._latest(sid)
             assert item is not None
             item.update(state=state, status_detail=detail[:500],
-                        needs_attention=state != "running", read=state == "running")
+                        updated_at=time.time(),
+                        needs_attention=state in {"waiting_approval", "paused"}, read=True)
             self._save()
             return dict(item)
+
+    def resume(self, sid: str) -> bool:
+        """Resume only the currently waiting turn; never revive a terminal row."""
+        with self._lock:
+            item = self._latest(sid)
+            if item is None or item.get("state") not in {"waiting_approval", "paused"}:
+                return False
+            item.update(state="running", status_detail="", updated_at=time.time(),
+                        needs_attention=False, read=True)
+            self._save()
+            return True
 
     def finish(self, sid: str, status: str) -> dict[str, Any]:
         state = "completed" if status == "completed" else (
@@ -121,8 +190,9 @@ class ActivityService:
         with self._lock:
             item = self._latest(sid)
             assert item is not None
-            item.update(state=state, finished_at=time.time(),
-                        needs_attention=state != "cancelled", read=state == "cancelled",
+            now = time.time()
+            item.update(state=state, finished_at=now, updated_at=now,
+                        needs_attention=False, read=state == "cancelled",
                         status_detail={"completed": "Task completed",
                                        "failed": "Task failed",
                                        "cancelled": "Task cancelled"}[state])
@@ -131,29 +201,22 @@ class ActivityService:
 
     def list(self, limit: int = 100) -> list[dict[str, Any]]:
         with self._lock:
-            return [dict(x) for x in reversed(self._events[-min(max(limit, 1), 500):])]
+            events = sorted(self._events, key=_activity_at, reverse=True)
+            return [dict(x) for x in events[:min(max(limit, 1), _MAX_EVENTS)]]
 
     def summary(self) -> dict[str, Any]:
         with self._lock:
+            return _summarize([dict(x) for x in self._events])
+
+    def snapshot(self, limit: int = 100) -> dict[str, Any]:
+        """Return rows and counters from the same locked ledger snapshot."""
+        with self._lock:
             events = [dict(x) for x in self._events]
-        active = {"running", "waiting_approval", "paused"}
-        workspaces: dict[str, dict[str, Any]] = {}
-        for item in events:
-            path = str(item.get("workspace") or "")
-            row = workspaces.setdefault(path, {"path": path,
-                "name": item.get("workspace_name") or Path(path).name or "Workspace",
-                "running": 0, "unread": 0, "attention": 0})
-            if item.get("state") in active:
-                row["running"] += 1
-            if item.get("needs_attention") and not item.get("read"):
-                row["unread"] += 1
-            if item.get("state") in {"failed", "waiting_approval", "paused"} and not item.get("read"):
-                row["attention"] += 1
-        return {"running": sum(x.get("state") in active for x in events),
-                "unread": sum(bool(x.get("needs_attention")) and not x.get("read") for x in events),
-                "attention": sum(x.get("state") in {"failed", "waiting_approval", "paused"}
-                                 and not x.get("read") for x in events),
-                "workspaces": list(workspaces.values())}
+        ordered = sorted(events, key=_activity_at, reverse=True)
+        return {
+            "events": ordered[:min(max(limit, 1), _MAX_EVENTS)],
+            "summary": _summarize(events),
+        }
 
     def ack(self, event_id: str | None = None, *, sid: str | None = None) -> int:
         changed = 0
@@ -163,7 +226,7 @@ class ActivityService:
                     continue
                 if sid is not None and item.get("session_id") != sid:
                     continue
-                if item.get("needs_attention") and not item.get("read"):
+                if not item.get("read"):
                     item["read"] = True
                     changed += 1
             if changed:

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -25,8 +25,7 @@ def _json(request: Request, response: Response, payload: dict):
 @router.get("", dependencies=[Depends(require_token)])
 def list_activity(request: Request, response: Response,
                   limit: int = Query(100, ge=1, le=500)):
-    return _json(request, response,
-                 {"events": activity.list(limit), "summary": activity.summary()})
+    return _json(request, response, activity.snapshot(limit))
 
 
 @router.get("/summary", dependencies=[Depends(require_token)])

--- a/backend/ask_user_question.py
+++ b/backend/ask_user_question.py
@@ -188,6 +188,14 @@ def submit_answer(session_id: str, question_id: str, answers: dict[str, Any]) ->
     fut = _pending.get((session_id, question_id))
     if fut is None or fut.done():
         return False
+    # Move the current turn back to running before resolving the Future. Once
+    # resolved, the model can immediately finish or ask another question, so a
+    # later resume write could overwrite a newer state.
+    try:
+        from .activity import activity
+        activity.resume(session_id)
+    except Exception:
+        pass
     fut.set_result(answers)
     return True
 

--- a/backend/permission_request.py
+++ b/backend/permission_request.py
@@ -86,6 +86,13 @@ def submit_decision(session_id: str, request_id: str, decision: str,
     fut = _pending.get((session_id, request_id))
     if fut is None or fut.done():
         return False
+    # Resume before waking the model; after set_result it may finish or produce
+    # another permission prompt before this call stack gets control again.
+    try:
+        from .activity import activity
+        activity.resume(session_id)
+    except Exception:
+        pass
     fut.set_result({"decision": decision, "message": message})
     return True
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -514,7 +514,12 @@ function portal() {
     },
     activity: {
       show: false, loading: false, events: [],
-      summary: { running: 0, unread: 0, attention: 0, workspaces: [] },
+      summary: {
+        running: 0, unread: 0, attention: 0,
+        groups: { review: 0, running: 0, failed: 0, history: 0 },
+        group_unread: { review: 0, running: 0, failed: 0, history: 0 },
+        workspaces: [],
+      },
       // group key -> true when the user asked to see past the row cap.
       expanded: {},
       // Selected group keys. Empty array = no filter = show every group.
@@ -522,6 +527,8 @@ function portal() {
     },
     _activityEtags: {},
     _activityFetchPromises: {},
+    _activityRequestSeq: 0,
+    _activityAppliedSeq: 0,
     // Per-task "run-now" inflight flag — disables retry / send buttons
     // until the LLM call returns and history is reloaded. Keyed by task id.
     schedRunning: {},
@@ -21661,16 +21668,26 @@ function portal() {
     async fetchActivity(opts = {}) {
       const key = opts.summaryOnly ? "summary" : "events";
       if (this._activityFetchPromises[key]) return this._activityFetchPromises[key];
+      const seq = ++this._activityRequestSeq;
       const promise = (async () => {
         try {
-          const path = opts.summaryOnly ? "/api/activity/summary" : "/api/activity?limit=150";
+          const path = opts.summaryOnly ? "/api/activity/summary" : "/api/activity?limit=500";
           const headers = { ...this.hdr() };
           if (this._activityEtags[key]) headers["If-None-Match"] = this._activityEtags[key];
-          const r = await fetch(path, { headers });
+          let r = await fetch(path, { headers });
+          // A long-lived tab can retain an ETag while Alpine state is rebuilt.
+          // Never accept a 304 as the only source for an empty task list.
+          if (r.status === 304 && !opts.summaryOnly && !this.activity.events.length) {
+            delete this._activityEtags[key];
+            delete headers["If-None-Match"];
+            r = await fetch(path, { headers, cache: "reload" });
+          }
           if (r.status === 304 || !r.ok) return false;
           const etag = r.headers.get("etag");
           if (etag) this._activityEtags[key] = etag;
           const data = await r.json();
+          if (seq < this._activityAppliedSeq) return false;
+          this._activityAppliedSeq = seq;
           const summary = opts.summaryOnly ? data : data.summary;
           if (summary) this.activity.summary = summary;
           if (!opts.summaryOnly && Array.isArray(data.events)) this.activity.events = data.events;
@@ -21690,31 +21707,40 @@ function portal() {
     },
     activityGroups() {
       const zh = this.lang === "zh";
-      // Grouped strictly by STATE, in the order the user has to act on them.
-      // Read/unread deliberately no longer decides the group: it used to, and
-      // a finished task jumped from "results to review" into "recent" the
-      // moment you glanced at it — items moving under the cursor makes the
-      // list impossible to build any spatial memory of. Unread is shown
-      // in-row instead (see .activity-row.is-unread).
+      // Attention order: new results first, then live work, failures, history.
+      // A completed row intentionally moves to history after it is opened.
       return [
-        { key: "attention", label: zh ? "待决策" : "Awaiting decision", states: ["waiting_approval"] },
-        // Failure used to live under a heading that read "Recent" — a failed
-        // task is not a completed one, and burying it there is why the filter
-        // below needed a special case to keep unread failures visible at all.
-        { key: "failed", label: zh ? "运行失败" : "Failed", states: ["failed"] },
-        // Paused is an interrupted run, not an outcome, so it belongs here
-        // rather than under a heading that asks the user for a decision.
-        { key: "running", label: zh ? "进行中" : "Running", states: ["running", "paused"] },
-        { key: "done", label: zh ? "已结束" : "Finished", states: ["completed", "cancelled"] },
+        { key: "review", label: zh ? "已完成 · 待查看" : "Completed · Unread" },
+        { key: "running", label: zh ? "进行中" : "Running" },
+        { key: "failed", label: zh ? "运行失败" : "Failed" },
+        { key: "history", label: zh ? "历史任务" : "History" },
       ];
     },
-    // Rows shown per group before "show all". A durable cross-workspace
-    // ledger accumulates hundreds of finished tasks, and an uncapped list
-    // buries the two groups that need action under the one that does not.
     ACTIVITY_GROUP_CAP: 5,
+    activityMatchesGroup(item, key) {
+      if (!item) return false;
+      if (key === "review") return item.state === "completed" && !item.read;
+      if (key === "running") return ["running", "waiting_approval", "paused"].includes(item.state);
+      if (key === "failed") return item.state === "failed";
+      if (key === "history") {
+        return (item.state === "completed" && !!item.read) || item.state === "cancelled";
+      }
+      return false;
+    },
+    activityEventTimestamp(item) {
+      return Number(item?.updated_at || item?.finished_at || item?.started_at || 0);
+    },
     activityAllEvents(group) {
-      const states = new Set(group.states || []);
-      return (this.activity.events || []).filter(item => states.has(item.state));
+      const activeRank = { waiting_approval: 0, paused: 1, running: 2 };
+      return (this.activity.events || [])
+        .filter(item => this.activityMatchesGroup(item, group.key))
+        .sort((a, b) => {
+          if (group.key === "running") {
+            const rank = (activeRank[a.state] ?? 9) - (activeRank[b.state] ?? 9);
+            if (rank) return rank;
+          }
+          return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+        });
     },
     activityEvents(group) {
       const all = this.activityAllEvents(group);
@@ -21728,13 +21754,10 @@ function portal() {
     toggleActivityGroup(key) {
       this.activity.expanded[key] = !this.activity.expanded[key];
     },
-    // Header-chip count. Deliberately computed from the loaded events rather
-    // than from `activity.summary`: the backend summary only reports
-    // running/unread/attention, which is exactly why the header used to show
-    // two numbers while the body showed four groups. Counting client-side
-    // keeps the two in sync with no API change.
     activityGroupCount(group) {
-      return this.activityAllEvents(group).length;
+      const count = this.activity.summary?.groups?.[group.key];
+      return Number.isFinite(Number(count))
+        ? Number(count) : this.activityAllEvents(group).length;
     },
     activityVisibleGroups() {
       const groups = this.activityGroups();
@@ -21742,10 +21765,6 @@ function portal() {
       if (!on.length) return groups;
       return groups.filter(g => on.includes(g.key));
     },
-    // Multi-select, not radio. The chips read as a filter bar, and a filter bar
-    // that silently drops your previous pick when you add a second one is the
-    // kind of thing you only notice after wondering where the failures went.
-    // Empty selection === show everything (no "all" chip needed).
     isActivityFilterOn(key) {
       return (this.activity.filter || []).includes(key);
     },
@@ -21754,22 +21773,22 @@ function portal() {
       const at = on.indexOf(key);
       if (at >= 0) on.splice(at, 1);
       else on.push(key);
-      // Replace the array rather than mutate: Alpine v3 doesn't deep-wrap
-      // array contents, so an in-place splice on the nested `activity.filter`
-      // wouldn't re-run the `:class` bindings.
       this.activity.filter = on;
     },
     clearActivityFilter() {
       this.activity.filter = [];
     },
-    // Unread-in-this-group count. Drives the chip's colour: a group only earns
-    // its warning/danger tint while something in it is UNACKED. Opening an
-    // event acks it (openActivityEvent → POST /ack), so a failure you've
-    // already looked at stops shouting — previously the red dot was keyed to
-    // "group is non-empty", which meant it never went away.
+    activityIsUnreadResult(item) {
+      return !!item && ["completed", "failed"].includes(item.state) && !item.read;
+    },
+    activityRequiresAction(item) {
+      return !!item && ["waiting_approval", "paused"].includes(item.state);
+    },
     activityGroupUnread(group) {
+      const count = this.activity.summary?.group_unread?.[group.key];
+      if (Number.isFinite(Number(count))) return Number(count);
       return this.activityAllEvents(group)
-        .filter(x => x && x.needs_attention && !x.read).length;
+        .filter(item => this.activityIsUnreadResult(item) || this.activityRequiresAction(item)).length;
     },
     activityStateLabel(state) {
       const zh = this.lang === "zh";
@@ -21778,22 +21797,38 @@ function portal() {
         failed: zh ? "失败" : "Failed", cancelled: zh ? "已取消" : "Cancelled" })[state] || state;
     },
     activityTime(item) {
-      const ts = Number(item.finished_at || item.started_at || 0) * 1000;
+      const ts = this.activityEventTimestamp(item) * 1000;
       return ts ? new Date(ts).toLocaleString(this.lang === "zh" ? "zh-CN" : "en-US",
         { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "";
     },
-    async openActivityEvent(item) {
-      if (!item) return;
-      if (item.needs_attention && !item.read) {
+    async ackActivityEvent(item, retries = 2) {
+      if (!this.activityIsUnreadResult(item)) return true;
+      for (let attempt = 0; attempt <= retries; attempt += 1) {
         try {
           const r = await fetch(`/api/activity/${encodeURIComponent(item.id)}/ack`,
             { method: "POST", headers: this.hdr() });
-          if (r.ok) { const d = await r.json(); item.read = true; this.activity.summary = d.summary; }
+          if (r.ok) {
+            const d = await r.json();
+            this._activityAppliedSeq = ++this._activityRequestSeq;
+            item.read = true;
+            this.activity.events = [...this.activity.events];
+            this.activity.summary = d.summary;
+            return true;
+          }
         } catch (_) {}
+        if (attempt < retries) await new Promise(resolve => setTimeout(resolve, 250));
       }
+      this.toast(this.lang === "zh" ? "已打开任务，但未能同步已查看状态" :
+        "Opened the task, but could not sync its read state", "warn", 3000);
+      return false;
+    },
+    async openActivityEvent(item) {
+      if (!item) return;
       this.activity.show = false;
+      const ack = this.ackActivityEvent(item);
       const sid = item.session_id || item.thread_id;
       if (sid) await this._openSessionFromDeeplink(sid);
+      await ack;
       this._syncAppBadge();
     },
     async ackAllActivity() {
@@ -21801,7 +21836,9 @@ function portal() {
         const r = await fetch("/api/activity/ack-all", { method: "POST", headers: this.hdr() });
         if (!r.ok) return;
         const d = await r.json();
+        this._activityAppliedSeq = ++this._activityRequestSeq;
         for (const item of this.activity.events) item.read = true;
+        this.activity.events = [...this.activity.events];
         this.activity.summary = d.summary;
         this._syncAppBadge();
       } catch (_) {}
@@ -21818,11 +21855,13 @@ function portal() {
           { method: "POST", headers: this.hdr() });
         if (!r.ok) return;
         const d = await r.json();
+        this._activityAppliedSeq = ++this._activityRequestSeq;
         if (d.summary) this.activity.summary = d.summary;
         if (Number(d.changed) > 0) {
           for (const item of this.activity.events || []) {
             if ((item.session_id || item.thread_id) === sid) item.read = true;
           }
+          this.activity.events = [...this.activity.events];
         }
         this._syncAppBadge();
         if (Number(d.changed) === 0 && retries > 0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5087,15 +5087,12 @@
         <span class="modal-title"><svg class="modal-title-icon"><use href="#i-inbox"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
         <button class="modal-close" @click="activity.show=false" aria-label="Close">×</button>
       </div>
-      <!-- One chip per state group, in the SAME order as the groups below, so
-           the header and the body answer the same question. Chips keep their
-           slot at count 0 — "Failed 0" is information, and a chip that appears
-           and disappears can never be found by muscle memory. Tap to filter. -->
+      <!-- One chip per attention group, in the same order as the sections below:
+           completed results to review, live work, failures, then viewed history. -->
       <div class="activity-summary">
         <template x-for="group in activityGroups()" :key="group.key">
-          <!-- Multi-select filter chips. `has-unread` (NOT "group is
-               non-empty") is what turns on the colour, so a failure you've
-               opened goes quiet — opening an event acks it server-side. -->
+          <!-- Multi-select filters. Colour reflects unread results or a live
+               task waiting for user action, never mere group non-emptiness. -->
           <button class="activity-chip" type="button"
                   :class="[group.key, activityGroupCount(group) ? '' : 'is-empty',
                            activityGroupUnread(group) ? 'has-unread' : '',
@@ -5123,7 +5120,10 @@
           <section class="activity-group" x-show="activityEvents(group).length">
             <h3 x-text="group.label"></h3>
             <template x-for="item in activityEvents(group)" :key="item.id">
-              <button class="activity-row" @click="openActivityEvent(item)" :class="item.state + ((item.needs_attention && !item.read) ? ' is-unread' : '')">
+              <button class="activity-row" @click="openActivityEvent(item)"
+                      :class="item.state
+                        + (activityIsUnreadResult(item) ? ' is-unread' : '')
+                        + (activityRequiresAction(item) ? ' requires-action' : '')">
                 <span class="activity-state-dot"></span>
                 <span class="activity-row-main">
                   <strong x-text="item.task_summary || item.session_name"></strong>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3203,25 +3203,21 @@ pre.text {
 .activity-modal { width:620px; max-width:calc(100vw - 32px); }
 .activity-summary { display:flex; align-items:center; flex-wrap:wrap; gap:6px; padding:10px 14px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
 .activity-summary .btn-ghost { margin-left:auto; }
-/* Status chips. One per group below, always all four, always in the same
-   order — a chip that vanishes at count 0 can't be found by muscle memory,
-   and "Failed 0" is worth stating. Non-zero danger states colour themselves. */
+/* Status chips follow the same attention order as the body. Counts come from
+   the full backend ledger, while colour only signals unread/actionable work. */
 .activity-chip { display:inline-flex; align-items:center; gap:6px; padding:5px 10px; border:1px solid var(--c-border); border-radius:var(--r-full); background:transparent; color:var(--c-fg-2); font:inherit; font-size:var(--fs-xs); line-height:1.2; cursor:pointer; transition:background var(--t-fast), border-color var(--t-fast), color var(--t-fast), opacity var(--t-fast); }
 .activity-chip b { font-weight:var(--fw-medium); color:var(--c-fg-1); font-variant-numeric:tabular-nums; }
 .activity-chip-dot { width:7px; height:7px; flex:0 0 7px; border-radius:50%; background:var(--c-fg-3); }
-/* Dot colour is keyed to UNREAD, not to "the group has rows". A failure you
-   already opened is history, not an alarm — opening an event acks it, and the
-   chip must go quiet in response or the red dot is permanent furniture.
-   Colour split: 待决策 is a prompt (amber, "you need to do something"),
-   运行失败 is an outcome (red, "something broke"). Both were red before,
-   which flattened a question and a failure into the same signal. */
-.activity-chip.attention.has-unread .activity-chip-dot { background:var(--c-warn); }
+.activity-chip.review.has-unread .activity-chip-dot { background:var(--c-success); }
 .activity-chip.failed.has-unread .activity-chip-dot { background:var(--c-danger); }
 .activity-chip.running .activity-chip-dot { background:var(--c-running); }
-.activity-chip.done .activity-chip-dot { background:var(--c-fg-4); }
+.activity-chip.running.has-unread .activity-chip-dot { background:var(--c-warn); }
+.activity-chip.history .activity-chip-dot { background:var(--c-fg-4); }
 .activity-chip.running:not(.is-empty) .activity-chip-dot { animation:muse-breath 1.8s ease-in-out infinite; }
-.activity-chip.attention.has-unread { border-color:color-mix(in srgb, var(--c-warn) 45%, transparent); color:var(--c-warn); }
-.activity-chip.attention.has-unread b { color:var(--c-warn); }
+.activity-chip.review.has-unread { border-color:color-mix(in srgb, var(--c-success) 42%, transparent); color:var(--c-success); }
+.activity-chip.review.has-unread b { color:var(--c-success); }
+.activity-chip.running.has-unread { border-color:color-mix(in srgb, var(--c-warn) 45%, transparent); color:var(--c-warn); }
+.activity-chip.running.has-unread b { color:var(--c-warn); }
 .activity-chip.failed.has-unread { border-color:color-mix(in srgb, var(--c-danger) 42%, transparent); color:var(--c-danger); }
 .activity-chip.failed.has-unread b { color:var(--c-danger); }
 .activity-chip:hover { background:var(--c-bg-2); }
@@ -3238,12 +3234,12 @@ pre.text {
 .activity-row { width:100%; display:flex; align-items:center; gap:10px; padding:10px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); text-align:left; cursor:pointer; }
 .activity-row:hover { background:var(--c-bg-2); }
 .activity-row.is-unread { background:var(--c-accent-soft); box-shadow:inset 3px 0 0 var(--c-accent); }
-.activity-state-dot { width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--c-fg-3); }
-.activity-row.running .activity-state-dot { background:var(--c-running); animation:muse-breath 1.8s ease-in-out infinite; }
-/* Terminal tasks are not notifications. Only an unread result gets the green marker. */
-.activity-row.completed .activity-state-dot,.activity-row.cancelled .activity-state-dot { visibility:hidden; }
-.activity-row.is-unread .activity-state-dot { visibility:visible; background:var(--c-success); }
-.activity-row.failed .activity-state-dot,.activity-row.waiting_approval .activity-state-dot,.activity-row.paused .activity-state-dot { background:var(--c-danger); }
+.activity-state-dot { width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--c-fg-3); visibility:hidden; }
+.activity-row.running .activity-state-dot { visibility:visible; background:var(--c-running); animation:muse-breath 1.8s ease-in-out infinite; }
+.activity-row.waiting_approval .activity-state-dot,.activity-row.paused .activity-state-dot { visibility:visible; background:var(--c-warn); }
+.activity-row.completed.is-unread .activity-state-dot { visibility:visible; background:var(--c-success); }
+.activity-row.failed.is-unread .activity-state-dot { visibility:visible; background:var(--c-danger); }
+.activity-row.failed .activity-row-side > span { color:var(--c-danger); }
 .activity-row-main { min-width:0; flex:1; display:flex; flex-direction:column; gap:3px; }
 .activity-row-main strong,.activity-row-main small { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .activity-row-main small,.activity-row-side small { color:var(--c-fg-3); font-size:var(--fs-xs); }

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -32,9 +32,87 @@ def test_summary_and_ack(tmp_path, monkeypatch):
     summary = service.summary()
     assert summary["unread"] == 1
     assert summary["attention"] == 1
+    assert summary["groups"] == {
+        "review": 0, "running": 0, "failed": 1, "history": 0,
+    }
+    assert summary["group_unread"]["failed"] == 1
     assert summary["workspaces"][0]["unread"] == 1
     assert service.ack(item["id"]) == 1
-    assert service.summary()["unread"] == 0
+    acknowledged = service.summary()
+    assert acknowledged["unread"] == 0
+    assert acknowledged["attention"] == 0
+    assert acknowledged["groups"]["failed"] == 1
+    assert acknowledged["group_unread"]["failed"] == 0
+
+
+def test_completed_moves_from_review_to_history_after_ack(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    service.start("s1", summary="produce result")
+    item = service.finish("s1", "completed")
+    summary = service.summary()
+    assert summary["groups"]["review"] == 1
+    assert summary["groups"]["history"] == 0
+
+    assert service.ack(item["id"]) == 1
+    summary = service.summary()
+    assert summary["groups"]["review"] == 0
+    assert summary["groups"]["history"] == 1
+
+
+def test_waiting_for_user_is_actionable_but_not_an_unread_result(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    service.start("s1", summary="ask a question")
+    service.set_state("s1", "waiting_approval", detail="Waiting for user input")
+    summary = service.summary()
+    assert summary["running"] == 1
+    assert summary["unread"] == 0
+    assert summary["attention"] == 1
+    assert summary["group_unread"]["running"] == 1
+
+    assert service.resume("s1") is True
+    summary = service.summary()
+    assert summary["running"] == 1
+    assert summary["attention"] == 0
+    assert summary["group_unread"]["running"] == 0
+
+
+def test_resume_never_revives_a_terminal_row(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    service.start("s1", summary="short task")
+    service.finish("s1", "completed")
+
+    assert service.resume("s1") is False
+    row = service.list()[0]
+    assert row["state"] == "completed"
+    assert row["turn_count"] == 1
+    assert row["finished_at"] is not None
+
+
+def test_snapshot_keeps_rows_and_summary_on_one_ledger_view(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    service.start("s1", summary="produce result")
+    service.finish("s1", "completed")
+
+    snapshot = service.snapshot(500)
+    assert len(snapshot["events"]) == 1
+    assert snapshot["events"][0]["state"] == "completed"
+    assert snapshot["summary"]["groups"]["review"] == 1
+
+
+def test_list_sorts_by_latest_transition_not_storage_position(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    ticks = iter([1, 2, 3, 4, 5, 6])
+    monkeypatch.setattr("backend.activity.time.time", lambda: next(ticks))
+    service.start("s1", summary="old session")
+    service.finish("s1", "completed")
+    service.start("s2", summary="new session")
+    service.finish("s2", "completed")
+    service.start("s1", summary="old session, new turn")
+    service.finish("s1", "completed")
+
+    rows = service.list()
+    assert [row["session_id"] for row in rows] == ["s1", "s2"]
+    assert rows[0]["updated_at"] == 6
 
 
 def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
@@ -43,5 +121,7 @@ def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
     restarted = ActivityService(tmp_path)
     row = restarted.list()[0]
     assert row["state"] == "failed"
-    assert row["needs_attention"] is True
+    assert row["needs_attention"] is False
+    assert row["read"] is False
+    assert row["updated_at"] == row["finished_at"]
     assert json.loads((Path(tmp_path) / ".muselab" / "activity.json").read_text())

--- a/tests/test_ask_user_question.py
+++ b/tests/test_ask_user_question.py
@@ -25,6 +25,25 @@ def test_submit_answer_returns_false_when_no_pending():
     assert auq.submit_answer("sess-X", "q-doesnt-exist", {"Q?": "A"}) is False
 
 
+def test_submit_answer_resumes_before_waking_model(monkeypatch):
+    order = []
+
+    class FakeFuture:
+        def done(self):
+            return False
+
+        def set_result(self, value):
+            order.append(("resolve", value))
+
+    from backend import activity as activity_module
+    monkeypatch.setattr(activity_module.activity, "resume",
+                        lambda sid: order.append(("resume", sid)))
+    auq._pending[("sess-X", "q-1")] = FakeFuture()
+
+    assert auq.submit_answer("sess-X", "q-1", {"Q?": "A"}) is True
+    assert order == [("resume", "sess-X"), ("resolve", {"Q?": "A"})]
+
+
 def test_unregister_cancels_pending_futures():
     """Stream ending should cancel any in-flight question futures so the tool
     handler raises and the model gets an error result (vs. leaking memory)."""

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -629,27 +629,35 @@ def test_failed_transcript_refresh_preserves_last_good_messages():
     assert "this.messages = st.messages" not in failed
 
 
-def test_activity_center_groups_strictly_by_state():
+def test_activity_center_groups_by_attention_order_and_read_state():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
 
-    # Failure gets its own group. It used to sit under a heading that read
-    # "Recent" — a failed task is not a completed one — and burying it there
-    # is why the filter needed an `item.state === "failed"` special case to
-    # keep unread failures from being hidden by the read-only rule.
-    assert 'states: ["waiting_approval"]' in app
-    assert 'states: ["failed"]' in app
-    assert 'states: ["running", "paused"]' in app
-    assert 'states: ["completed", "cancelled"]' in app
-    assert "readOnly" not in app
-    assert 'item.state === "failed"' not in app
+    review = app.index('{ key: "review"')
+    running = app.index('{ key: "running"', review)
+    failed = app.index('{ key: "failed"', running)
+    history = app.index('{ key: "history"', failed)
+    assert review < running < failed < history
 
-    # Read state no longer decides the group, so a finished task cannot jump
-    # between sections the moment the user glances at it.
-    assert "unreadOnly" not in app
-
-    # Each group collapses past a fixed number of rows.
+    assert 'key === "review") return item.state === "completed" && !item.read' in app
+    assert '["running", "waiting_approval", "paused"].includes(item.state)' in app
+    assert 'key === "failed") return item.state === "failed"' in app
+    assert 'item.state === "completed" && !!item.read' in app
+    assert 'item.state === "cancelled"' in app
     assert "ACTIVITY_GROUP_CAP: 5" in app
     assert "activityHiddenCount(group)" in app
+    assert '"/api/activity?limit=500"' in app
+    assert "r.status === 304 && !opts.summaryOnly && !this.activity.events.length" in app
+    assert 'cache: "reload"' in app
+    assert "const rank = (activeRank[a.state] ?? 9)" in app
+    assert "return this.activityEventTimestamp(b)" in app
+    assert "this._activityAppliedSeq = ++this._activityRequestSeq" in app
+
+    # The left marker is unread/action state, not a permanent failure marker.
+    assert "activityIsUnreadResult(item) ? ' is-unread'" in html
+    assert ".activity-row.failed.is-unread .activity-state-dot" in css
+    assert ".activity-row.failed .activity-state-dot,.activity-row.waiting_approval" not in css
 
 
 def test_activity_center_uses_two_compact_numberless_status_dots():

--- a/tests/test_permission_request.py
+++ b/tests/test_permission_request.py
@@ -34,6 +34,28 @@ def test_submit_decision_bad_decision_returns_false():
     assert perm.submit_decision("s1", "qid", "maybe") is False
 
 
+def test_submit_decision_resumes_before_waking_model(monkeypatch):
+    order = []
+
+    class FakeFuture:
+        def done(self):
+            return False
+
+        def set_result(self, value):
+            order.append(("resolve", value))
+
+    from backend import activity as activity_module
+    monkeypatch.setattr(activity_module.activity, "resume",
+                        lambda sid: order.append(("resume", sid)))
+    perm._pending[("s1", "qid")] = FakeFuture()
+
+    assert perm.submit_decision("s1", "qid", "allow") is True
+    assert order == [
+        ("resume", "s1"),
+        ("resolve", {"decision": "allow", "message": None}),
+    ]
+
+
 def test_input_key_bash_safe_binary_uses_first_word():
     # Safe binaries broaden the always-allow cache to the first word so
     # "ls -la X" and "ls Y" share one grant.


### PR DESCRIPTION
## 变更类型
- [x] 修复（bugfix）
- [x] 重构（refactor）
- [ ] 新功能（feature）
- [ ] 文档（docs）

## 变更说明
- 将任务中心按「已完成·待查看 → 进行中 → 运行失败 → 历史任务」排序。
- 将已完成任务按查看状态拆分，打开后自动移入历史任务。
- 失败任务查看后清除左侧红点，同时保留红色失败状态文字。
- 按最新状态变更时间排序，并让列表与摘要来自同一份活动快照。
- 修复等待用户问答／授权后恢复运行的状态竞态。
- 将任务列表加载范围与 500 条持久化上限对齐，并增加空列表遇到 304 时的重新拉取兜底。

## 测试情况
- `102 passed`：活动账本、问答恢复、权限恢复和前端静态回归测试。
- `compileall` 通过。
- `git diff --check` 通过。
- 生产环境实测：任务分组、待查看结果、失败红点和历史记录显示正常。

## 审查检查项
- [x] 代码符合规范
- [x] 添加／更新了测试
- [x] 自测通过
- [x] 未提交 `AUDIT-2026-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)