### PR TITLE
fix(chat): 关闭中断提醒后不再重复弹出

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1978,6 +1978,13 @@ function portal() {
       return this.lang === "zh" ? `${d} 天前` : `${d}d ago`;
     },
 
+    async _dismissInterruptedTurn(sid) {
+      const r = await fetch(`/api/chat/interrupted-turns/${encodeURIComponent(sid)}/dismiss`, {
+        method: "POST", headers: this.hdr(),
+      });
+      if (!r.ok) throw new Error(`dismiss interrupted turn failed: HTTP ${r.status}`);
+    },
+
     // Toast any turns the previous muselab process left in-flight at the
     // moment it died. Backend persists `sessions/active_turns/<sid>.json`
     // on turn start and deletes it on clean completion — anything left
@@ -2016,11 +2023,13 @@ function portal() {
             try {
               await this.openTab(turn.sid);
               if (this.currentId !== turn.sid) return;
-              await fetch(`/api/chat/interrupted-turns/${turn.sid}/dismiss`, {
-                method: "POST", headers: this.hdr(),
-              });
+              await this._dismissInterruptedTurn(turn.sid);
             } catch (_) { /* keep the durable breadcrumb for next boot */ }
           },
+          // Closing the banner is also an explicit acknowledgement. Previously
+          // only "Open" dismissed the durable sidecar, so tapping × made the
+          // same warning return on every app launch.
+          onDismiss: () => this._dismissInterruptedTurn(turn.sid),
         });
       }
     },
@@ -4699,7 +4708,13 @@ function portal() {
       }
       if (timeout) setTimeout(() => this.dismissToast(id), timeout);
     },
-    dismissToast(id) { this.toasts = this.toasts.filter(t => t.id !== id); },
+    dismissToast(id, userInitiated = false) {
+      const toast = this.toasts.find(t => t.id === id);
+      this.toasts = this.toasts.filter(t => t.id !== id);
+      if (userInitiated && toast?.action?.onDismiss) {
+        Promise.resolve(toast.action.onDismiss()).catch(() => {});
+      }
+    },
     runToastAction(t) {
       try { t.action && t.action.onClick && t.action.onClick(); }
       finally { this.dismissToast(t.id); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3609,7 +3609,7 @@
                 @click="runToastAction(t)" x-text="t.action && t.action.label"></button>
         <button class="close"
                 :title="lang==='zh' ? '关闭' : 'Dismiss'"
-                @click="dismissToast(t.id)"><svg style="width:14px;height:14px"><use href="#i-x"/></svg></button>
+                @click="dismissToast(t.id, true)"><svg style="width:14px;height:14px"><use href="#i-x"/></svg></button>
       </div>
     </template>
   </div>

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -474,17 +474,24 @@ def test_stream_reconnect_is_pinned_to_backend_turn_identity():
     assert "turnId: d.turn_id || streamState.activeTurnId || \"\"" in send
 
 
-def test_interrupted_turn_is_dismissed_only_after_open():
+def test_interrupted_turn_is_dismissed_after_open_or_manual_close():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    helper_start = app.index("async _dismissInterruptedTurn(sid)")
+    helper_end = app.index("\n    // Toast any turns", helper_start)
+    helper = app[helper_start:helper_end]
     start = app.index("async _checkInterruptedTurns()")
     end = app.index("\n    // 10s heartbeat", start)
     recovery = app[start:end]
 
+    assert "/api/chat/interrupted-turns/${encodeURIComponent(sid)}/dismiss" in helper
     click_at = recovery.index("onClick: async () =>")
     open_at = recovery.index("await this.openTab(turn.sid)", click_at)
-    dismiss_at = recovery.index("/dismiss", open_at)
+    dismiss_at = recovery.index("await this._dismissInterruptedTurn(turn.sid)", open_at)
     assert click_at < open_at < dismiss_at
-    assert recovery.count("/dismiss") == 1
+    assert "onDismiss: () => this._dismissInterruptedTurn(turn.sid)" in recovery
+    assert 'dismissToast(t.id, true)' in html
+    assert "userInitiated && toast?.action?.onDismiss" in app
 
 
 def test_mobile_keyboard_watchdog_clears_stale_pwa_viewport_inset():


### PR DESCRIPTION
## 变更类型
- [x] 修复（bugfix）
- [ ] 重构（refactor）
- [ ] 新功能（feature）
- [ ] 文档（docs）

## 变更说明
- 点击中断提醒右上角「×」时，同步调用后端确认接口并删除持久化 sidecar。
- 点击「打开」后复用同一个确认函数，统一处理 URL 编码和异常。
- 仅手动关闭触发持久确认；自动超时移除 Toast 不会误删恢复记录。
- 更新前端回归测试，覆盖「打开」和「手动关闭」两条确认路径。

## 测试情况
- `105 passed`：前端静态回归测试与后端回归测试。
- `node --check frontend/app.js` 通过。
- `git diff --check` 通过。

## 审查检查项
- [x] 代码符合规范
- [x] 添加／更新了测试
- [x] 自测通过
- [x] 未提交 `AUDIT-2026-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)