### PR TITLE
fix: 同步任务中心与会话终态

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import threading
 import time
 import uuid
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
@@ -77,6 +80,11 @@ class ActivityService:
     def __init__(self, root: Path = ROOT):
         self.path = root / ".muselab" / "activity.json"
         self._lock = threading.RLock()
+        self._generation = uuid.uuid4().hex
+        self._revision = 0
+        self._subscribers: dict[
+            asyncio.Queue[dict[str, Any]], asyncio.AbstractEventLoop
+        ] = {}
         self._events = self._load()
         changed = self._collapse_sessions()
         for item in self._events:
@@ -102,6 +110,83 @@ class ActivityService:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         atomic_write_text(self.path, json.dumps(
             self._events[-_MAX_EVENTS:], ensure_ascii=False, indent=2))
+
+    @staticmethod
+    def _enqueue_update(
+        queue: asyncio.Queue[dict[str, Any]],
+        payload: dict[str, Any],
+    ) -> None:
+        """Deliver the latest ledger change without an unbounded SSE backlog."""
+        if queue.full():
+            with contextlib.suppress(asyncio.QueueEmpty):
+                queue.get_nowait()
+            payload = {
+                "generation": payload["generation"],
+                "revision": payload["revision"],
+                "summary": payload["summary"],
+                "resync": True,
+            }
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(payload)
+
+    def _publish_locked(
+        self,
+        *,
+        item: dict[str, Any] | None = None,
+        acked_ids: list[str] | None = None,
+    ) -> None:
+        """Fan out a compact transition to SSE subscribers.
+
+        Activity mutations run in FastAPI worker threads (and chat explicitly
+        uses ``asyncio.to_thread``), so subscribers retain their owning event
+        loops and delivery crosses the boundary via ``call_soon_threadsafe``.
+        """
+        self._revision += 1
+        summary = _summarize([dict(x) for x in self._events])
+        summary["generation"] = self._generation
+        summary["revision"] = self._revision
+        payload: dict[str, Any] = {
+            "generation": self._generation,
+            "revision": self._revision,
+            "summary": summary,
+        }
+        if item is not None:
+            payload["item"] = dict(item)
+        if acked_ids:
+            payload["acked_ids"] = list(acked_ids)
+        stale: list[asyncio.Queue[dict[str, Any]]] = []
+        for queue, loop in tuple(self._subscribers.items()):
+            try:
+                loop.call_soon_threadsafe(self._enqueue_update, queue, payload)
+            except RuntimeError:
+                stale.append(queue)
+        for queue in stale:
+            self._subscribers.pop(queue, None)
+
+    @contextlib.asynccontextmanager
+    async def subscribe(
+        self,
+    ) -> AsyncIterator[asyncio.Queue[dict[str, Any]]]:
+        """Subscribe to future task transitions from the current event loop."""
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1)
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            self._subscribers[queue] = loop
+        try:
+            yield queue
+        finally:
+            with self._lock:
+                self._subscribers.pop(queue, None)
+
+    @property
+    def revision(self) -> int:
+        with self._lock:
+            return self._revision
+
+    @property
+    def generation(self) -> str:
+        with self._lock:
+            return self._generation
 
     def _collapse_sessions(self) -> bool:
         latest: dict[str, dict[str, Any]] = {}
@@ -132,16 +217,24 @@ class ActivityService:
         return next((x for x in reversed(self._events)
                      if x.get("session_id") == sid), None)
 
-    def start(self, sid: str, *, summary: str = "") -> dict[str, Any]:
+    def start(
+        self,
+        sid: str,
+        *,
+        summary: str = "",
+        kind: str = "turn",
+        source_id: str = "",
+    ) -> dict[str, Any]:
         now = time.time()
         name, workspace, workspace_name = self._metadata(sid)
         with self._lock:
             item = self._latest(sid)
             if item is None:
                 item = {"id": uuid.uuid4().hex, "session_id": sid,
-                        "kind": "turn", "turn_count": 0}
+                        "turn_count": 0}
                 self._events.append(item)
             item.update(
+                kind=(kind or "turn")[:40],
                 workspace=workspace, workspace_name=workspace_name,
                 session_name=name, state="running",
                 task_summary=(summary or item.get("task_summary") or name)[:500],
@@ -149,8 +242,13 @@ class ActivityService:
                 updated_at=now, needs_attention=False, read=True,
                 turn_count=int(item.get("turn_count") or 0) + 1,
             )
+            if source_id:
+                item["source_id"] = source_id[:200]
+            else:
+                item.pop("source_id", None)
             self._events = self._events[-_MAX_EVENTS:]
             self._save()
+            self._publish_locked(item=item)
             return dict(item)
 
     def set_state(self, sid: str, state: str, *, detail: str = "") -> dict[str, Any]:
@@ -167,6 +265,7 @@ class ActivityService:
                         updated_at=time.time(),
                         needs_attention=state in {"waiting_approval", "paused"}, read=True)
             self._save()
+            self._publish_locked(item=item)
             return dict(item)
 
     def resume(self, sid: str) -> bool:
@@ -178,6 +277,7 @@ class ActivityService:
             item.update(state="running", status_detail="", updated_at=time.time(),
                         needs_attention=False, read=True)
             self._save()
+            self._publish_locked(item=item)
             return True
 
     def finish(self, sid: str, status: str) -> dict[str, Any]:
@@ -197,6 +297,7 @@ class ActivityService:
                                        "failed": "Task failed",
                                        "cancelled": "Task cancelled"}[state])
             self._save()
+            self._publish_locked(item=item)
             return dict(item)
 
     def list(self, limit: int = 100) -> list[dict[str, Any]]:
@@ -206,20 +307,29 @@ class ActivityService:
 
     def summary(self) -> dict[str, Any]:
         with self._lock:
-            return _summarize([dict(x) for x in self._events])
+            result = _summarize([dict(x) for x in self._events])
+            result["generation"] = self._generation
+            result["revision"] = self._revision
+            return result
 
     def snapshot(self, limit: int = 100) -> dict[str, Any]:
         """Return rows and counters from the same locked ledger snapshot."""
         with self._lock:
             events = [dict(x) for x in self._events]
+            generation = self._generation
+            revision = self._revision
         ordered = sorted(events, key=_activity_at, reverse=True)
+        summary = _summarize(events)
+        summary["generation"] = generation
+        summary["revision"] = revision
         return {
             "events": ordered[:min(max(limit, 1), _MAX_EVENTS)],
-            "summary": _summarize(events),
+            "summary": summary,
         }
 
     def ack(self, event_id: str | None = None, *, sid: str | None = None) -> int:
         changed = 0
+        acked_ids: list[str] = []
         with self._lock:
             for item in self._events:
                 if event_id is not None and item.get("id") != event_id:
@@ -229,8 +339,11 @@ class ActivityService:
                 if not item.get("read"):
                     item["read"] = True
                     changed += 1
+                    if item.get("id"):
+                        acked_ids.append(str(item["id"]))
             if changed:
                 self._save()
+                self._publish_locked(acked_ids=acked_ids)
         return changed
 
 

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -2,13 +2,17 @@
 
 import hashlib
 import json
+from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, Depends, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 from .activity import activity
 from .auth import require_token
+from .capability_tickets import tickets
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
+_EVENT_TICKET_TTL_S = 45
 
 
 def _json(request: Request, response: Response, payload: dict):
@@ -31,6 +35,62 @@ def list_activity(request: Request, response: Response,
 @router.get("/summary", dependencies=[Depends(require_token)])
 def activity_summary(request: Request, response: Response):
     return _json(request, response, activity.summary())
+
+
+@router.post("/events-ticket", dependencies=[Depends(require_token)])
+def mint_activity_event_ticket() -> dict:
+    ticket = tickets.mint(
+        "activity",
+        (),
+        ttl=_EVENT_TICKET_TTL_S,
+        single_use=True,
+    )
+    return {"ticket": ticket, "expires_in": _EVENT_TICKET_TTL_S}
+
+
+def _require_activity_event_ticket(ticket: str = Query("")) -> None:
+    if not tickets.validate(ticket, "activity", ()):
+        raise HTTPException(
+            status_code=401,
+            detail="invalid or expired activity event ticket",
+        )
+
+
+@router.get("/events", dependencies=[Depends(_require_activity_event_ticket)])
+async def activity_events() -> EventSourceResponse:
+    """Push task state transitions instead of waiting for the 10 s fallback poll."""
+
+    async def events() -> AsyncIterator[ServerSentEvent]:
+        async with activity.subscribe() as queue:
+            yield ServerSentEvent(
+                event="ready",
+                data=json.dumps(
+                    {
+                        "generation": activity.generation,
+                        "revision": activity.revision,
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+            while True:
+                payload = await queue.get()
+                yield ServerSentEvent(
+                    event="update",
+                    data=json.dumps(
+                        payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                )
+
+    return EventSourceResponse(
+        events(),
+        ping=20,
+        headers={
+            "Cache-Control": "no-cache, no-store",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.post("/ack-all", dependencies=[Depends(require_token)])

--- a/backend/api_scheduler.py
+++ b/backend/api_scheduler.py
@@ -135,7 +135,8 @@ def delete_task_endpoint(tid: str) -> dict:
 async def run_task_now_endpoint(tid: str) -> dict:
     """Trigger an out-of-schedule run of an existing task. Fire-and-forget:
     the actual LLM call happens in a background asyncio.task so the HTTP
-    response returns immediately. UI polls /history to see the result.
+    response returns immediately. Activity SSE carries running/terminal state;
+    the UI refreshes history when that terminal event arrives.
 
     Used for: (a) "retry" on a failed history entry; (b) manual smoke-test
     after editing prompt / model without waiting for the next fire window."""

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -723,6 +723,10 @@ class TurnBroadcast:
         # before the client exists in `_clients` and before `self.task` above is
         # created. `_start_turn` owns and clears this handle.
         self.startup_task: "asyncio.Task | None" = None
+        # The global activity row starts as soon as this broadcast reserves the
+        # session, before cold client/MCP startup. Startup failure/cancellation
+        # uses this bit to close only rows that were actually created.
+        self.activity_started = False
 
     def publish(self, event: dict) -> None:
         """Route one SSE event to the record channel, the live channel, or both.
@@ -950,6 +954,10 @@ def _session_runtime_lock_for(session_id: str) -> asyncio.Lock:
 # task settlement + auto-continuation and released the reader.
 _sessions_with_inflight_tasks: dict[str, set[str]] = {}
 _task_watchers: dict[str, asyncio.Task] = {}
+# Small post-response maintenance tasks, currently used to refresh compacted
+# transcript counts after the verified compact result has already reached the
+# browser. Strong references prevent accidental mid-run garbage collection.
+_maintenance_tasks: set[asyncio.Task] = set()
 # Original user-turn start (epoch seconds) retained across the detached gap and
 # every headless continuation. `/active` returns it after a page refresh so the
 # footer timer keeps counting from the real turn start instead of restarting.
@@ -971,12 +979,12 @@ _TASK_WATCH_TIMEOUT = env_int("MUSELAB_TASK_WATCH_TIMEOUT", 1800, min_value=60)
 # AssistantMessage + ResultMessage before closing the continuation and
 # unpinning — bounding the worst case (no auto-continue ever comes) instead of
 # holding the client + the _active_turns slot for the full _TASK_WATCH_TIMEOUT.
-_CONTINUATION_GRACE = env_int("MUSELAB_CONTINUATION_GRACE", 60, min_value=5)
+_CONTINUATION_GRACE = env_int("MUSELAB_CONTINUATION_GRACE", 8, min_value=2)
 # Short grace for USER-STOPPED tasks: the CLI doesn't auto-continue after a
 # deliberate stop, so the watcher only needs a token window before closing
 # the continuation (frees the attached FE from an idle "streaming…" footer).
 _STOPPED_CONTINUATION_GRACE = env_int(
-    "MUSELAB_STOPPED_CONTINUATION_GRACE", 5, min_value=1)
+    "MUSELAB_STOPPED_CONTINUATION_GRACE", 2, min_value=1)
 # task_id -> description, surviving across the turn that started the task. The
 # per-turn inflight_tasks dict is local to a turn. This module-level cache keeps
 # the label available to the detached watcher and across watcher replacement.
@@ -2585,6 +2593,7 @@ async def shutdown_runtime() -> None:
     tasks: set[asyncio.Task] = {
         task for task in _task_watchers.values() if not task.done()
     }
+    tasks.update(task for task in _maintenance_tasks if not task.done())
     for broadcast in tuple(_active_turns.values()):
         broadcast.cancelled = True
         for attr in ("startup_task", "task"):
@@ -2614,6 +2623,7 @@ async def shutdown_runtime() -> None:
         _active_turns.clear()
         _sessions_with_inflight_tasks.clear()
         _task_watchers.clear()
+        _maintenance_tasks.clear()
 
     async def _disconnect(client: ClaudeSDKClient) -> None:
         try:
@@ -2863,24 +2873,27 @@ def list_sessions_api(
     # when it finishes). The frontend's local `tabState[sid].streaming` only
     # knows about turns THIS browser kicked off — a turn started on phone A
     # left phone B's picker dot dark. Falling back to `s.active` fixes that.
-    active_sids = {
+    turn_active_sids = {
         sid for sid, bc in _active_turns.items()
         if bc is not None and not bc.done
     }
-    active_sids.update(
+    background_active_sids = {
         sid for sid, task_ids in _sessions_with_inflight_tasks.items()
         if task_ids
-    )
-    active_sids.update(
+    }
+    background_active_sids.update(
         sid for sid, watcher in _task_watchers.items()
         if watcher is not None and not watcher.done()
     )
+    active_sids = turn_active_sids | background_active_sids
     # Copy each dict (never mutate the shared list_sessions() cache) + add the
     # live `active` flag. Only the returned subset is processed now, not all N.
     sessions = []
     for s in subset:
         s = dict(s)  # don't mutate cache
         s["active"] = s.get("id") in active_sids
+        s["turn_active"] = s.get("id") in turn_active_sids
+        s["background_active"] = s.get("id") in background_active_sids
         sessions.append(s)
     # Piggy-back orphan-attachments GC here — runs at most hourly. Cheaper
     # than a cron, and naturally fires whenever the UI is in use.
@@ -2907,8 +2920,14 @@ def list_sessions_api(
     # active turn set), so key on those and skip the dumps+md5 when nothing
     # changed. Any session mutation bumps the generation; a turn starting /
     # finishing changes active_sids; different limit/ids/q get their own key.
-    _etag_key = (sess.list_sessions_generation(), limit, ids, q_norm,
-                 frozenset(active_sids))
+    _etag_key = (
+        sess.list_sessions_generation(),
+        limit,
+        ids,
+        q_norm,
+        frozenset(turn_active_sids),
+        frozenset(background_active_sids),
+    )
     _hit = _LIST_ETAG_CACHE.get("v")
     if _hit is not None and _hit[0] == _etag_key:
         etag = _hit[1]
@@ -5932,11 +5951,82 @@ async def context_breakdown(session_id: str, model: str = "") -> dict:
 
 @router.post("/sessions/{sid}/native-compact", dependencies=[Depends(require_token)])
 async def native_compact_session_api(sid: str) -> dict:
-    async with _session_runtime_lock_for(sid):
-        bc = _active_turns.get(sid)
-        if bc is not None and not bc.done:
-            raise HTTPException(409, "cannot compact while a turn is active")
-        return await _native_compact_session_locked(sid)
+    timeout_s = env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)
+    try:
+        # One deadline covers lock acquisition, client startup, /compact and
+        # the authoritative post-command token verification. Previously only
+        # the slash command itself was bounded, so a wedged control probe could
+        # leave the HTTP request and compacting UI open forever.
+        async with asyncio.timeout(timeout_s):
+            async with _session_runtime_lock_for(sid):
+                bc = _active_turns.get(sid)
+                if bc is not None and not bc.done:
+                    raise HTTPException(409, "cannot compact while a turn is active")
+                return await _native_compact_session_locked(sid)
+    except asyncio.TimeoutError:
+        sys.stderr.write(f"[chat] native /compact total timeout sid={sid[:8]}\n")
+        sys.stderr.flush()
+        raise HTTPException(
+            504, "native /compact timed out — CLI may be hung") from None
+
+
+def _refresh_compacted_message_counts(sid: str, model: str) -> None:
+    """Refresh sidebar counters after the compact result is already visible."""
+    new_msgs = _get_session_msgs(sid, model)
+    n_turns = sum(1 for sm in new_msgs if _is_real_user_prompt(sm))
+    sess.bump_session(
+        sid,
+        message_count=len(new_msgs),
+        turn_count=n_turns,
+    )
+
+
+def _schedule_post_compact_refresh(
+    sid: str,
+    model: str,
+    usage: dict[str, Any],
+) -> None:
+    async def _run() -> None:
+        try:
+            if endpoints.is_third_party(model):
+                capability = await _detect_gateway_context_capability(model)
+                real_max = _positive_int(usage.get("maxTokens"))
+                real_total = _positive_int(usage.get("totalTokens"))
+                sess_u = _session_usage.setdefault(sid, {})
+                details = _context_limit_details(
+                    model,
+                    sdk_max=real_max,
+                    sdk_raw=_positive_int(usage.get("rawMaxTokens")),
+                    stored=_positive_int(sess_u.get("context_limit")),
+                    capability=capability,
+                )
+                _apply_context_limit_details(sess_u, details)
+                threshold = _compact_threshold(
+                    model,
+                    _positive_int(details.get("context_limit")),
+                    _positive_int(usage.get("autoCompactThreshold")),
+                    sdk_max=real_max,
+                    capability=capability,
+                )
+                if threshold:
+                    sess_u["auto_compact_threshold"] = threshold
+                if real_total:
+                    _mark_context_used(
+                        sess_u, "sdk_context", estimate=True)
+                    limit = _positive_int(sess_u.get("context_limit"))
+                    if limit:
+                        sess_u["context_used_pct"] = round(
+                            real_total / limit * 100, 1)
+            await asyncio.to_thread(
+                _refresh_compacted_message_counts, sid, model)
+        except Exception as e:
+            sys.stderr.write(
+                f"[chat] post-compact count refresh skipped sid={sid[:8]}: "
+                f"{type(e).__name__}: {e}\n")
+
+    task = asyncio.create_task(_run())
+    _maintenance_tasks.add(task)
+    task.add_done_callback(_maintenance_tasks.discard)
 
 
 async def _native_compact_session_locked(sid: str) -> dict:
@@ -5966,8 +6056,8 @@ async def _native_compact_session_locked(sid: str) -> dict:
             before_total = _positive_int((await client.get_context_usage()).get("totalTokens"))
         except Exception:
             pass
-        # Bound the wait: a hung CLI /compact would otherwise leave this HTTP
-        # request open forever (the main turn loop has its own 1800s guard).
+        # Bound the command too for direct internal callers. The HTTP endpoint
+        # has an outer deadline that also covers lock/client/verification.
         # 300s is ~2x the observed worst case (~150s at 190K tokens) now that
         # the command reads through the pump instead of racing it.
         async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)):
@@ -6027,26 +6117,8 @@ async def _native_compact_session_locked(sid: str) -> dict:
         if real_total:
             sess_u["context_used"] = real_total
         if endpoints.is_third_party(model):
-            capability = await _detect_gateway_context_capability(model)
-            details = _context_limit_details(
-                model,
-                sdk_max=real_max,
-                sdk_raw=_positive_int(cu.get("rawMaxTokens")),
-                stored=_positive_int(sess_u.get("context_limit")),
-                capability=capability,
-            )
-            _apply_context_limit_details(sess_u, details)
             sess_u["sdk_context_max_tokens"] = real_max
             sess_u["sdk_context_raw_max_tokens"] = _positive_int(cu.get("rawMaxTokens"))
-            threshold = _compact_threshold(
-                model,
-                _positive_int(details.get("context_limit")),
-                _positive_int(cu.get("autoCompactThreshold")),
-                sdk_max=real_max,
-                capability=capability,
-            )
-            if threshold:
-                sess_u["auto_compact_threshold"] = threshold
             if real_total:
                 _mark_context_used(sess_u, "sdk_context", estimate=True)
         elif real_max:
@@ -6065,17 +6137,11 @@ async def _native_compact_session_locked(sid: str) -> dict:
             f"[chat] post-compact ctx refresh skipped for sid={sid[:8]}: "
             f"{type(_e).__name__}\n")
         sys.stderr.flush()
-    # Refresh message_count + turn_count so the sidebar reflects the
-    # compacted size. turn_count uses the real-prompt filter — see the
-    # comment on _is_real_user_prompt for why bare `type == "user"` over-
-    # counts by 5-10× in tool-heavy sessions.
-    try:
-        new_msgs = await asyncio.to_thread(_get_session_msgs, sid, model)
-        n_turns = sum(1 for sm in new_msgs if _is_real_user_prompt(sm))
-        sess.bump_session(sid, message_count=len(new_msgs),
-                           turn_count=n_turns)
-    except Exception:
-        pass
+    # Message/turn recount can scan a very large transcript. It is
+    # presentation bookkeeping, not part of compact correctness; schedule it
+    # after the verified token drop so the browser can leave "compacting"
+    # immediately. The next session read also self-heals these counters.
+    _schedule_post_compact_refresh(sid, model, dict(post_compact_usage or {}))
     return {"ok": True}
 
 
@@ -6103,11 +6169,17 @@ def fork_session_api(sid: str, req: ForkReq) -> dict:
     active = _active_turns.get(sid)
     if active is not None and not active.done:
         raise HTTPException(409, "cannot fork while a turn is active")
-    if _sessions_with_inflight_tasks.get(sid):
-        raise HTTPException(
-            409,
-            "cannot fork while background tasks are still running",
-        )
+    # A detached background task belongs to the source CLI process, not to
+    # the JSONL transcript. Forking here is therefore a point-in-time snapshot:
+    # the fork receives every complete record persisted when the SDK reads the
+    # file, while the process and its eventual continuation stay in the source
+    # session. The SDK reads the source bytes once and its JSONL parser ignores
+    # an incomplete final append, so this does not clone a half-written record.
+    # Keep the stricter active-turn guard above: ordinary token/tool streaming
+    # writes continuously and does not yet have a clean user-visible boundary.
+    background_tasks_pending = len(
+        _sessions_with_inflight_tasks.get(sid, ())
+    )
     source_model = (src_meta.get("model") or MODEL).strip()
     source_name = (src_meta.get("name") or "会话").strip()
     requested_title = (req.title or "").strip()
@@ -6160,6 +6232,7 @@ def fork_session_api(sid: str, req: ForkReq) -> dict:
     return {
         **meta,
         "session_id": new_sid,
+        "source_background_tasks_pending": background_tasks_pending,
     }
 
 
@@ -8733,45 +8806,53 @@ async def _watch_inflight_tasks(
                 "cta": "retry",
                 "retryable": True,
             })
-        # Persist the completion time the way a normal turn does (see the
-        # set_message_annotation call in _handle_result_message). Without it
-        # the turn-footer under a background-task reply stays blank: the FE
-        # stamps `ts` in memory, but _reconcileCompletedContinuation reloads
-        # the session from canonical history right after this `done`, and only
-        # sidecar annotations survive that reload.
-        #
-        # The uuid MUST come from the transcript tail, not from the live
-        # message object — annotations are keyed by transcript uuid, which is
-        # why the normal path resolves it through _recent_turn_uuids too.
-        try:
-            asst_uuid, _ = await asyncio.to_thread(
-                _recent_turn_uuids, session_id, False)
-            if asst_uuid:
-                existing = await asyncio.to_thread(
-                    sess.get_message_annotations, session_id)
-                # Never overwrite. A continuation that ended without a reply of
-                # its own resolves to the PREVIOUS turn's assistant message,
-                # which already carries that turn's timestamp.
-                if "ts" not in (existing.get(asst_uuid) or {}):
-                    _cont_elapsed = round(max(0.0, time.time() - b.started_at), 1)
-                    await asyncio.to_thread(
-                        sess.set_message_annotation,
-                        session_id, asst_uuid,
-                        model=b.model,
-                        ts=int(time.time() * 1000),
-                        elapsed_s=_cont_elapsed if _cont_elapsed >= 1 else None)
-        except Exception as e:
-            # A missing footer timestamp must never take the continuation down.
-            sys.stderr.write(
-                f"[chat] continuation ts annotation failed "
-                f"sid={session_id[:8]}: {type(e).__name__}: {e}\n")
-            sys.stderr.flush()
+        # The broadcast terminal boundary is user-facing truth. Close it
+        # before transcript scans / annotation writes so a slow sidecar or
+        # long JSONL cannot leave the continuation footer pulsing after the
+        # SDK has already emitted its ResultMessage.
         b.publish({"event": "done", "data": json.dumps(done_payload)})
         b.finish()
         async with _lock:
             if _active_turns.get(session_id) is b:
                 _active_turns.pop(session_id, None)
         _remember_recent_turn(session_id, b)
+        # Persist the completion time the way a normal turn does (see the
+        # set_message_annotation call in _handle_result_message). The uuid MUST
+        # come from the transcript tail because annotations are keyed by the
+        # persisted uuid. This is presentation bookkeeping, so run it after
+        # the watcher has released its stream slot; a slow transcript scan or
+        # sidecar write must not delay footer completion or queue draining.
+        async def _annotate_completion() -> None:
+            try:
+                asst_uuid, _ = await asyncio.to_thread(
+                    _recent_turn_uuids, session_id, False)
+                if asst_uuid:
+                    existing = await asyncio.to_thread(
+                        sess.get_message_annotations, session_id)
+                    # Never overwrite. A continuation that ended without a
+                    # reply of its own resolves to the previous turn's
+                    # assistant message, which already has that timestamp.
+                    if "ts" not in (existing.get(asst_uuid) or {}):
+                        cont_elapsed = round(
+                            max(0.0, time.time() - b.started_at), 1)
+                        await asyncio.to_thread(
+                            sess.set_message_annotation,
+                            session_id, asst_uuid,
+                            model=b.model,
+                            ts=int(time.time() * 1000),
+                            elapsed_s=(
+                                cont_elapsed if cont_elapsed >= 1 else None),
+                        )
+            except Exception as e:
+                # A missing footer timestamp must never affect the continuation.
+                sys.stderr.write(
+                    f"[chat] continuation ts annotation failed "
+                    f"sid={session_id[:8]}: {type(e).__name__}: {e}\n")
+                sys.stderr.flush()
+
+        annotation_task = asyncio.create_task(_annotate_completion())
+        _maintenance_tasks.add(annotation_task)
+        annotation_task.add_done_callback(_maintenance_tasks.discard)
 
     async def _request_explicit_resume(reason: str) -> bool:
         """Ask the existing SDK session to finish the originating request.
@@ -8861,8 +8942,8 @@ async def _watch_inflight_tasks(
     # Status of the most recent settle. A USER-STOPPED task almost never
     # produces an auto-continue reaction (the CLI treats the stop as user
     # intent), so waiting the full _CONTINUATION_GRACE leaves the attached
-    # frontend spinning "streaming…" for 60 idle seconds after the card
-    # already flipped ⏹ (2026-06-11 footer complaint). Use a short grace
+    # frontend spinning "streaming…" after the card already flipped ⏹
+    # (2026-06-11 footer complaint). Use a short grace
     # for stopped settles; a reaction that somehow arrives later is not
     # lost — it buffers in the SDK queue and the next turn's in-turn
     # dispatch drains it.
@@ -8929,6 +9010,7 @@ async def _watch_inflight_tasks(
                                 "summary": getattr(msg, "summary", None),
                                 "output_file": getattr(msg, "output_file", None),
                                 "usage": dict(getattr(msg, "usage", None) or {}),
+                                "background_tasks_pending": len(pending),
                             })})
                 elif isinstance(msg, TaskUpdatedMessage):
                     terminal = _terminal_task_update(msg)
@@ -8946,6 +9028,7 @@ async def _watch_inflight_tasks(
                             if cont is None:
                                 await _open_continuation()
                             if cont is not None:
+                                terminal["background_tasks_pending"] = len(pending)
                                 cont.publish({
                                     "event": "task_notification",
                                     "data": json.dumps(terminal),
@@ -9018,6 +9101,7 @@ async def _watch_inflight_tasks(
                                 "status": n.get("status") or None,
                                 "summary": n.get("summary") or None,
                                 "output_file": n.get("output_file") or None,
+                                "background_tasks_pending": len(pending),
                             })})
                 elif isinstance(msg, ResultMessage):
                     # End of the CLI's auto-continue reaction — close the
@@ -9174,9 +9258,43 @@ async def _finish_cancelled_startup(
     async with _lock:
         if _active_turns.get(session_id) is broadcast:
             _active_turns.pop(session_id, None)
+    await _finish_activity(session_id, broadcast, "cancelled")
     _remember_recent_turn(session_id, broadcast)
     _delete_active_turn_sidecar(session_id)
     return broadcast
+
+
+async def _start_activity_early(
+    session_id: str,
+    broadcast: TurnBroadcast,
+    prompt: str,
+) -> None:
+    """Expose a reserved turn while its SDK client is still starting."""
+    try:
+        from .activity import activity as _activity
+        await asyncio.to_thread(
+            _activity.start, session_id, summary=prompt)
+        broadcast.activity_started = True
+    except Exception as e:
+        sys.stderr.write(f"[activity] start failed sid={session_id}: {e}\n")
+
+
+async def _finish_activity(
+    session_id: str,
+    broadcast: TurnBroadcast,
+    status: str,
+) -> None:
+    """Close the activity row once, whether startup or the turn ends."""
+    if not broadcast.activity_started:
+        return
+    try:
+        from .activity import activity as _activity
+        await asyncio.to_thread(_activity.finish, session_id, status)
+    except Exception as e:
+        sys.stderr.write(
+            f"[activity] startup finish failed sid={session_id}: {e}\n")
+    finally:
+        broadcast.activity_started = False
 
 
 async def _start_turn(
@@ -9308,6 +9426,13 @@ async def _start_turn(
     # Effort is per-session; read from metadata (settable via PATCH). Empty
     # string = SDK adaptive default, which is what the existing behavior was.
     effort_to_use = (s.get("effort") or "").strip()
+    # "Running" means the backend accepted and exclusively reserved the turn,
+    # not that a cold CLI/MCP client has already finished starting. Publishing
+    # here removes the user-visible startup gap while the terminal cleanup
+    # paths below prevent failed starts from becoming phantom running rows.
+    await _start_activity_early(session_id, broadcast, prompt)
+    if broadcast.cancelled:
+        return await _finish_cancelled_startup(session_id, broadcast)
     # Wrap get_client so SDK / auth pre-check errors surface as a typed
     # _TurnStartError the caller can shape (the /stream handler → SSE error
     # event / 504; the queue drain → pause + push) instead of bubbling up as
@@ -9334,6 +9459,7 @@ async def _start_turn(
             if _active_turns.get(session_id) is broadcast:
                 broadcast.finish()
                 _active_turns.pop(session_id, None)
+        await _finish_activity(session_id, broadcast, "failed")
         raise _TurnStartError(
             "Client connection timed out — CLI process may be hung",
             status=504)
@@ -9350,6 +9476,7 @@ async def _start_turn(
             if _active_turns.get(session_id) is broadcast:
                 broadcast.finish()
                 _active_turns.pop(session_id, None)
+        await _finish_activity(session_id, broadcast, "cancelled")
         raise
     except Exception as e:
         err_msg = str(e) or f"{type(e).__name__}"
@@ -9359,6 +9486,7 @@ async def _start_turn(
             if _active_turns.get(session_id) is broadcast:
                 broadcast.finish()
                 _active_turns.pop(session_id, None)
+        await _finish_activity(session_id, broadcast, "failed")
         raise _TurnStartError(err_msg)
 
     # Stop can race the final instant of client startup: the client may have
@@ -9366,14 +9494,6 @@ async def _start_turn(
     # list. Do not send the prompt after the user has already cancelled.
     if broadcast.cancelled:
         return await _finish_cancelled_startup(session_id, broadcast)
-
-    # Record only after the SDK client is ready, so connection failures do not
-    # leave a phantom running task in the global activity center.
-    try:
-        from .activity import activity as _activity
-        await asyncio.to_thread(_activity.start, session_id, summary=prompt)
-    except Exception as e:
-        sys.stderr.write(f"[activity] start failed sid={session_id}: {e}\n")
 
     # Pull attachments from the in-memory store; build content blocks for the
     # SDK. Consume them — same attachment won't be re-sent on retry.
@@ -9600,7 +9720,16 @@ async def _start_turn(
         close to full.
         """
         try:
-            cu = await client.get_context_usage()
+            # This probe is advisory when no compact is needed. Never let a
+            # wedged SDK control request delay the user's real prompt for the
+            # full compact window.
+            cu = await asyncio.wait_for(
+                client.get_context_usage(),
+                timeout=min(
+                    10,
+                    env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1),
+                ),
+            )
         except Exception as e:
             sys.stderr.write(
                 f"[chat-preflight] get_context_usage skipped sid={session_id[:8]} "
@@ -9672,16 +9801,31 @@ async def _start_turn(
         # acknowledge itself cannot kill the turn it just made room for.
         cmd_error: Exception | None = None
         try:
-            async with asyncio.timeout(env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)):
-                await _run_sdk_command_checked(client, "/compact")
-        except Exception as e:
-            cmd_error = e
-            sys.stderr.write(
-                f"[chat-preflight] native compact reported failure sid={session_id[:8]} "
-                f"model={model_to_use}: {type(e).__name__}: {e} — verifying\n")
-            sys.stderr.flush()
-        try:
-            cu2 = await client.get_context_usage()
+            # One compact deadline covers both the slash command and the
+            # authoritative token-drop verification. The old split left the
+            # compact bubble spinning forever when the second control request
+            # hung after `/compact` had already succeeded.
+            async with asyncio.timeout(
+                env_int("MUSELAB_COMPACT_TIMEOUT_S", 300, min_value=1)
+            ):
+                try:
+                    await _run_sdk_command_checked(client, "/compact")
+                except Exception as e:
+                    cmd_error = e
+                    sys.stderr.write(
+                        f"[chat-preflight] native compact reported failure "
+                        f"sid={session_id[:8]} model={model_to_use}: "
+                        f"{type(e).__name__}: {e} — verifying\n")
+                    sys.stderr.flush()
+                cu2 = await client.get_context_usage()
+        except asyncio.TimeoutError:
+            await _emit_compact(
+                emit,
+                "end",
+                ok=False,
+                error="native compact timed out during command or verification",
+            )
+            raise
         except Exception as e:
             # Can't observe the outcome, so the command's verdict is all we
             # have. No reading also means no evidence of success.
@@ -10218,6 +10362,11 @@ async def _start_turn(
                     "summary": summary,
                     "output_file": output_file,
                     "usage": dict(getattr(msg, "usage", None) or {}),
+                    "background_tasks_pending": max(
+                        0,
+                        len(_sessions_with_inflight_tasks.get(
+                            session_id, ())) - (1 if tid else 0),
+                    ),
                 })}
                 # In-turn settle (the rare case where a background task finishes
                 # before this turn's ResultMessage). The card already flipped via
@@ -10241,6 +10390,8 @@ async def _start_turn(
                     f"[chat] in-turn terminal update sid={session_id[:8]} "
                     f"task={tid} status={terminal['status']} won={won_updated}\n")
                 if won_updated:
+                    terminal["background_tasks_pending"] = len(
+                        _sessions_with_inflight_tasks.get(session_id, ()))
                     yield {
                         "event": "task_notification",
                         "data": json.dumps(terminal),
@@ -10288,6 +10439,79 @@ async def _start_turn(
             sess_u["total_cost_usd"] += cost
             sess_u["last_turn_at"] = time.time()
 
+            # ResultMessage is the SDK's authoritative turn boundary. Do the
+            # small status/error accounting needed by the browser immediately,
+            # close the global activity row, and emit `done` BEFORE slower
+            # bookkeeping below (context control calls, transcript parsing,
+            # push fan-out, JSONL compatibility cleanup). The old ordering kept
+            # the footer pulsing "Running" for seconds after the final answer
+            # was already visible.
+            was_cancelled = session_id in _pending_interrupts
+            _pending_interrupts.discard(session_id)
+            broadcast.cancelled = was_cancelled
+            _result_error = _sdk_result_error(msg)
+            _turn_error = _merge_sdk_errors([
+                *turn_sdk_errors,
+                *([_result_error] if _result_error else []),
+            ])
+            _is_error = _turn_error is not None
+            _subtype = getattr(msg, "subtype", None)
+            _errors = getattr(msg, "errors", None) or []
+            if not isinstance(_errors, (list, tuple)):
+                _errors = [_errors]
+            _api_error_status = (
+                (_turn_error or {}).get("api_error_status")
+                or getattr(msg, "api_error_status", None)
+            )
+            _error_message = (_turn_error or {}).get("message", "")
+            _error_class = _classify_stream_error(_error_message) if _is_error else {
+                "kind": None, "cta": None, "retryable": False,
+            }
+            _activity_status = ("cancelled" if was_cancelled else
+                                "failed" if _is_error else "completed")
+            await _finish_activity(session_id, broadcast, _activity_status)
+            _done_session_usage = dict(sess_u)
+            _done_memory_recall = mem0.pop_recall_trace(session_id)
+            _done_background_tasks = len(
+                _merge_session_inflight(session_id, inflight_tasks)
+            )
+            yield {"event": "done", "data": json.dumps({
+                "duration_ms": getattr(msg, "duration_ms", None),
+                "total_cost_usd": cost,
+                "model": model_to_use,
+                "stats": _stats,
+                "cancelled": was_cancelled,
+                "is_error": _is_error,
+                "error": _error_message,
+                "kind": _error_class["kind"],
+                "cta": _error_class["cta"],
+                "retryable": _error_class["retryable"],
+                "result_subtype": _subtype,
+                "errors": (_dedupe_error_parts([*_errors, _error_message])
+                           if _is_error else []),
+                "api_error_status": _api_error_status,
+                "turn_usage": {
+                    "input_tokens": in_t,
+                    "output_tokens": out_t,
+                    "cache_read_tokens": cr_t,
+                    "cache_creation_tokens": cc_t,
+                },
+                # Context-control refresh continues below. Assistant-message
+                # usage has already updated this snapshot; a later API read
+                # sees the authoritative postprocessed value.
+                "session_usage": _done_session_usage,
+                "budget_usd": _budget_usd(),
+                "budget_used_pct": (
+                    round(_stats["total_cost_usd"] / _budget_usd() * 100, 1)
+                    if _budget_usd() > 0 else 0
+                ),
+                "memory_recall": _done_memory_recall,
+                "background_tasks_pending": _done_background_tasks,
+            })}
+
+            # Everything below is post-turn persistence/telemetry. It remains
+            # inside the detached pump so browser disconnects cannot cancel it,
+            # but it no longer delays the user-visible terminal event.
             # Pull authoritative max-window from SDK so the meter reflects the
             # ACTUAL effective limit (which may be 1M for Pro/Max subscribers,
             # not the hardcoded 200K in MODEL_CONTEXT_LIMITS). One control
@@ -10488,20 +10712,6 @@ async def _start_turn(
                                turn_count=n_turns,
                                auto_rename_from=_rename_src)
             sess.update_model(session_id, model_to_use)
-            # Was this turn cancelled by an explicit /interrupt? The FE
-            # closes its EventSource immediately on stop-click, which
-            # zeroes live_subscribers below — without this flag, the
-            # "no live subscriber → fire push" path would buzz the user
-            # for a reply they just cancelled. Consume the flag (.discard
-            # always returns None — wrap with `in` test then discard).
-            # (2026-05-23 user report)
-            was_cancelled = session_id in _pending_interrupts
-            _pending_interrupts.discard(session_id)
-            # Record on the broadcast so the queue-drain trigger (which runs
-            # in _pump_gen_to_broadcast's finally, after _pending_interrupts
-            # is already cleared here) can tell "user stopped" from "finished
-            # / errored" and pause instead of advancing the queue.
-            broadcast.cancelled = was_cancelled
             # Web Push on turn-done. Three gates, in order:
             #   1. Turn was NOT user-cancelled — see was_cancelled above.
             #   2. No device has heartbeated /api/presence recently — i.e.
@@ -10615,30 +10825,6 @@ async def _start_turn(
                     await asyncio.to_thread(_jc.clean_session, session_id)
                 except Exception as e:
                     sys.stderr.write(f"[chat] jsonl cleanup failed: {e}\n")
-            # SDK reports turn-level failures THROUGH ResultMessage, not as
-            # exceptions: max-turns / budget exceeded, permission denied,
-            # API errors all arrive as a normal ResultMessage with
-            # is_error=True (+ subtype / errors detail). Surface them in the
-            # done payload so the FE can render a failure state — previously
-            # these turns looked identical to successes in UI and history.
-            _result_error = _sdk_result_error(msg)
-            _turn_error = _merge_sdk_errors([
-                *turn_sdk_errors,
-                *([_result_error] if _result_error else []),
-            ])
-            _is_error = _turn_error is not None
-            _subtype = getattr(msg, "subtype", None)
-            _errors = getattr(msg, "errors", None) or []
-            if not isinstance(_errors, (list, tuple)):
-                _errors = [_errors]
-            _api_error_status = (
-                (_turn_error or {}).get("api_error_status")
-                or getattr(msg, "api_error_status", None)
-            )
-            _error_message = (_turn_error or {}).get("message", "")
-            _error_class = _classify_stream_error(_error_message) if _is_error else {
-                "kind": None, "cta": None, "retryable": False,
-            }
             # Memory write is deferred until turn status is known. Clean
             # exchanges may be consolidated into memories. Cancelled turns are
             # evidence-only (never fact candidates), which preserves the useful
@@ -10656,52 +10842,6 @@ async def _start_turn(
                 memory_outcome_scheduled = mem0.schedule_failed(
                     session_id, model_to_use, prompt,
                     "".join(assistant_acc), _error_message, new_asst_uuid)
-            yield {"event": "done", "data": json.dumps({
-                "duration_ms": getattr(msg, "duration_ms", None),
-                "total_cost_usd": cost,
-                "model": model_to_use,
-                "stats": _stats,
-                # Flag so the FE can skip celebration UI (success toast /
-                # green-dot tab unread badge would be wrong for a user-
-                # cancelled turn — they clicked stop, they know).
-                "cancelled": was_cancelled,
-                "is_error": _is_error,
-                "error": _error_message,
-                "kind": _error_class["kind"],
-                "cta": _error_class["cta"],
-                "retryable": _error_class["retryable"],
-                "result_subtype": _subtype,
-                "errors": (_dedupe_error_parts([*_errors, _error_message])
-                           if _is_error else []),
-                "api_error_status": _api_error_status,
-                # turn_usage: cumulative (ResultMessage.usage). FE should
-                # prefer session_usage.context_* for window display. Will be
-                # removed once FE is fully migrated.
-                "turn_usage": {
-                    "input_tokens": in_t,
-                    "output_tokens": out_t,
-                    "cache_read_tokens": cr_t,
-                    "cache_creation_tokens": cc_t,
-                },
-                "session_usage": _session_usage[session_id],
-                "budget_usd": _budget_usd(),
-                "budget_used_pct": (
-                    round(_stats["total_cost_usd"] / _budget_usd() * 100, 1)
-                    if _budget_usd() > 0 else 0
-                ),
-                # White-box recall trace. The content is already bounded and
-                # provenance-only; the UI keeps it collapsed by default.
-                "memory_recall": mem0.pop_recall_trace(session_id),
-                # Main ResultMessage can arrive while SDK-native background
-                # Agent/Bash tasks continue. The browser keeps the turn footer
-                # alive and queues follow-ups until their detached watcher
-                # completes, preventing old continuation text from appearing
-                # beneath a newer user message.
-                "background_tasks_pending": len(
-                    _merge_session_inflight(session_id, inflight_tasks)
-                ),
-            })}
-
         # event_gen is now driven by a detached background task (see
         # stream endpoint below), so the SSE generator doesn't cancel
         # these workers when the browser disconnects — they complete
@@ -10861,6 +11001,7 @@ async def _start_turn(
         nonlocal memory_outcome_scheduled
         turn_errored = False
         turn_error_text = ""
+        terminal_published = False
         try:
             # None → asyncio.timeout is a no-op wrapper (no deadline armed).
             async with asyncio.timeout(BG_TIMEOUT_S or None):
@@ -10888,7 +11029,13 @@ async def _start_turn(
                         except (ValueError, TypeError):
                             pass
                     broadcast.publish(ev)
+                    if isinstance(ev, dict) and ev.get("event") == "done":
+                        terminal_published = True
         except asyncio.TimeoutError:
+            if terminal_published:
+                sys.stderr.write(
+                    f"[chat] post-turn bookkeeping timed out sid={session_id}\n")
+                return
             turn_errored = True
             turn_error_text = f"turn exceeded {BG_TIMEOUT_S}s"
             sys.stderr.write(
@@ -10898,6 +11045,11 @@ async def _start_turn(
             broadcast.publish(
                 _error_event(f"turn exceeded {BG_TIMEOUT_S}s"))
         except Exception as e:
+            if terminal_published:
+                sys.stderr.write(
+                    f"[chat] post-turn bookkeeping failed sid={session_id} "
+                    f"exc={type(e).__name__}: {e}\n")
+                return
             turn_errored = True
             turn_error_text = f"{type(e).__name__}: {e}"
             import traceback as _tb
@@ -10920,14 +11072,10 @@ async def _start_turn(
                         "".join(assistant_acc),
                         turn_error_text or "turn stream failed",
                         broadcast.turn_id)
-            try:
-                from .activity import activity as _activity
-                _activity_status = ("cancelled" if broadcast.cancelled else
-                                    "failed" if turn_errored else "completed")
-                await asyncio.to_thread(
-                    _activity.finish, session_id, _activity_status)
-            except Exception as e:
-                sys.stderr.write(f"[activity] finish failed sid={session_id}: {e}\n")
+            _activity_status = ("cancelled" if broadcast.cancelled else
+                                "failed" if turn_errored else "completed")
+            await _finish_activity(
+                session_id, broadcast, _activity_status)
             broadcast.finish()
             _active_turns.pop(session_id, None)
             if session_id in _pending_runtime_rebuilds:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -28,7 +28,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from .settings import ROOT, atomic_write_text, is_chinese_locale
+from .settings import ROOT, atomic_write_text, env_int, is_chinese_locale
 
 
 def _scheduled_label_prefix() -> str:
@@ -649,6 +649,8 @@ async def _execute_task(task: dict) -> None:
     mode = _effective_session_mode(task)
     reply_text = ""
     error: str | None = None
+    cancelled = False
+    activity_started = False
 
     async with _task_lock(tid):
         # Resolve `sid` INSIDE the lock so two parallel run-now clicks
@@ -688,6 +690,19 @@ async def _execute_task(task: dict) -> None:
         else:
             sid = task["session_id"]
         try:
+            from .activity import activity as _activity
+            _activity.start(
+                sid,
+                summary=task["name"],
+                kind="scheduled",
+                source_id=tid,
+            )
+            activity_started = True
+        except Exception as e:
+            sys.stderr.write(
+                f"[scheduler] activity start failed for {tid}: "
+                f"{type(e).__name__}: {e}\n")
+        try:
             # Tasks created before the scheduler UI had a model picker stored
             # model=""; SDK then silently fell back to its built-in default
             # (which differs from whatever the user has selected in the chat
@@ -696,12 +711,30 @@ async def _execute_task(task: dict) -> None:
             # default when task.model is empty.
             from .settings import MODEL as _DEFAULT_MODEL
             model = task.get("model") or _DEFAULT_MODEL
-            reply_text, error = await _run_sdk_task_turn(
-                sid, model, task["prompt"])
+            timeout_s = env_int(
+                "MUSELAB_SCHEDULER_TIMEOUT_S", 1800, min_value=0)
+            async with asyncio.timeout(timeout_s or None):
+                reply_text, error = await _run_sdk_task_turn(
+                    sid, model, task["prompt"])
             if error:
                 sys.stderr.write(
                     f"[scheduler] task {tid} ({task['name']}) "
                     f"result is_error: {error}\n")
+        except asyncio.TimeoutError:
+            error = (
+                "scheduled task timed out after "
+                f"{env_int('MUSELAB_SCHEDULER_TIMEOUT_S', 1800, min_value=0)}s"
+            )
+            sys.stderr.write(
+                f"[scheduler] task {tid} ({task['name']}) timed out\n")
+        except asyncio.CancelledError:
+            # Service shutdown cancels tracked scheduler tasks. CancelledError
+            # inherits BaseException, so the generic handler below does not
+            # see it. Persist an explicit cancelled result before propagating;
+            # otherwise `error is None` in finally records a false success.
+            cancelled = True
+            error = "scheduled task cancelled by service shutdown"
+            raise
         except Exception as e:
             error = f"{type(e).__name__}: {e}"
             sys.stderr.write(f"[scheduler] task {tid} ({task['name']}) failed: {error}\n")
@@ -731,6 +764,18 @@ async def _execute_task(task: dict) -> None:
                 if len(_state["history"]) > _HISTORY_CAP:
                     _state["history"] = _state["history"][-_HISTORY_CAP:]
                 _save_state()
+            if activity_started:
+                try:
+                    from .activity import activity as _activity
+                    _activity.finish(
+                        sid,
+                        "cancelled" if cancelled else (
+                            "failed" if error else "completed"),
+                    )
+                except Exception as e:
+                    sys.stderr.write(
+                        f"[scheduler] activity finish failed for {tid}: "
+                        f"{type(e).__name__}: {e}\n")
             # Fire Web Push to every subscribed device — but skip when the
             # user is actively at one of their devices (presence heartbeat
             # within GRACE_SECONDS). In-app the UI already flashes the bell
@@ -743,6 +788,8 @@ async def _execute_task(task: dict) -> None:
             # 4-toggle UI down to one "notify me" switch).
             # Errors swallowed — push is best-effort, must never break the loop.
             try:
+                if cancelled:
+                    raise
                 from . import presence as _presence
                 if _presence.recently_active():
                     # User is at their screen — UI badge + foreground vibrate

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -517,6 +517,10 @@ function portal() {
     },
     activity: {
       show: false, loading: false, events: [],
+      // Status groups remain the default operational view. The alternate
+      // timeline shows every state by its latest transition time.
+      view: "status",
+      viewLoaded: false,
       summary: {
         running: 0, unread: 0, attention: 0,
         groups: { review: 0, running: 0, failed: 0, history: 0 },
@@ -532,8 +536,14 @@ function portal() {
     _activityFetchPromises: {},
     _activityRequestSeq: 0,
     _activityAppliedSeq: 0,
-    // Per-task "run-now" inflight flag — disables retry / send buttons
-    // until the LLM call returns and history is reloaded. Keyed by task id.
+    _activityGeneration: "",
+    _activityRevision: 0,
+    _activityLiveSource: null,
+    _activityLiveSeq: 0,
+    _activityLiveTimer: null,
+    _activityLiveVisibilityBound: false,
+    // Per-task "run-now" inflight flag — disables retry / send buttons until
+    // activity SSE reports a terminal state. Keyed by task id.
     schedRunning: {},
     // Single notification switch — collapsed from 4 toggles (vibrate /
     // push / notify_scheduled / notify_normal) on 2026-05-28 because the
@@ -1949,6 +1959,7 @@ function portal() {
       this._startSessionsSync();
       this._startFileEvents();
       this.fetchActivity();
+      this._startActivityEvents();
       this._startMemoryMonitor();
       // Restoring a saved current session means the user is already looking at
       // it; clear any completion that landed before this page loaded.
@@ -5661,6 +5672,10 @@ function portal() {
         // task settlement opens a continuation broadcast.
         backgroundActive: false,
         backgroundTaskCount: 0,
+        // A background task can settle before Claude starts its automatic
+        // follow-up reaction. Keep the transport attached, but suppress the
+        // generic running footer during that idle protocol gap.
+        _continuationAwaitingReaction: false,
         // Exact backend turn currently owned by this tab. Session id is not
         // sufficient: a reconnect for turn A must never attach to newer B.
         activeTurnId: "",
@@ -5683,6 +5698,11 @@ function portal() {
         _lastSseActivity: 0,
         _stallWatch: null,
         _serverActiveObserved: false,
+        // A terminal SSE event is newer than the last polled session-list
+        // snapshot. Keep its activity flags authoritative until the backend
+        // list echoes the same state, so an in-flight stale response cannot
+        // relight the tab's running dot for another poll interval.
+        _sessionActivityExpected: null,
         _streamHealthProbe: null,
         _reconnectTimer: null,
         _canonicalResyncTimer: null,
@@ -5798,6 +5818,9 @@ function portal() {
       if (st.activeTurnId === undefined) st.activeTurnId = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
       if (!Number.isFinite(st.lastEventSeq)) st.lastEventSeq = 0;
+      if (st._sessionActivityExpected === undefined) {
+        st._sessionActivityExpected = null;
+      }
       return st;
     },
 
@@ -6210,10 +6233,10 @@ function portal() {
       const bgState = this.tabState[sid];
       if (!this._bgHasRunningCard(sid)
           && !(bgState && bgState.backgroundActive)) return;
-      // Hard cap mirrors the server's MUSELAB_TASK_WATCH_TIMEOUT (1800s): at an
-      // 8s cadence that's ~225 ticks. Prevents an interval lingering forever if
+      // Hard cap mirrors the server's MUSELAB_TASK_WATCH_TIMEOUT (1800s): at a
+      // 2s cadence that's ~900 ticks. Prevents an interval lingering forever if
       // the user navigates away and the running card never resolves on the FE.
-      let ticksLeft = 230;
+      let ticksLeft = 910;
       const tick = async () => {
         if (ticksLeft-- <= 0) { this._stopBgContPoller(sid); return; }
         const ownerState = this.tabState[sid];
@@ -6314,7 +6337,7 @@ function portal() {
           }
         } catch (_e) {}
       };
-      this._bgContPollers[sid] = setInterval(tick, 8000);
+      this._bgContPollers[sid] = setInterval(tick, 2000);
       tick();   // kick once immediately
     },
     _stopBgContPoller(sid) {
@@ -6807,6 +6830,32 @@ function portal() {
       }
       return out;
     },
+    _retainExpectedSessionActivity(meta) {
+      const st = meta && this.tabState && this.tabState[meta.id];
+      const expected = st && st._sessionActivityExpected;
+      if (!expected) return meta;
+      // This guard should normally clear on the first post-terminal list
+      // response. Bound it defensively so a broken/legacy backend cannot hide
+      // a genuinely new cross-device turn forever.
+      if (Date.now() - Number(expected.at || 0) > 15_000) {
+        st._sessionActivityExpected = null;
+        return meta;
+      }
+      const fields = ["active", "turn_active", "background_active"];
+      const echoed = fields.every(field =>
+        Object.prototype.hasOwnProperty.call(meta, field)
+        && !!meta[field] === !!expected[field]);
+      if (echoed) {
+        st._sessionActivityExpected = null;
+        return meta;
+      }
+      return {
+        ...meta,
+        active: !!expected.active,
+        turn_active: !!expected.turn_active,
+        background_active: !!expected.background_active,
+      };
+    },
     // Shared session-list applier. Snapshots the prior server-side `active`
     // flags BEFORE swapping in the new list (FIX ⑩) so we can detect a
     // streaming→idle transition that happened on another device: when a turn
@@ -6833,7 +6882,9 @@ function portal() {
       if (_pending.length) {
         next = [...(_pending.map(id => _om[id])), ...next];
       }
-      next = next.map(meta => this._retainExpectedSessionSettings(meta));
+      next = next
+        .map(meta => this._retainExpectedSessionSettings(meta))
+        .map(meta => this._retainExpectedSessionActivity(meta));
       // Keep the OPEN conversation's messages live too — not just the session
       // LIST. Runs BEFORE the equality early-return so it fires every pull even
       // when the picker itself doesn't need a re-render (e.g. a turn still
@@ -7028,6 +7079,7 @@ function portal() {
       st.streaming = false;
       st.backgroundActive = false;
       st.backgroundTaskCount = 0;
+      st._continuationAwaitingReaction = false;
       st._draining = false;
       st._reconnectAttempts = 0;
       st._serverActiveObserved = false;
@@ -7147,6 +7199,8 @@ function portal() {
         if ((x.model || "") !== (y.model || "")) return false;
         if (!!x.pinned !== !!y.pinned) return false;
         if (!!x.active !== !!y.active) return false;
+        if (!!x.turn_active !== !!y.turn_active) return false;
+        if (!!x.background_active !== !!y.background_active) return false;
         if ((x.updated_at || 0) !== (y.updated_at || 0)) return false;
         if ((x.message_count || 0) !== (y.message_count || 0)) return false;
         if ((x.effort || "") !== (y.effort || "")) return false;
@@ -8119,11 +8173,43 @@ function portal() {
       // chat.py's _active_turns). So the blue "streaming" dot lights up on
       // every device, not just the one that sent the message.
       const s = this.sessions.find(x => x.id === tid);
-      return !!(s && s.active);
+      if (!s) return false;
+      // New backends distinguish a transcript-writing turn/continuation from
+      // a detached background process. Fork is safe in the latter state but
+      // not while JSONL is actively streaming. Fall back to the legacy
+      // aggregate flag during rolling upgrades.
+      if (Object.prototype.hasOwnProperty.call(s, "turn_active")) {
+        return !!s.turn_active;
+      }
+      return !!s.active;
+    },
+    _setSessionActivityExpectation(tid, backgroundActive = false) {
+      if (!tid) return;
+      const st = this._ensureTabState(tid);
+      const background = !!backgroundActive;
+      st._sessionActivityExpected = {
+        active: background,
+        turn_active: false,
+        background_active: background,
+        at: Date.now(),
+      };
+      // Apply the terminal transition in the same browser tick as `done`.
+      // The next list pull confirms and clears the expectation.
+      this.sessions = (this.sessions || []).map(session =>
+        session.id === tid
+          ? {
+              ...session,
+              active: background,
+              turn_active: false,
+              background_active: background,
+            }
+          : session);
     },
     isTabBackgroundActive(tid) {
       const st = this.tabState[tid];
-      return !!(st && st.backgroundActive);
+      if (st && st.backgroundActive) return true;
+      const s = this.sessions.find(x => x.id === tid);
+      return !!(s && s.background_active);
     },
     isTabRunning(tid) {
       return this.isTabBackgroundActive(tid) || this.isTabStreaming(tid);
@@ -10182,8 +10268,8 @@ function portal() {
           } catch (_) {}
           const message = response.status === 409
             ? (this.lang === "zh"
-              ? "等当前回复或后台任务完成后再 Fork"
-              : "Wait for the active turn or background task to finish")
+              ? "等当前正在写入的回复完成后再 Fork"
+              : "Wait for the currently streaming reply to finish")
             : (/no messages/i.test(detail)
               ? (this.lang === "zh" ? "空会话无法 Fork" : "An empty conversation cannot be forked")
               : (this.lang === "zh" ? "Fork 对话失败" : "Could not fork conversation"));
@@ -10208,11 +10294,15 @@ function portal() {
         st._loaded = false;
         await this.openTab(newId);
         this.toast(
-          upToMessageId
-            ? (this.lang === "zh" ? "已从这里创建分支" : "Forked from this point")
-            : (this.lang === "zh" ? "已 Fork 对话" : "Conversation forked"),
+          Number(payload.source_background_tasks_pending) > 0
+            ? (this.lang === "zh"
+              ? `已从当前进度 Fork；${payload.source_background_tasks_pending} 个后台任务仍在原会话运行`
+              : `Forked the current snapshot; ${payload.source_background_tasks_pending} background task(s) remain in the source`)
+            : (upToMessageId
+              ? (this.lang === "zh" ? "已从这里创建分支" : "Forked from this point")
+              : (this.lang === "zh" ? "已 Fork 对话" : "Conversation forked")),
           "success",
-          2200,
+          Number(payload.source_background_tasks_pending) > 0 ? 4200 : 2200,
         );
         return meta;
       } catch (error) {
@@ -20422,8 +20512,13 @@ function portal() {
       const primaryWorkspace = (this.sessionWorkspaces.find(w => w.primary) || {}).path || "";
       const streamWorkspace = (streamSession && streamSession.cwd) || primaryWorkspace;
 
-      if (!isReconnect) streamState._serverActiveObserved = false;
+      if (!isReconnect) {
+        streamState._serverActiveObserved = false;
+        // A real new local turn supersedes any just-finished list expectation.
+        streamState._sessionActivityExpected = null;
+      }
       streamState.streaming = true;
+      streamState._continuationAwaitingReaction = false;
       if (streamSid === this.currentId) this.streaming = true;
       // A live turn renders DIRECTLY into the visible pane, so it must never be
       // hidden by the bulk-reveal gate. `messagesReady=false` drives
@@ -20483,10 +20578,8 @@ function portal() {
       // Fresh (non-reconnect) sends always start at now.
       let _streamStartMs;
       if (isReconnect) {
-        if (isContinuation && streamState.backgroundActive
-            && streamState._streamStartedAt) {
-          _streamStartMs = streamState._streamStartedAt;
-        } else if (opts.startedAt) _streamStartMs = opts.startedAt * 1000;
+        if (isContinuation) _streamStartMs = Date.now();
+        else if (opts.startedAt) _streamStartMs = opts.startedAt * 1000;
         else if (streamState._streamStartedAt) _streamStartMs = streamState._streamStartedAt;
         else _streamStartMs = Date.now();
       } else {
@@ -20842,6 +20935,38 @@ function portal() {
         else { curBubble = null; acc = ""; }
       };
       const closeAsst = () => { flushRender(); curBubble = null; acc = ""; };
+      const _setContinuationAwaitingReaction = (waiting) => {
+        if (!isContinuation) return;
+        const next = !!waiting;
+        if (streamState._continuationAwaitingReaction === next) return;
+        streamState._continuationAwaitingReaction = next;
+        if (next) {
+          if (streamState._streamTimer) {
+            clearInterval(streamState._streamTimer);
+            streamState._streamTimer = null;
+          }
+          streamState._streamStartedAt = 0;
+          streamState.streamElapsed = 0;
+          if (this.currentId === streamSid) {
+            this._streamTimer = null;
+            this._streamStartedAt = 0;
+            this.streamElapsed = 0;
+          }
+          return;
+        }
+        if (!streamState.streaming || streamState._streamTimer) return;
+        streamState._streamStartedAt = Date.now();
+        streamState._streamTimer = setInterval(() => {
+          const elapsed = Math.max(
+            0, (Date.now() - streamState._streamStartedAt) / 1000);
+          streamState.streamElapsed = elapsed;
+          if (this.currentId === streamSid) this.streamElapsed = elapsed;
+        }, 1000);
+        if (this.currentId === streamSid) {
+          this._streamStartedAt = streamState._streamStartedAt;
+          this._streamTimer = streamState._streamTimer;
+        }
+      };
 
       // Re-render the in-flight assistant bubble from the accumulated text.
       // Exposed on streamState so the global selectionchange guard (see
@@ -20903,6 +21028,7 @@ function portal() {
       es.addEventListener("text", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        _setContinuationAwaitingReaction(false);
         if (!openAsst()) return;
         acc += d.text;
         curBubble.text = acc;
@@ -20928,6 +21054,7 @@ function portal() {
       es.addEventListener("thinking", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        _setContinuationAwaitingReaction(false);
         closeAsst();
         // Backend yields one SSE event per thinking_delta. Coalesce them
         // into the most recent thinking message so we see ONE block per
@@ -20948,6 +21075,7 @@ function portal() {
       es.addEventListener("tool_use", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        _setContinuationAwaitingReaction(false);
         closeAsst();
         // `id` is the SDK's toolu_xxx tool_use_id. Critical for
         // _taskSubjectMapForMessages — it pairs each TaskCreate
@@ -20983,6 +21111,7 @@ function portal() {
       es.addEventListener("tool_result", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        _setContinuationAwaitingReaction(false);
         // `text` (up to 50KB) drives the "expand" affordance and per-tool
         // rich renderers (Bash terminal / Read with gutter / WebFetch card).
         // `tool_name` lets the FE pick a renderer without scanning backwards
@@ -21005,6 +21134,7 @@ function portal() {
       es.addEventListener("task_started", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        _setContinuationAwaitingReaction(false);
         applyTaskStatus(d.tool_use_id, {
           task_id: d.task_id,
           state: "running",
@@ -21036,6 +21166,18 @@ function portal() {
           summary: d.summary || "",
           output_file: d.output_file || "",
         });
+        const remaining = Number(d.background_tasks_pending);
+        if (Number.isFinite(remaining)) {
+          this._setBackgroundTaskActive(
+            streamSid,
+            remaining > 0,
+            streamState._streamStartedAt / 1000,
+            remaining,
+          );
+        }
+        if (isContinuation && (!Number.isFinite(remaining) || remaining <= 0)) {
+          _setContinuationAwaitingReaction(true);
+        }
         // User-perceivable settle feedback (mirrors the server's
         // _on_task_settled which handles the away-from-screen case via
         // presence-gated Web Push; this branch covers the at-screen case):
@@ -21163,8 +21305,13 @@ function portal() {
       // cancellation flag (user clicked stop). For those, suppress the
       // green-dot unread indicator — the user knows they cancelled, an
       // "attention!" dot would imply something new arrived.
-      const _markDone = (cancelled = false, backgroundPending = false) => {
+      const _markDone = (
+        cancelled = false,
+        backgroundPending = false,
+        authoritativeTerminal = false,
+      ) => {
         streamState.streaming = false;
+        streamState._continuationAwaitingReaction = false;
         streamState.es = null;
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
@@ -21187,6 +21334,12 @@ function portal() {
           streamState._streamStartedAt / 1000,
           backgroundPending,
         );
+        if (authoritativeTerminal) {
+          this._setSessionActivityExpectation(
+            streamSid,
+            Number(backgroundPending) > 0 && !cancelled,
+          );
+        }
         // If the user is on a different tab when this turn lands, flag
         // unread so the tab strip can show a green dot. Doing it inside
         // _markDone covers every termination path (done / error /
@@ -21361,8 +21514,8 @@ function portal() {
           ? Math.max(0, Number(d.background_tasks_pending) || 0)
           : 0;
         es.close();
-        _markDone(!!d.cancelled, backgroundPending);
-        _stopTimer(backgroundPending > 0);
+        _markDone(!!d.cancelled, backgroundPending, true);
+        _stopTimer();
         if (isContinuation && !d.cancelled) {
           this._reconcileCompletedContinuation(
             streamSid, streamState, continuationFinalText,
@@ -21485,7 +21638,7 @@ function portal() {
         // Instead: silently reload history (surfacing the finished reply) and
         // let the queue drain continue.
         if (serverError === "no active turn") {
-          es.close(); _markDone(); _stopTimer();
+          es.close(); _markDone(false, false, true); _stopTimer();
           this.loadSession(streamSid).then(() => {
             this.$nextTick(() => this._drainPendingQueue(streamSid));
           });
@@ -21497,7 +21650,7 @@ function portal() {
           if (!isContinuation) {
             markUserFailed(serverError, errKind, errCta, errRetryable);
           }
-          es.close(); _markDone(); _stopTimer();
+          es.close(); _markDone(false, false, true); _stopTimer();
           // Pause auto-drain — same context likely fails the next message
           // too (quota / auth / cross-vendor signature). The failed user
           // bubble surfaces a "resume queue (N)" CTA so the user can
@@ -21583,7 +21736,7 @@ function portal() {
             if (!d.active) {
               // Backend turn already finished while we were disconnected.
               // Refresh session from disk to pick up the completed reply.
-              _markDone(); _stopTimer();
+              _markDone(false, false, true); _stopTimer();
               if (this.currentId === streamSid) this.loadSession(streamSid);
               streamState._reconnectAttempts = 0;
               return;
@@ -21593,8 +21746,8 @@ function portal() {
               // its SDK background task still owns the session reader. There
               // is no broadcast to attach to yet: preserve the running footer
               // and let the continuation poller discover the next broadcast.
-              _markDone(false, true);
-              _stopTimer(true);
+              _markDone(false, true, true);
+              _stopTimer();
               this._ensureBgContPoller(streamSid);
               streamState._reconnectAttempts = 0;
               return;
@@ -21640,7 +21793,7 @@ function portal() {
       es.addEventListener("cancelled", () => {
         flushRender();
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
-        es.close(); _markDone(true); _stopTimer();
+        es.close(); _markDone(true, false, true); _stopTimer();
         // User explicitly stopped — pause the queue too. Auto-draining
         // here would be surprising (they cancelled for a reason, almost
         // never "just this one but please send the rest"). The paused
@@ -22302,7 +22455,21 @@ function portal() {
     // ===== global cross-workspace activity center =====
     async fetchActivity(opts = {}) {
       const key = opts.summaryOnly ? "summary" : "events";
+      // A full snapshot also satisfies a summary refresh. Conversely, if a
+      // cheap summary is already in flight when the user opens the center,
+      // let it settle and then start the full request with a newer sequence.
+      // This prevents the global stale-response guard from discarding the only
+      // response that contains rows.
+      if (opts.summaryOnly && this._activityFetchPromises.events) {
+        return this._activityFetchPromises.events;
+      }
       if (this._activityFetchPromises[key]) return this._activityFetchPromises[key];
+      if (!opts.summaryOnly && this._activityFetchPromises.summary) {
+        await this._activityFetchPromises.summary;
+        if (this._activityFetchPromises[key]) {
+          return this._activityFetchPromises[key];
+        }
+      }
       const seq = ++this._activityRequestSeq;
       const promise = (async () => {
         try {
@@ -22324,8 +22491,22 @@ function portal() {
           if (seq < this._activityAppliedSeq) return false;
           this._activityAppliedSeq = seq;
           const summary = opts.summaryOnly ? data : data.summary;
-          if (summary) this.activity.summary = summary;
-          if (!opts.summaryOnly && Array.isArray(data.events)) this.activity.events = data.events;
+          if (summary) {
+            this.activity.summary = summary;
+            const generation = String(summary.generation || "");
+            if (generation && generation !== this._activityGeneration) {
+              this._activityGeneration = generation;
+              this._activityRevision = 0;
+            }
+            this._activityRevision = Math.max(
+              this._activityRevision,
+              Number(summary.revision) || 0,
+            );
+          }
+          if (!opts.summaryOnly && Array.isArray(data.events)) {
+            this.activity.events = data.events;
+            this._syncScheduledActivitySnapshot(data.events);
+          }
           this._syncAppBadge();
           return true;
         } catch (_) { return false; }
@@ -22335,10 +22516,28 @@ function portal() {
       finally { if (this._activityFetchPromises[key] === promise) delete this._activityFetchPromises[key]; }
     },
     async openActivityCenter() {
+      if (!this.activity.viewLoaded) {
+        this.activity.viewLoaded = true;
+        try {
+          const saved = localStorage.getItem("muselab_activity_view");
+          if (saved === "status" || saved === "timeline") {
+            this.activity.view = saved;
+          } else if (saved === "finished") {
+            // Migrate the short-lived terminal-only view to the corrected
+            // all-status timeline.
+            this.activity.view = "timeline";
+          }
+        } catch (_) {}
+      }
       this.activity.show = true;
       this.activity.loading = true;
       await this.fetchActivity();
       this.activity.loading = false;
+    },
+    setActivityView(view) {
+      if (view !== "status" && view !== "timeline") return;
+      this.activity.view = view;
+      try { localStorage.setItem("muselab_activity_view", view); } catch (_) {}
     },
     activityGroups() {
       const zh = this.lang === "zh";
@@ -22354,6 +22553,7 @@ function portal() {
     ACTIVITY_GROUP_CAP: 5,
     activityMatchesGroup(item, key) {
       if (!item) return false;
+      if (key === "timeline") return true;
       if (key === "review") return item.state === "completed" && !item.read;
       if (key === "running") return ["running", "waiting_approval", "paused"].includes(item.state);
       if (key === "failed") return item.state === "failed";
@@ -22370,6 +22570,9 @@ function portal() {
       return (this.activity.events || [])
         .filter(item => this.activityMatchesGroup(item, group.key))
         .sort((a, b) => {
+          if (group.key === "timeline") {
+            return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+          }
           if (group.key === "running") {
             const rank = (activeRank[a.state] ?? 9) - (activeRank[b.state] ?? 9);
             if (rank) return rank;
@@ -22395,6 +22598,14 @@ function portal() {
         ? Number(count) : this.activityAllEvents(group).length;
     },
     activityVisibleGroups() {
+      if (this.activity.view === "timeline") {
+        return [{
+          key: "timeline",
+          label: this.lang === "zh"
+            ? "全部会话（按时间倒序）"
+            : "All sessions (newest first)",
+        }];
+      }
       const groups = this.activityGroups();
       const on = this.activity.filter || [];
       if (!on.length) return groups;
@@ -22435,6 +22646,173 @@ function portal() {
       const ts = this.activityEventTimestamp(item) * 1000;
       return ts ? new Date(ts).toLocaleString(this.lang === "zh" ? "zh-CN" : "en-US",
         { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "";
+    },
+    _stopActivityEvents() {
+      ++this._activityLiveSeq;
+      if (this._activityLiveSource) {
+        try { this._activityLiveSource.close(); } catch (_) {}
+      }
+      this._activityLiveSource = null;
+      if (this._activityLiveTimer) clearTimeout(this._activityLiveTimer);
+      this._activityLiveTimer = null;
+    },
+    async _refreshActivityFromSignal() {
+      return await this.fetchActivity({
+        summaryOnly: !this.activity.show && this.activity.events.length > 0,
+      });
+    },
+    _syncScheduledActivitySnapshot(events) {
+      const scheduled = (events || []).filter(
+        item => item && item.kind === "scheduled" && item.source_id,
+      );
+      if (!scheduled.length) return;
+      const active = new Set(
+        scheduled
+          .filter(item => ["running", "waiting_approval", "paused"].includes(item.state))
+          .map(item => String(item.source_id)),
+      );
+      const next = { ...(this.schedRunning || {}) };
+      for (const item of scheduled) {
+        next[String(item.source_id)] = active.has(String(item.source_id));
+      }
+      this.schedRunning = next;
+    },
+    _applyScheduledActivity(item) {
+      if (!item || item.kind !== "scheduled" || !item.source_id) return;
+      const taskId = String(item.source_id);
+      const running = ["running", "waiting_approval", "paused"].includes(item.state);
+      this.schedRunning = {
+        ...(this.schedRunning || {}),
+        [taskId]: running,
+      };
+      this._schedLiveRunning = this._schedLiveRunning || {};
+      this._schedLiveRunning[taskId] = running;
+      if (!running) {
+        // The activity transition is the authoritative completion signal.
+        // Refresh both the result row and last_run immediately instead of
+        // guessing with fixed 1.5s / 8s timers.
+        this.loadSchedulerHistory().catch(() => {});
+        this.loadSchedulerTasks().catch(() => {});
+      }
+    },
+    _applyActivityUpdate(payload) {
+      const generation = String(payload?.generation || "");
+      if (generation && generation !== this._activityGeneration) {
+        this._activityGeneration = generation;
+        this._activityRevision = 0;
+      }
+      const revision = Number(payload?.revision) || 0;
+      if (revision && revision <= this._activityRevision) return;
+      if (payload?.resync) {
+        this._activityRevision = Math.max(this._activityRevision, revision);
+        this._activityAppliedSeq = ++this._activityRequestSeq;
+        Promise.resolve(this._refreshActivityFromSignal()).finally(
+          () => this._refreshActivityFromSignal(),
+        );
+        return;
+      }
+      // A pushed transition is newer than any HTTP snapshot already in
+      // flight. Retire those requests so a slow response cannot roll back the
+      // just-applied live state.
+      this._activityAppliedSeq = ++this._activityRequestSeq;
+      const item = payload?.item;
+      if (item && item.id) {
+        const at = this.activity.events.findIndex(row => row.id === item.id);
+        if (at >= 0) this.activity.events.splice(at, 1, item);
+        else this.activity.events.unshift(item);
+        this.activity.events = [...this.activity.events];
+        this._applyScheduledActivity(item);
+      }
+      const acked = new Set(
+        Array.isArray(payload?.acked_ids) ? payload.acked_ids : [],
+      );
+      if (acked.size) {
+        for (const row of this.activity.events) {
+          if (acked.has(row.id)) row.read = true;
+        }
+        this.activity.events = [...this.activity.events];
+      }
+      if (payload?.summary) this.activity.summary = payload.summary;
+      this._activityRevision = Math.max(this._activityRevision, revision);
+      this._syncAppBadge();
+    },
+    async _startActivityEvents() {
+      if (!this.token || typeof EventSource === "undefined") return;
+      if (typeof document !== "undefined"
+          && document.visibilityState !== "visible") {
+        this._stopActivityEvents();
+        return;
+      }
+      if (this._activityLiveSource) return;
+      this._stopActivityEvents();
+      const seq = ++this._activityLiveSeq;
+      let ticket = "";
+      try {
+        const r = await fetch("/api/activity/events-ticket", {
+          method: "POST",
+          headers: this.hdr(),
+        });
+        if (!r.ok) throw new Error("activity ticket failed");
+        ticket = String((await r.json()).ticket || "");
+      } catch (_) {
+        if (seq === this._activityLiveSeq) {
+          this._activityLiveTimer = setTimeout(
+            () => this._startActivityEvents(),
+            1500,
+          );
+        }
+        return;
+      }
+      if (seq !== this._activityLiveSeq || !ticket) return;
+      const es = new EventSource(
+        `/api/activity/events?ticket=${encodeURIComponent(ticket)}`,
+      );
+      this._activityLiveSource = es;
+      const owns = () => (
+        seq === this._activityLiveSeq && this._activityLiveSource === es
+      );
+      es.addEventListener("ready", (ev) => {
+        if (!owns()) return;
+        let payload;
+        try { payload = JSON.parse(ev.data); } catch (_) { return; }
+        const generation = String(payload.generation || "");
+        if ((generation && generation !== this._activityGeneration)
+            || (Number(payload.revision) || 0) > this._activityRevision) {
+          this._refreshActivityFromSignal();
+        }
+      });
+      es.addEventListener("update", (ev) => {
+        if (!owns()) return;
+        let payload;
+        try { payload = JSON.parse(ev.data); } catch (_) { return; }
+        this._applyActivityUpdate(payload);
+      });
+      es.onerror = () => {
+        if (!owns()) return;
+        // Capability tickets are single-use; disable EventSource's native
+        // retry and mint a fresh scoped ticket for the next connection.
+        try { es.close(); } catch (_) {}
+        this._activityLiveSource = null;
+        this._activityLiveTimer = setTimeout(
+          () => this._startActivityEvents(),
+          1500,
+        );
+      };
+      if (!this._activityLiveVisibilityBound) {
+        this._activityLiveVisibilityBound = true;
+        document.addEventListener("visibilitychange", () => {
+          if (document.visibilityState !== "visible") {
+            this._stopActivityEvents();
+          } else {
+            this._refreshActivityFromSignal();
+            this._startActivityEvents();
+          }
+        });
+        window.addEventListener(
+          "pagehide",
+          () => this._stopActivityEvents(),
+        );
+      }
     },
     async ackActivityEvent(item, retries = 2) {
       if (!this.activityIsUnreadResult(item)) return true;
@@ -22917,9 +23295,9 @@ function portal() {
       }
       if (r.ok) await this.loadSchedulerTasks();
     },
-    // Out-of-schedule run. Backend dispatches a background task; we poll
-    // history once and again after a short delay so the new entry shows
-    // up without waiting for the next periodic refresh.
+    // Out-of-schedule run. The backend publishes the real running + terminal
+    // state through the global activity stream; the button and history follow
+    // that authoritative lifecycle instead of fixed-delay history guesses.
     async runSchedTaskNow(t) {
       if (!t || !t.id) return;
       // Double-tap guard is a TIMESTAMP, not a boolean flag. The button is no
@@ -22933,9 +23311,20 @@ function portal() {
       this._lastSchedRun = this._lastSchedRun || {};
       if (now - (this._lastSchedRun[t.id] || 0) < 1200) return;
       this._lastSchedRun[t.id] = now;
-      // Cosmetic only: spin the glyph for ~900ms so the click is perceptible.
+      // Optimistic until the activity `running` event lands. A fail-safe
+      // clears it if the live channel is unavailable; an actual live run owns
+      // the flag until its terminal activity event.
+      this._schedLiveRunning = this._schedLiveRunning || {};
+      delete this._schedLiveRunning[t.id];
       this.schedRunning[t.id] = true;
-      setTimeout(() => { this.schedRunning[t.id] = false; }, 900);
+      setTimeout(() => {
+        if (this._schedLiveRunning[t.id] === undefined) {
+          this.schedRunning = {
+            ...(this.schedRunning || {}),
+            [t.id]: false,
+          };
+        }
+      }, 10000);
       try {
         const r = await fetch(
           "/api/scheduler/tasks/" + encodeURIComponent(t.id) + "/run",
@@ -22945,11 +23334,11 @@ function portal() {
                      ? "已触发，结果稍后出现在下方运行记录"
                      : "Triggered — result will appear in the run log below",
                     "success", 3000);
-        // Surface the new history entry as the background run lands. Cheap,
-        // swallow their own errors.
-        setTimeout(() => this.loadSchedulerHistory().catch(() => {}), 1500);
-        setTimeout(() => this.loadSchedulerHistory().catch(() => {}), 8000);
       } catch (e) {
+        this.schedRunning = {
+          ...(this.schedRunning || {}),
+          [t.id]: false,
+        };
         this.toast((this.lang === "zh" ? "触发失败: " : "Trigger failed: ")
                     + ((e && e.message) || e), "error", 4000);
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2786,6 +2786,7 @@
                exactly one of the two is ever visible. -->
           <div class="turn-running-bar"
                x-show="pane && pane.streaming
+                       && !(pane._continuationAwaitingReaction)
                        && paneMsgs.length
                        && paneMsgs[paneMsgs.length - 1].role !== 'user'"
                x-cloak>
@@ -5377,11 +5378,20 @@
     <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="activity.show=false">
       <div class="modal-head">
         <span class="modal-title"><svg class="modal-title-icon"><use href="#i-inbox"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
+        <div class="activity-view-switch" role="group"
+             :aria-label="lang==='zh' ? '任务视图' : 'Task view'">
+          <button type="button" @click="setActivityView('status')"
+                  :class="{ active: activity.view === 'status' }"
+                  x-text="lang==='zh' ? '按状态' : 'By status'"></button>
+          <button type="button" @click="setActivityView('timeline')"
+                  :class="{ active: activity.view === 'timeline' }"
+                  x-text="lang==='zh' ? '时间倒序' : 'By time'"></button>
+        </div>
         <button class="modal-close" @click="activity.show=false" aria-label="Close">×</button>
       </div>
       <!-- One chip per attention group, in the same order as the sections below:
            completed results to review, live work, failures, then viewed history. -->
-      <div class="activity-summary">
+      <div class="activity-summary" x-show="activity.view === 'status'">
         <template x-for="group in activityGroups()" :key="group.key">
           <!-- Multi-select filters. Colour reflects unread results or a live
                task waiting for user action, never mere group non-emptiness. -->
@@ -5438,7 +5448,8 @@
         <!-- Filtering to an empty group must say so, or the body just goes
              blank and reads as a loading failure. -->
         <div class="hint-row"
-             x-show="!activity.loading && activity.events.length && activity.filter.length
+             x-show="!activity.loading && activity.view === 'status'
+               && activity.events.length && activity.filter.length
                && !activityVisibleGroups().some(g => activityEvents(g).length)"
              x-text="lang==='zh' ? '该状态下暂无任务' : 'No tasks in this state'"></div>
       </div>
@@ -5691,13 +5702,10 @@
                           :title="lang==='zh' ? '历史运行' : 'Past runs'">
                     <svg><use href="#i-history"/></svg>
                   </button>
-                  <!-- NO :disabled here. A stuck schedRunning[t.id] used to
-                       leave the native disabled attribute on, so the button
-                       showed `not-allowed` and ate the click ("鼠标一挪上去就是
-                       禁用的标志，点不了", 2026-06-09). Double-fire is now
-                       guarded by a timestamp in runSchedTaskNow; schedRunning
-                       only drives the cosmetic spinner (paper-plane → spinning
-                       refresh glyph, see .icon-btn.is-running in styles.css). -->
+                  <!-- NO :disabled here. Double-fire is guarded by a timestamp
+                       in runSchedTaskNow; schedRunning follows the backend's
+                       live scheduled-activity lifecycle and drives the
+                       paper-plane → spinning refresh glyph. -->
                   <button class="icon-btn sm" @click.stop="runSchedTaskNow(t)"
                           :class="{ 'is-running': schedRunning[t.id] }"
                           :title="schedRunning[t.id]

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3200,6 +3200,10 @@ pre.text {
 }
 .files-head-workspace .workspace-picker-btn { width: 100%; max-width: none; border-radius: var(--r-sm); }
 .activity-modal { width:620px; max-width:calc(100vw - 32px); }
+.activity-view-switch { display:inline-flex; margin-left:auto; padding:2px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); }
+.activity-view-switch button { padding:4px 9px; border:0; border-radius:calc(var(--r-md) - 2px); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); cursor:pointer; }
+.activity-view-switch button:hover { color:var(--c-fg-1); }
+.activity-view-switch button.active { background:var(--c-bg-1); color:var(--c-fg-0); box-shadow:var(--shadow-sm); }
 .activity-summary { display:flex; align-items:center; flex-wrap:wrap; gap:6px; padding:10px 14px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
 .activity-summary .btn-ghost { margin-left:auto; }
 /* Status chips follow the same attention order as the body. Counts come from

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -1,0 +1,217 @@
+"""Browser coverage for the global activity center's live timeline."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "playwright.sync_api",
+    reason="install with: uv add --group dev pytest-playwright",
+)
+from playwright.sync_api import Page, expect  # noqa: E402
+
+
+def _login(page: Page, base: str, token: str) -> None:
+    page.goto(base, wait_until="domcontentloaded")
+    page.wait_for_selector(".login, .chat-tabs-list", state="visible", timeout=5000)
+    if page.locator(".login").is_visible():
+        page.fill('.login input[type="password"]', token)
+        page.keyboard.press("Enter")
+    expect(page.locator(".chat-tabs-list")).to_be_visible(timeout=5000)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          return app && app.authed && app.appReady && app._sessionsInitialized;
+        }"""
+    )
+
+
+def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app._activityLiveSource
+            && app._activityLiveSource.readyState === EventSource.OPEN;
+        }""",
+        timeout=5000,
+    )
+
+    page.locator(".activity-center-btn").click()
+    expect(page.locator(".activity-modal")).to_be_visible()
+
+    page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const base = {
+            kind: 'turn',
+            workspace: '/tmp/e2e',
+            workspace_name: 'e2e',
+            session_name: 'Activity test',
+            status_detail: '',
+            read: true,
+          };
+          app._applyActivityUpdate({
+            generation: 'e2e-generation',
+            revision: 1,
+            item: {
+              ...base,
+              id: 'older',
+              session_id: 'older-session',
+              task_summary: 'Older completed task',
+              state: 'completed',
+              started_at: 10,
+              finished_at: 100,
+              updated_at: 100,
+            },
+            summary: {
+              generation: 'e2e-generation',
+              revision: 1,
+              running: 0,
+              unread: 0,
+              attention: 0,
+              groups: {review: 0, running: 0, failed: 0, history: 1},
+              group_unread: {review: 0, running: 0, failed: 0, history: 0},
+              workspaces: [],
+            },
+          });
+          app._applyActivityUpdate({
+            generation: 'e2e-generation',
+            revision: 2,
+            item: {
+              ...base,
+              id: 'newer',
+              session_id: 'newer-session',
+              task_summary: 'Newer failed task',
+              state: 'failed',
+              started_at: 20,
+              finished_at: 300,
+              updated_at: 300,
+            },
+            summary: {
+              generation: 'e2e-generation',
+              revision: 2,
+              running: 0,
+              unread: 0,
+              attention: 0,
+              groups: {review: 0, running: 0, failed: 1, history: 1},
+              group_unread: {review: 0, running: 0, failed: 0, history: 0},
+              workspaces: [],
+            },
+          });
+          app._applyActivityUpdate({
+            generation: 'e2e-generation',
+            revision: 3,
+            item: {
+              ...base,
+              id: 'newest',
+              session_id: 'newest-session',
+              task_summary: 'Newest running task',
+              state: 'running',
+              started_at: 400,
+              finished_at: null,
+              updated_at: 400,
+            },
+            summary: {
+              generation: 'e2e-generation',
+              revision: 3,
+              running: 1,
+              unread: 0,
+              attention: 0,
+              groups: {review: 0, running: 1, failed: 1, history: 1},
+              group_unread: {review: 0, running: 0, failed: 0, history: 0},
+              workspaces: [],
+            },
+          });
+          app.setActivityView('timeline');
+        }"""
+    )
+
+    expect(page.locator(".activity-view-switch button").nth(1)).to_have_class(
+        "active"
+    )
+    labels = page.locator(".activity-group .activity-row strong")
+    expect(labels).to_have_count(3)
+    assert labels.all_text_contents() == [
+        "Newest running task",
+        "Newer failed task",
+        "Older completed task",
+    ]
+
+
+def test_terminal_event_wins_over_stale_tab_activity_snapshot(
+    page: Page, backend_url, auth_token
+):
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = 'tab-terminal-e2e';
+          const st = app._ensureTabState(sid);
+          st.streaming = false;
+          st.backgroundActive = false;
+          app.sessions = [
+            ...app.sessions.filter(session => session.id !== sid),
+            {
+              id: sid,
+              name: 'Terminal state test',
+              active: true,
+              turn_active: true,
+              background_active: false,
+            },
+          ];
+          const before = app.isTabRunning(sid);
+
+          app._setSessionActivityExpectation(sid, false);
+          const immediate = app.isTabRunning(sid);
+
+          // A list request that started before `done` may still return the old
+          // running flags. It must not relight the dot.
+          const stale = app._retainExpectedSessionActivity({
+            id: sid,
+            active: true,
+            turn_active: true,
+            background_active: false,
+          });
+          app.sessions = app.sessions.map(
+            session => session.id === sid ? {...session, ...stale} : session,
+          );
+          const afterStale = app.isTabRunning(sid);
+          const expectationHeld = !!st._sessionActivityExpected;
+
+          // Once the backend echoes idle, release the guard. A later genuine
+          // cross-device running transition must become visible normally.
+          app._retainExpectedSessionActivity({
+            id: sid,
+            active: false,
+            turn_active: false,
+            background_active: false,
+          });
+          const expectationCleared = !st._sessionActivityExpected;
+          app.sessions = app.sessions.map(session =>
+            session.id === sid
+              ? {
+                  ...session,
+                  active: true,
+                  turn_active: true,
+                  background_active: false,
+                }
+              : session);
+          const laterRemoteTurn = app.isTabRunning(sid);
+          return {
+            before,
+            immediate,
+            afterStale,
+            expectationHeld,
+            expectationCleared,
+            laterRemoteTurn,
+          };
+        }"""
+    )
+    assert result == {
+        "before": True,
+        "immediate": False,
+        "afterStale": False,
+        "expectationHeld": True,
+        "expectationCleared": True,
+        "laterRemoteTurn": True,
+    }

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,5 +1,8 @@
+import asyncio
 import json
 from pathlib import Path
+
+import pytest
 
 from backend.activity import ActivityService
 
@@ -23,6 +26,26 @@ def test_one_row_per_session_and_latest_prompt(tmp_path, monkeypatch):
     assert rows[0]["id"] == first["id"] == second["id"]
     assert rows[0]["task_summary"] == "second task"
     assert rows[0]["turn_count"] == 2
+
+
+def test_start_records_source_kind_and_clears_it_for_plain_turn(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    scheduled = service.start(
+        "s1",
+        summary="daily report",
+        kind="scheduled",
+        source_id="task-1",
+    )
+    assert scheduled["kind"] == "scheduled"
+    assert scheduled["source_id"] == "task-1"
+
+    service.finish("s1", "completed")
+    plain = service.start("s1", summary="follow-up")
+    assert plain["kind"] == "turn"
+    assert "source_id" not in plain
 
 
 def test_summary_and_ack(tmp_path, monkeypatch):
@@ -125,3 +148,45 @@ def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
     assert row["read"] is False
     assert row["updated_at"] == row["finished_at"]
     assert json.loads((Path(tmp_path) / ".muselab" / "activity.json").read_text())
+
+
+@pytest.mark.asyncio
+async def test_subscriber_receives_task_transition_without_polling(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    async with service.subscribe() as queue:
+        await asyncio.to_thread(service.start, "s1", summary="live task")
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert payload["revision"] == 1
+    assert payload["item"]["session_id"] == "s1"
+    assert payload["item"]["state"] == "running"
+    assert payload["summary"]["running"] == 1
+    assert payload["summary"]["revision"] == 1
+    assert payload["summary"]["generation"] == payload["generation"]
+
+
+@pytest.mark.asyncio
+async def test_slow_subscriber_gets_resync_marker(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    async with service.subscribe() as queue:
+        await asyncio.to_thread(service.start, "s1", summary="first")
+        await asyncio.sleep(0)
+        await asyncio.to_thread(service.start, "s2", summary="second")
+        await asyncio.sleep(0)
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert payload["revision"] == 2
+    assert payload["resync"] is True
+    assert payload["summary"]["running"] == 2
+
+
+def test_activity_event_ticket_requires_authentication(client, auth):
+    denied = client.post("/api/activity/events-ticket")
+    assert denied.status_code == 401
+
+    response = client.post("/api/activity/events-ticket", headers=auth)
+    assert response.status_code == 200
+    assert response.json()["ticket"].startswith("activity.")

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -179,6 +179,8 @@ def test_session_list_marks_detached_background_work_active(chat_mod, client):
         assert response.status_code == 200, response.text
         row = next(s for s in response.json()["sessions"] if s["id"] == sid)
         assert row["active"] is True
+        assert row["turn_active"] is False
+        assert row["background_active"] is True
     finally:
         chat_mod._sessions_with_inflight_tasks.pop(sid, None)
 
@@ -250,8 +252,11 @@ def test_interrupt_does_not_inherit_sdk_60_second_ack_timeout(
 async def test_interrupt_cancels_cold_client_startup_immediately(
         chat_mod, monkeypatch):
     """Stop must work before get_client() has produced a cached client."""
+    from backend import activity as activity_module
+
     sid = "sid-cold-start"
     startup_entered = asyncio.Event()
+    activity_transitions = []
 
     async def slow_get_client(*_args, **_kwargs):
         startup_entered.set()
@@ -268,10 +273,23 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
         lambda _sid: {"model": "glm-5.2-internal", "effort": ""},
     )
     monkeypatch.setattr(chat_mod.sess, "update_permission", lambda *_a: True)
+    monkeypatch.setattr(
+        activity_module.activity,
+        "start",
+        lambda activity_sid, *, summary="": activity_transitions.append(
+            ("start", activity_sid, summary)),
+    )
+    monkeypatch.setattr(
+        activity_module.activity,
+        "finish",
+        lambda activity_sid, status: activity_transitions.append(
+            ("finish", activity_sid, status)),
+    )
 
     start_task = asyncio.create_task(chat_mod._start_turn(sid, "stop me"))
     await asyncio.wait_for(startup_entered.wait(), timeout=1)
     broadcast = chat_mod._active_turns[sid]
+    assert activity_transitions == [("start", sid, "stop me")]
 
     result = await chat_mod.interrupt(sid)
     finished = await asyncio.wait_for(start_task, timeout=1)
@@ -284,6 +302,10 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
     assert [event["event"] for event in broadcast.replay_events()] == ["cancelled"]
     assert sid not in chat_mod._active_turns
     assert sid not in chat_mod._clients
+    assert activity_transitions == [
+        ("start", sid, "stop me"),
+        ("finish", sid, "cancelled"),
+    ]
     recent = chat_mod._recent_turns.pop(sid, None)
     if recent is not None:
         recent.close()
@@ -644,6 +666,40 @@ def test_fork_rejects_active_source_session(
     assert called is False
 
 
+def test_fork_snapshots_source_while_background_task_keeps_running(
+    chat_mod,
+    client,
+    monkeypatch,
+):
+    source = client.post(
+        "/api/chat/sessions",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "background source"},
+    )
+    assert source.status_code == 200, source.text
+    sid = source.json()["id"]
+    chat_mod._sessions_with_inflight_tasks[sid] = {"task-a", "task-b"}
+    new_sid = "11111111-2222-4333-8444-555555555555"
+    called = False
+
+    def fake_fork(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return SimpleNamespace(session_id=new_sid)
+
+    monkeypatch.setattr(chat_mod, "sdk_fork_session", fake_fork)
+    response = client.post(
+        f"/api/chat/sessions/{sid}/fork",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"title": "background snapshot"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert called is True
+    assert response.json()["source_background_tasks_pending"] == 2
+    assert chat_mod._sessions_with_inflight_tasks[sid] == {"task-a", "task-b"}
+
+
 def test_native_compact_rejects_success_without_token_drop(chat_mod, client, monkeypatch):
     sid = _make_compact_session(client)
     result = ResultMessage(
@@ -662,3 +718,79 @@ def test_native_compact_rejects_success_without_token_drop(chat_mod, client, mon
     )
     assert r.status_code == 500, r.text
     assert "did not decrease" in r.json()["detail"]
+
+
+def test_native_compact_total_timeout_covers_post_command_verification(
+    chat_mod,
+    client,
+    monkeypatch,
+):
+    sid = _make_compact_session(client)
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1,
+        is_error=False, num_turns=1, session_id=sid,
+    )
+
+    class SlowVerifyClient(_FakeCompactClient):
+        async def get_context_usage(self):
+            try:
+                return {"totalTokens": next(self.totals), "maxTokens": 200_000}
+            except StopIteration:
+                await asyncio.Event().wait()
+
+    fake = SlowVerifyClient(result, totals=(190_000,))
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    original_env_int = chat_mod.env_int
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        chat_mod,
+        "env_int",
+        lambda name, default, **kwargs: (
+            0.02 if name == "MUSELAB_COMPACT_TIMEOUT_S"
+            else original_env_int(name, default, **kwargs)
+        ),
+    )
+
+    r = client.post(
+        f"/api/chat/sessions/{sid}/native-compact",
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert r.status_code == 504, r.text
+    assert "timed out" in r.json()["detail"]
+
+
+def test_native_compact_returns_after_verification_and_schedules_recount(
+    chat_mod,
+    client,
+    monkeypatch,
+):
+    sid = _make_compact_session(client)
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1,
+        is_error=False, num_turns=1, session_id=sid,
+    )
+    fake = _FakeCompactClient(result, totals=(190_000, 50_000))
+    scheduled = []
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        chat_mod,
+        "_schedule_post_compact_refresh",
+        lambda compact_sid, model, usage: scheduled.append(
+            (compact_sid, model, usage)),
+    )
+
+    r = client.post(
+        f"/api/chat/sessions/{sid}/native-compact",
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert r.status_code == 200, r.text
+    assert scheduled
+    assert scheduled[0][0] == sid
+    assert scheduled[0][2]["totalTokens"] == 50_000

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -230,6 +230,88 @@ def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypa
     assert sid not in chat_mod._active_turns
 
 
+def test_done_is_published_before_slow_post_turn_bookkeeping(
+        stream_env, client, monkeypatch):
+    """ResultMessage ends the UI turn before context/JSONL bookkeeping."""
+    from backend import activity as activity_module
+
+    chat_mod = stream_env
+    sid = _make_session(client)
+
+    async def exercise():
+        context_entered = asyncio.Event()
+        release_context = asyncio.Event()
+        activity_transitions = []
+        context_calls = 0
+
+        class _SlowPostprocessClient(_FakeStreamClient):
+            async def get_context_usage(self):
+                nonlocal context_calls
+                context_calls += 1
+                if context_calls == 1:
+                    # Preflight accounting happens before the model query and
+                    # is intentionally not part of this regression.
+                    return {
+                        "maxTokens": 200_000,
+                        "totalTokens": 1000,
+                    }
+                context_entered.set()
+                await release_context.wait()
+                return {
+                    "maxTokens": 200_000,
+                    "totalTokens": 1234,
+                }
+
+        fake = _SlowPostprocessClient([ResultMessage(
+            subtype="success", duration_ms=10, duration_api_ms=9,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0,
+            usage={"input_tokens": 1, "output_tokens": 1},
+        )])
+
+        async def fake_get_client(*_args, **_kwargs):
+            return fake
+
+        monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+        monkeypatch.setattr(
+            activity_module.activity,
+            "start",
+            lambda activity_sid, *, summary="": activity_transitions.append(
+                ("start", activity_sid, summary)),
+        )
+        monkeypatch.setattr(
+            activity_module.activity,
+            "finish",
+            lambda activity_sid, status: activity_transitions.append(
+                ("finish", activity_sid, status)),
+        )
+
+        broadcast = await chat_mod._start_turn(sid, "quick reply")
+        await asyncio.wait_for(context_entered.wait(), timeout=1)
+
+        # The context refresh is deliberately blocked, yet both the browser
+        # terminal event and the global activity completion already happened.
+        assert any(
+            event.get("event") == "done"
+            for event in broadcast.replay_events()
+        )
+        assert activity_transitions == [
+            ("start", sid, "quick reply"),
+            ("finish", sid, "completed"),
+        ]
+        assert broadcast.done is False
+
+        release_context.set()
+        await asyncio.wait_for(broadcast.task, timeout=1)
+        assert broadcast.done is True
+        assert sid not in chat_mod._active_turns
+        recent = chat_mod._recent_turns.pop(sid, None)
+        if recent is not None:
+            recent.close()
+
+    asyncio.run(exercise())
+
+
 def test_stream_drops_prior_turn_replay_but_keeps_late_task_lifecycle(
         stream_env, client, monkeypatch):
     """A pooled SDK queue may start with the preceding turn's delayed tail.
@@ -810,6 +892,18 @@ def test_watcher_opens_continuation_turn_and_unpins(stream_env):
         chat_mod._task_watchers.pop(sid, None)
         chat_mod._active_turns.pop(sid, None)
         chat_mod._recent_turns.pop(sid, None)
+
+
+def test_continuation_terminal_precedes_annotation_bookkeeping(stream_env):
+    """The footer terminal event must not wait for transcript sidecars."""
+    import inspect
+
+    source = inspect.getsource(stream_env._watch_inflight_tasks)
+    done_at = source.index(
+        'b.publish({"event": "done", "data": json.dumps(done_payload)})')
+    annotate_at = source.index("_recent_turn_uuids, session_id, False")
+    assert done_at < annotate_at
+    assert stream_env._CONTINUATION_GRACE <= 8
 
 
 def test_watcher_explicitly_resumes_when_auto_continuation_stream_ends(stream_env):
@@ -1673,14 +1767,29 @@ def test_stream_early_get_client_failure_emits_error_frame(stream_env, client, m
     """If get_client itself raises (e.g. auth pre-check), the handler must
     surface an SSE error frame, NOT bubble a 500 — the FE can only render
     typed errors from the frame, not from a 500."""
+    from backend import activity as activity_module
+
     chat_mod = stream_env
     sid = _make_session(client)
+    activity_transitions = []
 
     async def boom_get_client(session_id, model, permission="bypassPermissions", effort=""):
         from claude_agent_sdk import ClaudeSDKError
         raise ClaudeSDKError("Claude model requires auth: run `claude login`")
 
     monkeypatch.setattr(chat_mod, "get_client", boom_get_client)
+    monkeypatch.setattr(
+        activity_module.activity,
+        "start",
+        lambda activity_sid, *, summary="": activity_transitions.append(
+            ("start", activity_sid, summary)),
+    )
+    monkeypatch.setattr(
+        activity_module.activity,
+        "finish",
+        lambda activity_sid, status: activity_transitions.append(
+            ("finish", activity_sid, status)),
+    )
 
     r = client.get(f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
                    f"&prompt=hi&model=claude-sonnet-4-6")
@@ -1690,6 +1799,10 @@ def test_stream_early_get_client_failure_emits_error_frame(stream_env, client, m
     assert err is not None, f"no error frame: {events}"
     assert err["kind"] == "auth"
     assert sid not in chat_mod._active_turns
+    assert activity_transitions == [
+        ("start", sid, "hi"),
+        ("finish", sid, "failed"),
+    ]
 
 
 def _ok_turn(sid):

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -113,7 +113,8 @@ def test_memory_center_and_chat_recall_trace_are_wired():
     assert 'data-page="memory"' in index
     assert "Skill 只能生成候选" in index
     assert "memoryRecall" in index
-    assert '"memory_recall": mem0.pop_recall_trace(session_id)' in chat
+    assert "_done_memory_recall = mem0.pop_recall_trace(session_id)" in chat
+    assert '"memory_recall": _done_memory_recall' in chat
     assert '@router.post("/skills/{artifact_id}/approve")' in api
 
 
@@ -681,9 +682,16 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert '"/api/activity?limit=500"' in app
     assert "r.status === 304 && !opts.summaryOnly && !this.activity.events.length" in app
     assert 'cache: "reload"' in app
+    assert "opts.summaryOnly && this._activityFetchPromises.events" in app
+    assert "!opts.summaryOnly && this._activityFetchPromises.summary" in app
     assert "const rank = (activeRank[a.state] ?? 9)" in app
     assert "return this.activityEventTimestamp(b)" in app
     assert "this._activityAppliedSeq = ++this._activityRequestSeq" in app
+    assert '"/api/activity/events-ticket"' in app
+    assert "new EventSource(" in app
+    assert 'this.activity.view === "timeline"' in app
+    assert 'key === "timeline") return true' in app
+    assert "setActivityView('timeline')" in html
 
     # The left marker is unread/action state, not a permanent failure marker.
     assert "activityIsUnreadResult(item) ? ' is-unread'" in html
@@ -818,16 +826,15 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     assert "if (!waitForTerminalEvent || !st.streaming)" in stop
     cancelled_start = app.index('es.addEventListener("cancelled"')
     cancelled_end = app.index("\n      });", cancelled_start)
-    assert "_markDone(true)" in app[cancelled_start:cancelled_end]
-    mark_done_start = app.index(
-        "const _markDone = (cancelled = false, backgroundPending = false)")
+    assert "_markDone(true, false, true)" in app[cancelled_start:cancelled_end]
+    mark_done_start = app.index("const _markDone = (")
     mark_done_end = app.index("\n      };", mark_done_start)
     assert "streamState._stopping = false" in app[
         mark_done_start:mark_done_end]
     assert "this.isTabStreaming(this.currentId)" in app
 
 
-def test_background_task_gap_keeps_footer_running_without_blocking_composer():
+def test_background_task_gap_stops_footer_without_blocking_composer():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
@@ -835,16 +842,16 @@ def test_background_task_gap_keeps_footer_running_without_blocking_composer():
 
     assert "backgroundActive: false" in app
     assert "backgroundTaskCount: 0" in app
-    # A pending background task keeps the card + footer alive but must NOT
-    # make the composer busy: the backend pump owns the session stream now, so
-    # the task's completion arrives as its own message instead of colliding
-    # with a new turn. Blocking here parked every follow-up on the queue.
+    # A pending background task keeps its card alive but must NOT keep the
+    # completed turn's footer timer or make the composer busy: the backend pump
+    # owns the session stream now, so task completion arrives independently.
     assert "|| (st && st.compacting));" in app
     assert "if (st && (st.streaming || st.compacting)) return true;" in app
     assert "if (status.background) return false;" in app
     assert "d.background && d.attachable === false" in app
     assert "background_tasks_pending" in app
-    assert "_stopTimer(backgroundPending > 0)" in app
+    assert "_stopTimer();" in app
+    assert "_continuationAwaitingReaction: false" in app
     # The turn footer must key off a REAL streaming turn. It used to also
     # suppress itself on backgroundActive, which hid the completion timestamp
     # of every turn that finished while a background task was still pending.
@@ -866,6 +873,9 @@ def test_background_task_gap_keeps_footer_running_without_blocking_composer():
     # during a live turn this clause would otherwise render an empty rule.
     assert "(m.role === 'assistant' && m.uuid && !(pane && pane.streaming))" in html
     assert 'x-show="m.role === \'assistant\' && m.uuid' in html
+    assert 'Object.prototype.hasOwnProperty.call(s, "turn_active")' in app
+    assert "return !!s.turn_active" in app
+    assert "return !!(s && s.background_active)" in app
 
 
 def test_attachment_uploads_have_deadlines_and_never_log_filenames():
@@ -1007,6 +1017,45 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     assert "expectedText" in app
     assert "const stillOwned = () => this.tabState[sid] === ownerState" in app
     assert "if (!isContinuation)" in send
+
+
+def test_background_settlement_pauses_footer_until_reaction_starts():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    send_start = app.index("async send(opts = {})")
+    send = app[send_start:app.index("async stop()", send_start)]
+
+    assert "_setContinuationAwaitingReaction(true)" in send
+    assert "_setContinuationAwaitingReaction(false)" in send
+    assert "background_tasks_pending" in send
+    assert "_continuationAwaitingReaction: false" in app
+    assert "!(pane._continuationAwaitingReaction)" in html
+
+
+def test_terminal_event_immediately_settles_tab_activity_snapshot():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    assert "_sessionActivityExpected: null" in app
+    assert "_retainExpectedSessionActivity(meta)" in app
+    assert ".map(meta => this._retainExpectedSessionActivity(meta))" in app
+    assert "_setSessionActivityExpectation(tid, backgroundActive = false)" in app
+    done_start = app.index("const _markDone = (")
+    done = app[done_start:app.index("const markUserFailed =", done_start)]
+    assert "if (authoritativeTerminal)" in done
+    assert "this._setSessionActivityExpectation(" in done
+    assert "_markDone(!!d.cancelled, backgroundPending, true);" in app
+
+
+def test_scheduler_uses_activity_completion_instead_of_fixed_history_polling():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("_applyScheduledActivity(item)")
+    live = app[start:app.index("_applyActivityUpdate(payload)", start)]
+    run_start = app.index("async runSchedTaskNow(t)")
+    run = app[run_start:app.index("retrySchedHistory(h)", run_start)]
+
+    assert "item.kind !== \"scheduled\"" in live
+    assert "this.loadSchedulerHistory()" in live
+    assert "this.loadSchedulerTasks()" in live
+    assert "setTimeout(() => this.loadSchedulerHistory()" not in run
 
 
 def test_workspace_gate_does_not_destroy_retry_or_edit_before_send_rejects():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,10 +1,8 @@
-"""Tests for backend.scheduler — focused on the 2026-05-28 fresh/reuse
-session_mode addition. _execute_task itself is not unit-tested (needs the
-Claude SDK + a real model call); we cover the state-management surface
-that fresh mode introduced and the back-compat path for old tasks."""
+"""Tests for scheduler state, execution lifecycle, and schedule math."""
 from __future__ import annotations
 
 import asyncio
+import pytest
 
 
 def _sched_mod(app_module):
@@ -112,6 +110,132 @@ def test_sdk_turn_rejects_session_with_interactive_owner(
     finally:
         chat._active_turns.pop(sid, None)
         chat._session_runtime_locks.pop(sid, None)
+
+
+def _execution_task(tid: str = "exec-task") -> dict:
+    return {
+        "id": tid,
+        "name": "Execution task",
+        "prompt": "produce a result",
+        "session_id": f"session-{tid}",
+        "session_mode": "reuse",
+        "model": "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_task_publishes_activity_and_success_history(
+    app_module,
+    monkeypatch,
+):
+    sched = _sched_mod(app_module)
+    from backend import activity as activity_module
+    transitions = []
+
+    async def run_turn(*_args, **_kwargs):
+        return "finished", None
+
+    monkeypatch.setattr(sched, "_run_sdk_task_turn", run_turn)
+    monkeypatch.setattr(
+        activity_module.activity,
+        "start",
+        lambda sid, **kwargs: transitions.append(("start", sid, kwargs)),
+    )
+    monkeypatch.setattr(
+        activity_module.activity,
+        "finish",
+        lambda sid, status: transitions.append(("finish", sid, status)),
+    )
+    from backend import presence
+    monkeypatch.setattr(presence, "recently_active", lambda: True)
+    monkeypatch.setattr(presence, "last_seen_age", lambda: 0.0)
+
+    task = _execution_task()
+    await sched._execute_task(task)
+
+    assert sched._state["history"][-1]["ok"] is True
+    assert sched._state["history"][-1]["reply_preview"] == "finished"
+    assert transitions[0] == (
+        "start",
+        task["session_id"],
+        {
+            "summary": task["name"],
+            "kind": "scheduled",
+            "source_id": task["id"],
+        },
+    )
+    assert transitions[-1] == ("finish", task["session_id"], "completed")
+
+
+@pytest.mark.asyncio
+async def test_execute_task_cancellation_is_not_recorded_as_success(
+    app_module,
+    monkeypatch,
+):
+    sched = _sched_mod(app_module)
+    from backend import activity as activity_module
+    entered = asyncio.Event()
+    transitions = []
+
+    async def blocked(*_args, **_kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(sched, "_run_sdk_task_turn", blocked)
+    monkeypatch.setattr(
+        activity_module.activity,
+        "start",
+        lambda sid, **kwargs: transitions.append(("start", sid, kwargs)),
+    )
+    monkeypatch.setattr(
+        activity_module.activity,
+        "finish",
+        lambda sid, status: transitions.append(("finish", sid, status)),
+    )
+
+    task = _execution_task("cancel-task")
+    running = asyncio.create_task(sched._execute_task(task))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    running.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running
+
+    history = sched._state["history"]
+    assert len(history) == 1
+    assert history[0]["ok"] is False
+    assert "cancelled" in history[0]["error"]
+    assert transitions[-1] == ("finish", task["session_id"], "cancelled")
+
+
+@pytest.mark.asyncio
+async def test_execute_task_has_bounded_unattended_runtime(
+    app_module,
+    monkeypatch,
+):
+    sched = _sched_mod(app_module)
+
+    async def blocked(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    original_env_int = sched.env_int
+    monkeypatch.setattr(sched, "_run_sdk_task_turn", blocked)
+    monkeypatch.setattr(
+        sched,
+        "env_int",
+        lambda name, default, **kwargs: (
+            0.01 if name == "MUSELAB_SCHEDULER_TIMEOUT_S"
+            else original_env_int(name, default, **kwargs)
+        ),
+    )
+    from backend import presence
+    monkeypatch.setattr(presence, "recently_active", lambda: True)
+    monkeypatch.setattr(presence, "last_seen_age", lambda: 0.0)
+
+    await sched._execute_task(_execution_task("timeout-task"))
+
+    row = sched._state["history"][-1]
+    assert row["ok"] is False
+    assert "timed out" in row["error"]
 
 
 # ---- delete_task ----
@@ -329,7 +453,6 @@ def test_api_task_history_404_for_unknown_task(client, auth, app_module):
 # (weekday-in-set, hour==slot, soonest within window) for weekly/monthly so
 # we don't reimplement the SUT's calendar walk in the assertion.
 
-import pytest  # noqa: E402  (kept local to this section's needs)
 from datetime import datetime, timedelta, timezone  # noqa: E402
 
 # UTC+8, the same offset the rest of this file passes as tz_offset_minutes=480.


### PR DESCRIPTION
## 变更类型

- [ ] 新功能 (feature)
- [x] 修复 (bugfix)
- [x] 重构 (refactor)
- [ ] 文档 (docs)
- [ ] 其他 (other)

## 变更说明

- 为全局任务中心增加全部状态、按最新变更时间倒序的视图，并使用短期能力票据建立活动 SSE。
- 让普通会话在后端预留回合时立即进入运行中，让调度任务复用同一活动账本并补齐超时、取消和终态。
- 缩短后台任务续接空档，优先发送终止事件，把消息注解和压缩后的非关键统计移出响应关键路径。
- 允许存在后台任务时从已持久化快照 Fork；后台工作继续留在来源会话。
- 统一 Footer 与会话 Tab 的终态：done 到达时立即熄灭运行亮点，并阻止在途旧列表响应重新点亮。

## 关联 Issue

无。

## 测试情况

- 230 项影响面 pytest / 前端契约 / Playwright 用例通过。
- uv run ruff check backend/ tests/ 通过。
- bash scripts/lint.sh 通过。
- node --check frontend/app.js 通过。
- git diff --check 通过。
- 本地 muselab-main.service 重启后健康检查通过，127.0.0.1:8770 正常监听。

## 截图（如适用）

无；新增 Playwright 用例覆盖全状态时间倒序与 Tab 终态竞态。

## 审查检查项

- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 未包含凭据、个人数据或私有示例
