### PR TITLE
feat(ux): 支持目录引用并修复终端输入

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1904,8 +1904,8 @@ function portal() {
         setTimeout(() => {
           this.toast(
             this.lang === "zh"
-              ? "Tip：⌘K 命令面板 · / 斜杠命令 · @ 引用文件 · ↑ 回滚上一条"
-              : "Tip: ⌘K command palette · / slash commands · @ to reference files · ↑ to recall last message",
+              ? "Tip：⌘K 命令面板 · / 斜杠命令 · @ 引用文件或目录 · ↑ 回滚上一条"
+              : "Tip: ⌘K command palette · / slash commands · @ to reference files or folders · ↑ to recall last message",
             "info", 7000);
           this._setLS("muselab_seen_help", "1");
         }, 1500);
@@ -14148,7 +14148,7 @@ function portal() {
           if (!n.is_dir) await this.openFile(n);
           break;
         case "mention":
-          this.insertFileMention(n.path);
+          this.insertFileMention(n.path, !!n.is_dir);
           break;
         case "copyPath":
           await navigator.clipboard?.writeText(n.path);
@@ -15659,6 +15659,85 @@ function portal() {
       return /^(?:(?:\x1b\[<\d+;\d+;\d+[Mm])|(?:\x1b\[\d+;\d+;\d+M)|(?:\x1b\[M[\s\S]{3}))+$/
         .test(data);
     },
+    _terminalDataIsReplayReply(data) {
+      // Every xterm-generated reply to a replayed DA / DSR / OSC / DCS query
+      // is an escape sequence. Printable keyboard and IME input is not. This
+      // lets users type while a large scrollback is still being parsed
+      // without leaking stale device replies into the live PTY.
+      return typeof data === "string" && data.startsWith("\x1b");
+    },
+    _terminalTextInputDelta(before, after) {
+      const oldText = String(before || "");
+      const newText = String(after || "");
+      if (oldText === newText) return "";
+      let prefix = 0;
+      const common = Math.min(oldText.length, newText.length);
+      while (prefix < common && oldText[prefix] === newText[prefix]) prefix += 1;
+      return "\x7f".repeat(oldText.length - prefix) + newText.slice(prefix);
+    },
+    _attachTerminalImeFallback(term) {
+      const textarea = term && term.textarea;
+      const state = { pending: null, disposed: false };
+      if (!textarea) return state;
+      const keyCode = event => Number(event.keyCode || event.which || 0);
+      const onKeyDown = event => {
+        // iOS Chinese IMEs report digits, punctuation and spaces through the
+        // keyCode=229 path. Their textarea value may update only by keyup,
+        // after xterm's keydown timer has already checked it.
+        if (keyCode(event) !== 229 || event.isComposing) return;
+        if (!state.pending) {
+          state.pending = {
+            baseline: textarea.value,
+            delivered: false,
+            recovering: false,
+          };
+        }
+      };
+      const onCompositionStart = () => { state.pending = null; };
+      const onKeyUp = event => {
+        if (keyCode(event) !== 229 || !state.pending) return;
+        const pending = state.pending;
+        setTimeout(() => {
+          if (state.disposed || state.pending !== pending || pending.delivered) return;
+          const delta = this._terminalTextInputDelta(
+            pending.baseline, textarea.value);
+          if (delta) {
+            pending.recovering = true;
+            term.input(delta, true);
+          }
+          if (state.pending === pending) state.pending = null;
+        }, 0);
+      };
+      textarea.addEventListener("keydown", onKeyDown);
+      textarea.addEventListener("keyup", onKeyUp);
+      textarea.addEventListener("compositionstart", onCompositionStart);
+      state.dispose = () => {
+        state.disposed = true;
+        state.pending = null;
+        textarea.removeEventListener("keydown", onKeyDown);
+        textarea.removeEventListener("keyup", onKeyUp);
+        textarea.removeEventListener("compositionstart", onCompositionStart);
+      };
+      return state;
+    },
+    _terminalNormalizeImeData(data, state, term) {
+      const pending = state && state.pending;
+      if (!pending || pending.recovering || typeof data !== "string") return data;
+      const after = String(term?.textarea?.value || "");
+      const expected = this._terminalTextInputDelta(pending.baseline, after);
+      if (!expected) return data;
+      // xterm 6's keyCode=229 fallback handles append-only edits, but for an
+      // equal-length IME replacement it emits the entire helper textarea.
+      // Rewrite only that exact legacy output; unrelated terminal data keeps
+      // flowing untouched.
+      const legacy = after.length > pending.baseline.length
+        ? after.replace(pending.baseline, "")
+        : after.length < pending.baseline.length ? "\x7f" : after;
+      if (data !== expected && data !== legacy) return data;
+      pending.delivered = true;
+      state.pending = null;
+      return expected;
+    },
     _terminalHandleInput(data, term = this._terminal) {
       if (!this._terminalDataIsMouseReport(data)) {
         this._terminalSend(data);
@@ -15937,6 +16016,8 @@ function portal() {
         this._terminalFit = fit;
         this._attachTerminalTouchScroll(host, term);
         this._attachTerminalSelectionCopy(host, term);
+        const imeFallback = this._attachTerminalImeFallback(term);
+        this._terminalImeCleanup = () => imeFallback.dispose?.();
         let replayActive = false;
         let replayWritesPending = 0;
         const sendSize = () => {
@@ -15951,11 +16032,14 @@ function portal() {
         this._terminalResizeObserver = new ResizeObserver(() => sendSize());
         this._terminalResizeObserver.observe(host);
         term.onData(data => {
+          data = this._terminalNormalizeImeData(data, imeFallback, term);
           // Replaying historical output can re-run old DA/DSR/OSC queries.
           // xterm answers them through onData, but the original process is no
           // longer waiting; forwarding the reply makes readline show fragments
-          // such as "0;276;0c". Suppress input only while replay is parsing.
-          if (replayActive || replayWritesPending) return;
+          // such as "0;276;0c". Suppress only escape-prefixed device replies:
+          // printable keyboard/IME data must remain responsive during replay.
+          if ((replayActive || replayWritesPending)
+              && this._terminalDataIsReplayReply(data)) return;
           this._terminalHandleInput(data, term);
         });
         term.onResize(() => sendSize());
@@ -16070,6 +16154,8 @@ function portal() {
       this._terminalResizeObserver = null;
       if (this._terminalTouchCleanup) this._terminalTouchCleanup();
       if (this._terminalSelectionCleanup) this._terminalSelectionCleanup();
+      if (this._terminalImeCleanup) this._terminalImeCleanup();
+      this._terminalImeCleanup = null;
       this._terminalSuppressMouseUntil = 0;
       const socket = this._terminalSocket;
       this._terminalSocket = null;
@@ -18964,11 +19050,16 @@ function portal() {
     },
 
     // ===== @ mention =====
-    insertFileMention(path) {
+    _mentionPath(path, isDir = false) {
       const fileRoot = this.fileWorkspacePath();
-      const mentionPath = this.currentWorkspacePath() === fileRoot
+      let mentionPath = this.currentWorkspacePath() === fileRoot
         ? path
         : fileRoot.replace(/\/$/, "") + "/" + String(path || "").replace(/^\//, "");
+      if (isDir && mentionPath && !mentionPath.endsWith("/")) mentionPath += "/";
+      return mentionPath;
+    },
+    insertFileMention(path, isDir = false) {
+      const mentionPath = this._mentionPath(path, isDir);
       const mention = "@" + mentionPath + " ";
       this.input = (this.input || "") + (this.input && !this.input.endsWith(" ") ? " " : "") + mention;
       if (this.$refs.chatInput) this.$refs.chatInput.focus();
@@ -19863,7 +19954,7 @@ function portal() {
           }
         }
         if (mentionSeq !== this._mentionSeq) return;
-        const searchResults = (d.entries || []).filter(e => !e.is_dir);
+        const searchResults = d.entries || [];
         const openPaths = new Set(openMatches.map(t => t.path));
         const fresh = searchResults.filter(e => !openPaths.has(e.path));
         this.mentionResults = [...openMatches, ...fresh].slice(0, 15);
@@ -19879,10 +19970,11 @@ function portal() {
       const ta = this.$refs.chatInput;
       const before = this.input.slice(0, this.mentionAnchor);
       const after = this.input.slice(ta.selectionStart);
-      this.input = before + "@" + item.path + " " + after;
+      const mentionPath = this._mentionPath(item.path, !!item.is_dir);
+      this.input = before + "@" + mentionPath + " " + after;
       this._cancelMentionLookup();
       this.$nextTick(() => {
-        const newPos = (before + "@" + item.path + " ").length;
+        const newPos = (before + "@" + mentionPath + " ").length;
         ta.setSelectionRange(newPos, newPos);
         ta.focus();
       });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3671,11 +3671,12 @@
       <span class="icon"><svg><use href="#i-upload"/></svg></span><span x-text="t('btn.upload')"></span>
     </button>
     <div class="ctx-sep" x-show="!ctxMenu.multi && (ctxMenu.node && ctxMenu.node.is_dir)"></div>
-    <!-- 文件专属 -->
+    <!-- 文件专属：预览 -->
     <button class="ctx-item" @click="ctxAction('open')" x-show="!ctxMenu.multi && !(ctxMenu.node && ctxMenu.node.is_dir)">
       <span class="icon"><svg><use href="#i-eye"/></svg></span><span x-text="t('btn.preview')"></span>
     </button>
-    <button class="ctx-item" @click="ctxAction('mention')" x-show="!ctxMenu.multi && !(ctxMenu.node && ctxMenu.node.is_dir)">
+    <!-- 文件或目录：引用到对话 -->
+    <button class="ctx-item" @click="ctxAction('mention')" x-show="!ctxMenu.multi">
       <span class="icon"><svg><use href="#i-at"/></svg></span><span x-text="t('btn.at_mention')"></span>
     </button>
     <button class="ctx-item" @click="ctxAction('download')" x-show="!ctxMenu.multi && !(ctxMenu.node && ctxMenu.node.is_dir)">
@@ -4998,7 +4999,7 @@
             </tr>
             <tr>
               <td><span class="kbd">@</span></td>
-              <td x-text="lang==='zh' ? '在输入框引用 archive 文件（自动补全）' : 'Mention archive file in input (autocomplete)'"></td>
+              <td x-text="lang==='zh' ? '在输入框引用 archive 文件或目录（自动补全）' : 'Mention archive file or folder in input (autocomplete)'"></td>
             </tr>
             <tr>
               <td><span class="kbd">/</span></td>

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -30,6 +30,53 @@ def _login(page: Page, base: str, token: str) -> None:
     )
 
 
+def test_directory_can_be_mentioned_from_search_and_tree_action(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const created = await fetch('/api/files/mkdir', {
+            method: 'POST',
+            headers: {...app.fileHdr(), 'Content-Type': 'application/json'},
+            body: JSON.stringify({path: 'mention-folder'}),
+          });
+          if (!created.ok) throw new Error(await created.text());
+
+          await app.fetchMention('mention-folder');
+          const directory = app.mentionResults.find(
+            item => item.path === 'mention-folder'
+          );
+          if (!directory) return {found: false};
+
+          app.input = '查看 @mention-folder';
+          app.mentionAnchor = app.input.lastIndexOf('@');
+          const input = app.$refs.chatInput;
+          input.value = app.input;
+          input.setSelectionRange(app.input.length, app.input.length);
+          app.pickMention(app.mentionResults.indexOf(directory));
+          await new Promise(resolve => app.$nextTick(resolve));
+          const pickerInput = app.input;
+
+          app.input = '';
+          app.ctxMenu = {show: true, x: 0, y: 0, node: directory, multi: 0};
+          await app.ctxAction('mention');
+          return {
+            found: true,
+            isDir: directory.is_dir,
+            pickerInput,
+            treeInput: app.input,
+          };
+        }"""
+    )
+    assert result == {
+        "found": True,
+        "isDir": True,
+        "pickerInput": "查看 @mention-folder/ ",
+        "treeInput": "@mention-folder/ ",
+    }
+
+
 def test_external_file_changes_refresh_tree_without_manual_reload(
         page: Page, backend_url, auth_token):
     """Direct API mutations stand in for Agent/terminal writes and deletes."""

--- a/tests/e2e/test_terminal_mobile.py
+++ b/tests/e2e/test_terminal_mobile.py
@@ -430,6 +430,47 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
             }"""
         )
 
+        # iOS Chinese IMEs can update xterm's hidden textarea only at keyup
+        # for keyCode=229 digits/punctuation. Exercise that exact event shape,
+        # including an equal-length replacement which needs DEL + insert.
+        ime_outbound = page.evaluate(
+            """async () => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              const term = app._terminal;
+              const textarea = term.textarea;
+              const dispatch229 = (type, key) => {
+                const event = new KeyboardEvent(type, {bubbles: true, key});
+                Object.defineProperty(event, "keyCode", {value: 229});
+                Object.defineProperty(event, "which", {value: 229});
+                textarea.dispatchEvent(event);
+              };
+              const run = async (before, after, key) => {
+                app.__terminalOutboundData = [];
+                textarea.value = before;
+                dispatch229("keydown", key);
+                textarea.value = after;
+                dispatch229("keyup", key);
+                await new Promise(resolve => setTimeout(resolve, 30));
+                return app.__terminalOutboundData.slice();
+              };
+              const result = {
+                digit: await run("", "1", "1"),
+                punctuation: await run("", "，", "，"),
+                replacement: await run(" ", "。", "。"),
+                replayReply: app._terminalDataIsReplayReply("\\u001b[>0;276;0c"),
+                printable: app._terminalDataIsReplayReply("1，。"),
+              };
+              app._terminalSend("\\u0003");
+              await new Promise(resolve => setTimeout(resolve, 30));
+              return result;
+            }"""
+        )
+        assert "".join(ime_outbound["digit"]) == "1"
+        assert "".join(ime_outbound["punctuation"]) == "，"
+        assert "".join(ime_outbound["replacement"]) == "\x7f。"
+        assert ime_outbound["replayReply"] is True
+        assert ime_outbound["printable"] is False
+
         # A device query produced by an old process remains in the server
         # replay buffer. Reopening the terminal must render it without sending
         # xterm's fresh DA2 reply (ESC[>0;276;0c) into the current shell.

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1218,12 +1218,16 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "terminalMobileKey(text)" in app
     assert "this._terminalSend(text)" in app
     assert "_terminalDataIsMouseReport(data)" in app
+    assert "_terminalDataIsReplayReply(data)" in app
+    assert "_terminalTextInputDelta(before, after)" in app
+    assert "_attachTerminalImeFallback(term)" in app
+    assert "_terminalNormalizeImeData(data, state, term)" in app
     assert "_terminalHandleInput(data, term = this._terminal)" in app
     assert 'term.buffer?.active?.type !== "alternate"' in app
     assert '"\\x1b[?1000l\\x1b[?1002l\\x1b[?1003l\\x1b[?1005l"' in app
     assert "let replayActive = false" in app
     assert "let replayWritesPending = 0" in app
-    assert "if (replayActive || replayWritesPending) return" in app
+    assert "&& this._terminalDataIsReplayReply(data)) return" in app
     assert 'message.type === "replay_start"' in app
     assert 'message.type === "replay_end"' in app
     assert "if (this._terminal) this._terminal.focus()" in app


### PR DESCRIPTION
## What this changes

让文件树目录和 `@` 自动补全都能把目录以 `@path/` 引用到对话；同时修复终端历史回放期间吞掉普通输入，以及 iOS 中文输入法通过 `keyCode=229` 输入数字、标点和空格时漏发或等长替换错误的问题。

## Why

目录此前被前端菜单和搜索结果主动排除；终端则把回放解析期间的所有 `onData` 一概丢弃，xterm 6 对 iOS 中文 IME 的 229 路径也缺少 keyup 兜底，导致移动端数字和标点显得不灵敏。

## Testing

- [x] `node --check frontend/app.js`
- [x] `git diff --check`
- [x] `.venv/bin/python -m pytest tests/test_frontend_lint.py -q`（77 passed）
- [x] `.venv/bin/python -m pytest tests/test_terminal.py -q`（5 passed）
- [x] `RUN_E2E=1 .venv/bin/python -m pytest tests/e2e/test_files_preview.py::test_directory_can_be_mentioned_from_search_and_tree_action tests/e2e/test_terminal_mobile.py::test_mobile_terminal_sheet_create_and_real_touch_scrollback -v`（2 passed，真实 Chromium + PTY）
- [x] `muselab-main.service` 重启后 `/api/health` 为 `ok`，线上静态资产与目录搜索已验收

## Checklist

- [x] No secrets committed
- [x] 用户可见帮助文案已更新为“文件或目录”
- [x] No runtime dependency added