### PR TITLE
fix(mobile): 保留应用重开前的页签

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1927,13 +1927,7 @@ function portal() {
       // ensures the openFile-induced mobileTab="preview" assignment
       // settles before we override it back to the user's actual last tab.
       // Desktop ignores mobileTab entirely so this is a no-op there.
-      if (this._pendingMobileTab) {
-        const wantTab = this._pendingMobileTab;
-        this._pendingMobileTab = null;
-        this.$nextTick(() => {
-          if (this._isMobileLayout()) this.setMobileTab(wantTab);
-        });
-      }
+      this._restorePendingMobileTab();
       // Block readiness on context-info (the most important one for the
       // onboarding cards). Others come along in parallel.
       try {
@@ -4581,12 +4575,26 @@ function portal() {
                         { preview: !!(_restored && _restored.preview) })
               .catch(() => { /* file went away — nothing to do */ });
         }
+        // login() is the first-sign-in counterpart of _bootApp(). Keep the
+        // same ordering here: preview/terminal restoration may prepare a
+        // hidden surface, but it must not replace the mobile pane the user
+        // actually left visible.
+        this._restorePendingMobileTab();
         // First sign-in never routes through _bootApp (it inlines a subset of
         // the boot work above), so without this the new user has no heartbeat
         // / stale-JS reload / presence reporting / bell badge refresh until a
         // manual refresh. Shared with _bootApp; safe to call once here.
         this._startLiveConnections();
       } catch (e) { this.loginErr = e.message; }
+    },
+
+    _restorePendingMobileTab() {
+      if (!this._pendingMobileTab) return;
+      const wantTab = this._pendingMobileTab;
+      this._pendingMobileTab = null;
+      this.$nextTick(() => {
+        if (this._isMobileLayout()) this.setMobileTab(wantTab);
+      });
     },
 
     logout() {
@@ -15347,7 +15355,11 @@ function portal() {
         this._teardownTerminalView();
       }
       if (restore && this.previewSurface === "terminal" && activeExists) {
-        await this.openTerminal(this.activeTerminalId);
+        // Rebuild the terminal surface in the background without treating
+        // startup/workspace restoration like an explicit tap. In particular,
+        // a late terminal-list response must not overwrite the last mobile
+        // pane (chat/files) with "preview".
+        await this.openTerminal(this.activeTerminalId, { reveal: false });
       }
     },
     async createTerminal(profileId) {
@@ -15947,7 +15959,7 @@ function portal() {
         this._terminalTouchCleanup = null;
       };
     },
-    async openTerminal(id, { reconnect = false } = {}) {
+    async openTerminal(id, { reconnect = false, reveal = true } = {}) {
       const row = this.terminals.find(item => item.id === id);
       if (!row) return;
       this._teardownTerminalView();
@@ -15957,7 +15969,7 @@ function portal() {
       this.terminalManagerOpen = false;
       this.terminalConnection = "connecting";
       this.terminalExitCode = row.exit_code;
-      if (this._isMobileLayout()) this.setMobileTab("preview");
+      if (reveal && this._isMobileLayout()) this.setMobileTab("preview");
       this._scheduleSavePrefs();
       try {
         await this._loadTerminalLib();
@@ -16074,7 +16086,7 @@ function portal() {
           }
           return true;
         });
-        term.focus();
+        if (reveal || !this._isMobileLayout()) term.focus();
 
         const ticketResponse = await this.api(`/api/terminals/${id}/ticket`, {
           method: "POST",
@@ -16093,7 +16105,7 @@ function portal() {
           if (seq !== this._terminalConnectSeq) return;
           this.terminalConnection = "connected";
           sendSize();
-          term.focus();
+          if (reveal || !this._isMobileLayout()) term.focus();
         };
         socket.onmessage = event => {
           if (seq !== this._terminalConnectSeq) return;
@@ -16131,7 +16143,8 @@ function portal() {
             this.terminalConnection = "reconnecting";
             clearTimeout(this._terminalReconnectTimer);
             this._terminalReconnectTimer = setTimeout(
-              () => this.openTerminal(id, { reconnect: true }), reconnect ? 2200 : 1000);
+              () => this.openTerminal(id, { reconnect: true, reveal: false }),
+              reconnect ? 2200 : 1000);
           } else if (this.terminalConnection !== "exited") {
             this.terminalConnection = "disconnected";
           }

--- a/tests/e2e/test_terminal_mobile.py
+++ b/tests/e2e/test_terminal_mobile.py
@@ -652,3 +652,135 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
                 created_id,
             )
         context.close()
+
+
+def test_mobile_reopen_keeps_last_pane_while_terminal_restores(
+        browser: Browser, browser_name: str, backend_url: str, auth_token: str):
+    """A restored/reconnecting terminal must not route a phone away from chat/files."""
+    if browser_name != "chromium":
+        pytest.skip("mobile cold-start coverage runs on Chromium")
+
+    context = browser.new_context(
+        viewport={"width": 390, "height": 844},
+        device_scale_factor=2,
+        has_touch=True,
+        is_mobile=True,
+    )
+    page = context.new_page()
+    created_id = ""
+    try:
+        _login(page, backend_url, auth_token)
+        created_id = page.evaluate(
+            """async () => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              const result = await app.api("/api/terminals", {
+                method: "POST",
+                headers: app.fileHdr(),
+                json: {rows: 20, cols: 80, profile_id: ""},
+              });
+              if (!result.ok) throw new Error(result.error || "create failed");
+              app.terminals = [...app.terminals, result.data];
+              await app.openTerminal(result.data.id);
+              return result.data.id;
+            }"""
+        )
+        page.wait_for_function(
+            """() => document.querySelector("#app")._x_dataStack[0]
+              .terminalConnection === "connected" """
+        )
+
+        def reopen_on(pane: str) -> dict:
+            page.evaluate(
+                """pane => {
+                  const app = document.querySelector("#app")._x_dataStack[0];
+                  app.setMobileTab(pane);
+                  app.savePrefs();
+                }""",
+                pane,
+            )
+            page.reload(wait_until="domcontentloaded")
+            page.wait_for_function(
+                """() => {
+                  const app = document.querySelector("#app")?._x_dataStack?.[0];
+                  return app?.authed
+                    && app.terminals.some(row => row.id === app.activeTerminalId)
+                    && app.terminalConnection === "connected";
+                }""",
+                # Earlier tests deliberately leave a very large current chat
+                # in the disposable backend. Its first render can occupy the
+                # mobile main thread even though terminal restore is already
+                # progressing, so use the suite's normal slow-start budget.
+                timeout=30000,
+            )
+            # Let the delayed terminal restore and preference coalescer settle;
+            # the old race changed both values shortly after initial paint.
+            page.wait_for_timeout(250)
+            return page.evaluate(
+                """() => {
+                  const app = document.querySelector("#app")._x_dataStack[0];
+                  const prefs = JSON.parse(
+                    localStorage.getItem("muselab_prefs") || "{}");
+                  return {
+                    mobileTab: app.mobileTab,
+                    storedTab: prefs.mobileTab,
+                    previewSurface: app.previewSurface,
+                    activeTerminalId: app.activeTerminalId,
+                    terminalConnected: app.terminalConnection === "connected",
+                    hiddenTerminalFocused:
+                      document.activeElement === app._terminal?.textarea,
+                  };
+                }"""
+            )
+
+        chat_state = reopen_on("chat")
+        assert chat_state == {
+            "mobileTab": "chat",
+            "storedTab": "chat",
+            "previewSurface": "terminal",
+            "activeTerminalId": created_id,
+            "terminalConnected": True,
+            "hiddenTerminalFocused": False,
+        }
+
+        # A transport reconnect uses the same openTerminal plumbing. It must
+        # remain a background repair while the terminal pane is hidden.
+        page.evaluate(
+            """() => document.querySelector("#app")._x_dataStack[0]
+              ._terminalSocket.close()"""
+        )
+        page.wait_for_function(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              return app.terminalConnection === "connected"
+                && app.mobileTab === "chat";
+            }""",
+            timeout=10000,
+        )
+        page.wait_for_timeout(250)
+        assert page.evaluate(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              const prefs = JSON.parse(
+                localStorage.getItem("muselab_prefs") || "{}");
+              return app.mobileTab === "chat" && prefs.mobileTab === "chat"
+                && document.activeElement !== app._terminal?.textarea;
+            }"""
+        )
+
+        files_state = reopen_on("files")
+        assert files_state == {
+            "mobileTab": "files",
+            "storedTab": "files",
+            "previewSurface": "terminal",
+            "activeTerminalId": created_id,
+            "terminalConnected": True,
+            "hiddenTerminalFocused": False,
+        }
+    finally:
+        if created_id:
+            page.evaluate(
+                """id => document.querySelector("#app")?._x_dataStack?.[0]
+                  ?.closeTerminal(id, {confirm: false})""",
+                created_id,
+            )
+        context.close()

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -178,6 +178,22 @@ def test_mobile_preview_captures_before_hiding_and_pins_tree_taps():
     assert html.count("@click=\"setMobileTab('") == 3
 
 
+def test_terminal_restore_and_reconnect_do_not_hijack_mobile_tab():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    restore_start = app.index("async fetchTerminals(")
+    restore_end = app.index("\n    async createTerminal", restore_start)
+    restore = app[restore_start:restore_end]
+    terminal_start = app.index("async openTerminal(")
+    terminal_end = app.index("\n    _teardownTerminalView", terminal_start)
+    terminal = app[terminal_start:terminal_end]
+
+    assert "this._restorePendingMobileTab();" in app
+    assert "this.openTerminal(this.activeTerminalId, { reveal: false })" in restore
+    assert "async openTerminal(id, { reconnect = false, reveal = true } = {})" in terminal
+    assert 'if (reveal && this._isMobileLayout()) this.setMobileTab("preview")' in terminal
+    assert "this.openTerminal(id, { reconnect: true, reveal: false })" in terminal
+
+
 def test_primary_mobile_surfaces_keep_native_touch_scrolling():
     css = (FRONTEND / "styles.css").read_text()
     marker = "contract explicit on every primary mobile surface."


### PR DESCRIPTION
## What this changes

区分用户主动打开终端与后台恢复终端：冷启动、首次登录和终端断线重连只恢复隐藏终端表面，不再强制切换移动端页签或抢占隐藏输入焦点。新增聊天页、文件页关闭重开以及隐藏终端重连的真实浏览器回归。

## Why

移动端关闭后重新打开应用时，异步终端恢复会晚于页签偏好恢复完成，并复用主动打开终端的逻辑，把用户从上次停留的聊天页或文件页切回预览终端，还会把错误页签再次持久化。

## Testing

- [x] `node --check frontend/app.js`
- [x] `pytest -q tests/test_frontend_lint.py`（78 passed）
- [x] `RUN_E2E=1 pytest -q tests/e2e/test_terminal_mobile.py --browser chromium`（4 passed）
- [x] 重启 `muselab-main.service`，验证 `GET /api/health` 为 `ok`，8770 实际静态资源包含修复

## Checklist

- [x] No secrets committed
- [x] Docs updated if behavior visible to users（无需用户文档变更；行为由内联说明与回归测试固化）
- [x] If adds runtime dep: install scripts updated（N/A，无新增依赖）