### PR TITLE
fix(ux): 修复移动端终端并扩展任务时间线

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -351,6 +351,7 @@ function portal() {
     _terminalResizeObserver: null,
     _terminalTouchCleanup: null,
     _terminalSuppressMouseUntil: 0,
+    _terminalTouchWheelDispatching: false,
     _terminalReconnectTimer: null,
     _terminalConnectSeq: 0,
     _terminalSelectionCleanup: null,
@@ -15689,69 +15690,109 @@ function portal() {
     },
     _attachTerminalImeFallback(term) {
       const textarea = term && term.textarea;
-      const state = { pending: null, disposed: false };
+      const state = {
+        active229: false,
+        baseline: "",
+        composing: false,
+        disposed: false,
+        recovering: false,
+        settleTimer: null,
+      };
       if (!textarea) return state;
       const keyCode = event => Number(event.keyCode || event.which || 0);
-      const onKeyDown = event => {
-        // iOS Chinese IMEs report digits, punctuation and spaces through the
-        // keyCode=229 path. Their textarea value may update only by keyup,
-        // after xterm's keydown timer has already checked it.
-        if (keyCode(event) !== 229 || event.isComposing) return;
-        if (!state.pending) {
-          state.pending = {
-            baseline: textarea.value,
-            delivered: false,
-            recovering: false,
-          };
+      const flush = () => {
+        if (state.disposed || !state.active229 || state.composing) return;
+        const after = String(textarea.value || "");
+        const delta = this._terminalTextInputDelta(state.baseline, after);
+        state.baseline = after;
+        if (delta) {
+          state.recovering = true;
+          try { term.input(delta, true); }
+          finally { state.recovering = false; }
         }
       };
-      const onCompositionStart = () => { state.pending = null; };
-      const onKeyUp = event => {
-        if (keyCode(event) !== 229 || !state.pending) return;
-        const pending = state.pending;
-        setTimeout(() => {
-          if (state.disposed || state.pending !== pending || pending.delivered) return;
-          const delta = this._terminalTextInputDelta(
-            pending.baseline, textarea.value);
-          if (delta) {
-            pending.recovering = true;
-            term.input(delta, true);
+      const onKeyDown = event => {
+        // iOS Chinese IMEs report digits, punctuation and spaces through the
+        // keyCode=229 path. xterm handles that with one setTimeout snapshot per
+        // keydown; rapid keys can overlap and clear a later character's state.
+        // Own only the non-composing 229 path in capture phase, leaving the
+        // browser's default edit intact and using its actual input value below.
+        if (keyCode(event) !== 229 || event.isComposing || state.composing) {
+          if (state.active229) {
+            flush();
+            state.active229 = false;
           }
-          if (state.pending === pending) state.pending = null;
-        }, 0);
+          return;
+        }
+        clearTimeout(state.settleTimer);
+        flush();
+        state.active229 = true;
+        state.baseline = String(textarea.value || "");
       };
-      textarea.addEventListener("keydown", onKeyDown);
-      textarea.addEventListener("keyup", onKeyUp);
+      const onInput = () => { flush(); };
+      const onKeyUp = event => {
+        if (keyCode(event) !== 229 || !state.active229) return;
+        clearTimeout(state.settleTimer);
+        // Some iOS keyboards update the helper textarea after keyup instead of
+        // firing input synchronously. Keep a short fallback window; the next
+        // 229 keydown flushes this state first, so rapid digits cannot be lost.
+        state.settleTimer = setTimeout(() => {
+          flush();
+          state.active229 = false;
+          state.settleTimer = null;
+        }, 50);
+      };
+      const onCompositionStart = () => {
+        clearTimeout(state.settleTimer);
+        state.active229 = false;
+        state.composing = true;
+      };
+      const onCompositionEnd = () => { state.composing = false; };
+      textarea.addEventListener("keydown", onKeyDown, true);
+      textarea.addEventListener("keyup", onKeyUp, true);
+      textarea.addEventListener("input", onInput);
       textarea.addEventListener("compositionstart", onCompositionStart);
+      textarea.addEventListener("compositionend", onCompositionEnd);
       state.dispose = () => {
         state.disposed = true;
-        state.pending = null;
-        textarea.removeEventListener("keydown", onKeyDown);
-        textarea.removeEventListener("keyup", onKeyUp);
+        state.active229 = false;
+        clearTimeout(state.settleTimer);
+        state.settleTimer = null;
+        textarea.removeEventListener("keydown", onKeyDown, true);
+        textarea.removeEventListener("keyup", onKeyUp, true);
+        textarea.removeEventListener("input", onInput);
         textarea.removeEventListener("compositionstart", onCompositionStart);
+        textarea.removeEventListener("compositionend", onCompositionEnd);
       };
       return state;
     },
     _terminalNormalizeImeData(data, state, term) {
-      const pending = state && state.pending;
-      if (!pending || pending.recovering || typeof data !== "string") return data;
+      if (!state || !state.active229 || state.recovering
+          || typeof data !== "string") return data;
       const after = String(term?.textarea?.value || "");
-      const expected = this._terminalTextInputDelta(pending.baseline, after);
+      const expected = this._terminalTextInputDelta(state.baseline, after);
       if (!expected) return data;
-      // xterm 6's keyCode=229 fallback handles append-only edits, but for an
-      // equal-length IME replacement it emits the entire helper textarea.
-      // Rewrite only that exact legacy output; unrelated terminal data keeps
-      // flowing untouched.
-      const legacy = after.length > pending.baseline.length
-        ? after.replace(pending.baseline, "")
-        : after.length < pending.baseline.length ? "\x7f" : after;
-      if (data !== expected && data !== legacy) return data;
-      pending.delivered = true;
-      state.pending = null;
+      // The xterm input event normally emits only the inserted suffix, while
+      // an equal-length replacement emits the new textarea value without the
+      // DEL needed by the PTY. Normalize either shape to the authoritative
+      // before/after delta, then advance the baseline so our input listener
+      // sees that xterm already delivered this edit and does not duplicate it.
+      const native = after.length > state.baseline.length
+        ? after.replace(state.baseline, "")
+        : after.length < state.baseline.length ? "\x7f" : after;
+      if (data !== expected && data !== native) return data;
+      state.baseline = after;
       return expected;
     },
     _terminalHandleInput(data, term = this._terminal) {
       if (!this._terminalDataIsMouseReport(data)) {
+        this._terminalSend(data);
+        return;
+      }
+      // A vertical touch gesture in an alternate-buffer TUI is deliberately
+      // converted to xterm wheel input. It is the one mouse report allowed
+      // through while the post-touch click-suppression window is active.
+      if (this._terminalTouchWheelDispatching) {
         this._terminalSend(data);
         return;
       }
@@ -15897,6 +15938,28 @@ function portal() {
         remainder = 0;
         claimed = false;
       };
+      const dispatchTuiWheel = (touch, lines) => {
+        const screen = host.querySelector(".xterm-screen") || host;
+        const steps = Math.min(12, Math.max(1, Math.abs(lines)));
+        const deltaY = lines < 0 ? -100 : 100;
+        this._terminalTouchWheelDispatching = true;
+        try {
+          for (let i = 0; i < steps; i += 1) {
+            screen.dispatchEvent(new WheelEvent("wheel", {
+              bubbles: true,
+              cancelable: true,
+              view: window,
+              clientX: touch.clientX,
+              clientY: touch.clientY,
+              deltaX: 0,
+              deltaY,
+              deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+            }));
+          }
+        } finally {
+          this._terminalTouchWheelDispatching = false;
+        }
+      };
       const onStart = event => {
         if (event.touches.length !== 1) return reset();
         const touch = event.touches[0];
@@ -15929,7 +15992,15 @@ function portal() {
           : Math.ceil(remainder / linePx);
         if (!lines) return;
         remainder -= lines * linePx;
-        term.scrollLines(lines);
+        if (term.buffer?.active?.type === "alternate") {
+          // Full-screen TUIs have no xterm scrollback. Re-feed the gesture as
+          // real xterm wheel events so mouse-aware apps (Claude Code, vim,
+          // less) scroll their own pages; xterm falls back to cursor keys when
+          // the alternate-buffer app has not enabled mouse tracking.
+          dispatchTuiWheel(touch, lines);
+        } else {
+          term.scrollLines(lines);
+        }
       };
       const onEnd = event => {
         // Mobile browsers synthesize a mouse press/release after touchend.
@@ -16057,6 +16128,11 @@ function portal() {
         term.onResize(() => sendSize());
         term.attachCustomKeyEventHandler(event => {
           if (event.type !== "keydown") return true;
+          // Claim non-composing keyCode=229 before xterm's composition helper
+          // schedules its own textarea snapshot. The DOM input event remains
+          // untouched and _attachTerminalImeFallback reconciles/supplements it.
+          if (Number(event.keyCode || event.which || 0) === 229
+              && !event.isComposing && !imeFallback.composing) return false;
           const key = String(event.key || "").toLowerCase();
           // Copy deliberately does NOT take plain Ctrl+C: that is SIGINT, the
           // single most important key in a terminal. Cmd+C / Ctrl+Shift+C only.
@@ -16170,6 +16246,7 @@ function portal() {
       if (this._terminalImeCleanup) this._terminalImeCleanup();
       this._terminalImeCleanup = null;
       this._terminalSuppressMouseUntil = 0;
+      this._terminalTouchWheelDispatching = false;
       const socket = this._terminalSocket;
       this._terminalSocket = null;
       if (socket) {
@@ -22656,6 +22733,7 @@ function portal() {
       ];
     },
     ACTIVITY_GROUP_CAP: 5,
+    ACTIVITY_TIMELINE_CAP: 10,
     activityMatchesGroup(item, key) {
       if (!item) return false;
       if (key === "timeline") return true;
@@ -22688,11 +22766,15 @@ function portal() {
     activityEvents(group) {
       const all = this.activityAllEvents(group);
       if (this.activity.expanded[group.key]) return all;
-      return all.slice(0, this.ACTIVITY_GROUP_CAP);
+      return all.slice(0, this.activityGroupCap(group));
+    },
+    activityGroupCap(group) {
+      return group?.key === "timeline"
+        ? this.ACTIVITY_TIMELINE_CAP : this.ACTIVITY_GROUP_CAP;
     },
     activityHiddenCount(group) {
       return Math.max(
-        0, this.activityAllEvents(group).length - this.ACTIVITY_GROUP_CAP);
+        0, this.activityAllEvents(group).length - this.activityGroupCap(group));
     },
     toggleActivityGroup(key) {
       this.activity.expanded[key] = !this.activity.expanded[key];

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -122,6 +122,18 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
               workspaces: [],
             },
           });
+          for (let index = 0; index < 9; index += 1) {
+            app.activity.events.push({
+              ...base,
+              id: `extra-${index}`,
+              session_id: `extra-session-${index}`,
+              task_summary: `Extra task ${index}`,
+              state: 'completed',
+              started_at: 90 - index,
+              finished_at: 90 - index,
+              updated_at: 90 - index,
+            });
+          }
           app.setActivityView('timeline');
         }"""
     )
@@ -130,12 +142,16 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
         "active"
     )
     labels = page.locator(".activity-group .activity-row strong")
-    expect(labels).to_have_count(3)
-    assert labels.all_text_contents() == [
+    expect(labels).to_have_count(10)
+    assert labels.all_text_contents()[:3] == [
         "Newest running task",
         "Newer failed task",
         "Older completed task",
     ]
+    more = page.locator(".activity-group-more")
+    expect(more).to_have_text("2 more")
+    more.click()
+    expect(labels).to_have_count(12)
 
 
 def test_terminal_event_wins_over_stale_tab_activity_snapshot(

--- a/tests/e2e/test_terminal_mobile.py
+++ b/tests/e2e/test_terminal_mobile.py
@@ -430,9 +430,10 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
             }"""
         )
 
-        # iOS Chinese IMEs can update xterm's hidden textarea only at keyup
-        # for keyCode=229 digits/punctuation. Exercise that exact event shape,
-        # including an equal-length replacement which needs DEL + insert.
+        # iOS Chinese IMEs report digits/punctuation through keyCode=229 and
+        # can update xterm's hidden textarea at input or only after keyup.
+        # Exercise both paths plus rapid consecutive digits: none may be
+        # dropped or duplicated.
         ime_outbound = page.evaluate(
             """async () => {
               const app = document.querySelector("#app")._x_dataStack[0];
@@ -444,19 +445,44 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
                 Object.defineProperty(event, "which", {value: 229});
                 textarea.dispatchEvent(event);
               };
-              const run = async (before, after, key) => {
-                app.__terminalOutboundData = [];
+              const input229 = (before, after, key) => {
                 textarea.value = before;
                 dispatch229("keydown", key);
                 textarea.value = after;
+                textarea.dispatchEvent(new InputEvent("input", {
+                  bubbles: true, data: key, inputType: "insertText",
+                }));
                 dispatch229("keyup", key);
-                await new Promise(resolve => setTimeout(resolve, 30));
+              };
+              const run = async (before, after, key) => {
+                app.__terminalOutboundData = [];
+                input229(before, after, key);
+                await new Promise(resolve => setTimeout(resolve, 80));
                 return app.__terminalOutboundData.slice();
               };
+              app.__terminalOutboundData = [];
+              input229("", "1", "1");
+              input229("1", "12", "2");
+              input229("12", "123", "3");
+              input229("123", "123，", "，");
+              await new Promise(resolve => setTimeout(resolve, 80));
+              const rapid = app.__terminalOutboundData.slice();
+
+              // Keyup-only fallback: change the value after both keyboard
+              // events, with no input event, like delayed iOS helper updates.
+              app.__terminalOutboundData = [];
+              textarea.value = "";
+              dispatch229("keydown", "7");
+              dispatch229("keyup", "7");
+              textarea.value = "7";
+              await new Promise(resolve => setTimeout(resolve, 80));
+              const delayed = app.__terminalOutboundData.slice();
               const result = {
                 digit: await run("", "1", "1"),
                 punctuation: await run("", "，", "，"),
                 replacement: await run(" ", "。", "。"),
+                rapid,
+                delayed,
                 replayReply: app._terminalDataIsReplayReply("\\u001b[>0;276;0c"),
                 printable: app._terminalDataIsReplayReply("1，。"),
               };
@@ -468,6 +494,8 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
         assert "".join(ime_outbound["digit"]) == "1"
         assert "".join(ime_outbound["punctuation"]) == "，"
         assert "".join(ime_outbound["replacement"]) == "\x7f。"
+        assert "".join(ime_outbound["rapid"]) == "123，"
+        assert "".join(ime_outbound["delayed"]) == "7"
         assert ime_outbound["replayReply"] is True
         assert ime_outbound["printable"] is False
 
@@ -528,8 +556,9 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
         )
         assert not any(value.startswith("\x1b[<") for value in outbound)
 
-        # Touch gestures must never leak mouse-coordinate reports while a
-        # full-screen app has enabled the alternate buffer and SGR pixels.
+        # A vertical swipe in a full-screen TUI must become wheel input so the
+        # app can scroll its own page. A plain tap still must not leak its
+        # synthesized mouse click into the TUI.
         page.evaluate(
             """async () => {
               const app = document.querySelector("#app")._x_dataStack[0];
@@ -552,12 +581,68 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
             host_box["y"] + host_box["height"] * 0.35,
             host_box["y"] + host_box["height"] * 0.78,
         )
+        page.wait_for_timeout(250)
+        tui_wheel = page.evaluate(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              return {
+                raw: app.__terminalRawInput.slice(),
+                outbound: app.__terminalOutboundData.slice(),
+              };
+            }"""
+        )
+        assert any(
+            re.fullmatch(r"\x1b\[<64;\d+;\d+M", value)
+            for value in tui_wheel["raw"]
+        ), repr(tui_wheel)
+        assert any(
+            re.fullmatch(r"\x1b\[<64;\d+;\d+M", value)
+            for value in tui_wheel["outbound"]
+        ), repr(tui_wheel)
+        page.evaluate(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              app.__terminalRawInput = [];
+              app.__terminalOutboundData = [];
+            }"""
+        )
+        _touch_swipe_down(
+            page,
+            host_box["x"] + host_box["width"] / 2,
+            host_box["y"] + host_box["height"] * 0.78,
+            host_box["y"] + host_box["height"] * 0.35,
+        )
+        page.wait_for_timeout(250)
+        tui_wheel_down = page.evaluate(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              return {
+                raw: app.__terminalRawInput.slice(),
+                outbound: app.__terminalOutboundData.slice(),
+              };
+            }"""
+        )
+        assert any(
+            re.fullmatch(r"\x1b\[<65;\d+;\d+M", value)
+            for value in tui_wheel_down["raw"]
+        ), repr(tui_wheel_down)
+        assert any(
+            re.fullmatch(r"\x1b\[<65;\d+;\d+M", value)
+            for value in tui_wheel_down["outbound"]
+        ), repr(tui_wheel_down)
+        page.evaluate(
+            """() => {
+              const app = document.querySelector("#app")._x_dataStack[0];
+              app.__terminalRawInput = [];
+              app.__terminalOutboundData = [];
+            }"""
+        )
         _touch_tap(
             page,
             host_box["x"] + host_box["width"] / 2,
             host_box["y"] + host_box["height"] / 2,
         )
-        page.wait_for_timeout(1000)
+        page.wait_for_timeout(750)
         raw_touch_input = page.evaluate(
             """() => document.querySelector("#app")._x_dataStack[0]
               .__terminalRawInput"""
@@ -641,6 +726,23 @@ def test_mobile_terminal_sheet_create_and_real_touch_scrollback(
               return term && term.buffer.active.viewportY < before;
             }""",
             arg=before["viewportY"],
+        )
+        scrolled_viewport = page.evaluate(
+            """() => document.querySelector("#app")._x_dataStack[0]
+              ._terminal.buffer.active.viewportY"""
+        )
+        _touch_swipe_down(
+            page,
+            host_box["x"] + host_box["width"] / 2,
+            host_box["y"] + host_box["height"] * 0.78,
+            host_box["y"] + host_box["height"] * 0.35,
+        )
+        page.wait_for_function(
+            """before => {
+              const term = document.querySelector("#app")._x_dataStack[0]._terminal;
+              return term && term.buffer.active.viewportY > before;
+            }""",
+            arg=scrolled_viewport,
         )
     finally:
         if created_id:

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -694,6 +694,9 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'item.state === "completed" && !!item.read' in app
     assert 'item.state === "cancelled"' in app
     assert "ACTIVITY_GROUP_CAP: 5" in app
+    assert "ACTIVITY_TIMELINE_CAP: 10" in app
+    assert 'group?.key === "timeline"' in app
+    assert "this.activityGroupCap(group)" in app
     assert "activityHiddenCount(group)" in app
     assert '"/api/activity?limit=500"' in app
     assert "r.status === 304 && !opts.summaryOnly && !this.activity.events.length" in app
@@ -1238,6 +1241,9 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "_terminalTextInputDelta(before, after)" in app
     assert "_attachTerminalImeFallback(term)" in app
     assert "_terminalNormalizeImeData(data, state, term)" in app
+    assert 'textarea.addEventListener("keydown", onKeyDown, true)' in app
+    assert 'textarea.addEventListener("input", onInput)' in app
+    assert "Number(event.keyCode || event.which || 0) === 229" in app
     assert "_terminalHandleInput(data, term = this._terminal)" in app
     assert 'term.buffer?.active?.type !== "alternate"' in app
     assert '"\\x1b[?1000l\\x1b[?1002l\\x1b[?1003l\\x1b[?1005l"' in app
@@ -1262,6 +1268,9 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "if (event.cancelable) event.preventDefault()" in app
     assert "event.stopPropagation()" in app
     assert "term.scrollLines(lines)" in app
+    assert 'new WheelEvent("wheel"' in app
+    assert "this._terminalTouchWheelDispatching = true" in app
+    assert "if (this._terminalTouchWheelDispatching)" in app
     assert "this._terminalSuppressMouseUntil = performance.now() + 500" in app
     assert "this._terminalSuppressMouseUntil = performance.now() + 800" in app
     assert "if (this._terminalTouchCleanup) this._terminalTouchCleanup()" in app


### PR DESCRIPTION
## 变更类型
- [x] 修复（bugfix）
- [ ] 新功能（feature）
- [ ] 重构（refactor）
- [ ] 文档（docs）

## 变更说明
- 修复移动端普通终端历史区无法稳定上下滑动的问题。
- 将全屏 TUI 的纵向触摸手势转换为真实 xterm 滚轮输入，支持 Claude Code、vim、less 等应用内翻页，同时继续抑制触摸后合成点击。
- 修复 iOS `keyCode=229` 输入链路竞争，避免数字、中文标点和快速连续输入丢失或重复。
- 全局任务中心“时间倒序”视图首屏由 5 条增至 10 条；按状态分组仍保持每组 5 条。

## 前后对比
- 修复前：全屏 TUI 滑动无效；iOS 数字/标点可能延迟、丢失或重复；时间倒序首屏仅显示 5 个会话。
- 修复后：普通 scrollback 与全屏 TUI 均支持双向滑动；`123，` 等快速输入按原样送达；时间倒序首屏显示 10 个会话并可展开剩余记录。

## 测试情况
- `ruff check backend/ tests/`
- `bash scripts/lint.sh`
- `node --check frontend/app.js`
- 非 E2E：48/48 个测试文件逐文件通过（避免仓库已知的单进程模块重载内存累积）
- Chromium E2E：`tests/e2e/test_activity_center.py` 与 `tests/e2e/test_terminal_mobile.py`，6 passed

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了回归测试
- [x] 自测通过
- [x] 无敏感信息或个人数据
- [x] 文档无需更新