### PR TITLE
docs(readme): 移除移动端浅色预览

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@
 <table align="center">
 <tr>
 <td align="center"><a href="promo/media/screenshot-mobile-files.jpeg"><img src="promo/media/screenshot-mobile-files.jpeg" width="180" alt="移动端文件区"></a></td>
-<td align="center"><a href="promo/media/screenshot-mobile-preview.png"><img src="promo/media/screenshot-mobile-preview.png" width="180" alt="移动端浅色预览"></a></td>
 <td align="center"><a href="promo/media/screenshot-mobile-chat.png"><img src="promo/media/screenshot-mobile-chat.png" width="180" alt="移动端 Agent 对话"></a></td>
 <td align="center"><a href="promo/media/screenshot-mobile.png"><img src="promo/media/screenshot-mobile.png" width="180" alt="移动端深色预览"></a></td>
 </tr>
 <tr>
 <td align="center">移动端 · 文件区</td>
-<td align="center">移动端 · 浅色预览</td>
 <td align="center">移动端 · Agent 对话</td>
 <td align="center">移动端 · 深色主题</td>
 </tr>

--- a/README_en.md
+++ b/README_en.md
@@ -27,13 +27,11 @@
 <table align="center">
 <tr>
 <td align="center"><a href="promo/media/screenshot-mobile-files.jpeg"><img src="promo/media/screenshot-mobile-files.jpeg" width="180" alt="Mobile file browser"></a></td>
-<td align="center"><a href="promo/media/screenshot-mobile-preview.png"><img src="promo/media/screenshot-mobile-preview.png" width="180" alt="Mobile light-theme preview"></a></td>
 <td align="center"><a href="promo/media/screenshot-mobile-chat.png"><img src="promo/media/screenshot-mobile-chat.png" width="180" alt="Mobile Agent conversation"></a></td>
 <td align="center"><a href="promo/media/screenshot-mobile.png"><img src="promo/media/screenshot-mobile.png" width="180" alt="Mobile dark-theme preview"></a></td>
 </tr>
 <tr>
 <td align="center">Mobile · files</td>
-<td align="center">Mobile · light preview</td>
 <td align="center">Mobile · Agent conversation</td>
 <td align="center">Mobile · dark theme</td>
 </tr>


### PR DESCRIPTION
## 变更类型
- [x] 文档 (docs)

## 变更说明
- 从中文 README 的移动端画廊移除浅色预览卡片
- 同步从英文 README 移除对应卡片
- 保留图片资产，宣传页仍可继续使用

## 测试情况
- git diff --check 通过
- 确认中英文 README 不再引用该卡片
- 确认其余截图资源均存在

## 审查检查项
- [x] 变更范围仅限 README
- [x] 中英文内容保持一致
- [x] 自测通过