### PR TITLE
feat(activity): 支持任务时间排序与置顶

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -327,6 +327,26 @@ class ActivityService:
             "summary": summary,
         }
 
+    def set_pin(self, event_id: str, pinned: bool) -> dict[str, Any] | None:
+        """Persist a pin and return the exact ledger revision it belongs to."""
+        with self._lock:
+            item = next(
+                (row for row in self._events if row.get("id") == event_id),
+                None,
+            )
+            if item is None:
+                return None
+            target = bool(pinned)
+            if bool(item.get("pinned")) != target:
+                item["pinned"] = target
+                self._save()
+                self._publish_locked(item=item)
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "item": dict(item),
+            }
+
     def ack(self, event_id: str | None = None, *, sid: str | None = None) -> int:
         changed = 0
         acked_ids: list[str] = []

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 from .activity import activity
@@ -13,6 +14,10 @@ from .capability_tickets import tickets
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
 _EVENT_TICKET_TTL_S = 45
+
+
+class ActivityPatchRequest(BaseModel):
+    pinned: bool
 
 
 def _json(request: Request, response: Response, payload: dict):
@@ -96,6 +101,14 @@ async def activity_events() -> EventSourceResponse:
 @router.post("/ack-all", dependencies=[Depends(require_token)])
 def ack_all():
     return {"ok": True, "changed": activity.ack(), "summary": activity.summary()}
+
+
+@router.patch("/{event_id}", dependencies=[Depends(require_token)])
+def patch_activity(event_id: str, req: ActivityPatchRequest):
+    update = activity.set_pin(event_id, req.pinned)
+    if update is None:
+        raise HTTPException(status_code=404, detail="activity not found")
+    return {"ok": True, **update}
 
 
 @router.post("/{event_id}/ack", dependencies=[Depends(require_token)])

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -520,9 +520,9 @@ function portal() {
     },
     activity: {
       show: false, loading: false, events: [],
-      // Status groups remain the default operational view. The alternate
-      // timeline shows every state by its latest transition time.
-      view: "status",
+      // The global center opens on the cross-status timeline by default.
+      // An explicit user choice is still restored from localStorage.
+      view: "timeline",
       viewLoaded: false,
       summary: {
         running: 0, unread: 0, attention: 0,
@@ -545,6 +545,7 @@ function portal() {
     _activityLiveSeq: 0,
     _activityLiveTimer: null,
     _activityLiveVisibilityBound: false,
+    _activityPinPending: {},
     // Per-task "run-now" inflight flag — disables retry / send buttons until
     // activity SSE reports a terminal state. Keyed by task id.
     schedRunning: {},
@@ -25035,6 +25036,8 @@ function portal() {
         .filter(item => this.activityMatchesGroup(item, group.key))
         .sort((a, b) => {
           if (group.key === "timeline") {
+            const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
+            if (pinRank) return pinRank;
             return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
           }
           if (group.key === "running") {
@@ -25070,8 +25073,8 @@ function portal() {
         return [{
           key: "timeline",
           label: this.lang === "zh"
-            ? "全部会话（按时间倒序）"
-            : "All sessions (newest first)",
+            ? "全部任务（置顶优先 · 时间倒序）"
+            : "All tasks (pinned, then newest)",
         }];
       }
       const groups = this.activityGroups();
@@ -25114,6 +25117,46 @@ function portal() {
       const ts = this.activityEventTimestamp(item) * 1000;
       return ts ? new Date(ts).toLocaleString(this.lang === "zh" ? "zh-CN" : "en-US",
         { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "";
+    },
+    async toggleActivityPin(item) {
+      if (!item?.id || this.activity.view !== "timeline") return false;
+      const eventId = String(item.id);
+      if (this._activityPinPending[eventId]) return false;
+      const previous = !!item.pinned;
+      const target = !previous;
+      this._activityPinPending = {
+        ...this._activityPinPending,
+        [eventId]: true,
+      };
+
+      // Reorder immediately, and retire any snapshot that started before this
+      // mutation so it cannot briefly restore the old pin state.
+      const current = this.activity.events.find(row => row.id === eventId);
+      if (current) current.pinned = target;
+      this.activity.events = [...this.activity.events];
+      this._activityAppliedSeq = ++this._activityRequestSeq;
+      try {
+        const { ok, data, error } = await this.api(
+          `/api/activity/${encodeURIComponent(eventId)}`,
+          { method: "PATCH", json: { pinned: target } },
+        );
+        if (!ok || !data?.item) throw new Error(error || "activity pin failed");
+        // The PATCH response has the same envelope as an SSE update, so this
+        // also works when the live channel is unavailable. A duplicate SSE
+        // revision is ignored by _applyActivityUpdate.
+        this._applyActivityUpdate(data);
+        return true;
+      } catch (_) {
+        const latest = this.activity.events.find(row => row.id === eventId);
+        if (latest && !!latest.pinned === target) latest.pinned = previous;
+        this.activity.events = [...this.activity.events];
+        this.toast(this.lang === "zh" ? "置顶操作失败" : "Could not update pin", "error");
+        return false;
+      } finally {
+        const pending = { ...this._activityPinPending };
+        delete pending[eventId];
+        this._activityPinPending = pending;
+      }
     },
     _stopActivityEvents() {
       ++this._activityLiveSeq;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5517,17 +5517,35 @@
           <section class="activity-group" x-show="activityEvents(group).length">
             <h3 x-text="group.label"></h3>
             <template x-for="item in activityEvents(group)" :key="item.id">
-              <button class="activity-row" @click="openActivityEvent(item)"
-                      :class="item.state
-                        + (activityIsUnreadResult(item) ? ' is-unread' : '')
-                        + (activityRequiresAction(item) ? ' requires-action' : '')">
-                <span class="activity-state-dot"></span>
-                <span class="activity-row-main">
-                  <strong x-text="item.task_summary || item.session_name"></strong>
-                  <small><span x-text="item.workspace_name"></span><span x-show="item.session_name"> · <span x-text="item.session_name"></span></span><span x-show="item.status_detail"> · <span x-text="item.status_detail"></span></span></small>
-                </span>
-                <span class="activity-row-side"><span x-text="activityStateLabel(item.state)"></span><small x-text="activityTime(item)"></small></span>
-              </button>
+              <div class="activity-row-wrap"
+                   :class="{ pinned: activity.view === 'timeline' && item.pinned }">
+                <button class="activity-row" type="button"
+                        @click="openActivityEvent(item)"
+                        :class="item.state
+                          + (activityIsUnreadResult(item) ? ' is-unread' : '')
+                          + (activityRequiresAction(item) ? ' requires-action' : '')">
+                  <span class="activity-state-dot"></span>
+                  <span class="activity-row-main">
+                    <strong x-text="item.task_summary || item.session_name"></strong>
+                    <small><span x-text="item.workspace_name"></span><span x-show="item.session_name"> · <span x-text="item.session_name"></span></span><span x-show="item.status_detail"> · <span x-text="item.status_detail"></span></span></small>
+                  </span>
+                  <span class="activity-row-side"><span x-text="activityStateLabel(item.state)"></span><small x-text="activityTime(item)"></small></span>
+                </button>
+                <button class="activity-pin" type="button"
+                        x-show="activity.view === 'timeline'"
+                        :class="{ active: item.pinned, pending: _activityPinPending[item.id] }"
+                        :disabled="!!_activityPinPending[item.id]"
+                        :aria-pressed="!!item.pinned"
+                        :aria-label="item.pinned ? (lang==='zh' ? '取消置顶' : 'Unpin') : (lang==='zh' ? '置顶任务' : 'Pin task')"
+                        :title="item.pinned ? (lang==='zh' ? '取消置顶' : 'Unpin') : (lang==='zh' ? '置顶任务' : 'Pin task')"
+                        @click.stop="toggleActivityPin(item)">
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="12" y1="17" x2="12" y2="22"/>
+                    <path d="M5 17h14l-1.5-5H6.5L5 17z"/>
+                    <path d="M9 12V5h6v7"/>
+                  </svg>
+                </button>
+              </div>
             </template>
             <button class="activity-group-more" type="button"
                     x-show="activityHiddenCount(group) > 0"

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3235,9 +3235,17 @@ pre.text {
 .activity-group h3 { margin:10px 4px 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
 .activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
 .activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
+.activity-row-wrap { display:flex; align-items:center; border-radius:var(--r-sm); }
+.activity-row-wrap.pinned { background:color-mix(in srgb, var(--c-accent) 7%, transparent); }
 .activity-row { width:100%; display:flex; align-items:center; gap:10px; padding:10px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); text-align:left; cursor:pointer; }
+.activity-row-wrap .activity-row { width:auto; min-width:0; flex:1; }
 .activity-row:hover { background:var(--c-bg-2); }
 .activity-row.is-unread { background:var(--c-accent-soft); box-shadow:inset 3px 0 0 var(--c-accent); }
+.activity-pin { width:30px; height:30px; flex:0 0 30px; margin-right:6px; padding:0; display:flex; align-items:center; justify-content:center; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-4); opacity:0.5; cursor:pointer; transition:opacity var(--t-fast), color var(--t-fast), background var(--t-fast); }
+.activity-row-wrap:hover .activity-pin,.activity-pin:focus-visible { opacity:1; }
+.activity-pin:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.activity-pin.active { color:var(--c-accent); opacity:1; }
+.activity-pin:disabled { opacity:0.35; cursor:wait; }
 .activity-state-dot { width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--c-fg-3); visibility:hidden; }
 .activity-row.running .activity-state-dot { visibility:visible; background:var(--c-running); animation:muse-breath 1.8s ease-in-out infinite; }
 .activity-row.waiting_approval .activity-state-dot,.activity-row.paused .activity-state-dot { visibility:visible; background:var(--c-warn); }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -30,6 +30,7 @@ def _login(page: Page, base: str, token: str) -> None:
 
 
 def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_token):
+    page.add_init_script("localStorage.removeItem('muselab_activity_view')")
     _login(page, backend_url, auth_token)
     page.wait_for_function(
         """() => {
@@ -42,6 +43,55 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
 
     page.locator(".activity-center-btn").click()
     expect(page.locator(".activity-modal")).to_be_visible()
+    expect(page.locator(".activity-view-switch button").nth(1)).to_have_class(
+        "active"
+    )
+
+    pin_requests: list[dict] = []
+
+    def patch_pin(route):
+        request = route.request.post_data_json
+        pin_requests.append(request)
+        pinned = bool(request["pinned"])
+        revision = 3 + len(pin_requests)
+        summary = {
+            "generation": "e2e-generation",
+            "revision": revision,
+            "running": 1,
+            "unread": 0,
+            "attention": 0,
+            "groups": {"review": 0, "running": 1, "failed": 1, "history": 1},
+            "group_unread": {"review": 0, "running": 0, "failed": 0, "history": 0},
+            "workspaces": [],
+        }
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "ok": True,
+                "generation": "e2e-generation",
+                "revision": revision,
+                "item": {
+                    "kind": "turn",
+                    "workspace": "/tmp/e2e",
+                    "workspace_name": "e2e",
+                    "session_name": "Activity test",
+                    "status_detail": "",
+                    "read": True,
+                    "id": "older",
+                    "session_id": "older-session",
+                    "task_summary": "Older completed task",
+                    "state": "completed",
+                    "started_at": 10,
+                    "finished_at": 100,
+                    "updated_at": 100,
+                    "pinned": pinned,
+                },
+                "summary": summary,
+            }),
+        )
+
+    page.route("**/api/activity/older", patch_pin)
 
     page.evaluate(
         """() => {
@@ -54,6 +104,8 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
             status_detail: '',
             read: true,
           };
+          app.activity.events = [];
+          app.activity.expanded = {};
           app._applyActivityUpdate({
             generation: 'e2e-generation',
             revision: 1,
@@ -138,13 +190,9 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
               updated_at: 90 - index,
             });
           }
-          app.setActivityView('timeline');
         }"""
     )
 
-    expect(page.locator(".activity-view-switch button").nth(1)).to_have_class(
-        "active"
-    )
     labels = page.locator(".activity-group .activity-row strong")
     expect(labels).to_have_count(10)
     assert labels.all_text_contents()[:3] == [
@@ -152,6 +200,32 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
         "Newer failed task",
         "Older completed task",
     ]
+
+    older = page.locator(".activity-row-wrap").filter(
+        has_text="Older completed task"
+    )
+    pin = older.locator(".activity-pin")
+    expect(pin).to_have_attribute("aria-pressed", "false")
+    pin.click()
+    expect(pin).to_be_enabled()
+    expect(pin).to_have_attribute("aria-pressed", "true")
+    assert labels.all_text_contents()[:3] == [
+        "Older completed task",
+        "Newest running task",
+        "Newer failed task",
+    ]
+    expect(page.locator(".activity-modal")).to_be_visible()
+
+    pin.click()
+    expect(pin).to_be_enabled()
+    expect(pin).to_have_attribute("aria-pressed", "false")
+    assert labels.all_text_contents()[:3] == [
+        "Newest running task",
+        "Newer failed task",
+        "Older completed task",
+    ]
+    assert pin_requests == [{"pinned": True}, {"pinned": False}]
+
     more = page.locator(".activity-group-more")
     expect(more).to_have_text("2 more")
     more.click()

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -138,6 +138,38 @@ def test_list_sorts_by_latest_transition_not_storage_position(tmp_path, monkeypa
     assert rows[0]["updated_at"] == 6
 
 
+def test_pin_persists_without_rewriting_activity_time(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    ticks = iter([1, 2, 3, 4, 5])
+    monkeypatch.setattr("backend.activity.time.time", lambda: next(ticks))
+    old = service.start("s1", summary="older task")
+    service.finish("s1", "completed")
+    service.start("s2", summary="newer task")
+    service.finish("s2", "completed")
+
+    revision = service.revision
+    update = service.set_pin(old["id"], True)
+    assert update is not None
+    pinned = update["item"]
+    assert pinned["pinned"] is True
+    assert pinned["updated_at"] == 2
+    assert update["revision"] == service.revision == revision + 1
+    assert update["generation"] == service.generation
+    # The backend remains a chronological ledger. Pin priority belongs only
+    # to the task center's timeline presentation.
+    assert [row["session_id"] for row in service.list()] == ["s2", "s1"]
+
+    restarted = ActivityService(tmp_path)
+    restored = next(row for row in restarted.list() if row["session_id"] == "s1")
+    assert restored["pinned"] is True
+    resumed = restarted.start("s1", summary="same task, next turn")
+    assert resumed["pinned"] is True
+    unpinned = restarted.set_pin(old["id"], False)
+    assert unpinned is not None
+    assert unpinned["item"]["pinned"] is False
+    assert restarted.set_pin("missing", True) is None
+
+
 def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
     service = _service(tmp_path, monkeypatch)
     service.start("s1", summary="long task")
@@ -190,3 +222,42 @@ def test_activity_event_ticket_requires_authentication(client, auth):
     response = client.post("/api/activity/events-ticket", headers=auth)
     assert response.status_code == 200
     assert response.json()["ticket"].startswith("activity.")
+
+
+def test_activity_pin_endpoint_is_authenticated_and_returns_live_envelope(
+    client,
+    auth,
+    tmp_path,
+    monkeypatch,
+):
+    from backend import activity_api
+
+    service = _service(tmp_path, monkeypatch)
+    started = service.start("s1", summary="pin from task center")
+    service.finish("s1", "completed")
+    monkeypatch.setattr(activity_api, "activity", service)
+
+    denied = client.patch(
+        f"/api/activity/{started['id']}",
+        json={"pinned": True},
+    )
+    assert denied.status_code == 401
+
+    missing = client.patch(
+        "/api/activity/missing",
+        headers=auth,
+        json={"pinned": True},
+    )
+    assert missing.status_code == 404
+
+    response = client.patch(
+        f"/api/activity/{started['id']}",
+        headers=auth,
+        json={"pinned": True},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["item"]["pinned"] is True
+    assert payload["revision"] == service.revision
+    assert payload["generation"] == service.generation

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -979,6 +979,9 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
 
+    activity_state = app[app.index("activity: {"):app.index("_activityEtags:")]
+    assert 'view: "timeline"' in activity_state
+
     review = app.index('{ key: "review"')
     running = app.index('{ key: "running"', review)
     failed = app.index('{ key: "failed"', running)
@@ -1008,6 +1011,12 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'this.activity.view === "timeline"' in app
     assert 'key === "timeline") return true' in app
     assert "setActivityView('timeline')" in html
+    assert "const pinRank = Number(!!b.pinned) - Number(!!a.pinned)" in app
+    assert "async toggleActivityPin(item)" in app
+    assert 'method: "PATCH", json: { pinned: target }' in app
+    assert '@click.stop="toggleActivityPin(item)"' in html
+    assert 'x-show="activity.view === \'timeline\'"' in html
+    assert ".activity-pin.active" in css
 
     # The left marker is unread/action state, not a permanent failure marker.
     assert "activityIsUnreadResult(item) ? ' is-unread'" in html


### PR DESCRIPTION
## What this changes

全局任务中心在没有已保存偏好时默认使用时间倒序视图；时间视图新增任务置顶／取消置顶，并通过持久化活动账本与 SSE 在刷新、重启和多标签页间保持一致。置顶仅影响时间视图，不改变任务真实更新时间或按状态视图。

## Why

最近任务是任务中心最常用的入口，同时用户需要把少数持续关注的任务固定在时间线顶部，而不干扰现有会话列表的置顶语义。

## Testing

- [x] `uv run pytest tests/` passes（CI 三个 Python／平台矩阵全部通过）
- [x] Backend/frontend targeted tests：104 passed
- [x] Activity Center Playwright E2E：3 passed
- [x] Ruff、`node --check frontend/app.js`、`git diff --check` 通过
- [x] 隔离浏览器验证默认时间视图、置顶／取消置顶排序及点击隔离

## Checklist

- [x] No secrets committed
- [x] Docs updated if behavior visible to users（视图标签与按钮文案已同步更新；README 无对应说明）
- [x] If adds runtime dep: install scripts updated（无新增依赖）