### PR TITLE
fix(chat): 恢复发送草稿并改进文件路径处理

### DIFF
--- a/backend/files.py
+++ b/backend/files.py
@@ -1719,13 +1719,16 @@ def search(
     q: str,
     limit: int = 100,
     show_hidden: bool = False,
+    exact: bool = False,
     root: Path = Depends(_workspace_root),
 ) -> dict:
-    """Filename / dirname substring search. Same `_cached_walk` win as
-    grep — bigger here in relative terms because search only reads
-    names (no file content), so the directory-listing IS the entire
-    cost. Repeat searches over a quiet archive drop from ~200 ms to
-    ~20 ms on a 3000-file tree."""
+    """Filename / dirname search, optionally matching the whole name.
+
+    Uses the same `_cached_walk` win as grep — bigger here in relative
+    terms because search only reads names (no file content), so the
+    directory-listing IS the entire cost. Repeat searches over a quiet
+    archive drop from ~200 ms to ~20 ms on a 3000-file tree.
+    """
     q_lower = q.strip().lower()
     if not q_lower:
         return {"entries": []}
@@ -1733,7 +1736,11 @@ def search(
     for dirpath, dirnames, filenames in _cached_walk(
             root, SEARCH_IGNORE, show_hidden):
         for name in dirnames + filenames:
-            if q_lower in name.lower():
+            name_lower = name.lower()
+            matches_query = (
+                name_lower == q_lower if exact else q_lower in name_lower
+            )
+            if matches_query:
                 full = Path(dirpath) / name
                 try:
                     stat = full.stat()

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1316,6 +1316,13 @@ function portal() {
         }
         localStorage.removeItem(oldK);
       }
+      // `pagehide` is bfcache-friendly (unlike an unconditional
+      // beforeunload handler) and still fires for browser refresh/PWA close.
+      // Flush the current composer synchronously so even a refresh immediately
+      // after the last keystroke keeps the draft.
+      window.addEventListener("pagehide", () => {
+        this._captureComposerState(this.currentId);
+      });
       this.initTheme();
       this.initLang();
       this.initMascot();
@@ -4402,20 +4409,28 @@ function portal() {
       this.openByPathToasted(p);
     },
 
-    // Fallback resolver for chat-link clicks whose path doesn't resolve
-    // workspace-relative. Searches the workspace by basename and returns every
-    // ROOT-relative path whose full path ends with the clicked path (same
-    // file, just a missing prefix). Caller decides: 0 → not-found toast,
+    // Fallback resolver for chat-link clicks whose path doesn't resolve from
+    // the workspace root. Prefer candidates whose full path ends with the
+    // clicked path (only a prefix is missing). If none do, fall back to every
+    // exact-basename match: models often preserve the filename but hallucinate
+    // or omit its parent directory. Caller decides: 0 → not-found toast,
     // 1 → open, >1 → disambiguation picker. Returns [{path,name}, ...].
-    async _findBySuffix(path, name, requestHeaders = this.fileHdr()) {
+    async _findChatFileCandidates(path, name, requestHeaders = this.fileHdr()) {
       try {
-        const r = await fetch("/api/files/search?q=" + encodeURIComponent(name) + "&limit=50",
+        const r = await fetch("/api/files/search?q=" + encodeURIComponent(name)
+          + "&exact=true&limit=200",
           { headers: requestHeaders });
         if (!r.ok) return [];
         const d = await r.json();
-        const suffix = "/" + path.replace(/^\/+/, "");
-        return (d.entries || []).filter(e =>
-          !e.is_dir && e.name === name && ("/" + e.path).endsWith(suffix));
+        const requested = String(path || "").replace(/\\/g, "/")
+          .replace(/^\.\//, "").replace(/^\/+/, "");
+        const suffix = "/" + requested;
+        const wantedName = String(name || "").toLowerCase();
+        const exactNameMatches = (d.entries || []).filter(e =>
+          !e.is_dir && String(e.name || "").toLowerCase() === wantedName);
+        const suffixMatches = exactNameMatches.filter(e =>
+          ("/" + String(e.path || "").replace(/\\/g, "/")).endsWith(suffix));
+        return suffixMatches.length ? suffixMatches : exactNameMatches;
       } catch (_) { return []; }
     },
 
@@ -4464,11 +4479,11 @@ function portal() {
         // Direct ROOT-relative lookup missed. The model commonly emits a path
         // relative to a subdirectory of the workspace root (e.g. "learning/x.html"
         // when the file actually lives at "claude_space/learning/x.html").
-        // Search the workspace by basename and accept a UNIQUE hit whose full
-        // path ends with the clicked path — same file, just a missing prefix.
-        // Generic (no hardcoded dir) and safe (suffix + exact-name + sole-match).
+        // Search by exact basename. Full-path suffix matches win; when the
+        // model got the directory wrong, a unique basename is still safe to
+        // open. Multiple candidates always go through explicit disambiguation.
         if (!hit) {
-          const matches = await this._findBySuffix(path, name, requestHeaders);
+          const matches = await this._findChatFileCandidates(path, name, requestHeaders);
           if (!this._workspaceIsCurrent(ownerWorkspace)) return;
           let resolved = "";
           if (matches.length === 1) {
@@ -4755,6 +4770,125 @@ function portal() {
       }
     },
 
+    // Chat drafts are browser-local and session-scoped. Keep the text in a
+    // small standalone store instead of muselab_prefs so a hard refresh can
+    // recover what the user was typing without serialising File objects or
+    // short-lived upload handles. `pending` is a tiny outbox: while the
+    // stream ticket/SSE handshake is still in flight the composer is visually
+    // cleared, but the submitted text remains recoverable until onopen proves
+    // that the backend accepted the turn.
+    _chatDraftStoreKey: "muselab_chat_drafts_v1",
+    _chatDraftStore() {
+      const stored = this._getLSJson(this._chatDraftStoreKey, null);
+      if (!stored || stored.schema !== 1 || !stored.drafts
+          || typeof stored.drafts !== "object" || Array.isArray(stored.drafts)) {
+        return { schema: 1, drafts: {} };
+      }
+      return stored;
+    },
+    _chatDraftRecord(id) {
+      if (!id) return { text: "", pending: "", updatedAt: 0 };
+      const raw = this._chatDraftStore().drafts[id];
+      if (!raw || typeof raw !== "object") {
+        return { text: "", pending: "", updatedAt: 0 };
+      }
+      return {
+        text: typeof raw.text === "string" ? raw.text : "",
+        pending: typeof raw.pending === "string" ? raw.pending : "",
+        updatedAt: Number(raw.updatedAt) || 0,
+      };
+    },
+    _writeChatDraftRecord(id, record) {
+      if (!id) return false;
+      const store = this._chatDraftStore();
+      const drafts = { ...store.drafts };
+      const text = typeof record.text === "string" ? record.text : "";
+      const pending = typeof record.pending === "string" ? record.pending : "";
+      if (text || pending) {
+        drafts[id] = { text, pending, updatedAt: Date.now() };
+      } else {
+        delete drafts[id];
+      }
+      // A closed tab keeps its draft, but bound abandoned entries so stale
+      // session ids can never consume localStorage indefinitely.
+      const ids = Object.keys(drafts);
+      if (ids.length > 100) {
+        ids.sort((a, b) => (Number(drafts[b]?.updatedAt) || 0)
+          - (Number(drafts[a]?.updatedAt) || 0));
+        for (const staleId of ids.slice(100)) delete drafts[staleId];
+      }
+      return this._setLS(this._chatDraftStoreKey, JSON.stringify({
+        schema: 1, drafts,
+      }));
+    },
+    _mergeChatDraftText(first, second) {
+      first = typeof first === "string" ? first : "";
+      second = typeof second === "string" ? second : "";
+      if (!first || first === second) return second || first;
+      if (!second) return first;
+      return first + "\n\n" + second;
+    },
+    _cancelChatDraftTimer(id) {
+      if (!id || !this._chatDraftTimers || !this._chatDraftTimers[id]) return;
+      clearTimeout(this._chatDraftTimers[id]);
+      delete this._chatDraftTimers[id];
+    },
+    _persistChatDraft(id, text) {
+      if (!id) return false;
+      this._cancelChatDraftTimer(id);
+      const record = this._chatDraftRecord(id);
+      record.text = typeof text === "string" ? text : "";
+      return this._writeChatDraftRecord(id, record);
+    },
+    _schedulePersistChatDraft(id, text) {
+      if (!id) return;
+      if (!this._chatDraftTimers) this._chatDraftTimers = {};
+      clearTimeout(this._chatDraftTimers[id]);
+      const snapshot = typeof text === "string" ? text : "";
+      this._chatDraftTimers[id] = setTimeout(() => {
+        delete this._chatDraftTimers[id];
+        this._persistChatDraft(id, snapshot);
+      }, 120);
+    },
+    _stageChatRecoveryDraft(id, text) {
+      if (!id || typeof text !== "string" || !text) return;
+      this._cancelChatDraftTimer(id);
+      const record = this._chatDraftRecord(id);
+      record.pending = this._mergeChatDraftText(record.pending, text);
+      if (record.text === text) record.text = "";
+      this._writeChatDraftRecord(id, record);
+    },
+    _commitChatRecoveryDraft(id, text) {
+      if (!id || typeof text !== "string" || !text) return;
+      const record = this._chatDraftRecord(id);
+      if (record.pending === text) {
+        record.pending = "";
+        this._writeChatDraftRecord(id, record);
+      }
+    },
+    _consumePersistedChatDraft(id) {
+      const record = this._chatDraftRecord(id);
+      const recovered = this._mergeChatDraftText(record.pending, record.text);
+      if (record.pending) {
+        record.text = recovered;
+        record.pending = "";
+        this._writeChatDraftRecord(id, record);
+      }
+      return recovered;
+    },
+    _resolveChatRecoveryDraft(id, text) {
+      if (!id) return;
+      this._cancelChatDraftTimer(id);
+      this._writeChatDraftRecord(id, {
+        text: typeof text === "string" ? text : "", pending: "",
+      });
+    },
+    _deletePersistedChatDraft(id) {
+      if (!id) return;
+      this._cancelChatDraftTimer(id);
+      this._writeChatDraftRecord(id, { text: "", pending: "" });
+    },
+
     // Convenience: bilingual error toast for common "<verb> failed: <body>"
     // patterns. Call sites used to inline `this.toast("保存失败：" + …, "error")`
     // which gave English users a Chinese-only message. Pass the verb key
@@ -4878,6 +5012,7 @@ function portal() {
       // Best-effort: persist current state first in case savePrefs hasn't
       // run recently (e.g. user has been streaming for a while and prefs
       // didn't change). Cheap, idempotent.
+      try { this._captureComposerState(this.currentId); } catch (_) {}
       try { this.savePrefs(); } catch (_) {}
       this.toast(this.lang === "zh" ? "正在刷新…" : "Reloading…", "info", 1500);
       // Slight delay lets the toast render before the page tears down.
@@ -6180,10 +6315,14 @@ function portal() {
         // Newer half of the bounded bidirectional window. Chronological order is
         // always: _earlierMessages + messages + _laterMessages.
         _laterMessages: [],
-        // Composer state is intentionally memory-only. Closing/deleting the tab
-        // drops this object; savePrefs never serializes it, so refresh does too.
+        // Attachments/controllers stay memory-only; text is restored from the
+        // browser-local per-session draft store by _ensureTabState().
         draft: {
           input: "",
+          // False until _activateComposerState mirrors this slot into the
+          // root textarea. Prevents a second refresh during cold boot from
+          // copying the still-empty root input over a recovered draft.
+          _activated: false,
           pendingImages: [],
           pendingDocs: [],
           _historyIndex: -1,
@@ -6344,6 +6483,7 @@ function portal() {
       if (!this.tabState[id]) {
         this.tabState[id] = this._blankTabState();
         this.tabState[id]._sid = id;
+        this.tabState[id].draft.input = this._consumePersistedChatDraft(id);
         // The queue now lives server-side (sessions/{sid}.queue.json). We do
         // NOT pull it here — _ensureTabState is called synchronously all over
         // the place and shouldn't fire a fetch each time. The queue mirror is
@@ -7117,18 +7257,21 @@ function portal() {
       }
     },
 
-    _captureComposerState(id = this.currentId) {
+    _captureComposerState(id = this.currentId, { persist = true } = {}) {
       if (!id || id !== this.currentId) return;
       const st = this.tabState && this.tabState[id];
       if (!st || !st.draft) return;
+      if (st.draft._activated === false) return;
       st.draft.input = this.input || "";
       st.draft.pendingImages = this.pendingImages || [];
       st.draft.pendingDocs = this.pendingDocs || [];
       st.draft._sendWaitingForUpload = !!this._sendWaitingForUpload;
+      if (persist) this._persistChatDraft(id, st.draft.input);
     },
     _activateComposerState(id) {
       const st = this._ensureTabState(id);
       const draft = st.draft;
+      draft._activated = true;
       this.input = draft.input || "";
       this.pendingImages = draft.pendingImages;
       this.pendingDocs = draft.pendingDocs;
@@ -7314,6 +7457,15 @@ function portal() {
         this.connState = "reconnecting";
         return false;
       }
+      // An empty session can be recycled server-side while the browser is
+      // refreshing (especially after a send failed before its turn existed).
+      // Preserve the old landing tab's local text before choosing/creating a
+      // replacement id, then move it to that replacement below.
+      const previousId = this.currentId;
+      const previousState = previousId && this.tabState[previousId];
+      const previousDraft = previousState && previousState.draft
+        ? (previousState.draft.input || "")
+        : (previousId ? this._consumePersistedChatDraft(previousId) : "");
       const inWorkspace = this.workspaceSessions();
       const remembered = this.workspaceLastSession[this.currentWorkspacePath()];
       if (!inWorkspace.length) {
@@ -7339,6 +7491,14 @@ function portal() {
           ...this.workspaceLastSession,
           [this.currentWorkspacePath()]: this.currentId,
         };
+      }
+      if (previousId && previousId !== this.currentId && previousDraft) {
+        const landingState = this._ensureTabState(this.currentId);
+        landingState.draft.input = this._mergeChatDraftText(
+          previousDraft, landingState.draft.input || "",
+        );
+        this._persistChatDraft(this.currentId, landingState.draft.input);
+        this._deletePersistedChatDraft(previousId);
       }
       // [resident-panes] Seed the LRU with the landing tab only. Other restored
       // tabs lazy-mount on first switch (rebuild path), so a multi-tab restore
@@ -11172,6 +11332,7 @@ function portal() {
       const deletedIds = new Set((resp && resp.ids) || []);
       for (const sid of deletedIds) {
         this._disposeTabRuntime(sid);
+        this._deletePersistedChatDraft(sid);
       }
       this.openTabIds = (this.openTabIds || []).filter(id => !deletedIds.has(id));
       await this.refreshSessions();
@@ -14147,6 +14308,7 @@ function portal() {
         return false;
       }
       this._disposeTabRuntime(sid);
+      this._deletePersistedChatDraft(sid);
       await this.refreshSessions();
       this.openTabIds = (this.openTabIds || []).filter(id => id !== sid);
       if (this.currentId === sid) {
@@ -15890,7 +16052,15 @@ function portal() {
             stale.staleWorkspace = true;
             throw stale;
           }
-          throw new Error(detail || `HTTP ${r.status}`);
+          let parsedDetail = detail;
+          try {
+            const parsed = JSON.parse(detail);
+            parsedDetail = parsed && (parsed.detail || parsed.error) || detail;
+          } catch (_) {}
+          const error = new Error(parsedDetail || `HTTP ${r.status}`);
+          error.status = r.status;
+          error.detail = parsedDetail;
+          throw error;
         }
         const d = await r.json();
         if (!isOwner()) {
@@ -16126,6 +16296,19 @@ function portal() {
         this.savePrefs();
       }
     },
+    _fileTreeOpenError(path, error) {
+      const detail = String((error && (error.detail || error.message)) || "").trim();
+      const displayPath = "/" + String(path || "").replace(/^\/+/, "");
+      if (detail === "path escapes root") {
+        return this.lang === "zh"
+          ? `无法打开 ${displayPath}：该目录的实际位置不在当前工作区或已添加的工作区中。若这是软链接，请先把目标目录添加为工作区。`
+          : `Could not open ${displayPath}: its resolved location is outside the current or registered workspaces. If this is a symlink, add its target directory as a workspace first.`;
+      }
+      if (this.lang === "zh") {
+        return `无法打开 ${displayPath}${detail ? "：" + detail : ""}`;
+      }
+      return `Could not open ${displayPath}${detail ? ": " + detail : ""}`;
+    },
     async expand(n, opts = {}) {
       // Idempotency guard (both sides of the await): two concurrent reveals
       // — e.g. a fire-and-forget revealInTree racing an awaited one after a
@@ -16149,8 +16332,7 @@ function portal() {
       } catch (e) {
         if (!opts.quiet && !e.staleWorkspace
             && isCurrent()) {
-          this.toast(this.lang === "zh"
-            ? `无法展开 /${n.path}` : `Could not open /${n.path}`, "error", 3000);
+          this.toast(this._fileTreeOpenError(n.path, e), "error", 6000);
         }
         return false;
       }
@@ -21464,6 +21646,7 @@ function portal() {
           // Drop the old session's tab + cached state, then open a fresh one
           // in its slot. newSession() handles tabState + openTabIds + switch.
           this._disposeTabRuntime(oldId);
+          this._deletePersistedChatDraft(oldId);
           this.openTabIds = this.openTabIds.filter(x => x !== oldId);
           await this.newSession();
           this.toast(this.t("slash.cleared"), "success", 1500);
@@ -21988,6 +22171,8 @@ function portal() {
       // A real edit forks away from the recalled entry. Programmatic history
       // navigation updates x-model directly and does not emit an input event.
       this._resetChatInputHistory();
+      this._captureComposerState(this.currentId, { persist: false });
+      this._schedulePersistChatDraft(this.currentId, this.input || "");
       const ta = ev.target;
       const pos = ta.selectionStart;
       const text = this.input.slice(0, pos);
@@ -22449,8 +22634,11 @@ function portal() {
       const composerDocs = sendDraft.pendingDocs.slice();
       const ownsSendDraft = () => this.tabState[sendSid] === sendState
         && sendState.draft === sendDraft;
-      const clearSubmittedComposer = () => {
+      const clearSubmittedComposer = ({ preserveForHandshake = false } = {}) => {
         if (!ownsSendDraft()) return;
+        if (preserveForHandshake) {
+          this._stageChatRecoveryDraft(sendSid, composerText);
+        }
         if (sendDraft.input === composerText) sendDraft.input = "";
         this._resetChatInputHistory(sendDraft);
         const removeOwned = (items, sent) => {
@@ -22460,6 +22648,10 @@ function portal() {
         };
         removeOwned(sendDraft.pendingImages, new Set(composerImages));
         removeOwned(sendDraft.pendingDocs, new Set(composerDocs));
+        // Clearing the visible composer must not clear the durable backup
+        // until the SSE handshake succeeds. A newer draft typed during an
+        // await is persisted alongside that pending outgoing text.
+        this._persistChatDraft(sendSid, sendDraft.input);
         if (sendSid === this.currentId) {
           this._activateComposerState(sendSid);
           this.$nextTick(() => {
@@ -22548,6 +22740,7 @@ function portal() {
             sendDraft.input = "";
             this._resetChatInputHistory(sendDraft);
             if (this.currentId === sendSid) this.input = "";
+            this._persistChatDraft(sendSid, "");
           }
           this.$nextTick(() => { if (this.currentId === sendSid && this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
           await this._runSlash(m[1], m[2] || "");
@@ -22716,7 +22909,7 @@ function portal() {
       if (!isReconnect && !resumed) {
         // Remove only the captured payload; a newer draft typed during an await
         // stays in the still-global Phase 1 composer.
-        clearSubmittedComposer();
+        clearSubmittedComposer({ preserveForHandshake: true });
         this.$nextTick(() => {
           if (this.currentId !== sendSid) return;
           const ta = this.$refs.chatInput;
@@ -22871,18 +23064,73 @@ function portal() {
         });
         return tr;
       };
-      // Stop pressed while the ticket POST was still in flight: no backend turn
-      // was ever created, so the optimistic user bubble is a lie — it would sit
-      // in the transcript forever, unanswered and unrecoverable (a reload drops
-      // it because the server never persisted it). Roll the send back to the
-      // composer so the text stays editable and re-sendable.
-      const discardCancelledSend = () => {
+      // Restore a failed outgoing text without overwriting anything typed
+      // while the request was in flight. Attachments can be restored only
+      // before the ticket is consumed; their browser File/upload handles are
+      // deliberately not serialised across a page reload.
+      let submittedDraftRestored = false;
+      const restoreSubmittedComposer = (restoreAttachments = false) => {
+        if (isReconnect || resumed || submittedDraftRestored) return;
+        submittedDraftRestored = true;
+        if (ownsSendDraft()) {
+          sendDraft.input = this._mergeChatDraftText(
+            composerText, sendDraft.input || "",
+          );
+          if (restoreAttachments) {
+            const restoreOwned = (items, sent) => {
+              const missing = sent.filter(item => !items.includes(item));
+              if (missing.length) items.unshift(...missing);
+            };
+            restoreOwned(sendDraft.pendingImages, composerImages);
+            restoreOwned(sendDraft.pendingDocs, composerDocs);
+          }
+          this._resolveChatRecoveryDraft(sendSid, sendDraft.input);
+          if (sendSid === this.currentId) this._activateComposerState(sendSid);
+          return;
+        }
+        // The tab may have been closed during the failing request. Preserve
+        // the text in localStorage so reopening the session still recovers it.
+        const persisted = this._chatDraftRecord(sendSid);
+        this._resolveChatRecoveryDraft(sendSid, this._mergeChatDraftText(
+          composerText,
+          this._mergeChatDraftText(persisted.pending, persisted.text),
+        ));
+      };
+      // Stop/ticket failure before EventSource opens means no backend turn was
+      // created. Remove the optimistic bubble, restore the full local payload,
+      // and reset every stream flag/timer without relying on the later-scoped
+      // _markDone closure.
+      const rollbackUnstartedSend = () => {
         if (sentUserBubble) {
           this._removePaneMessage(streamState, sentUserBubble);
           sentUserBubble = null;
         }
-        if (ownsSendDraft() && !sendDraft.input) sendDraft.input = composerText;
-        if (sendSid === this.currentId) this._activateComposerState(sendSid);
+        restoreSubmittedComposer(true);
+        if (streamState._streamTimer) clearInterval(streamState._streamTimer);
+        if (streamState._stallWatch) clearInterval(streamState._stallWatch);
+        streamState._streamTimer = null;
+        streamState._stallWatch = null;
+        streamState._streamStartedAt = 0;
+        streamState.streamElapsed = 0;
+        streamState.streaming = false;
+        streamState._continuationAwaitingReaction = false;
+        streamState.es = null;
+        streamState._streamStartController = null;
+        streamState._cancelBeforeStream = false;
+        streamState._stopping = false;
+        streamState._serverActiveObserved = false;
+        streamState.activeTurnId = "";
+        streamState.parentTurnId = "";
+        streamState.lastEventSeq = 0;
+        streamState.streamingModel = "";
+        if (streamSid === this.currentId) {
+          this.streaming = false;
+          this.es = null;
+          this._streamTimer = null;
+          this._streamStartedAt = 0;
+          this.streamElapsed = 0;
+          this.streamingModel = "";
+        }
       };
       try {
         let tr = await _mintTicket();
@@ -22910,17 +23158,17 @@ function portal() {
         if (streamState._cancelBeforeStream) {
           // stop() already performed the authoritative local cleanup. The
           // ticket was never consumed, so no backend turn/transcript exists.
-          discardCancelledSend();
+          rollbackUnstartedSend();
           return false;
         }
         // Could not mint a ticket (server error / network) — fail the send
         // visibly rather than leaking prompt+token into the URL.
-        this._markDone(streamSid);
+        rollbackUnstartedSend();
         this.toast(this.lang === "zh"
           ? "发送失败：无法建立流式连接，请重试"
           : "Send failed: could not start the stream — please retry",
           "error", 4000);
-        return;
+        return false;
       } finally {
         if (streamState._streamStartController === streamStartController) {
           streamState._streamStartController = null;
@@ -22929,7 +23177,7 @@ function portal() {
       if (streamState._cancelBeforeStream) {
         // Ticket minted but Stop landed first — same rollback. The ticket is
         // never consumed and expires on its own.
-        discardCancelledSend();
+        rollbackUnstartedSend();
         return false;
       }
       const es = new EventSource(url);
@@ -22944,6 +23192,9 @@ function portal() {
       es.onopen = () => {
         streamState._reconnectAttempts = 0;
         streamState._lastSseActivity = Date.now();
+        if (!isReconnect && !resumed) {
+          this._commitChatRecoveryDraft(sendSid, composerText);
+        }
       };
 
       // ── Silent-stall watchdog ──────────────────────────────────────────
@@ -23897,6 +24148,7 @@ function portal() {
           if (!isContinuation) {
             markUserFailed(_detail, d.kind, d.cta, d.retryable);
           }
+          restoreSubmittedComposer(false);
           if (ownsCurBubble()) curBubble.error = _detail;
         }
         // Pass the backend's `cancelled` flag through to _markDone so it
@@ -24061,6 +24313,7 @@ function portal() {
           if (!isContinuation) {
             markUserFailed(serverError, errKind, errCta, errRetryable);
           }
+          restoreSubmittedComposer(false);
           es.close(); _markDone(false, false, true); _stopTimer();
           // Pause auto-drain — same context likely fails the next message
           // too (quota / auth / cross-vendor signature). The failed user

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -77,6 +77,115 @@ def test_directory_can_be_mentioned_from_search_and_tree_action(
     }
 
 
+def test_symlink_outside_workspace_error_is_actionable(
+        page: Page, backend_url, auth_token):
+    def reject_outside_link(route) -> None:
+        route.fulfill(
+            status=400,
+            content_type="application/json",
+            body='{"detail":"path escapes root"}',
+        )
+
+    page.route("**/api/files/list?path=outside-link*", reject_outside_link)
+    _login(page, backend_url, auth_token)
+    message = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.lang = 'zh';
+          app.childCache = {};
+          const node = {
+            path: 'outside-link', name: 'outside-link', is_dir: true, depth: 0,
+          };
+          app.visible = [node];
+          app.expanded = new Set();
+          app.toasts = [];
+          await app.expand(node);
+          return app.toasts.at(-1)?.msg || '';
+        }"""
+    )
+    assert "不在当前工作区或已添加的工作区中" in message
+    assert "先把目标目录添加为工作区" in message
+    assert "{\"detail\"" not in message
+
+
+def test_chat_file_path_falls_back_to_unique_name_and_disambiguates(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const filename = 'f4_seq_features_16d_spec.md';
+          const requested = `docs/${filename}`;
+          const write = async (path, content) => {
+            const response = await fetch('/api/files/write', {
+              method: 'PUT',
+              headers: {...app.fileHdr(), 'Content-Type': 'application/json'},
+              body: JSON.stringify({path, content}),
+            });
+            if (!response.ok) throw new Error(await response.text());
+          };
+
+          app.toasts = [];
+          const chooserCalls = [];
+          const realChooseOne = app.chooseOne;
+          app.chooseOne = async options => {
+            chooserCalls.push(options.choices.map(choice => choice.value).sort());
+            return options.choices.find(choice => choice.value.startsWith('src/'))?.value;
+          };
+          try {
+            // The model supplied docs/<name>, while the only file lives under
+            // a differently named directory. Unique basename is safe to open.
+            await write(`test/${filename}`, 'UNIQUE_BASENAME_TARGET');
+            await app.openByPathToasted(requested);
+            const unique = {selected: app.selected, rawText: app.rawText};
+
+            // Once another same-name file exists, never guess: expose both
+            // complete paths and respect the explicit choice.
+            await write(`src/${filename}`, 'DISAMBIGUATED_TARGET');
+            await app.openByPathToasted(requested);
+            const ambiguous = {selected: app.selected, rawText: app.rawText};
+
+            // A full suffix match is stronger than basename-only candidates
+            // and should open directly without another chooser.
+            await write(`sandbox/docs/${filename}`, 'SUFFIX_TARGET');
+            await app.openByPathToasted(requested);
+            const suffix = {selected: app.selected, rawText: app.rawText};
+            return {
+              unique,
+              ambiguous,
+              suffix,
+              chooserCalls,
+              notFound: app.toasts.some(toast =>
+                String(toast.msg || '').includes('文件不存在')
+                || String(toast.msg || '').includes('Not found')),
+            };
+          } finally {
+            app.chooseOne = realChooseOne;
+          }
+        }"""
+    )
+
+    assert result == {
+        "unique": {
+            "selected": "test/f4_seq_features_16d_spec.md",
+            "rawText": "UNIQUE_BASENAME_TARGET",
+        },
+        "ambiguous": {
+            "selected": "src/f4_seq_features_16d_spec.md",
+            "rawText": "DISAMBIGUATED_TARGET",
+        },
+        "suffix": {
+            "selected": "sandbox/docs/f4_seq_features_16d_spec.md",
+            "rawText": "SUFFIX_TARGET",
+        },
+        "chooserCalls": [[
+            "src/f4_seq_features_16d_spec.md",
+            "test/f4_seq_features_16d_spec.md",
+        ]],
+        "notFound": False,
+    }
+
+
 def test_external_file_changes_refresh_tree_without_manual_reload(
         page: Page, backend_url, auth_token):
     """Direct API mutations stand in for Agent/terminal writes and deletes."""

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -147,6 +147,127 @@ def test_composer_drafts_are_isolated_between_tabs(page: Page, backend_url, auth
     expect(textarea).to_have_value("draft-b")
 
 
+def test_pending_send_text_survives_hard_refresh(
+        page: Page, backend_url, auth_token):
+    """The composer is visually cleared before the ticket resolves. A refresh
+    in that exact no-response window must recover the submitted text."""
+    _login(page, backend_url, auth_token)
+    marker = "refresh-safe-pending-send"
+    textarea = page.locator(".chat-input-textarea")
+    textarea.fill(marker)
+    page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (url, init) => {
+            if (String(url).includes('/api/chat/stream/start')) {
+              return new Promise(() => {});
+            }
+            return originalFetch(url, init);
+          };
+          void app.send();
+        }"""
+    )
+    page.wait_for_function(
+        """([marker]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const store = JSON.parse(localStorage.getItem(
+            'muselab_chat_drafts_v1') || '{}');
+          return app.streaming && app.input === ''
+            && store.drafts?.[app.currentId]?.pending === marker;
+        }""",
+        arg=[marker],
+    )
+    page.reload(wait_until="domcontentloaded")
+    expect(page.locator(SEL_TABS)).to_be_visible(timeout=5000)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          return app && app.authed && app._sessionsInitialized && app.currentId;
+        }"""
+    )
+    restored = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            input: app.input,
+            currentId: app.currentId,
+            stateDraft: app.tabState[app.currentId]?.draft?.input,
+            store: JSON.parse(localStorage.getItem(
+              'muselab_chat_drafts_v1') || '{}'),
+          };
+        }"""
+    )
+    assert restored["input"] == marker, restored
+    expect(page.locator(".chat-input-textarea")).to_have_value(marker)
+
+
+def test_ticket_failure_restores_draft_and_idle_state(
+        page: Page, backend_url, auth_token):
+    attempts = 0
+
+    def reject_ticket(route) -> None:
+        nonlocal attempts
+        attempts += 1
+        route.fulfill(
+            status=503,
+            content_type="application/json",
+            body='{"detail":"ticket unavailable"}',
+        )
+
+    page.route("**/api/chat/stream/start", reject_ticket)
+    _login(page, backend_url, auth_token)
+    marker = "ticket-failure-recovered"
+    page.locator(".chat-input-textarea").fill(marker)
+    page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.pendingImages.push({
+            id: 'recover-image', mime: 'image/png', preview: 'data:image/png;base64,',
+            uploading: false, error: false,
+          });
+          app.pendingDocs.push({
+            id: 'recover-doc', name: 'recover.txt', kind: 'text',
+            uploading: false, error: false,
+          });
+        }"""
+    )
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const returned = await app.send();
+          const record = app._chatDraftRecord(app.currentId);
+          return {
+            returned,
+            input: app.input,
+            streaming: app.streaming,
+            pending: record.pending,
+            storedText: record.text,
+            imageIds: app.pendingImages.map(item => item.id),
+            docIds: app.pendingDocs.map(item => item.id),
+            bubbleCount: app.messages.filter(
+              m => m.role === 'user' && m.text === 'ticket-failure-recovered'
+            ).length,
+            hasToast: app.toasts.some(t => t.msg.includes('发送失败')
+              || t.msg.includes('Send failed')),
+          };
+        }"""
+    )
+    assert attempts == 2
+    assert result == {
+        "returned": False,
+        "input": marker,
+        "streaming": False,
+        "pending": "",
+        "storedText": marker,
+        "imageIds": ["recover-image"],
+        "docIds": ["recover-doc"],
+        "bubbleCount": 0,
+        "hasToast": True,
+    }
+    assert not page.locator("#jserr").is_visible()
+
+
 def test_upload_completion_stays_with_starting_tab(page: Page, backend_url, auth_token):
     _login(page, backend_url, auth_token)
     sid_a = page.evaluate(

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -313,6 +313,28 @@ def test_search_by_filename(client, auth):
     assert "README.md" in names
 
 
+def test_search_by_exact_filename_skips_substring_siblings(
+    client,
+    auth,
+    temp_root,
+):
+    nested = temp_root / "test"
+    nested.mkdir()
+    (nested / "f4_seq_features_16d_spec.md").write_text("target\n")
+    (nested / "f4_seq_features_16d_spec.md.bak").write_text("backup\n")
+
+    response = client.get(
+        "/api/files/search",
+        headers=auth,
+        params={"q": "F4_SEQ_FEATURES_16D_SPEC.MD", "exact": "true"},
+    )
+
+    assert response.status_code == 200
+    assert [entry["path"] for entry in response.json()["entries"]] == [
+        "test/f4_seq_features_16d_spec.md",
+    ]
+
+
 def test_grep_content(client, auth):
     r = client.get("/api/files/grep?q=first paragraph", headers=auth)
     hits = r.json()["hits"]

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -524,6 +524,8 @@ def test_workspace_file_requests_reject_late_previous_owner_results():
     assert "opts.ownerWorkspace || this.fileWorkspacePath()" in children
     assert "this._workspaceIsCurrent(ownerWorkspace)" in children
     assert "stale.staleWorkspace = true" in children
+    assert "parsed.detail || parsed.error" in children
+    assert "error.detail = parsedDetail" in children
     assert "_uniqueFileNodes(nodes)" in app
     assert "ownerWorkspace = this.fileWorkspacePath()" in upload
     assert "if (!this._workspaceIsCurrent(ownerWorkspace)) return" in upload
@@ -974,6 +976,25 @@ def test_runtime_setting_expected_values_expire_and_accept_remote_truth():
     assert "at: Date.now()" in app[tier_start:tier_end]
 
 
+def test_chat_file_link_fallback_prefers_suffix_then_unique_basename():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    resolver_start = app.index("async _findChatFileCandidates(")
+    resolver_end = app.index("\n    // List-choice variant", resolver_start)
+    resolver = app[resolver_start:resolver_end]
+    open_start = app.index("async openByPathToasted(path)")
+    open_end = app.index("\n    // Open a background-task result", open_start)
+    open_path = app[open_start:open_end]
+
+    assert '"&exact=true&limit=200"' in resolver
+    assert "const exactNameMatches" in resolver
+    assert "const suffixMatches" in resolver
+    assert "suffixMatches.length ? suffixMatches : exactNameMatches" in resolver
+    assert "this._findChatFileCandidates(path, name, requestHeaders)" in open_path
+    assert "matches.length === 1" in open_path
+    assert "matches.length > 1" in open_path
+    assert "await this.chooseOne({" in open_path
+
+
 def test_activity_center_groups_by_attention_order_and_read_state():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
@@ -1300,7 +1321,7 @@ def test_send_pins_owner_waits_before_enqueue_and_blocks_failed_attachments():
     assert "const sendDraft = sendState.draft" in send
     assert "const composerImages = sendDraft.pendingImages.slice()" in send
     assert "const composerDocs = sendDraft.pendingDocs.slice()" in send
-    assert "const clearSubmittedComposer = () =>" in send
+    assert "const clearSubmittedComposer = ({ preserveForHandshake = false } = {}) =>" in send
     assert "removeOwned(sendDraft.pendingImages" in send
     busy_branch = "await this._confirmSessionBusy(sendSid, sendState)"
     assert send.index("while (ownsSendDraft() && stillUploading())") < send.rindex(busy_branch)
@@ -1326,9 +1347,11 @@ def test_composer_draft_is_per_session_and_async_actions_pin_owner():
     assert 'pendingImages: []' in blank
     assert 'pendingDocs: []' in blank
     assert '_sendWaitingForUpload: false' in blank
-    assert "_captureComposerState(id = this.currentId)" in app
+    assert '_activated: false' in blank
+    assert "_captureComposerState(id = this.currentId, { persist = true } = {})" in app
     assert "_activateComposerState(id)" in app
     assert "this._activateComposerState(id)" in app
+    assert "if (st.draft._activated === false) return" in app
     assert attach.index("const ownerSid = this.currentId") < attach.index(
         "await this._maybeCompressImage")
     assert "ownerDraft.pendingImages.push(raw)" in attach
@@ -1338,6 +1361,44 @@ def test_composer_draft_is_per_session_and_async_actions_pin_owner():
     assert "ownerState.draft.pendingImages.includes(entry)" in editor
     assert "ownerState.draft.pendingImages.push(entry)" in image_gen
     assert "this.tabState[ownerSid] !== ownerState" in image_gen
+
+
+def test_chat_draft_survives_refresh_and_failed_stream_start():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    send_start = app.index("async send(opts = {})")
+    send = app[send_start:app.index("\n    async stop()", send_start)]
+
+    assert '_chatDraftStoreKey: "muselab_chat_drafts_v1"' in app
+    assert "_consumePersistedChatDraft(id)" in app
+    assert "this.tabState[id].draft.input = this._consumePersistedChatDraft(id)" in app
+    assert 'window.addEventListener("pagehide"' in app
+    assert "this._schedulePersistChatDraft(this.currentId, this.input" in app
+    assert "this._stageChatRecoveryDraft(sendSid, composerText)" in send
+    assert "clearSubmittedComposer({ preserveForHandshake: true })" in send
+    assert "this._commitChatRecoveryDraft(sendSid, composerText)" in send
+    assert "const rollbackUnstartedSend = () =>" in send
+    assert "restoreSubmittedComposer(true)" in send
+    assert "restoreOwned(sendDraft.pendingImages, composerImages)" in send
+    assert "restoreOwned(sendDraft.pendingDocs, composerDocs)" in send
+    assert "this._markDone(streamSid)" not in send
+    assert send.count("restoreSubmittedComposer(false)") >= 2
+    assert "this._deletePersistedChatDraft(sid)" in app
+    assert "const previousDraft = previousState && previousState.draft" in app
+    assert "landingState.draft.input = this._mergeChatDraftText" in app
+
+
+def test_symlink_outside_workspace_has_actionable_tree_error():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("_fileTreeOpenError(path, error)")
+    helper = app[start:app.index("\n    async expand(n, opts = {})", start)]
+    expand_start = app.index("async expand(n, opts = {})")
+    expand = app[expand_start:app.index("\n    collapse(n)", expand_start)]
+
+    assert 'detail === "path escapes root"' in helper
+    assert "不在当前工作区或已添加的工作区中" in helper
+    assert "先把目标目录添加为工作区" in helper
+    assert "outside the current or registered workspaces" in helper
+    assert "this._fileTreeOpenError(n.path, e)" in expand
 
 
 def test_queue_edit_does_not_borrow_active_composer_and_prompt_menu_is_removed():
@@ -1353,7 +1414,7 @@ def test_queue_edit_does_not_borrow_active_composer_and_prompt_menu_is_removed()
     assert "editSessionPrompt" not in app
 
 
-def test_tab_disposal_aborts_uploads_and_drops_memory_only_draft():
+def test_tab_disposal_aborts_memory_only_uploads_and_drops_runtime_state():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     start = app.index("_disposeTabRuntime(id)")
     dispose = app[start:app.index("async removeWorkspace", start)]


### PR DESCRIPTION
## 变更类型
- [x] 修复 (bugfix)

## 变更说明
- 为每个会话持久化文字草稿，刷新或 PWA 重开后自动恢复
- 在流式连接握手完成前保留待发送备份；启动失败时恢复文字、附件和空闲状态
- 空会话刷新后若被服务端回收，将草稿迁移到替代会话
- 对对话中的错误/缺前缀文件路径增加精确文件名回退，并在重名时要求用户选择
- 将软链接越界的原始 JSON 改为可操作的中英文提示，同时保留后端安全拦截

## 测试情况
- `python -m pytest -q tests/test_frontend_lint.py`（93 passed）
- `python -m pytest -q tests/test_files.py`（53 passed）
- Playwright：发送握手中刷新恢复、ticket 503 回滚、软链接越界提示（3 passed）
- Playwright：会话草稿隔离、完成态 DOM 对账、桌面热切换（3 passed）
- `uv run ruff check ...`、`bash scripts/lint.sh`、`node --check frontend/app.js`、`git diff --check`

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 未放松文件根目录/注册工作区安全边界