### PR TITLE
feat(ui): 优化会话、文件与独立侧问体验

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -327,6 +327,31 @@ class ActivityService:
             "summary": summary,
         }
 
+    def rename_session(self, sid: str, name: str) -> dict[str, Any] | None:
+        """Update only the mutable display name for a conversation row.
+
+        A rename is session metadata, not a task transition.  In particular it
+        must not touch ``updated_at``, read state, or the task summary: doing so
+        would move an old row to the front of the timeline or make a completed
+        result look new.  Publishing the otherwise unchanged row lets every
+        open Activity Center converge immediately through its existing SSE
+        connection.
+        """
+        with self._lock:
+            item = self._latest(sid)
+            if item is None:
+                return None
+            target = str(name)
+            if str(item.get("session_name") or "") != target:
+                item["session_name"] = target
+                self._save()
+                self._publish_locked(item=item)
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "item": dict(item),
+            }
+
     def set_pin(self, event_id: str, pinned: bool) -> dict[str, Any] | None:
         """Persist a pin and return the exact ledger revision it belongs to."""
         with self._lock:

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1048,6 +1048,13 @@ _lock = asyncio.Lock()
 # interactive turn mutex only covers /stream turns; scheduler and /compact
 # also call query()/receive_response() and therefore share this lock.
 _session_runtime_locks: dict[str, asyncio.Lock] = {}
+# Queue drain has a separate per-session mutex. It cannot reuse the runtime
+# lock because _maybe_drain_queue() calls _start_turn(), which acquires that
+# lock while starting/reusing the SDK client. Serialising the higher-level
+# dequeue + launch transaction prevents concurrent completion/enqueue kicks
+# from popping adjacent FIFO items before either reserves _active_turns[sid].
+_queue_drain_locks: dict[str, asyncio.Lock] = {}
+_queue_drain_tasks: dict[str, asyncio.Task] = {}
 # Session settings can change after a turn reserves `_active_turns[sid]` but
 # before its detached query task starts. Disconnecting in that gap kills the
 # freshly selected client. Mark rebuilds and consume them at the next safe SDK
@@ -1057,6 +1064,10 @@ _pending_runtime_rebuilds: set[str] = set()
 
 def _session_runtime_lock_for(session_id: str) -> asyncio.Lock:
     return _session_runtime_locks.setdefault(session_id, asyncio.Lock())
+
+
+def _queue_drain_lock_for(session_id: str) -> asyncio.Lock:
+    return _queue_drain_locks.setdefault(session_id, asyncio.Lock())
 
 # ---------------------------------------------------------------------------
 # Cross-turn background tasks (SDK-native run_in_background)
@@ -1094,6 +1105,13 @@ _background_turn_started_at: dict[str, float] = {}
 # Originating user-turn identity retained across the watcher gap. Every
 # continuation gets its own turn_id and exposes this value as parent_turn_id.
 _background_origin_turn_id: dict[str, str] = {}
+# Activity Center completion deferred past the main ResultMessage while an SDK
+# background task still owns the logical turn.  The value is the status the
+# originating turn would have published at its terminal boundary.  The final
+# watcher generation consumes it only after the last task notification and its
+# auto-continuation have both settled, keeping the global running dot aligned
+# with the tab's ``background_active`` dot.
+_background_activity_finishes: dict[str, str] = {}
 # Monotonic per-session ownership token for detached continuation readers.
 # Cancelling a task is cooperative, so a replaced watcher can receive one more
 # message before CancelledError lands. Generation checks keep that stale reader
@@ -3232,8 +3250,11 @@ async def shutdown_runtime() -> None:
         _active_turns.clear()
         _sessions_with_inflight_tasks.clear()
         _bg_task_pinned_at.clear()
+        _background_activity_finishes.clear()
         _task_watchers.clear()
         _maintenance_tasks.clear()
+        _queue_drain_tasks.clear()
+        _queue_drain_locks.clear()
 
     async def _disconnect(client: ClaudeSDKClient) -> None:
         try:
@@ -5120,12 +5141,19 @@ def _clear_session_runtime_state(sid: str) -> None:
     runtime_lock = _session_runtime_locks.get(sid)
     if runtime_lock is not None and not runtime_lock.locked():
         _session_runtime_locks.pop(sid, None)
+    drain_task = _queue_drain_tasks.pop(sid, None)
+    if drain_task is not None and not drain_task.done():
+        drain_task.cancel()
+    drain_lock = _queue_drain_locks.get(sid)
+    if drain_lock is not None and not drain_lock.locked():
+        _queue_drain_locks.pop(sid, None)
     _continuation_generations[sid] = _continuation_generations.get(sid, 0) + 1
     watcher = _task_watchers.pop(sid, None)
     if watcher is not None and not watcher.done():
         watcher.cancel()
     _background_turn_started_at.pop(sid, None)
     _background_origin_turn_id.pop(sid, None)
+    _background_activity_finishes.pop(sid, None)
     task_ids = _sessions_with_inflight_tasks.pop(sid, set())
     for task_id in task_ids:
         _bg_task_descriptions.pop(task_id, None)
@@ -5251,11 +5279,19 @@ async def purge_old_sessions_api(req: PurgeOldReq | None = None) -> dict:
 # Queued messages live in sessions/{sid}.queue.json (sess.*_queue helpers),
 # NOT in the browser. The drain trigger in _pump_gen_to_broadcast() pops the
 # head item and starts the next turn whenever a turn finishes — so the queue
-# advances with no browser attached. These endpoints are pure CRUD; the FE
-# uses them to enqueue / inspect / edit / pause the queue.
+# advances with no browser attached. Enqueue also schedules a drain kick: this
+# closes the completion race where the final one-shot drain observes an empty
+# queue just before a stale browser writes its follow-up. Other endpoints are
+# CRUD controls used to inspect / edit / pause the queue.
 # --------------------------------------------------------------------------
 class QueueEnqueueReq(BaseModel):
     text: str = ""
+    # Composer-only presentation fields for selected-text attachments. The
+    # SDK still receives `text` (which contains the readable quote context),
+    # while queued UI can keep the textarea body and removable quote chips
+    # distinct instead of showing an implementation prompt blob.
+    display_text: str = ""
+    selection_quotes: list[dict] | None = None
     image_ids: str = ""
     # Sender's permission mode at enqueue time. Persisted with the item so
     # the headless drain replays the turn under the same mode instead of
@@ -5272,6 +5308,35 @@ class QueuePauseReq(BaseModel):
 
 class QueueReorderReq(BaseModel):
     order: list[str]
+
+
+def _normalize_queue_selection_quotes(raw: list[dict] | None) -> list[dict]:
+    """Bound and shape browser-supplied quote-chip metadata.
+
+    This metadata is presentation-only; `_maybe_drain_queue` sends the already
+    composed `text` field. Keeping it plain and bounded prevents a malformed
+    client from turning the small queue sidecar into an unbounded data store.
+    """
+    normalized: list[dict] = []
+    for item in (raw or [])[:4]:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "")[:6000].strip()
+        if not text:
+            continue
+        source = str(item.get("source") or "preview")
+        role = str(item.get("role") or "")
+        normalized.append({
+            "id": str(item.get("id") or "")[:80],
+            "source": source if source in {"preview", "chat"} else "preview",
+            "role": role if role in {"", "user", "assistant"} else "",
+            "sessionId": str(item.get("sessionId") or "")[:80],
+            "messageId": str(item.get("messageId") or "")[:80],
+            "path": str(item.get("path") or "")[:1024],
+            "text": text,
+            "truncated": bool(item.get("truncated")),
+        })
+    return normalized
 
 
 @router.get("/sessions/{sid}/queue", dependencies=[Depends(require_token)])
@@ -5304,7 +5369,7 @@ def get_queue_api(sid: str) -> dict:
 
 
 @router.post("/sessions/{sid}/queue", dependencies=[Depends(require_token)])
-def enqueue_api(sid: str, req: QueueEnqueueReq) -> dict:
+async def enqueue_api(sid: str, req: QueueEnqueueReq) -> dict:
     text = (req.text or "").strip()
     if not text and not (req.image_ids or "").strip():
         raise HTTPException(400, "empty message")
@@ -5324,16 +5389,31 @@ def enqueue_api(sid: str, req: QueueEnqueueReq) -> dict:
             if current.get("permission") == "plan"
             else current.get("permission")
         )
+    selection_quotes = _normalize_queue_selection_quotes(
+        req.selection_quotes)
+    display_text = (
+        req.display_text
+        if selection_quotes
+        else (req.display_text or text)
+    )
     res = sess.enqueue_message(
         sid,
         text,
         req.image_ids or "",
         permission=req.permission or "",
+        display_text=display_text,
+        selection_quotes=selection_quotes,
         plan_return_permission=plan_return_permission,
     )
     if not res.get("ok"):
         # queue_full → 409 so the FE can surface "队列已满（上限 10 条）".
         raise HTTPException(409, res.get("error", "enqueue failed"))
+    # Do not await SDK startup in the HTTP request: an idle/cold session can
+    # take tens of seconds to connect. The scheduled task is retained in the
+    # maintenance registry, coalesced per sid and serialised with every other
+    # drain source. If a turn/watcher still owns the session this is a cheap
+    # no-op; that owner's completion remains the next wakeup.
+    _schedule_queue_drain(sid)
     return res
 
 
@@ -5506,7 +5586,16 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
 
     ok = False
     if req.name is not None:
-        ok = sess.rename_session(sid, req.name) or ok
+        renamed = sess.rename_session(sid, req.name)
+        ok = renamed or ok
+        if renamed:
+            # The task ledger stores one denormalized display name per
+            # conversation.  Keep it in lockstep with the session index and
+            # publish the targeted row over the existing Activity SSE.  This
+            # intentionally preserves task timestamps/read state, so a rename
+            # cannot reorder the task center or make a result unread again.
+            from .activity import activity as _activity
+            await asyncio.to_thread(_activity.rename_session, sid, req.name)
         # Also propagate to CLI's JSONL so list_sessions() / manual claude
         # CLI runs see the new title. Silent no-op if JSONL doesn't exist yet.
         try:
@@ -9106,6 +9195,8 @@ async def _watch_inflight_tasks(
     leave an old continuation buffered for the next user turn to misattribute."""
     cont: TurnBroadcast | None = None
     cont_state: dict | None = None
+    activity_failed = False
+    watcher_cancelled = False
 
     def _owns_generation() -> bool:
         return (generation is None
@@ -9272,6 +9363,7 @@ async def _watch_inflight_tasks(
         transcript rendering/conversation counts by the SDK's `isMeta`
         semantics.
         """
+        nonlocal activity_failed
         if (pending or cont is None or cont_state is None
                 or last_settle_status == "stopped"
                 or cont_state["explicit_resume_requested"]):
@@ -9303,6 +9395,7 @@ async def _watch_inflight_tasks(
             await client.query(_meta_prompt())
             return True
         except Exception as e:
+            activity_failed = True
             cont_state["incomplete_error"] = (
                 "后台任务已经完成，但最终答复续接失败。请发送“继续”让 Muse "
                 f"完成上一轮。（{type(e).__name__}）"
@@ -9313,6 +9406,8 @@ async def _watch_inflight_tasks(
             return False
 
     def _mark_incomplete() -> None:
+        nonlocal activity_failed
+        activity_failed = True
         if cont_state is not None and not cont_state.get("incomplete_error"):
             cont_state["incomplete_error"] = (
                 "后台任务已经完成，但没有生成最终答复。请发送“继续”让 Muse "
@@ -9536,8 +9631,10 @@ async def _watch_inflight_tasks(
         # Shutdown or explicit watcher replacement. Keep pins so a replacement
         # watcher can continue ownership; ordinary new turns never cancel a
         # live watcher.
+        watcher_cancelled = True
         raise
     except asyncio.TimeoutError:
+        activity_failed = True
         sys.stderr.write(
             f"[chat] task watcher sid={session_id} reached its absolute "
             f"task deadline, {len(pending)} task(s) still pending; "
@@ -9546,6 +9643,7 @@ async def _watch_inflight_tasks(
         for task_id in pending:
             _bg_task_descriptions.pop(task_id, None)
     except Exception as e:
+        activity_failed = True
         sys.stderr.write(
             f"[chat] task watcher sid={session_id} err: "
             f"{type(e).__name__}: {e}; unpinning client\n")
@@ -9567,6 +9665,13 @@ async def _watch_inflight_tasks(
         sys.stderr.write(
             f"[chat] task watcher exit sid={session_id[:8]} "
             f"pending_left={sorted(pending)}\n")
+        # Close the logical turn before queue drain can start another turn and
+        # reuse this session's single Activity Center row.
+        if (not watcher_cancelled
+                and _owns_generation()
+                and not _sessions_with_inflight_tasks.get(session_id)):
+            await _finish_background_activity(
+                session_id, failed=activity_failed)
         # Only clear the registry slot if it still points at us (a fresh
         # watcher may have replaced it).
         if _task_watchers.get(session_id) is asyncio.current_task():
@@ -9730,6 +9835,45 @@ async def _finish_activity(
             f"[activity] startup finish failed sid={session_id}: {e}\n")
     finally:
         broadcast.activity_started = False
+
+
+def _defer_activity_finish(
+    session_id: str,
+    broadcast: TurnBroadcast,
+    status: str,
+) -> bool:
+    """Transfer Activity Center ownership from a turn to its task watcher.
+
+    ``ResultMessage`` closes only the visible main response when SDK-native
+    background tasks remain.  Finishing the ledger row there made the task
+    center go quiet while the session tab correctly stayed yellow.  Clearing
+    ``broadcast.activity_started`` prevents the outer turn cleanup from closing
+    the row; the owning watcher generation consumes the deferred status later.
+    """
+    if not broadcast.activity_started:
+        return False
+    _background_activity_finishes[session_id] = status
+    broadcast.activity_started = False
+    return True
+
+
+async def _finish_background_activity(
+    session_id: str,
+    *,
+    failed: bool = False,
+) -> None:
+    """Close a deferred activity row after the detached logical turn ends."""
+    status = _background_activity_finishes.pop(session_id, None)
+    if status is None:
+        return
+    if failed:
+        status = "failed"
+    try:
+        from .activity import activity as _activity
+        await asyncio.to_thread(_activity.finish, session_id, status)
+    except Exception as e:
+        sys.stderr.write(
+            f"[activity] background finish failed sid={session_id}: {e}\n")
 
 
 async def _start_turn(
@@ -10965,12 +11109,17 @@ async def _start_turn(
             }
             _activity_status = ("cancelled" if was_cancelled else
                                 "failed" if _is_error else "completed")
-            await _finish_activity(session_id, broadcast, _activity_status)
             _done_session_usage = dict(sess_u)
             _done_memory_recall = mem0.pop_recall_trace(session_id)
             _done_background_tasks = len(
                 _merge_session_inflight(session_id, inflight_tasks)
             )
+            if _done_background_tasks:
+                _defer_activity_finish(
+                    session_id, broadcast, _activity_status)
+            else:
+                await _finish_activity(
+                    session_id, broadcast, _activity_status)
             # Capture once at the SDK's authoritative terminal boundary. The
             # sidecar write happens after slower context/transcript work, but it
             # must persist the same completion instant the browser saw in done.
@@ -11674,57 +11823,95 @@ async def _maybe_drain_queue(session_id: str) -> None:
     On a lost race (_TurnBusy) or start failure (_TurnStartError), the popped
     item is restored to the queue head so nothing is dropped. A start failure
     additionally pauses the queue (mirrors the turn-errored policy)."""
-    if session_id in _active_turns and not _active_turns[session_id].done:
-        return
-    watcher = _task_watchers.get(session_id)
-    if (_sessions_with_inflight_tasks.get(session_id)
-            or (watcher is not None and not watcher.done())):
-        return
-    item = sess.dequeue_message(session_id)
-    if item is None:
-        return
-    # Replay under the permission mode snapshotted at enqueue time. Items
-    # from before the snapshot existed (or enqueued without one) fail CLOSED
-    # to "default" — requiring tool approval is the safe direction; the old
-    # behavior (falling through to bypassPermissions) let queued messages
-    # skip approval the user's UI said was required.
-    perm = (item.get("permission") or "").strip() or "default"
-    if perm not in _VALID_PERMISSION_MODES:
-        # Headless context — can't 400. An unknown persisted value (pre-
-        # validation enqueue, hand-edited queue file) fails CLOSED to
-        # "default" rather than crashing the drain or reaching the SDK.
-        perm = "default"
-    try:
-        await _start_turn(
-            session_id,
-            item.get("text", ""),
-            permission=perm,
-            plan_return_permission=item.get("plan_return_permission", ""),
-            image_ids=item.get("image_ids", ""),
-            persist_permission=False,
-        )
-    except _TurnBusy:
-        # A manual turn grabbed the slot between our check and the
-        # reservation. Restore the item; that turn's completion will drain.
-        sess.requeue_head(session_id, item)
-    except _TurnStartError:
-        # Client init / 504 — restore the item and pause so we don't spin on
-        # a broken backend headlessly. User resumes to retry.
-        sess.requeue_head(session_id, item)
+    async with _queue_drain_lock_for(session_id):
+        if session_id in _active_turns and not _active_turns[session_id].done:
+            return
+        watcher = _task_watchers.get(session_id)
+        if (_sessions_with_inflight_tasks.get(session_id)
+                or (watcher is not None and not watcher.done())):
+            return
+        item = sess.dequeue_message(session_id)
+        if item is None:
+            return
+        # Replay under the permission mode snapshotted at enqueue time. Items
+        # from before the snapshot existed (or enqueued without one) fail CLOSED
+        # to "default" — requiring tool approval is the safe direction; the old
+        # behavior (falling through to bypassPermissions) let queued messages
+        # skip approval the user's UI said was required.
+        perm = (item.get("permission") or "").strip() or "default"
+        if perm not in _VALID_PERMISSION_MODES:
+            # Headless context — can't 400. An unknown persisted value (pre-
+            # validation enqueue, hand-edited queue file) fails CLOSED to
+            # "default" rather than crashing the drain or reaching the SDK.
+            perm = "default"
         try:
-            sess.set_queue_paused(session_id, True)
-        except Exception:
-            pass
-        _notify_queue_paused_on_error(session_id)
-    except Exception as e:
-        # Unexpected — restore + pause defensively, never lose the message.
-        sess.requeue_head(session_id, item)
+            await _start_turn(
+                session_id,
+                item.get("text", ""),
+                permission=perm,
+                plan_return_permission=item.get("plan_return_permission", ""),
+                image_ids=item.get("image_ids", ""),
+                persist_permission=False,
+            )
+        except asyncio.CancelledError:
+            # A graceful service shutdown can cancel a scheduled kick after it
+            # dequeued but before SDK startup completed. Preserve the accepted
+            # message for the next process. Session deletion removes metadata
+            # before cancelling its task, so deliberately do not recreate a
+            # queue file for an owner that no longer exists.
+            if sess.get_session(session_id) is not None:
+                sess.requeue_head(session_id, item)
+            raise
+        except _TurnBusy:
+            # A manual turn grabbed the slot between our check and the
+            # reservation. Restore the item; that turn's completion will drain.
+            sess.requeue_head(session_id, item)
+        except _TurnStartError:
+            # Client init / 504 — restore the item and pause so we don't spin on
+            # a broken backend headlessly. User resumes to retry.
+            sess.requeue_head(session_id, item)
+            try:
+                sess.set_queue_paused(session_id, True)
+            except Exception:
+                pass
+            _notify_queue_paused_on_error(session_id)
+        except Exception as e:
+            # Unexpected — restore + pause defensively, never lose the message.
+            sess.requeue_head(session_id, item)
+            try:
+                sess.set_queue_paused(session_id, True)
+            except Exception:
+                pass
+            sys.stderr.write(
+                f"[chat] queue drain crashed sid={session_id}: {e}\n")
+            _notify_queue_paused_on_error(session_id)
+
+
+def _schedule_queue_drain(session_id: str) -> None:
+    """Kick one retained, coalesced drain task without delaying enqueue HTTP."""
+    existing = _queue_drain_tasks.get(session_id)
+    if existing is not None and not existing.done():
+        return
+    task = asyncio.create_task(_maybe_drain_queue(session_id))
+    _queue_drain_tasks[session_id] = task
+    _maintenance_tasks.add(task)
+
+    def _done(done: asyncio.Task) -> None:
+        _maintenance_tasks.discard(done)
+        if _queue_drain_tasks.get(session_id) is done:
+            _queue_drain_tasks.pop(session_id, None)
+        if done.cancelled():
+            return
         try:
-            sess.set_queue_paused(session_id, True)
-        except Exception:
-            pass
-        sys.stderr.write(f"[chat] queue drain crashed sid={session_id}: {e}\n")
-        _notify_queue_paused_on_error(session_id)
+            exc = done.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            sys.stderr.write(
+                f"[chat] scheduled queue drain failed sid={session_id}: "
+                f"{type(exc).__name__}: {exc}\n")
+
+    task.add_done_callback(_done)
 
 
 async def _subscribe_broadcast(

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1265,7 +1265,8 @@ def set_message_count(sid: str, message_count: int,
 # window between a queue mutation and an annotation write. A dedicated file +
 # lock keeps the two independent.
 #
-# Shape: {"items": [{"id","text","image_ids","permission",
+# Shape: {"items": [{"id","text","display_text","selection_quotes",
+#                    "image_ids","permission",
 #                    "plan_return_permission","enqueued_at"}], "paused": bool}
 #   - items: FIFO; head is sent next by the drain trigger in chat.py
 #   - paused: set True when a queued turn errors / hits ask_user_question /
@@ -1340,6 +1341,8 @@ def get_queue(sid: str) -> dict:
 
 def enqueue_message(sid: str, text: str, image_ids: str = "",
                     permission: str = "",
+                    display_text: str = "",
+                    selection_quotes: list[dict] | None = None,
                     plan_return_permission: str | None = None) -> dict:
     """Append a message to the session's queue. Returns
     {'ok': bool, 'item'?: dict, 'queue': dict, 'error'?: str}. Rejects past
@@ -1355,6 +1358,8 @@ def enqueue_message(sid: str, text: str, image_ids: str = "",
         item = {
             "id": "q-" + uuid.uuid4().hex[:8],
             "text": text or "",
+            "display_text": display_text or "",
+            "selection_quotes": selection_quotes or [],
             "image_ids": image_ids or "",
             "permission": permission or "",
             "plan_return_permission": _normalize_plan_return_permission(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -371,6 +371,8 @@ function portal() {
     // nothing is open or the stat fetch 404s (stale/phantom tab).
     selectedMeta: null,
     _selectedMetaSeq: 0,
+    fileMetaClock: Date.now(),
+    _fileMetaClockTimer: null,
     // Set when a preview READ fails (404/413/403/…), so the unsupported empty
     // state can show a status-aware reason instead of always blaming the file
     // type. null = no error (genuine "unsupported type" or normal preview).
@@ -384,6 +386,26 @@ function portal() {
     previewFind: { open: false, query: "", matches: [], active: -1, count: 0, listOpen: false, truncated: false },
     _pfEls: [],
     PREVIEW_FIND_MAX_MATCHES: 500,
+    // Text selected in a parent-DOM file preview or a rendered chat bubble.
+    // The source snapshot is kept as plain serializable data; Range /
+    // Selection / DOM nodes never enter Alpine's reactive graph. HTML and PDF
+    // previews intentionally stay out of scope because their browsing
+    // contexts are sandboxed/browser-owned.
+    previewQuote: {
+      show: false, mode: "actions", source: "", role: "", sessionId: "",
+      messageId: "", text: "", path: "", question: "",
+      x: 0, y: 0, above: false, truncated: false, sending: false,
+      askSessionId: "", askSessionName: "", askPrompt: "", askError: "",
+      // Ask mode starts anchored to the selection. The first title-bar drag
+      // converts x/y to viewport-relative top/left coordinates until close.
+      dragged: false, dragging: false,
+    },
+    _previewSelectionBound: false,
+    _previewSelectionTimer: null,
+    _previewQuoteDrag: null,
+    _previewQuoteConstraintFrame: null,
+    _previewQuoteResizeObserver: null,
+    PREVIEW_QUOTE_MAX_CHARS: 6000,
     _previewLoadSeq: 0,
     _previewAbort: null,
     // Path-bound, short-lived credentials for script-capable HTML iframes.
@@ -711,6 +733,11 @@ function portal() {
     _streamStartedAt: 0,
     pendingImages: [],    // [{id, mime, preview (data URL), uploading, error, file}]
     pendingDocs: [],      // [{id, name, kind: 'pdf'|'text', uploading, error}]
+    // Selected preview/chat text attached to the current draft. Unlike the
+    // old quote action, these never rewrite `input`; they render as removable
+    // context chips above the composer and are folded into the actual prompt
+    // only when Send snapshots this exact tab's draft.
+    pendingQuotes: [],    // [{id, source, role, sessionId, messageId, path, text, truncated}]
     // Image annotation editor (L1: pen / rect / arrow / eraser + 5 colors + 3 sizes).
     // Opened via the ✎ button on an .img-chip. State is module-scoped on `this`
     // so the modal template can read it via x-show / :class. _baseBitmap is the
@@ -850,9 +877,11 @@ function portal() {
     mascotGreet: false,
 
     leftOpen: true,
-    rightOpen: true,
+    // Desktop's secondary right rail is the preview. Chat is the primary,
+    // always-mounted center pane and therefore has no open/closed flag.
+    previewOpen: true,
     leftWidth: 280,
-    rightWidth: 440,
+    previewWidth: 440,
     showHidden: false,
     // ===== Trash =====
     // Files /delete moves into <ROOT>/.muselab-dustbin/ instead of unlink
@@ -1246,6 +1275,7 @@ function portal() {
         if (this.tabCtxMenu) { this.closeTabMenu(); return; }
         if (this.settings.show) { this.settings.show = false; return; }
         if (this.modal.show && this.modal.cancel) { this.modal.cancel(); return; }
+        if (this.previewQuote.show) { this.dismissPreviewQuote(true); return; }
         // 退出编辑 — guard against silently discarding unsaved edits when ESC
         // is pressed out of habit (blur the focus). Only confirm when dirty.
         if (this.editing) { if (this._confirmLoseEdits()) this.editing = false; return; }
@@ -1329,6 +1359,7 @@ function portal() {
       this.configureMarked();
       this._initArtifacts();
       this._initStreamSelectionGuard();
+      this._initPreviewSelection();
       this._initAriaLabelMirror();
       // NOTE: loadTrash() does NOT run here — init() executes before the
       // user has supplied a token (token gating happens in _bootApp /
@@ -1344,6 +1375,10 @@ function portal() {
       // picker, slash /resume, etc. without requiring each entry point
       // to remember to call _scrollTabIntoView.
       this.$watch("currentId", (tid) => {
+        if (this.previewQuote.show && this.previewQuote.sessionId
+            && this.previewQuote.sessionId !== tid) {
+          this.dismissPreviewQuote(true);
+        }
         if (!tid) return;
         this.$nextTick(() => this._scrollTabIntoView(tid));
       });
@@ -1535,16 +1570,28 @@ function portal() {
                       "ctxBreakdown:", JSON.stringify(this.ctxBreakdown));
         console.groupEnd();
       });
-      this.$watch("editing", v => v ? this.mountCM() : this.unmountCM());
-      // Removed: rightOpen toast ("Muse 回来了") — the panel opening is self-evident.
+      this.$watch("editing", v => {
+        this.dismissPreviewQuote(true);
+        v ? this.mountCM() : this.unmountCM();
+      });
+      // Removed: pane-open toast — the panel opening is self-evident.
       // 编辑模式下切换文件时，重新挂载 CM 加载新文件内容
       this.$watch("selected", () => { if (this.editing) { this.unmountCM(); this.mountCM(); } });
       // Preview-header path + mtime strip: refresh the on-disk metadata
       // whenever the active file changes (tree click, tab switch, chat link,
       // boot restore). Fire once now too in case `selected` was restored
       // before this watcher attached.
-      this.$watch("selected", (p) => this.loadSelectedMeta(p));
+      this.$watch("selected", (p) => {
+        this.dismissPreviewQuote(true);
+        this.loadSelectedMeta(p);
+      });
       this.loadSelectedMeta(this.selected);
+      // Relative file times should age naturally while a preview remains
+      // open. One shared minute tick is enough; never attach a timer or stat
+      // request to each tree row.
+      this._fileMetaClockTimer = setInterval(() => {
+        this.fileMetaClock = Date.now();
+      }, 60_000);
       // beforeunload guard for the editor: register a handler ONLY while there
       // are unsaved edits, and remove it the moment they're saved/discarded.
       // Attaching beforeunload unconditionally would defeat the browser's
@@ -2675,7 +2722,7 @@ function portal() {
     },
     greetMascot(msg) {
       // 去重：同一条 msg 在 1.5s 内重复调用只 toast 一次（Alpine $watch 在某些场景会双触发，
-      // 比如 rightOpen 既被 loadPrefs 写又被点击 toggle 时的 render 顺序）。
+      // 比如 previewOpen 既被 loadPrefs 写又被点击 toggle 时的 render 顺序）。
       const now = Date.now();
       if (msg && this._lastGreetMsg === msg && now - this._lastGreetAt < 1500) {
         return;
@@ -5119,7 +5166,7 @@ function portal() {
       // the exact files the user was looking at — matches the chat-tab strip's
       // behavior via openTabIds.
       this._setLS("muselab_prefs", JSON.stringify({
-        schema: 7,          // v7 remembers the selected terminal profile
+        schema: 8,          // v8 makes chat center + preview the right rail
         model: this.model, defaultModel: this.defaultModel,
         permission: this.permission, defaultPermission: this.defaultPermission,
         currentId: this.currentId,
@@ -5133,8 +5180,8 @@ function portal() {
         activeWorkspace: this.activeWorkspace,
         workspaceLastSession: this.workspaceLastSession,
         workspaceSurfaces: this.workspaceSurfaces,
-        leftOpen: this.leftOpen, rightOpen: this.rightOpen,
-        leftWidth: this.leftWidth, rightWidth: this.rightWidth,
+        leftOpen: this.leftOpen, previewOpen: this.previewOpen,
+        leftWidth: this.leftWidth, previewWidth: this.previewWidth,
         showHidden: this.showHidden,
         openFilesCollapsed: this.openFilesCollapsed,
         openFilesHeight: this.openFilesHeight,
@@ -5193,9 +5240,14 @@ function portal() {
           this.workspaceSurfaces = p.workspaceSurfaces;
         }
         if (typeof p.leftOpen === "boolean") this.leftOpen = p.leftOpen;
-        if (typeof p.rightOpen === "boolean") this.rightOpen = p.rightOpen;
         if (typeof p.leftWidth === "number") this.leftWidth = p.leftWidth;
-        if (typeof p.rightWidth === "number") this.rightWidth = p.rightWidth;
+        // v7's rightOpen/rightWidth described the CHAT rail. In v8 chat is the
+        // always-visible center pane and PREVIEW owns the right rail. Preserve
+        // a useful old width, but never turn an old hidden-chat preference into
+        // a hidden preview on first load — the new layout should arrive intact.
+        if (typeof p.previewOpen === "boolean") this.previewOpen = p.previewOpen;
+        if (typeof p.previewWidth === "number") this.previewWidth = p.previewWidth;
+        else if (typeof p.rightWidth === "number") this.previewWidth = p.rightWidth;
         if (typeof p.showHidden === "boolean") this.showHidden = p.showHidden;
         if (p.currentId) this.currentId = p.currentId;
         if (Array.isArray(p.openTabIds)) this.openTabIds = p.openTabIds;
@@ -5228,11 +5280,10 @@ function portal() {
         if (typeof p.desktopFullPane === "string"
             && ["", "preview", "chat"].includes(p.desktopFullPane)) {
           this.desktopFullPane = p.desktopFullPane;
-          // Mirror toggleDesktopFull's invariant: fullscreen chat needs the
-          // right pane open or it restores to a blank screen (chat is hidden
-          // by .pane-hidden when rightOpen is false). rightOpen is restored
-          // just above, but guard against a persisted false slipping through.
-          if (p.desktopFullPane === "chat") this.rightOpen = true;
+          // Mirror toggleDesktopFull's invariant: fullscreen preview needs its
+          // optional right rail open or `.pane-hidden` would win over the
+          // fullscreen grid rule and restore a blank screen.
+          if (p.desktopFullPane === "preview") this.previewOpen = true;
         }
         if (typeof p.openFilesCollapsed === "boolean") this.openFilesCollapsed = p.openFilesCollapsed;
         // null = auto-fit; only restore an explicit user override.
@@ -6402,6 +6453,7 @@ function portal() {
           _activated: false,
           pendingImages: [],
           pendingDocs: [],
+          pendingQuotes: [],
           _historyIndex: -1,
           _historyDraft: "",
           _sendWaitingForUpload: false,
@@ -6597,6 +6649,7 @@ function portal() {
       if (st._sessionActivityExpected === undefined) {
         st._sessionActivityExpected = null;
       }
+      if (!Array.isArray(st.draft.pendingQuotes)) st.draft.pendingQuotes = [];
       return st;
     },
 
@@ -6666,6 +6719,11 @@ function portal() {
     setMobileTab(next) {
       if (!["files", "preview", "chat"].includes(next) || next === this.mobileTab) return;
       const previous = this.mobileTab;
+      if ((previous === "preview" && next !== "preview")
+          || (previous === "chat" && next !== "chat"
+              && this.previewQuote.source === "chat")) {
+        this.dismissPreviewQuote(true);
+      }
       const ownerPath = this.selected;
       const ownerLoadSeq = this._previewLoadSeq;
       const tabSeq = this._mobileTabSeq = (this._mobileTabSeq || 0) + 1;
@@ -6764,6 +6822,10 @@ function portal() {
         return {
           id: it.id,
           text: it.text || "",
+          displayText: Object.prototype.hasOwnProperty.call(it, "display_text")
+            ? (it.display_text || "") : (it.text || ""),
+          pendingQuotes: Array.isArray(it.selection_quotes)
+            ? it.selection_quotes : [],
           image_ids: it.image_ids || "",
           hasAttach: !!((it.image_ids || "").trim()),
           images,
@@ -6806,6 +6868,8 @@ function portal() {
           // drain replays the turn under this mode (fixes queued messages
           // bypassing tool approval the UI said was required).
           body: JSON.stringify({ text: item.text || "", image_ids,
+                                 display_text: item.displayText || "",
+                                 selection_quotes: item.pendingQuotes || [],
                                  permission,
                                  plan_return_permission: planReturnPermission }),
         });
@@ -7263,6 +7327,9 @@ function portal() {
       if (!item) return;
       // Snapshot before _syncQueueFromServer wipes the mirror.
       const text = item.text || "";
+      const displayText = Object.prototype.hasOwnProperty.call(item, "displayText")
+        ? (item.displayText || "") : text;
+      const quotes = (item.pendingQuotes || []).slice();
       const imgs = (item.images || []).slice();
       const docs = (item.docs || []).slice();
       try {
@@ -7272,7 +7339,7 @@ function portal() {
       await this._syncQueueFromServer(sid);
       if (this.tabState[sid] !== st) return;
       const draft = st.draft;
-      draft.input = text;
+      draft.input = displayText;
       // Rebuild the input-tray chips. No `file` on restored images, so the
       // in-chip "Annotate" button stays disabled (it guards on `!img.file`),
       // but the thumbnail + re-send path work fully.
@@ -7284,6 +7351,9 @@ function portal() {
         id: d.id, name: d.name, kind: d.kind,
         uploading: false, error: false,
       })));
+      draft.pendingQuotes.splice(
+        0, draft.pendingQuotes.length, ...quotes.map(q => ({ ...q })),
+      );
       if (sid === this.currentId) {
         this._activateComposerState(sid);
         this.$nextTick(() => {
@@ -7349,6 +7419,7 @@ function portal() {
       st.draft.input = this.input || "";
       st.draft.pendingImages = this.pendingImages || [];
       st.draft.pendingDocs = this.pendingDocs || [];
+      st.draft.pendingQuotes = this.pendingQuotes || [];
       st.draft._sendWaitingForUpload = !!this._sendWaitingForUpload;
       if (persist) this._persistChatDraft(id, st.draft.input);
     },
@@ -7359,6 +7430,7 @@ function portal() {
       this.input = draft.input || "";
       this.pendingImages = draft.pendingImages;
       this.pendingDocs = draft.pendingDocs;
+      this.pendingQuotes = draft.pendingQuotes;
       this._sendWaitingForUpload = !!draft._sendWaitingForUpload;
       this.$nextTick(() => {
         if (this.currentId === id && this.$refs.chatInput) {
@@ -9019,6 +9091,7 @@ function portal() {
           draft.input = "";
           draft.pendingImages.splice(0);
           draft.pendingDocs.splice(0);
+          draft.pendingQuotes.splice(0);
           draft._sendWaitingForUpload = false;
         }
         if (this.imageEditor.ownerSid === id) {
@@ -11417,6 +11490,27 @@ function portal() {
       if (!this._claimNonImeEnter(ev)) return;
       this.pickerCommitInlineRename();
     },
+    _applyRenamedSession(sid, name) {
+      const session = this.sessions.find(row => row.id === sid);
+      if (session) {
+        session.name = name;
+        session.auto_named = false;
+      }
+      // Activity rows carry a denormalized display name.  Patch the current
+      // browser synchronously after the successful request; the backend sends
+      // the same targeted row over Activity SSE so other tabs converge too.
+      // Never reload the conversation or the full Activity Center for a title
+      // change — both are unrelated surfaces and a reload can visibly churn
+      // their keyed DOM.
+      let activityChanged = false;
+      for (const item of this.activity.events || []) {
+        const itemSid = item.session_id || item.thread_id || "";
+        if (itemSid !== sid || item.session_name === name) continue;
+        item.session_name = name;
+        activityChanged = true;
+      }
+      if (activityChanged) this.activity.events = [...this.activity.events];
+    },
     async pickerCommitInlineRename() {
       const sid = this.renamingPickerSid;
       const name = (this.pickerRenameDraft || "").trim();
@@ -11431,8 +11525,7 @@ function portal() {
         body: JSON.stringify({ name }),
       });
       if (r.ok) {
-        cur.name = name;
-        cur.auto_named = false;
+        this._applyRenamedSession(sid, name);
       } else {
         this.toast(this.lang === "zh" ? "重命名失败" : "Rename failed", "error", 3000);
       }
@@ -13379,7 +13472,10 @@ function portal() {
         headers: { ...this.hdr(), "Content-Type": "application/json" },
         body: JSON.stringify({ name }),
       });
-      if (r.ok) { await this.refreshSessions(); this.toast(this.t("toast.renamed"), "success"); }
+      if (r.ok) {
+        this._applyRenamedSession(cur.id, name);
+        this.toast(this.t("toast.renamed"), "success");
+      }
     },
 
     // ===== settings modal =====
@@ -17384,6 +17480,7 @@ function portal() {
       return saved;
     },
     onPreviewViewportScroll() {
+      if (this.previewQuote.show) this.dismissPreviewQuote(true);
       clearTimeout(this._previewViewSaveTimer);
       const ownerPath = this.selected;
       const ownerLoadSeq = this._previewLoadSeq;
@@ -18871,6 +18968,7 @@ function portal() {
 
     async openFile(n, opts = {}) {
       if (!n || !n.path) return false;
+      this.dismissPreviewQuote(true);
       if (this.previewSurface === "terminal") this._teardownTerminalView();
       this.previewSurface = "file";
       // Clicking / double-clicking the file that already owns the editor is a
@@ -19443,17 +19541,86 @@ function portal() {
         if (!isOwner()) return;
         if (!r.ok) { this.selectedMeta = null; return; }
         const d = await r.json();
-        if (isOwner()) this.selectedMeta = d;
+        if (isOwner()) {
+          this.fileMetaClock = Date.now();
+          this.selectedMeta = d;
+        }
       } catch { if (isOwner()) this.selectedMeta = null; }
     },
-    // Format a unix-seconds mtime as "YYYY-MM-DD HH:mm" in local time for the
-    // preview-header strip. Returns "" for a falsy timestamp.
+    // Format a unix-seconds timestamp and its surrounding file metadata for
+    // the compact preview-header presentation below.
+    fileBreadcrumb(path) {
+      const parts = String(path || "").split("/").filter(Boolean);
+      parts.pop(); // the pane title already owns the basename
+      const root = this.lang === "zh" ? "根目录" : "Workspace root";
+      if (!parts.length) return root;
+      const tail = parts.slice(-3);
+      return `${parts.length > 3 ? "…" : root} › ${tail.join(" › ")}`;
+    },
+    // Exact local timestamp for metadata tooltips. The visible strip uses a
+    // quieter relative/calendar label instead.
     fmtMtime(ts) {
       if (!ts) return "";
       const d = new Date(ts * 1000);
       const p = (n) => String(n).padStart(2, "0");
       return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} `
-             + `${p(d.getHours())}:${p(d.getMinutes())}`;
+             + `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+    },
+    fmtRelativeMtime(ts) {
+      if (!ts) return "";
+      const nowMs = Number(this.fileMetaClock) || Date.now();
+      const then = new Date(Number(ts) * 1000);
+      const diffSeconds = Math.max(0, Math.floor((nowMs - then.getTime()) / 1000));
+      const zh = this.lang === "zh";
+      if (diffSeconds < 60) return zh ? "刚刚" : "just now";
+      if (diffSeconds < 3600) {
+        const minutes = Math.floor(diffSeconds / 60);
+        return zh ? `${minutes} 分钟前` : `${minutes} min ago`;
+      }
+      if (diffSeconds < 6 * 3600) {
+        const hours = Math.floor(diffSeconds / 3600);
+        return zh ? `${hours} 小时前` : `${hours} hr ago`;
+      }
+      const now = new Date(nowMs);
+      const dayKey = d => `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+      const clock = then.toLocaleTimeString(zh ? "zh-CN" : "en-US", {
+        hour: "2-digit", minute: "2-digit", hour12: !zh,
+      });
+      if (dayKey(then) === dayKey(now)) return zh ? `今天 ${clock}` : `Today ${clock}`;
+      const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
+      if (dayKey(then) === dayKey(yesterday)) {
+        return zh ? `昨天 ${clock}` : `Yesterday ${clock}`;
+      }
+      if (then.getFullYear() === now.getFullYear()) {
+        return then.toLocaleDateString(zh ? "zh-CN" : "en-US", {
+          month: "short", day: "numeric",
+        });
+      }
+      return then.toLocaleDateString(zh ? "zh-CN" : "en-US", {
+        year: "numeric", month: "short", day: "numeric",
+      });
+    },
+    fileSizeTitle(value) {
+      const size = Number(value);
+      if (!Number.isFinite(size) || size < 0) return "";
+      const exact = new Intl.NumberFormat(
+        this.lang === "zh" ? "zh-CN" : "en-US",
+      ).format(Math.round(size));
+      return this.lang === "zh" ? `${exact} 字节` : `${exact} bytes`;
+    },
+    fileMetaTitle(meta) {
+      if (!meta) return "";
+      const parts = [];
+      const size = Number(meta.size);
+      if (Number.isFinite(size) && size >= 0) {
+        parts.push(`${this.fmtSize(size)}（${this.fileSizeTitle(size)}）`);
+      }
+      if (meta.mtime) {
+        parts.push(this.lang === "zh"
+          ? `修改于 ${this.fmtMtime(meta.mtime)}`
+          : `Modified ${this.fmtMtime(meta.mtime)}`);
+      }
+      return parts.join(" · ");
     },
     closeAllTabs() {
       if (!this.tabs.length) return;
@@ -19661,9 +19828,18 @@ function portal() {
       return "";
     },
     fmtSize(n) {
-      if (n < 1024) return n + "B";
-      if (n < 1024 * 1024) return (n / 1024).toFixed(1) + "K";
-      return (n / 1024 / 1024).toFixed(1) + "M";
+      let value = Number(n);
+      if (!Number.isFinite(value) || value < 0) return "";
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      let unit = 0;
+      while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+      }
+      if (unit === 0) return `${Math.round(value)} B`;
+      const digits = value >= 100 ? 0 : 1;
+      const compact = value.toFixed(digits).replace(/\.0$/, "");
+      return `${compact} ${units[unit]}`;
     },
     // Returns a Promise that resolves once every block in `root` is
     // highlighted AND artifacts (mermaid/HTML) are rendered. Most callers
@@ -19920,6 +20096,675 @@ function portal() {
           if (typeof fn === "function") fn();
         }
       });
+    },
+
+    // Selection actions live in the parent document so the same small helper
+    // works for rendered chat bubbles, Markdown, plain text/code and table
+    // previews without weakening the HTML iframe sandbox. PDF remains
+    // browser-owned and is deliberately unsupported here as well.
+    _initPreviewSelection() {
+      if (this._previewSelectionBound) return;
+      this._previewSelectionBound = true;
+      document.addEventListener("selectionchange", () => {
+        // Focusing the inline question field collapses the document selection.
+        // The selected source has already been snapshotted, so retain the ask
+        // panel until the user sends, cancels or changes preview ownership.
+        if (this.previewQuote.show && this.previewQuote.mode === "ask") return;
+        clearTimeout(this._previewSelectionTimer);
+        this._previewSelectionTimer = setTimeout(() => {
+          this._previewSelectionTimer = null;
+          this._syncPreviewSelection();
+        }, 60);
+      });
+      document.addEventListener("pointerdown", (ev) => {
+        const inPopover = ev.target && ev.target.closest
+          && ev.target.closest(".preview-selection-popover");
+        if (!inPopover && this.previewQuote.show) this.dismissPreviewQuote(false);
+      }, true);
+      const onViewportResize = () => {
+        // Mobile keyboards can resize the visual viewport while the question
+        // textarea is focused. Do not interpret that as a cancellation.
+        if (this.previewQuote.show && this.previewQuote.mode !== "ask") {
+          this.dismissPreviewQuote(false);
+        } else if (this.previewQuote.show && this.previewQuote.dragged) {
+          this._schedulePreviewQuoteConstraint();
+        }
+      };
+      window.addEventListener("resize", onViewportResize);
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", onViewportResize);
+        window.visualViewport.addEventListener("scroll", onViewportResize);
+      }
+      this.$nextTick(() => {
+        const popover = this._previewQuoteElement();
+        if (!popover || !window.ResizeObserver) return;
+        this._previewQuoteResizeObserver = new ResizeObserver(() => {
+          // The compact answer grows while streaming. If the user parked the
+          // window near an edge, keep the growing shell in view without
+          // disturbing its position during ordinary content updates.
+          if (this.previewQuote.show && this.previewQuote.dragged
+              && !this.previewQuote.dragging) {
+            this._schedulePreviewQuoteConstraint();
+          }
+        });
+        this._previewQuoteResizeObserver.observe(popover);
+      });
+    },
+
+    _previewQuoteElement() {
+      return this.$refs.previewSelectionPopover
+        || document.querySelector(".preview-selection-popover");
+    },
+
+    _previewQuoteViewport() {
+      const viewport = window.visualViewport;
+      return {
+        left: viewport ? viewport.offsetLeft : 0,
+        top: viewport ? viewport.offsetTop : 0,
+        width: Math.max(1, viewport ? viewport.width : window.innerWidth),
+        height: Math.max(1, viewport ? viewport.height : window.innerHeight),
+      };
+    },
+
+    _clampPreviewQuotePosition(left, top, width, height) {
+      const viewport = this._previewQuoteViewport();
+      const margin = 12;
+      const minLeft = viewport.left + margin;
+      const minTop = viewport.top + margin;
+      const maxLeft = Math.max(
+        minLeft, viewport.left + viewport.width - Math.max(0, width) - margin,
+      );
+      const maxTop = Math.max(
+        minTop, viewport.top + viewport.height - Math.max(0, height) - margin,
+      );
+      return {
+        x: Math.min(maxLeft, Math.max(minLeft, Number(left) || 0)),
+        y: Math.min(maxTop, Math.max(minTop, Number(top) || 0)),
+      };
+    },
+
+    _constrainPreviewQuoteToViewport() {
+      if (!this.previewQuote.show || this.previewQuote.mode !== "ask"
+          || !this.previewQuote.dragged || this.previewQuote.dragging) return false;
+      const popover = this._previewQuoteElement();
+      if (!popover || !popover.getClientRects().length) return false;
+      const rect = popover.getBoundingClientRect();
+      const next = this._clampPreviewQuotePosition(
+        this.previewQuote.x, this.previewQuote.y, rect.width, rect.height,
+      );
+      if (next.x === this.previewQuote.x && next.y === this.previewQuote.y) {
+        return false;
+      }
+      this.previewQuote.x = next.x;
+      this.previewQuote.y = next.y;
+      return true;
+    },
+
+    _schedulePreviewQuoteConstraint() {
+      if (this._previewQuoteConstraintFrame != null) return;
+      const schedule = window.requestAnimationFrame || ((fn) => setTimeout(fn, 0));
+      this._previewQuoteConstraintFrame = schedule(() => {
+        this._previewQuoteConstraintFrame = null;
+        this._constrainPreviewQuoteToViewport();
+      });
+    },
+
+    startPreviewQuoteDrag(ev) {
+      if (!ev || !this.previewQuote.show || this.previewQuote.mode !== "ask"
+          || (ev.button != null && ev.button !== 0)
+          || ev.isPrimary === false) return false;
+      const target = ev.target && ev.target.closest ? ev.target : null;
+      const head = target && target.closest(".preview-selection-ask-head");
+      if (!head || (target.closest
+          && target.closest("button, input, textarea, select, a"))) return false;
+      const popover = this._previewQuoteElement();
+      if (!popover || !popover.contains(head)) return false;
+      const rect = popover.getBoundingClientRect();
+      const handle = ev.currentTarget || head;
+      this._previewQuoteDrag = {
+        pointerId: ev.pointerId,
+        startX: ev.clientX,
+        startY: ev.clientY,
+        left: rect.left,
+        top: rect.top,
+        handle,
+      };
+      Object.assign(this.previewQuote, {
+        x: rect.left,
+        y: rect.top,
+        above: false,
+        dragged: true,
+        dragging: true,
+      });
+      try { handle.setPointerCapture(ev.pointerId); } catch (_) {}
+      if (ev.cancelable) ev.preventDefault();
+      return true;
+    },
+
+    movePreviewQuoteDrag(ev) {
+      const drag = this._previewQuoteDrag;
+      if (!drag || !ev || ev.pointerId !== drag.pointerId) return false;
+      const popover = this._previewQuoteElement();
+      if (!popover) return false;
+      const rect = popover.getBoundingClientRect();
+      const next = this._clampPreviewQuotePosition(
+        drag.left + ev.clientX - drag.startX,
+        drag.top + ev.clientY - drag.startY,
+        rect.width,
+        rect.height,
+      );
+      this.previewQuote.x = next.x;
+      this.previewQuote.y = next.y;
+      if (ev.cancelable) ev.preventDefault();
+      return true;
+    },
+
+    finishPreviewQuoteDrag(ev) {
+      const drag = this._previewQuoteDrag;
+      if (!drag || (ev && ev.pointerId != null
+          && ev.pointerId !== drag.pointerId)) return false;
+      this._previewQuoteDrag = null;
+      this.previewQuote.dragging = false;
+      try {
+        if (drag.handle && drag.handle.hasPointerCapture
+            && drag.handle.hasPointerCapture(drag.pointerId)) {
+          drag.handle.releasePointerCapture(drag.pointerId);
+        }
+      } catch (_) {}
+      this._constrainPreviewQuoteToViewport();
+      if (ev && ev.cancelable) ev.preventDefault();
+      return true;
+    },
+
+    _cancelPreviewQuoteDrag() {
+      const drag = this._previewQuoteDrag;
+      this._previewQuoteDrag = null;
+      if (drag && drag.handle) {
+        try {
+          if (drag.handle.hasPointerCapture
+              && drag.handle.hasPointerCapture(drag.pointerId)) {
+            drag.handle.releasePointerCapture(drag.pointerId);
+          }
+        } catch (_) {}
+      }
+      this.previewQuote.dragging = false;
+    },
+
+    _previewSelectionHost(node) {
+      if (!node || this.previewSurface !== "file" || !this.selected) return null;
+      const body = this.$refs.previewBody;
+      const el = node.nodeType === 1 ? node : node.parentElement;
+      if (!body || !el || !body.contains(el) || !el.closest) return null;
+      const host = el.closest(".markdown, pre.text, .xlsx-preview");
+      if (!host || !body.contains(host) || !host.getClientRects().length) return null;
+      if (this.editing) {
+        return host.matches(".markdown") && !!host.closest(".editor-live-preview")
+          ? host : null;
+      }
+      if (host.closest(".editor-wrap")) return null;
+      if (this.previewMode === "md" && host.matches(".markdown")) return host;
+      if (this.previewMode === "text" && host.matches("pre.text")) return host;
+      if (this.previewMode === "csv" && host.matches(".csv-preview")) return host;
+      if (this.previewMode === "xlsx" && host.matches(".xlsx-preview")
+          && !host.matches(".csv-preview")) return host;
+      return null;
+    },
+
+    _chatSelectionHost(node) {
+      if (!node || !this.currentId) return null;
+      const body = this.$refs.chatBody;
+      const el = node.nodeType === 1 ? node : node.parentElement;
+      if (!body || !el || !body.contains(el) || !el.closest) return null;
+      if (el.closest("textarea, input, button, [contenteditable='true'], .edit-msg-wrap")) {
+        return null;
+      }
+      const pane = el.closest(".msg-pane[data-tid]");
+      if (!pane || pane.dataset.tid !== this.currentId || !body.contains(pane)
+          || !pane.getClientRects().length) return null;
+      const message = el.closest(".msg");
+      const bubble = el.closest(".bubble");
+      if (!message || !bubble || !message.contains(bubble)
+          || message.classList.contains("is-hidden") || !bubble.getClientRects().length) {
+        return null;
+      }
+      if (message.classList.contains("user")) {
+        const text = el.closest(".user-msg-text");
+        return text && bubble.classList.contains("user-bubble")
+          ? { host: bubble, role: "user", messageId: message.dataset.uuid || "" }
+          : null;
+      }
+      if (message.classList.contains("assistant")) {
+        return {
+          host: bubble,
+          role: "assistant",
+          messageId: message.dataset.uuid || "",
+        };
+      }
+      return null;
+    },
+
+    _syncPreviewSelection() {
+      if (this.previewQuote.show && this.previewQuote.mode === "ask") return;
+      const selection = window.getSelection && window.getSelection();
+      if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        this.dismissPreviewQuote(false);
+        return;
+      }
+      const previewAnchor = this._previewSelectionHost(selection.anchorNode);
+      const previewFocus = this._previewSelectionHost(selection.focusNode);
+      const chatAnchor = previewAnchor ? null : this._chatSelectionHost(selection.anchorNode);
+      const chatFocus = previewAnchor ? null : this._chatSelectionHost(selection.focusNode);
+      let source = "";
+      let role = "";
+      let messageId = "";
+      if (previewAnchor && previewAnchor === previewFocus) {
+        source = "preview";
+      } else if (chatAnchor && chatFocus && chatAnchor.host === chatFocus.host
+                 && chatAnchor.role === chatFocus.role) {
+        source = "chat";
+        role = chatAnchor.role;
+        messageId = chatAnchor.messageId || "";
+      } else {
+        this.dismissPreviewQuote(false);
+        return;
+      }
+      let selectedText = String(selection.toString() || "")
+        .replace(/\u00a0/g, " ")
+        .replace(/\r\n?/g, "\n")
+        .trim();
+      if (!selectedText) {
+        this.dismissPreviewQuote(false);
+        return;
+      }
+      const truncated = selectedText.length > this.PREVIEW_QUOTE_MAX_CHARS;
+      if (truncated) {
+        selectedText = selectedText.slice(0, this.PREVIEW_QUOTE_MAX_CHARS).trimEnd();
+      }
+      const range = selection.getRangeAt(0);
+      const rects = Array.from(range.getClientRects()).filter(r => r.width || r.height);
+      const rect = rects[rects.length - 1] || range.getBoundingClientRect();
+      if (!rect || (!rect.width && !rect.height)) {
+        this.dismissPreviewQuote(false);
+        return;
+      }
+      const viewportWidth = Math.max(1, window.innerWidth || 0);
+      const viewportHeight = Math.max(1, window.innerHeight || 0);
+      const popoverHalf = Math.min(170, Math.max(70, (viewportWidth - 24) / 2));
+      const above = viewportHeight - rect.bottom < 220 && rect.top > 220;
+      Object.assign(this.previewQuote, {
+        show: true,
+        mode: "actions",
+        source,
+        role,
+        sessionId: this.currentId,
+        messageId,
+        text: selectedText,
+        path: source === "preview" ? this.selected : "",
+        question: "",
+        x: Math.min(viewportWidth - popoverHalf - 12,
+          Math.max(popoverHalf + 12, rect.left + rect.width / 2)),
+        y: above ? rect.top : rect.bottom,
+        above,
+        truncated,
+        sending: false,
+        askSessionId: "",
+        askSessionName: "",
+        askPrompt: "",
+        askError: "",
+        dragged: false,
+        dragging: false,
+      });
+    },
+
+    dismissPreviewQuote(clearSelection = false) {
+      clearTimeout(this._previewSelectionTimer);
+      this._previewSelectionTimer = null;
+      this._cancelPreviewQuoteDrag();
+      Object.assign(this.previewQuote, {
+        show: false, mode: "actions", source: "", role: "", sessionId: "",
+        messageId: "", text: "", path: "", question: "",
+        x: 0, y: 0, above: false, truncated: false, sending: false,
+        dragged: false, dragging: false, askSessionId: "",
+        askSessionName: "", askPrompt: "", askError: "",
+      });
+      if (clearSelection) {
+        try {
+          const selection = window.getSelection && window.getSelection();
+          if (selection) selection.removeAllRanges();
+        } catch (_) {}
+      }
+    },
+
+    _previewQuoteBlock(snapshot = this.previewQuote) {
+      const quote = String(snapshot.text || "")
+        .split("\n")
+        .map(line => "> " + line)
+        .join("\n");
+      const clipped = snapshot.truncated
+        ? (this.lang === "zh" ? "\n> …（选区过长，已截断）" : "\n> … (selection truncated)")
+        : "";
+      if (snapshot.source === "chat") {
+        const mine = snapshot.role === "user";
+        const label = this.lang === "zh"
+          ? (mine ? "引用自我的消息：" : "引用自 Muse 回复：")
+          : (mine ? "Quoted from my message:" : "Quoted from Muse:");
+        return `${label}\n\n${quote}${clipped}`;
+      }
+      const sourcePath = String(snapshot.path || this.selected || "")
+        .replace(/`/g, "\\`");
+      const label = this.lang === "zh" ? "引用自" : "Quoted from";
+      const colon = this.lang === "zh" ? "：" : ":";
+      return `${label} \`${sourcePath}\`${colon}\n\n${quote}${clipped}`;
+    },
+
+    previewQuoteExcerpt(snapshot = this.previewQuote) {
+      const text = String((snapshot && snapshot.text) || "")
+        .replace(/\s+/g, " ").trim();
+      return text.length > 120 ? text.slice(0, 120).trimEnd() + "…" : text;
+    },
+
+    previewQuoteSourceName(snapshot = this.previewQuote) {
+      if (snapshot && snapshot.source === "chat") {
+        if (snapshot.role === "user") {
+          return this.lang === "zh" ? "我的消息" : "My message";
+        }
+        return this.lang === "zh" ? "Muse 回复" : "Muse reply";
+      }
+      const path = String((snapshot && snapshot.path) || "");
+      return path.split("/").pop() || path;
+    },
+
+    previewQuoteSourceIcon(snapshot = this.previewQuote) {
+      if (snapshot && snapshot.source === "chat") {
+        return snapshot.role === "user" ? "#i-user" : "#i-brain";
+      }
+      return "#i-file-text";
+    },
+
+    _selectionQuoteSnapshot(snapshot = this.previewQuote) {
+      return {
+        id: this._uuid(),
+        source: snapshot.source || "preview",
+        role: snapshot.role || "",
+        sessionId: snapshot.sessionId || this.currentId || "",
+        messageId: snapshot.messageId || "",
+        path: snapshot.path || "",
+        text: snapshot.text || "",
+        truncated: !!snapshot.truncated,
+      };
+    },
+
+    _composerPromptText(input, quotes) {
+      const blocks = (quotes || [])
+        .filter(q => q && String(q.text || "").trim())
+        .map(q => this._previewQuoteBlock(q));
+      const body = String(input || "").trim();
+      if (body) blocks.push(body);
+      return blocks.join("\n\n").trim();
+    },
+
+    userSelectionQuotes(message) {
+      return Array.isArray(message && message.selectionQuotes)
+        ? message.selectionQuotes : [];
+    },
+
+    userVisibleText(message) {
+      if (!message) return "";
+      return Object.prototype.hasOwnProperty.call(message, "displayText")
+        ? (message.displayText || "") : (message.text || "");
+    },
+
+    quotePreviewSelection() {
+      if (!this.currentId || !this.previewQuote.show || !this.previewQuote.text) {
+        this.toast(this.lang === "zh" ? "请先打开一个会话" : "Open a chat first", "warn", 2200);
+        return false;
+      }
+      this._captureComposerState(this.currentId);
+      const draft = this._ensureTabState(this.currentId).draft;
+      if (draft.pendingQuotes.length >= 4) {
+        this.toast(
+          this.lang === "zh" ? "一次最多引用 4 段内容" : "Up to 4 quotes per message",
+          "warn", 2200,
+        );
+        return false;
+      }
+      draft.pendingQuotes.push(this._selectionQuoteSnapshot());
+      this.pendingQuotes = draft.pendingQuotes;
+      this.dismissPreviewQuote(true);
+      if (this._isMobileLayout()) this.setMobileTab("chat");
+      this.$nextTick(() => {
+        const ta = this.$refs.chatInput;
+        if (ta) ta.focus();
+      });
+      return true;
+    },
+
+    removePendingQuote(index) {
+      if (!Number.isInteger(index) || index < 0) return;
+      this.pendingQuotes.splice(index, 1);
+    },
+
+    openPreviewSelectionAsk() {
+      if (!this.previewQuote.show || !this.previewQuote.text) return;
+      this._cancelPreviewQuoteDrag();
+      this.previewQuote.mode = "ask";
+      this.previewQuote.dragged = false;
+      this.previewQuote.question = "";
+      this.previewQuote.askSessionId = "";
+      this.previewQuote.askSessionName = "";
+      this.previewQuote.askPrompt = "";
+      this.previewQuote.askError = "";
+      this.$nextTick(() => {
+        // x-ref inside an x-if template is not guaranteed to join Alpine's
+        // root $refs collection on the same tick in every browser build.
+        const input = this.$refs.previewQuoteInput
+          || document.querySelector(".preview-selection-popover .preview-selection-ask textarea");
+        if (input) input.focus();
+      });
+    },
+
+    onPreviewQuoteAskEnter(ev) {
+      if (!ev || ev.isComposing || ev.keyCode === 229) return;
+      const isTouch = (window.matchMedia
+        && window.matchMedia("(pointer: coarse)").matches) || window.innerWidth < 768;
+      if (isTouch || ev.shiftKey || ev.ctrlKey || ev.metaKey) return;
+      ev.preventDefault();
+      this.sendPreviewSelectionQuestion();
+    },
+
+    async _createPreviewSelectionAskSession(snapshot, question) {
+      const sourceId = snapshot.sessionId || this.currentId;
+      const source = (this.sessions || []).find(s => s.id === sourceId);
+      const fallbackName = this.lang === "zh" ? "独立侧问" : "Side question";
+      const sourceName = (source && source.name) || (this.lang === "zh" ? "会话" : "Chat");
+      const questionHint = String(question || "").replace(/\s+/g, " ").trim().slice(0, 36);
+      const title = `${sourceName} · ${fallbackName}${questionHint ? `：${questionHint}` : ""}`;
+      const headers = { ...this.hdr(), "Content-Type": "application/json" };
+      let payload = null;
+      let forked = false;
+
+      // Prefer a real point-in-time fork so the side question inherits the
+      // conversation's useful context. A streaming/empty source cannot be
+      // forked safely; in that case fall back to an isolated session whose
+      // prompt still carries the selected text explicitly.
+      if (sourceId && source && !this.isTabStreaming(sourceId)) {
+        const response = await fetch(
+          `/api/chat/sessions/${encodeURIComponent(sourceId)}/fork`,
+          {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+              up_to_message_id: snapshot.source === "chat"
+                ? (snapshot.messageId || null) : null,
+              title,
+            }),
+          },
+        );
+        if (response.ok) {
+          payload = await response.json();
+          forked = true;
+        } else if (![400, 404, 409].includes(response.status)) {
+          throw new Error(`selection fork ${response.status}`);
+        }
+      }
+
+      if (!payload) {
+        const response = await fetch("/api/chat/sessions", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            name: title,
+            model: (source && source.model) || this.model || "",
+            permission: "default",
+            cwd: (source && source.cwd) || this.currentWorkspacePath(),
+            open_ids: this.openTabIds || [],
+          }),
+        });
+        if (!response.ok) throw new Error(`selection session ${response.status}`);
+        payload = await response.json();
+      }
+
+      const id = payload.id || payload.session_id;
+      if (!id) throw new Error("selection session missing id");
+      const meta = {
+        ...payload,
+        id,
+        name: payload.name || title,
+        active: false,
+        cwd: payload.cwd || (source && source.cwd) || this.currentWorkspacePath(),
+        _selectionAsk: true,
+        _selectionAskForked: forked,
+      };
+      this.sessions = [meta, ...this.sessions.filter(s => s.id !== id)];
+      this._sessionsEtag = "";
+      const state = this._ensureTabState(id);
+      // The compact panel only needs this branch-local turn. Canonical
+      // reconciliation may later hydrate inherited fork history in-place.
+      state._loaded = true;
+      state.permission = "default";
+      state.effort = this._normalizeEffort(meta.effort);
+      state.serviceTier = this._normalizeServiceTier(meta.service_tier);
+      return meta;
+    },
+
+    previewSelectionAskMessages() {
+      const sid = this.previewQuote.askSessionId;
+      const state = sid && this.tabState && this.tabState[sid];
+      const messages = state ? this._allPaneMessages(state) : [];
+      if (!messages.length) return [];
+      const expected = this.previewQuote.askPrompt || "";
+      let userIndex = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i] && messages[i].role === "user"
+            && (!expected || messages[i].text === expected)) {
+          userIndex = i;
+          break;
+        }
+      }
+      return messages.slice(userIndex + 1);
+    },
+
+    previewSelectionAskText() {
+      return this.previewSelectionAskMessages()
+        .filter(m => m && m.role === "assistant" && m.text)
+        .map(m => m.text)
+        .join("\n\n")
+        .trim();
+    },
+
+    previewSelectionAskHtml() {
+      const text = this.previewSelectionAskText();
+      return text ? this.mdRender(text) : "";
+    },
+
+    previewSelectionAskRunning() {
+      const sid = this.previewQuote.askSessionId;
+      const state = sid && this.tabState && this.tabState[sid];
+      return !!(this.previewQuote.sending
+        || (state && (state.streaming || state.backgroundActive)));
+    },
+
+    previewSelectionAskFailed() {
+      const sid = this.previewQuote.askSessionId;
+      const state = sid && this.tabState && this.tabState[sid];
+      if (!state) return false;
+      const messages = this._allPaneMessages(state);
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i] && messages[i].role === "user") return !!messages[i]._failed;
+      }
+      return false;
+    },
+
+    async openPreviewSelectionAskSession() {
+      const sid = this.previewQuote.askSessionId;
+      if (!sid) return false;
+      const state = this.tabState && this.tabState[sid];
+      // Once the side turn is done, opening the branch should reveal its
+      // inherited history too. While streaming, retain the live object graph.
+      if (state && !state.streaming && !state.es) state._loaded = false;
+      this.dismissPreviewQuote(true);
+      await this.openTab(sid);
+      if (this._isMobileLayout()) this.setMobileTab("chat");
+      return true;
+    },
+
+    async sendPreviewSelectionQuestion() {
+      if (!this.previewQuote.show || this.previewQuote.mode !== "ask"
+          || this.previewQuote.sending) return false;
+      const question = String(this.previewQuote.question || "").trim();
+      if (!question) return false;
+      if (!this.currentId) {
+        this.toast(this.lang === "zh" ? "请先打开一个会话" : "Open a chat first", "warn", 2200);
+        return false;
+      }
+      if (!this.availableModels || !this.availableModels.length) {
+        this.toast(this.lang === "zh" ? "请先在设置里配置一个模型" : "Configure a model in Settings first", "warn", 3000);
+        this.openSettings();
+        return false;
+      }
+      if (this.workspaceSwitching) return false;
+      const snapshot = {
+        source: this.previewQuote.source,
+        role: this.previewQuote.role,
+        sessionId: this.previewQuote.sessionId,
+        messageId: this.previewQuote.messageId,
+        path: this.previewQuote.path,
+        text: this.previewQuote.text,
+        truncated: this.previewQuote.truncated,
+      };
+      const prompt = this._previewQuoteBlock(snapshot)
+        + "\n\n" + (this.lang === "zh"
+          ? "这是一个独立侧问。请只基于已有上下文和上面的选中内容回答，不调用工具、不修改文件。\n问题："
+          : "This is an independent side question. Answer only from the existing context and selection; do not use tools or modify files.\nQuestion:")
+        + "\n" + question;
+      this.previewQuote.sending = true;
+      this.previewQuote.askError = "";
+      try {
+        const target = await this._createPreviewSelectionAskSession(snapshot, question);
+        this.previewQuote.askSessionId = target.id;
+        this.previewQuote.askSessionName = target.name || "";
+        this.previewQuote.askPrompt = prompt;
+        const result = await this.send({
+          sessionId: target.id,
+          detachedText: prompt,
+          permissionMode: "default",
+        });
+        if (result === false) {
+          this.previewQuote.askError = this.lang === "zh"
+            ? "侧问未能启动，可打开会话后重试"
+            : "Could not start the side question; open the chat to retry";
+          return false;
+        }
+        return true;
+      } catch (_) {
+        this.previewQuote.askError = this.lang === "zh"
+          ? "创建独立侧问失败，请重试"
+          : "Could not create the side question; please retry";
+        this.toast(this.previewQuote.askError, "error", 3000);
+        return false;
+      } finally {
+        this.previewQuote.sending = false;
+      }
     },
 
     // A11y: mirror every button's `title` attribute into `aria-label` so
@@ -21215,16 +22060,9 @@ function portal() {
       return EDITABLE_EXT.has(ext);
     },
 
-    // Files-pane visibility toggle wired to the preview-pane header's chevron
-    // button. Special-cased for fullscreen: when the preview pane is in
-    // desktop-fullscreen mode (this.desktopFullPane === "preview"), the files
-    // pane is already hidden by the fullscreen layout CSS — so tapping the
-    // chevron in that state should EXIT fullscreen (not just flip a flag
-    // that does nothing visible). We also force leftOpen=true on the exit
-    // path so the user lands on a layout where the files pane IS visible,
-    // matching the affordance the chevron just promised them.
-    // 2026-05-28 user request: "全屏预览模式下，点击 隐藏文件区按钮，
-    // 应该要自动退出全屏预览".
+    // Files visibility toggle in the center chat header. In chat fullscreen
+    // the side rail is already hidden by CSS, so the chevron exits focus mode
+    // and explicitly restores Files instead of flipping an invisible flag.
     toggleFilesPane() {
       if (this.desktopFullPane) {
         this.desktopFullPane = "";
@@ -21236,21 +22074,15 @@ function portal() {
       this.savePrefs();
     },
 
-    // Chat (Muse) pane visibility toggle, wired to the preview-pane header's
-    // right-hand chevron. Mirrors toggleFilesPane's fullscreen special-case:
-    // when the preview pane is fullscreen (desktopFullPane === "preview") the
-    // Muse pane is already hidden by the fullscreen layout, so tapping
-    // "hide Muse" would flip a flag that changes nothing visible. Instead we
-    // EXIT fullscreen and force the Muse pane open, landing the user on a
-    // layout where Muse IS visible — matching the affordance the button
-    // promises. 2026-05-29 user request: "预览区全屏的情况下，点击隐藏 Muse
-    // 按钮，应该自动退出全屏".
-    toggleChatPane() {
+    // Preview visibility toggle, wired to the center chat header's right-hand
+    // chevron. In either desktop fullscreen mode the side rail is already
+    // hidden, so the chevron exits fullscreen and explicitly restores preview.
+    togglePreviewPane() {
       if (this.desktopFullPane) {
         this.desktopFullPane = "";
-        this.rightOpen = true;
+        this.previewOpen = true;
       } else {
-        this.rightOpen = !this.rightOpen;
+        this.previewOpen = !this.previewOpen;
       }
       this.savePrefs();
     },
@@ -21258,7 +22090,7 @@ function portal() {
     layoutStyle() {
       // Desktop fullscreen on one pane — collapse to a single 1fr column
       // and let the CSS rule for [data-desktop-full="..."] handle hiding
-      // the others. Skips the persisted leftWidth/rightWidth so the
+      // the others. Skips the persisted leftWidth/previewWidth so the
       // chosen pane truly fills the viewport (no 280px ghost gutter).
       if (this.desktopFullPane) {
         return { gridTemplateColumns: "1fr" };
@@ -21273,7 +22105,7 @@ function portal() {
       const cols = [];
       if (this.leftOpen) cols.push(Math.min(this.leftWidth, maxW) + "px", "4px");
       cols.push("1fr");
-      if (this.rightOpen) cols.push("4px", Math.min(this.rightWidth, maxW) + "px");
+      if (this.previewOpen) cols.push("4px", Math.min(this.previewWidth, maxW) + "px");
       return { gridTemplateColumns: cols.join(" ") };
     },
     // Toggle desktop fullscreen for a pane. Click the same pane's
@@ -21292,16 +22124,13 @@ function portal() {
 
       const next = (this.desktopFullPane === pane) ? "" : pane;
       this.desktopFullPane = next;
-      // Force the target pane open — otherwise "fullscreen chat" with
-      // rightOpen=false would land on a blank screen (chat is hidden by
-      // `.pane-hidden` regardless of the data-desktop-full rules).
-      // Preview shares the center column so always rendered; only the
-      // chat side needs rightOpen forced. Skipped on exit (next === "")
-      // to preserve the user's prior leftOpen/rightOpen layout.
-      if (next === "chat") this.rightOpen = true;
+      // Force preview open when it is the target — `.pane-hidden` otherwise
+      // wins regardless of the fullscreen grid rule. Chat is always mounted in
+      // the center, so it needs no corresponding visibility flag.
+      if (next === "preview") this.previewOpen = true;
       // FIX ⑥ (2026-05-30 follow-up): persist the fullscreen state so a
       // refresh restores it. There's no $watch("desktopFullPane"), and the
-      // sibling exit paths (toggleFilesPane / toggleChatPane) already call
+      // sibling exit paths (toggleFilesPane / togglePreviewPane) already call
       // savePrefs — this entry/exit path was the one gap, so toggling
       // fullscreen via the maximize button never stuck across a reload.
       this.savePrefs();
@@ -21391,7 +22220,7 @@ function portal() {
     startResize(which, ev) {
       ev.preventDefault();
       const startX = ev.clientX;
-      const startW = which === "left" ? this.leftWidth : this.rightWidth;
+      const startW = which === "left" ? this.leftWidth : this.previewWidth;
       const target = ev.currentTarget;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
@@ -21438,26 +22267,26 @@ function portal() {
       const onMove = (e) => {
         const delta = isLeft ? (e.clientX - startX) : (startX - e.clientX);
         const targetW = startW + delta;
-        const isOpenNow = isLeft ? this.leftOpen : this.rightOpen;
+        const isOpenNow = isLeft ? this.leftOpen : this.previewOpen;
         if (isOpenNow && targetW < HIDE_AT) {
           // Going-down threshold crossed. Hide and remember the pre-drag
           // width so chevron-reopen later restores that size (rather than
           // showing a sliver). Drag continues so you can pull back out.
           if (isLeft) { this.leftWidth = startW; this.leftOpen = false; }
-          else        { this.rightWidth = startW; this.rightOpen = false; }
+          else        { this.previewWidth = startW; this.previewOpen = false; }
           return;
         }
         if (!isOpenNow && targetW >= SHOW_AT) {
           // Going-up threshold crossed during the same drag — re-open.
           if (isLeft) this.leftOpen = true;
-          else        this.rightOpen = true;
+          else        this.previewOpen = true;
         }
         // Only resize when actually open (post-show transition counts).
         const reopened = !isOpenNow && targetW >= SHOW_AT;
         if (isOpenNow || reopened) {
           const w = Math.max(SHOW_AT, Math.min(maxW, targetW));
           if (isLeft) this.leftWidth = w;
-          else        this.rightWidth = w;
+          else        this.previewWidth = w;
         }
         refreshCmSoon();   // keep CM in step with the editor pane's new width
       };
@@ -22621,6 +23450,10 @@ function portal() {
     // pointerdown on the chat body (see index.html) so onChatScroll can tell a
     // user scroll-up apart from a layout-induced scroll event.
     _userScrollIntent() {
+      if (this.previewQuote.show && this.previewQuote.source === "chat"
+          && this.previewQuote.mode !== "ask") {
+        this.dismissPreviewQuote(true);
+      }
       this._userScrollAt = Date.now();
       const st = this.currentId && this.tabState && this.tabState[this.currentId];
       if (st) st._userScrollAt = this._userScrollAt;
@@ -22854,19 +23687,29 @@ function portal() {
         return false;
       }
       const sendDraft = sendState.draft;
+      // A preview-selection question is an independent prompt, not a rewrite
+      // of the visible composer. Keep the current draft and every attachment
+      // untouched while still reusing the normal current-session queue/SSE
+      // lifecycle. This also makes ticket failure recovery a no-op for the
+      // unrelated composer.
+      const hasDetachedText = typeof opts.detachedText === "string";
       // Snapshot the pinned session's draft before any await. Every later read,
       // clear, upload wait and enqueue remains owned by this exact state object.
-      const composerText = sendDraft.input || "";
-      const composerImages = sendDraft.pendingImages.slice();
-      const composerDocs = sendDraft.pendingDocs.slice();
+      const composerInput = hasDetachedText ? opts.detachedText : (sendDraft.input || "");
+      const composerImages = hasDetachedText ? [] : sendDraft.pendingImages.slice();
+      const composerDocs = hasDetachedText ? [] : sendDraft.pendingDocs.slice();
+      const composerQuotes = hasDetachedText ? [] : sendDraft.pendingQuotes.slice();
+      const composerText = hasDetachedText
+        ? composerInput : this._composerPromptText(composerInput, composerQuotes);
       const ownsSendDraft = () => this.tabState[sendSid] === sendState
         && sendState.draft === sendDraft;
       const clearSubmittedComposer = ({ preserveForHandshake = false } = {}) => {
+        if (hasDetachedText) return;
         if (!ownsSendDraft()) return;
         if (preserveForHandshake) {
-          this._stageChatRecoveryDraft(sendSid, composerText);
+          this._stageChatRecoveryDraft(sendSid, composerInput);
         }
-        if (sendDraft.input === composerText) sendDraft.input = "";
+        if (sendDraft.input === composerInput) sendDraft.input = "";
         this._resetChatInputHistory(sendDraft);
         const removeOwned = (items, sent) => {
           for (let i = items.length - 1; i >= 0; i--) {
@@ -22875,6 +23718,7 @@ function portal() {
         };
         removeOwned(sendDraft.pendingImages, new Set(composerImages));
         removeOwned(sendDraft.pendingDocs, new Set(composerDocs));
+        removeOwned(sendDraft.pendingQuotes, new Set(composerQuotes));
         // Clearing the visible composer must not clear the durable backup
         // until the SSE handshake succeeds. A newer draft typed during an
         // await is persisted alongside that pending outgoing text.
@@ -22894,8 +23738,12 @@ function portal() {
       const sendMeta = (this.sessions || []).find(s => s.id === sendSid);
       const sendModel = sendSid === this.currentId
         ? this.model : ((sendMeta && sendMeta.model) || this.model);
-      const sendPermission = sendSid === this.currentId
+      const inheritedPermission = sendSid === this.currentId
         ? this.permission : ((sendMeta && sendMeta.permission) || "default");
+      const sendPermission = this._normalizePermissionMode(
+        opts.permissionMode || inheritedPermission,
+        "default",
+      );
       const sendPlanReturnPermission = sendPermission === "plan"
         ? ((sendMeta && sendMeta.plan_return_permission) || "")
         : "";
@@ -22956,14 +23804,14 @@ function portal() {
       // enqueued — they're meta-actions (/clear, /compact, /export) that
       // depend on session state at execution time, not user intent at
       // type time. We toast "wait for this turn to finish" instead.
-      if (!isReconnect && !resumed && text.startsWith("/")) {
+      if (!isReconnect && !resumed && !hasDetachedText && text.startsWith("/")) {
         const m = text.match(/^\/(\w+)(?:\s+(.*))?$/);
         if (m) {
           if (await this._confirmSessionBusy(sendSid, sendState)) {
             this.toast(this.t("queue.slash_blocked"), "warn", 3000);
             return;
           }
-          if (ownsSendDraft() && sendDraft.input === composerText) {
+          if (ownsSendDraft() && sendDraft.input === composerInput) {
             sendDraft.input = "";
             this._resetChatInputHistory(sendDraft);
             if (this.currentId === sendSid) this.input = "";
@@ -22980,7 +23828,7 @@ function portal() {
       } else {
         const hasAttachments = resumed
           ? !!((resumed.pendingImages || []).length || (resumed.pendingDocs || []).length)
-          : !!(composerImages.length || composerDocs.length);
+          : !!(composerImages.length || composerDocs.length || composerQuotes.length);
         if (!text && !hasAttachments) return;
       }
       // If any attachment is still mid-upload, silently wait for it to
@@ -23060,8 +23908,10 @@ function portal() {
           && await this._confirmSessionBusy(sendSid, sendState)) {
         const ok = await this._enqueueMessage(sendSid, {
           text,
+          displayText: composerInput,
           pendingImages: composerImages,
           pendingDocs: composerDocs,
+          pendingQuotes: composerQuotes,
           permission: sendPermission,
           plan_return_permission: sendPlanReturnPermission,
         });
@@ -23093,6 +23943,8 @@ function portal() {
         this._capLiveMessages(sendState);
         sentUserBubble = this._appendLiveMessage(sendState, {
           role: "user", text,
+          displayText: hasDetachedText ? text : composerInput,
+          selectionQuotes: composerQuotes.map(q => ({ ...q })),
           images: readyImages.map(im => ({
             preview: im.preview,
             // Pre-compute the URL the backend will serve once it
@@ -23133,7 +23985,7 @@ function portal() {
       // Reconnect: nothing to clear. Resumed: input/pendingImages were
       // already cleared at enqueue time, and the user may have typed a
       // new draft since — don't touch their work-in-progress.
-      if (!isReconnect && !resumed) {
+      if (!isReconnect && !resumed && !hasDetachedText) {
         // Remove only the captured payload; a newer draft typed during an await
         // stays in the still-global Phase 1 composer.
         clearSubmittedComposer({ preserveForHandshake: true });
@@ -23154,7 +24006,7 @@ function portal() {
           if (!this._isMobileLayout()) ta.focus();
         });
       }
-      this._cancelMentionLookup();
+      if (!hasDetachedText) this._cancelMentionLookup();
       // streamSid + streamState alias the sendSid snapshot taken at function
       // entry. We KEEP the local names `streamSid` / `streamState` because
       // every downstream event handler (text / thinking / tool_use / done /
@@ -23305,11 +24157,11 @@ function portal() {
       // deliberately not serialised across a page reload.
       let submittedDraftRestored = false;
       const restoreSubmittedComposer = (restoreAttachments = false) => {
-        if (isReconnect || resumed || submittedDraftRestored) return;
+        if (hasDetachedText || isReconnect || resumed || submittedDraftRestored) return;
         submittedDraftRestored = true;
         if (ownsSendDraft()) {
           sendDraft.input = this._mergeChatDraftText(
-            composerText, sendDraft.input || "",
+            composerInput, sendDraft.input || "",
           );
           if (restoreAttachments) {
             const restoreOwned = (items, sent) => {
@@ -23318,6 +24170,7 @@ function portal() {
             };
             restoreOwned(sendDraft.pendingImages, composerImages);
             restoreOwned(sendDraft.pendingDocs, composerDocs);
+            restoreOwned(sendDraft.pendingQuotes, composerQuotes);
           }
           this._resolveChatRecoveryDraft(sendSid, sendDraft.input);
           if (sendSid === this.currentId) this._activateComposerState(sendSid);
@@ -23327,7 +24180,7 @@ function portal() {
         // the text in localStorage so reopening the session still recovers it.
         const persisted = this._chatDraftRecord(sendSid);
         this._resolveChatRecoveryDraft(sendSid, this._mergeChatDraftText(
-          composerText,
+          composerInput,
           this._mergeChatDraftText(persisted.pending, persisted.text),
         ));
       };
@@ -23431,8 +24284,8 @@ function portal() {
       // (b) mid-stream reconnects don't visibly reset the displayed elapsed.
       es.onopen = () => {
         streamState._lastSseActivity = Date.now();
-        if (!isReconnect && !resumed) {
-          this._commitChatRecoveryDraft(sendSid, composerText);
+        if (!hasDetachedText && !isReconnect && !resumed) {
+          this._commitChatRecoveryDraft(sendSid, composerInput);
         }
       };
 
@@ -24237,7 +25090,9 @@ function portal() {
         // _markDone covers every termination path (done / error /
         // cancelled / reconnect-give-up) — no scattered flagging logic.
         // EXCEPT user-cancelled — they don't need a "ding, ready!" cue.
-        if (this.currentId !== streamSid && !cancelled) {
+        const visibleSideQuestion = this.previewQuote.show
+          && this.previewQuote.askSessionId === streamSid;
+        if (this.currentId !== streamSid && !cancelled && !visibleSideQuestion) {
           streamState.unread = true;
         }
         // Stamp the tail of the just-finished turn with completion
@@ -24478,7 +25333,14 @@ function portal() {
         // drain will hit st.compacting=true and bail; the compact-finally
         // path will pick it up. If the queue's tab isn't the active one,
         // drain bails too and activateTab handles it on return.
-        if (d.is_error) {
+        // A normal user turn error pauses the durable queue server-side, so
+        // mirror that state immediately while the final queue sync catches up.
+        // A background continuation is different: its originating task has
+        // already settled and the backend deliberately keeps queued user input
+        // runnable. Treating its incomplete auto-reaction as a queue failure
+        // stranded otherwise-valid follow-ups in the completion window.
+        const queueBlockingError = !!d.is_error && !isContinuation;
+        if (queueBlockingError) {
           if (streamState.pendingQueue && streamState.pendingQueue.length > 0) {
             streamState._queuePaused = true;
             setTimeout(() => {
@@ -25095,7 +25957,11 @@ function portal() {
       // Drop the failed bubble, put text back in input, and send.
       const idx = this.messages.indexOf(m);
       if (idx >= 0) this.messages.splice(idx, 1);
-      this.input = m.text || "";
+      this.input = this.userVisibleText(m);
+      this.pendingQuotes.splice(
+        0, this.pendingQuotes.length,
+        ...this.userSelectionQuotes(m).map(q => ({ ...q, id: this._uuid() })),
+      );
       // pendingImages/Docs we don't have here (preview state) — re-prompt
       // user to re-attach if they had files. Acceptable: error retry is rare.
       this.$nextTick(() => {
@@ -25129,7 +25995,7 @@ function portal() {
       }
       // Close any other open edit first (only one inline editor at a time).
       (this.messages || []).forEach(msg => { if (msg !== m && msg._editing) msg._editing = false; });
-      m._editText = m.text || "";
+      m._editText = this.userVisibleText(m);
       m._editing = true;
     },
 
@@ -25190,7 +26056,7 @@ function portal() {
       return (zh ? "Muse 出错：" : "Muse error: ") + s;
     },
     copyMsg(m) {
-      const text = m.text || "";
+      const text = m.role === "user" ? this.userVisibleText(m) : (m.text || "");
       navigator.clipboard?.writeText(text).then(
         () => {
           this.toast(this.t("toast.copied"), "success", 1500);

--- a/frontend/i18n/index.js
+++ b/frontend/i18n/index.js
@@ -11,7 +11,7 @@ window.MUSELAB_STRINGS = {
     "pane.chat": "Muse",
     // sidebar / toggles
     "btn.hide_left": "隐藏文件区",  "btn.show_left": "显示文件区",
-    "btn.hide_right": "隐藏 Muse", "btn.show_right": "显示 Muse",
+    "btn.hide_preview": "隐藏预览区", "btn.show_preview": "显示预览区",
     "btn.show_hidden": "显示隐藏文件", "btn.hide_hidden": "不显示隐藏文件",
     "btn.refresh": "刷新",
     "btn.upload": "上传到当前目录",
@@ -404,7 +404,7 @@ window.MUSELAB_STRINGS = {
     "pane.preview": "Preview",
     "pane.chat": "Muse",
     "btn.hide_left": "Hide files",  "btn.show_left": "Show files",
-    "btn.hide_right": "Hide Muse",  "btn.show_right": "Show Muse",
+    "btn.hide_preview": "Hide preview", "btn.show_preview": "Show preview",
     "btn.show_hidden": "Show hidden files", "btn.hide_hidden": "Hide hidden files",
     "btn.refresh": "Refresh",
     "btn.upload": "Upload to current dir",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -343,14 +343,15 @@
         </div>
         <!-- 全局任务中心入口已迁至对话区头栏 Skills 左侧 (2026-07-21) -->
         <button @click="$refs.upload.click()" class="icon-btn files-keep-mobile" :title="t('btn.upload')"><svg><use href="#i-upload"/></svg></button>
-        <button @click="mkdirPrompt()" class="icon-btn" :title="t('btn.new_dir')"><svg><use href="#i-folder-plus"/></svg></button>
-        <button @click="toggleHidden()" class="icon-btn"
+        <button @click="toggleHidden()" class="icon-btn files-hidden-toggle"
                 :class="showHidden ? 'active' : ''"
                 :disabled="treeLoading"
                 :title="showHidden ? t('btn.hide_hidden') : t('btn.show_hidden')">
           <svg><use href="#i-eye"/></svg>
         </button>
-        <button @click="toggleTheme()" class="icon-btn files-keep-mobile"
+        <!-- Theme is a global, frequently used action: keep the original
+             one-tap control instead of nesting it under file-pane options. -->
+        <button @click="toggleTheme()" class="icon-btn files-keep-mobile files-theme-toggle"
                 :title="theme==='light' ? t('btn.theme_dark') : theme==='dark' ? t('btn.theme_eyecare') : t('btn.theme_light')">
           <svg x-show="theme==='light'"><use href="#i-moon"/></svg>
           <svg x-show="theme==='dark'"><use href="#i-leaf"/></svg>
@@ -444,7 +445,7 @@
              @dragleave="dragOverRoot = false"
              @drop.prevent="onTreeRootDrop($event)">
           <span class="icon"><svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9M5 10v10h14V10"/></svg></span>
-          <span class="path" x-text="fileWorkspacePath() || contextInfo.workspace_root || contextInfo.archive_root || '—'"></span>
+          <span class="path" x-text="lang==='zh' ? '工作区根目录' : 'Workspace root'"></span>
           <!-- Root-level quick actions. Same doNewFile/doNewDir the per-dir
                "+" and ctx menu use — both already handle path:'' (root), so
                these are pure entry points, no new write paths. @click.stop
@@ -509,18 +510,22 @@
                  intercepts (system callout), leaving touch users no way to
                  rename / delete / copy a file. The "+" (new file here) stays
                  dir-only. @click.stop so the action doesn't also toggle the row. -->
-            <span class="tree-actions">
-              <button class="tree-action" type="button"
-                      x-show="n.is_dir"
-                      @click.stop="doNewFile(n)"
-                      :title="lang==='zh' ? '在此目录新建文件' : 'New file here'"
-                      aria-label="New file">+</button>
-              <button class="tree-action" type="button"
-                      @click.stop="openCtxMenu($event, n)"
-                      :title="lang==='zh' ? '更多操作（重命名 / 删除 / 复制 / 上传…）' : 'More (rename / delete / copy / upload…)'"
-                      aria-label="More">⋯</button>
+            <span class="tree-trailing">
+              <span class="size" x-show="!n.is_dir"
+                    :title="fileSizeTitle(n.size)"
+                    x-text="fmtSize(n.size)"></span>
+              <span class="tree-actions">
+                <button class="tree-action" type="button"
+                        x-show="n.is_dir"
+                        @click.stop="doNewFile(n)"
+                        :title="lang==='zh' ? '在此目录新建文件' : 'New file here'"
+                        aria-label="New file">+</button>
+                <button class="tree-action" type="button"
+                        @click.stop="openCtxMenu($event, n)"
+                        :title="lang==='zh' ? '更多操作（重命名 / 删除 / 复制 / 上传…）' : 'More (rename / delete / copy / upload…)'"
+                        aria-label="More">⋯</button>
+              </span>
             </span>
-            <span class="size" x-show="!n.is_dir" x-text="fmtSize(n.size)"></span>
           </li>
         </template>
         <li class="filelist-virtual-spacer" aria-hidden="true"
@@ -610,42 +615,41 @@
       </footer>
     </aside>
 
-    <!-- resizer between files and preview -->
-    <div class="resizer" :class="{'pane-hidden': !leftOpen}" @mousedown="startResize('left', $event)"></div>
+    <!-- Desktop visual order is files | chat | preview. The source keeps each
+         long-lived Alpine subtree singular; CSS `order` places chat in the
+         center without cloning or conditionally remounting either pane. -->
+    <!-- resizer between files and chat -->
+    <div class="resizer files-resizer" :class="{'pane-hidden': !leftOpen}" @mousedown="startResize('left', $event)"></div>
 
-    <!-- ============ 中：预览 ============ -->
+    <!-- ============ 右：预览（CSS 网格排序） ============ -->
     <section class="pane preview"
              :class="{
+               'pane-hidden': !previewOpen,
                'pane-floating-layer': terminalManagerOpen
                  || editorTabPickerOpen || !!previewTabCtxMenu
              }">
       <header class="pane-head">
-        <button @click="toggleFilesPane()" class="icon-btn"
-                :title="desktopFullPane === 'preview'
-                  ? (lang==='zh' ? '退出全屏并显示文件区' : 'Exit fullscreen & show files')
-                  : (leftOpen ? t('btn.hide_left') : t('btn.show_left'))">
-          <!-- In preview-fullscreen the chevron always reads as "show left"
-               (chevron-right) since files pane is hidden by the fullscreen
-               layout — tapping it exits fullscreen + un-hides the pane. -->
-          <svg x-show="leftOpen && desktopFullPane !== 'preview'"><use href="#i-chevron-left"/></svg>
-          <svg x-show="!leftOpen || desktopFullPane === 'preview'"><use href="#i-chevron-right"/></svg>
-        </button>
         <span class="pane-title"
               x-text="previewSurface==='terminal' && activeTerminal()
                 ? activeTerminal().name
                 : (selected ? selected.split('/').pop() : t('pane.preview'))"></span>
-        <!-- File path + last-modified strip. Fills the gap between the title
+        <!-- Parent path + compact metadata strip. Fills the gap between the title
              and the action icons; when no file is open it's empty but still
              flex:1, so it doubles as the old `.spacer`. Light/muted styling. -->
         <div class="pane-fileinfo" x-cloak>
           <template x-if="previewSurface==='file' && selected">
             <div class="pane-fileinfo-row">
-              <span class="pane-fileinfo-path" :title="selected" x-text="selected"></span>
-              <span class="pane-fileinfo-mtime"
-                    x-show="selectedMeta && selectedMeta.mtime">
-                <span class="pane-fileinfo-mtime-label"
-                      x-text="lang === 'zh' ? '上次修改 ' : 'modified '"></span><span
-                      x-text="selectedMeta && selectedMeta.mtime ? fmtMtime(selectedMeta.mtime) : ''"></span>
+              <span class="pane-fileinfo-path" :title="selected"
+                    x-text="fileBreadcrumb(selected)"></span>
+              <span class="pane-fileinfo-meta"
+                    x-show="selectedMeta && (selectedMeta.mtime || selectedMeta.size >= 0)"
+                    :title="fileMetaTitle(selectedMeta)">
+                <span x-show="selectedMeta && selectedMeta.size >= 0"
+                      x-text="selectedMeta ? fmtSize(selectedMeta.size) : ''"></span>
+                <span class="pane-fileinfo-sep"
+                      x-show="selectedMeta && selectedMeta.size >= 0 && selectedMeta.mtime">·</span>
+                <span x-show="selectedMeta && selectedMeta.mtime"
+                      x-text="selectedMeta && selectedMeta.mtime ? fmtRelativeMtime(selectedMeta.mtime) : ''"></span>
               </span>
             </div>
           </template>
@@ -812,16 +816,6 @@
                 :aria-pressed="desktopFullPane==='preview'">
           <svg x-show="desktopFullPane!=='preview'"><use href="#i-maximize"/></svg>
           <svg x-show="desktopFullPane==='preview'"><use href="#i-minimize"/></svg>
-        </button>
-        <button @click="toggleChatPane()" class="icon-btn"
-                :title="desktopFullPane === 'preview'
-                  ? (lang==='zh' ? '退出全屏并显示 Muse' : 'Exit fullscreen & show Muse')
-                  : (rightOpen ? t('btn.hide_right') : t('btn.show_right'))">
-          <!-- In preview-fullscreen the chevron always reads as "show Muse"
-               (chevron-left) since the Muse pane is hidden by the fullscreen
-               layout — tapping it exits fullscreen + un-hides the pane. -->
-          <svg x-show="rightOpen && desktopFullPane !== 'preview'"><use href="#i-chevron-right"/></svg>
-          <svg x-show="!rightOpen || desktopFullPane === 'preview'"><use href="#i-chevron-left"/></svg>
         </button>
       </header>
       <!-- Tab bar (VSCode-style multi-file) -->
@@ -1300,18 +1294,24 @@
       </div>
     </section>
 
-    <!-- resizer between preview and chat -->
-    <div class="resizer" :class="{'pane-hidden': !rightOpen}" @mousedown="startResize('right', $event)"></div>
+    <!-- resizer between chat and preview -->
+    <div class="resizer preview-resizer" :class="{'pane-hidden': !previewOpen}" @mousedown="startResize('right', $event)"></div>
 
-    <!-- ============ 右：chat ============ -->
+    <!-- ============ 中：chat（CSS 网格排序） ============ -->
     <aside class="pane chat"
            :class="{
-             'pane-hidden': !rightOpen,
              'pane-floating-layer': sessionPickerOpen || !!tabCtxMenu
                || ctxBreakdown.show || composerSettingsOpen
                || mentionShow || slashShow
            }">
       <header class="pane-head">
+        <button @click="toggleFilesPane()" class="icon-btn pane-side-toggle"
+                :title="desktopFullPane
+                  ? (lang==='zh' ? '退出全屏并显示文件区' : 'Exit fullscreen & show files')
+                  : (leftOpen ? t('btn.hide_left') : t('btn.show_left'))">
+          <svg x-show="leftOpen && !desktopFullPane"><use href="#i-chevron-left"/></svg>
+          <svg x-show="!leftOpen || desktopFullPane"><use href="#i-chevron-right"/></svg>
+        </button>
         <span class="pane-title">
           <span class="muse-mascot sm" :class="{'greet': mascotGreet, 'is-streaming': streaming}"
                 @click="cycleMascot()" :title="mascotLabel() + (lang==='zh'?'（点击换一位）':' (click for next muse)')">
@@ -1415,6 +1415,13 @@
           </svg>
         </button>
         <button @click="openSettings()" class="icon-btn" :title="t('btn.settings')"><svg><use href="#i-settings"/></svg></button>
+        <button @click="togglePreviewPane()" class="icon-btn pane-side-toggle"
+                :title="desktopFullPane
+                  ? (lang==='zh' ? '退出全屏并显示预览区' : 'Exit fullscreen & show preview')
+                  : (previewOpen ? t('btn.hide_preview') : t('btn.show_preview'))">
+          <svg x-show="previewOpen && !desktopFullPane"><use href="#i-chevron-right"/></svg>
+          <svg x-show="!previewOpen || desktopFullPane"><use href="#i-chevron-left"/></svg>
+        </button>
       </header>
 
       <!-- Context breakdown popup — shows SDK get_context_usage() output
@@ -1952,6 +1959,21 @@
                   <div class="msg-row">
                     <span class="msg-avatar user-avatar" x-text="userAvatarText()"></span>
                     <div class="bubble user-bubble" @click="onUserBubbleClick(m)">
+                      <template x-if="userSelectionQuotes(m).length">
+                        <div class="user-msg-quotes">
+                          <template x-for="(quote, qidx) in userSelectionQuotes(m)"
+                                    :key="quote.id || ('quote-'+qidx)">
+                            <div class="user-msg-quote"
+                                 :title="previewQuoteExcerpt(quote)">
+                              <svg aria-hidden="true"><use :href="previewQuoteSourceIcon(quote)"/></svg>
+                              <div>
+                                <strong x-text="previewQuoteSourceName(quote)"></strong>
+                                <span x-text="previewQuoteExcerpt(quote)"></span>
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </template>
                       <template x-if="(m.images && m.images.length) || (m.docs && m.docs.length)">
                         <div class="user-msg-imgs">
                           <template x-for="(im, ii) in (m.images || [])" :key="'i'+ii">
@@ -2010,7 +2032,8 @@
                         </div>
                       </template>
                       <template x-if="!m._editing">
-                        <span class="user-msg-text" x-html="userTextHtml(m.text)"></span>
+                        <span class="user-msg-text" x-show="userVisibleText(m)"
+                              x-html="userTextHtml(userVisibleText(m))"></span>
                       </template>
                     </div>
                   </div>
@@ -2972,7 +2995,16 @@
                       <svg><use href="#i-x"/></svg>
                     </button>
                   </div>
-                  <div class="queued-text" x-show="q.text" x-text="q.text"></div>
+                  <div class="queued-quote-list" x-show="q.pendingQuotes && q.pendingQuotes.length">
+                    <template x-for="(quote, qidx) in (q.pendingQuotes || [])"
+                              :key="quote.id || ('queued-quote-'+qidx)">
+                      <div class="queued-quote-chip" :title="previewQuoteExcerpt(quote)">
+                        <svg aria-hidden="true"><use :href="previewQuoteSourceIcon(quote)"/></svg>
+                        <span x-text="previewQuoteSourceName(quote) + ' · ' + previewQuoteExcerpt(quote)"></span>
+                      </div>
+                    </template>
+                  </div>
+                  <div class="queued-text" x-show="q.displayText" x-text="q.displayText"></div>
                   <!-- FIX ③: the server resolves queued upload IDs against its
                        in-memory store, so we can render real image thumbnails
                        and named doc chips here — matching how a SENT message
@@ -3202,7 +3234,25 @@
              auto-wait (sendMessage) already handles the rare case where the
              upload is still in flight. Only the .error state gets a visual —
              a red border via .img-chip.error / .doc-chip.error in styles.css. -->
-        <div class="img-attachments" x-show="pendingImages.length || pendingDocs.length">
+        <div class="img-attachments"
+             x-show="pendingQuotes.length || pendingImages.length || pendingDocs.length">
+          <template x-for="(quote, i) in pendingQuotes"
+                    :key="quote.id || ('q'+i)">
+            <div class="selection-quote-chip" :title="previewQuoteExcerpt(quote)">
+              <span class="selection-quote-icon">
+                <svg aria-hidden="true"><use :href="previewQuoteSourceIcon(quote)"/></svg>
+              </span>
+              <div class="selection-quote-body">
+                <div class="selection-quote-source" x-text="previewQuoteSourceName(quote)"></div>
+                <div class="selection-quote-text" x-text="previewQuoteExcerpt(quote)"></div>
+              </div>
+              <button type="button" class="selection-quote-x icon-btn sm"
+                      @click="removePendingQuote(i)"
+                      :title="lang==='zh' ? '移除引用' : 'Remove quote'">
+                <svg><use href="#i-x"/></svg>
+              </button>
+            </div>
+          </template>
           <template x-for="(img, i) in pendingImages" :key="img.id || ('i'+i)">
             <div class="img-chip" :class="{ uploading: img.uploading, error: img.error }">
               <!-- empty :src would resolve to page URL and fail (see queued-img guard) -->
@@ -3499,7 +3549,7 @@
                  shows while streaming. Same shape + size + fill — they
                  read as a sibling pair (blue send / red stop). -->
             <button @click="send()"
-                    :disabled="workspaceSwitching || !availableModels.length || tabState[currentId]?._permissionChangePending || runtimeSettingsPending() || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingImages.length && !pendingDocs.length)"
+                    :disabled="workspaceSwitching || !availableModels.length || tabState[currentId]?._permissionChangePending || runtimeSettingsPending() || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingQuotes.length && !pendingImages.length && !pendingDocs.length)"
                     class="btn-primary chat-toolbar-send chat-toolbar-queue"
                     :aria-label="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')"
                     :title="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')">
@@ -3538,6 +3588,135 @@
       </button>
     </nav>
 
+  </div>
+
+  <!-- Parent-DOM selection helper for file previews and chat bubbles. HTML
+       stays sandboxed and PDF is browser-owned, so neither browsing context
+       is inspected here. Quote adds a removable context chip to the visible
+       composer. Ask creates a separate lightweight branch and keeps its
+       answer inside this compact panel until the user explicitly opens it. -->
+  <div class="preview-selection-popover"
+       x-ref="previewSelectionPopover"
+       x-show="authed && previewQuote.show"
+       x-cloak
+       :class="{
+         'place-above': previewQuote.above,
+         'is-asking': previewQuote.mode === 'ask',
+         'is-dragged': previewQuote.dragged,
+         'is-dragging': previewQuote.dragging,
+       }"
+       :style="{ left: previewQuote.x + 'px', top: previewQuote.y + 'px' }"
+       role="dialog"
+       :aria-label="previewQuote.mode === 'ask'
+         ? (lang === 'zh' ? '针对选中内容询问' : 'Ask about selection')
+         : (lang === 'zh' ? '选中内容操作' : 'Selection actions')"
+       @pointerdown.stop
+       @click.stop>
+    <template x-if="previewQuote.mode === 'actions'">
+      <div class="preview-selection-actions" role="toolbar"
+           :aria-label="lang === 'zh' ? '选中内容操作' : 'Selection actions'">
+        <button type="button" @pointerdown.prevent @click="quotePreviewSelection()"
+                :title="lang === 'zh' ? '作为文本附件引用' : 'Attach as quoted text'">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M7 17h4V9H5v6a2 2 0 0 0 2 2Zm10 0h2V9h-6v6a2 2 0 0 0 2 2h2Z"/>
+          </svg>
+          <span x-text="lang === 'zh' ? '引用' : 'Quote'"></span>
+        </button>
+        <span class="preview-selection-divider" aria-hidden="true"></span>
+        <button type="button" @pointerdown.prevent @click="openPreviewSelectionAsk()"
+                :title="lang === 'zh' ? '展开独立侧问' : 'Open an independent side question'">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3a7 7 0 0 0-4.7 12.2L6 20l4.2-1.4A7 7 0 1 0 12 3Zm0 3.1a2.7 2.7 0 0 1 1.2 5.1c-.8.4-1.2.8-1.2 1.6v.3h-1.8v-.5c0-1.3.6-2.1 1.8-2.7.6-.3.9-.8.9-1.3 0-.7-.5-1.2-1.3-1.2-.7 0-1.3.4-1.8 1.1L8.5 7.4A4 4 0 0 1 12 6.1Zm-1.9 8.4H12V16h-1.9v-1.5Z"/>
+          </svg>
+          <span x-text="lang === 'zh' ? '询问' : 'Ask'"></span>
+        </button>
+      </div>
+    </template>
+    <template x-if="previewQuote.mode === 'ask'">
+      <div class="preview-selection-ask-shell"
+           @pointerdown="startPreviewQuoteDrag($event)"
+           @pointermove="movePreviewQuoteDrag($event)"
+           @pointerup="finishPreviewQuoteDrag($event)"
+           @pointercancel="finishPreviewQuoteDrag($event)"
+           @lostpointercapture="finishPreviewQuoteDrag($event)">
+        <form class="preview-selection-ask"
+              x-show="!previewQuote.askSessionId"
+              @submit.prevent="sendPreviewSelectionQuestion()">
+          <div class="preview-selection-ask-head">
+            <div class="preview-selection-source">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><use :href="previewQuoteSourceIcon()"/></svg>
+              <span x-text="previewQuoteSourceName()"
+                    :title="previewQuote.source === 'preview' ? previewQuote.path : previewQuoteSourceName()"></span>
+              <small x-show="previewQuote.truncated"
+                     x-text="lang === 'zh' ? '已截断' : 'truncated'"></small>
+            </div>
+            <span class="preview-selection-drag-grip" aria-hidden="true"
+                  :title="lang === 'zh' ? '拖动窗口' : 'Drag window'">
+              <svg viewBox="0 0 12 18"><circle cx="3" cy="4" r="1"/><circle cx="9" cy="4" r="1"/><circle cx="3" cy="9" r="1"/><circle cx="9" cy="9" r="1"/><circle cx="3" cy="14" r="1"/><circle cx="9" cy="14" r="1"/></svg>
+            </span>
+            <button type="button" class="preview-selection-close"
+                    @click="dismissPreviewQuote(true)"
+                    :title="lang === 'zh' ? '取消' : 'Cancel'">×</button>
+          </div>
+          <blockquote class="preview-selection-excerpt" x-text="previewQuoteExcerpt()"></blockquote>
+          <textarea x-model="previewQuote.question"
+                    x-ref="previewQuoteInput"
+                    rows="2"
+                    autocomplete="off"
+                    :placeholder="lang === 'zh' ? '针对这段内容询问…' : 'Ask about this selection…'"
+                    @keydown.enter="onPreviewQuoteAskEnter($event)"
+                    @keydown.escape.stop.prevent="dismissPreviewQuote(true)"></textarea>
+          <div class="preview-selection-error" x-show="previewQuote.askError"
+               x-text="previewQuote.askError"></div>
+          <div class="preview-selection-ask-foot">
+            <span x-text="lang === 'zh' ? '将展开为独立侧问' : 'Opens as a separate side question'"></span>
+            <button type="submit" class="preview-selection-send"
+                    :disabled="!previewQuote.question.trim() || previewQuote.sending || !currentId || workspaceSwitching || !availableModels.length"
+                    :title="lang === 'zh' ? '开始侧问' : 'Start side question'">
+              <span class="spinner-sm" x-show="previewQuote.sending"></span>
+              <svg x-show="!previewQuote.sending" aria-hidden="true"><use href="#i-send"/></svg>
+            </button>
+          </div>
+        </form>
+
+        <div class="preview-selection-answer" x-show="previewQuote.askSessionId">
+          <div class="preview-selection-ask-head">
+            <div class="preview-selection-source">
+              <svg aria-hidden="true"><use href="#i-fork"/></svg>
+              <span x-text="lang === 'zh' ? '独立侧问' : 'Side question'"></span>
+            </div>
+            <span class="preview-selection-drag-grip" aria-hidden="true"
+                  :title="lang === 'zh' ? '拖动窗口' : 'Drag window'">
+              <svg viewBox="0 0 12 18"><circle cx="3" cy="4" r="1"/><circle cx="9" cy="4" r="1"/><circle cx="3" cy="9" r="1"/><circle cx="9" cy="9" r="1"/><circle cx="3" cy="14" r="1"/><circle cx="9" cy="14" r="1"/></svg>
+            </span>
+            <button type="button" class="preview-selection-close"
+                    @click="dismissPreviewQuote(true)"
+                    :title="lang === 'zh' ? '关闭' : 'Close'">×</button>
+          </div>
+          <div class="preview-selection-question" x-text="previewQuote.question"></div>
+          <div class="preview-selection-answer-loading"
+               x-show="previewSelectionAskRunning() && !previewSelectionAskText()">
+            <span class="spinner-sm"></span>
+            <span x-text="lang === 'zh' ? '正在回答…' : 'Answering…'"></span>
+          </div>
+          <div class="preview-selection-answer-body markdown"
+               x-show="previewSelectionAskText()"
+               x-html="previewSelectionAskHtml()"></div>
+          <div class="preview-selection-error"
+               x-show="previewQuote.askError || previewSelectionAskFailed()"
+               x-text="previewQuote.askError || (lang === 'zh' ? '侧问没有完成，可打开会话重试' : 'The side question did not finish; open the chat to retry')"></div>
+          <div class="preview-selection-ask-foot">
+            <span x-text="lang === 'zh' ? '不写入当前会话' : 'Kept out of the current chat'"></span>
+            <button type="button" class="preview-selection-open"
+                    @click="openPreviewSelectionAskSession()"
+                    :title="lang === 'zh' ? '打开完整分支会话' : 'Open the full branch chat'">
+              <svg aria-hidden="true"><use href="#i-chevron-right"/></svg>
+              <span x-text="lang === 'zh' ? '打开会话' : 'Open chat'"></span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
   </div>
 
   <!-- ============ Message outline modal ============

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -595,6 +595,15 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
   height: 100vh; height: 100dvh;
   width: 100vw; overflow: hidden;
 }
+/* Desktop information hierarchy: files | chat | preview. Keep a single copy
+   of each large Alpine subtree and use Grid's visual ordering, so changing the
+   layout never tears down the live conversation DOM or preview/editor state. */
+.layout > .pane.files { order: 1; }
+.layout > .files-resizer { order: 2; }
+.layout > .pane.chat { order: 3; }
+.layout > .preview-resizer { order: 4; }
+.layout > .pane.preview { order: 5; border-right: 0; }
+.layout > .mobile-tab-bar { order: 6; }
 .pane {
   display: flex; flex-direction: column;
   border-right: 1px solid var(--c-border);
@@ -680,10 +689,10 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
     transition: grid-template-rows var(--t-base);
   }
   /* Hide every pane by default; show only the one matching the active tab.
-     `!important` on the active pane is load-bearing: leftOpen/rightOpen are
+     `!important` on the active pane is load-bearing: leftOpen/previewOpen are
      persisted from DESKTOP use, where collapsing a side pane sets them false
      and adds `.pane-hidden` (display:none !important). On mobile the bottom
-     tab bar — NOT leftOpen/rightOpen — owns pane visibility, but without
+     tab bar — NOT leftOpen/previewOpen — owns pane visibility, but without
      !important here the persisted `.pane-hidden` wins and the Files/Chat tab
      renders a blank pane (no file tree, no search box). Re-assert. */
   .layout .pane { display: none; }
@@ -692,6 +701,7 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
   .layout[data-mobile-tab="chat"]    .pane.chat    { display: flex !important; grid-column: 1; }
   /* Drop the resizer bars (they belong to columns we no longer render) */
   .layout .resizer { display: none; }
+  .pane-side-toggle { display: none !important; }
   /* Hide the trash footer entirely on mobile. Its only live affordance on
      touch was click-to-open-trash (drag-to-delete is dead — HTML5 DnD never
      fires on touchscreens). Per product call, drop it: deletion already has
@@ -902,6 +912,7 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
     gap: var(--sp-2);
     width: 100%;
   }
+  .pane.preview .pane-head .pane-fileinfo-meta,
   .pane.preview .pane-head .pane-fileinfo-mtime { margin-left: auto; }
 
   /* Chat toolbar: keep attach + model + permission + effort + ctx-ring + send.
@@ -1601,20 +1612,21 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   min-width: 0; max-height: 100%; overflow: hidden; line-height: 1.25;
 }
 .pane-head .pane-fileinfo-path {
-  color: var(--c-fg-4); font-size: var(--fs-2xs); font-weight: var(--fw-normal);
+  color: var(--c-fg-4); font-size: var(--fs-xs); font-weight: var(--fw-normal);
   max-width: 100%;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  /* Left-truncate so the distinctive tail (…/dir/file.md) stays visible. */
-  direction: rtl; text-align: left; unicode-bidi: plaintext;
+  /* fileBreadcrumb() already keeps the useful tail to three directories. */
+  direction: ltr; text-align: left; unicode-bidi: plaintext;
 }
+.pane-head .pane-fileinfo-meta,
 .pane-head .pane-fileinfo-mtime {
-  color: var(--c-fg-4); font-size: var(--fs-2xs); opacity: 0.8;
+  color: var(--c-fg-4); font-size: var(--fs-xs); opacity: 0.82;
   flex-shrink: 0; font-variant-numeric: tabular-nums;
   /* Never wrap. "上次修改 2026-06-05 15:28" folding one glyph per line is what
      turned a 12px strip into a 50px tower and broke the header. */
   white-space: nowrap;
 }
-.pane-head .pane-fileinfo-mtime-label { opacity: 0.75; }
+.pane-head .pane-fileinfo-sep { padding: 0 3px; opacity: 0.65; }
 
 /* The files-header command-palette button is mobile-only (the mobile @media
    flips it to inline-flex). On desktop the palette lives in the chat header,
@@ -1648,6 +1660,7 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   flex: 1; min-height: 0;
   display: flex; flex-direction: column;
   overflow: hidden;
+  container-type: inline-size;
   /* Position context for the absolutely-positioned PTR indicator —
      it floats above the list without taking layout space. */
   position: relative;
@@ -1680,15 +1693,13 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 }
 .filelist-sticky-root {
   display: flex; align-items: center; gap: 6px;
-  padding: 6px 12px;
-  font-family: var(--font-mono);
+  padding: 5px 10px;
   font-size: var(--fs-xs);
   color: var(--c-fg-2);
   background: var(--c-bg-1);
   /* Strong divider so the boundary between the (transient) open-files area
      and the (persistent) tree is unmistakable. */
-  border-bottom: 1px solid var(--c-border-strong);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid var(--c-border);
   flex-shrink: 0;
   user-select: none;
   cursor: default;
@@ -1846,9 +1857,9 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 }
 .filelist li {
   display: flex; align-items: center; gap: var(--sp-1);
-  /* VSCode-tight: was 26px → 22px. Saves vertical space, matches what
-     users expect from a file tree. */
-  padding: 2px 10px; min-height: 22px;
+  /* Compact without becoming fiddly: 28px keeps the hierarchy dense while
+     leaving icons, text and hover actions enough vertical breathing room. */
+  padding: 3px 10px; min-height: 28px;
   cursor: pointer;
   /* -webkit-/-moz- prefixes are REQUIRED: mobile WebKit (iOS Safari) ignores
      the unprefixed `user-select: none`, so without these the long-press on a
@@ -1899,13 +1910,19 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 }
 .filelist li:hover { background: var(--c-bg-2); }
 
-/* VSCode-style inline actions on directory rows. Pinned to the right
-   via margin-left:auto on the li-flex. Hidden by default, revealed on
-   row hover (desktop) or faded permanently on touch. */
+/* One stable trailing column owns either metadata or actions. Hover swaps the
+   two in-place, so buttons never squeeze the file name or sit beside a size. */
+.filelist li .tree-trailing {
+  position: relative; margin-left: auto;
+  flex: 0 0 64px; height: 22px; min-width: 0;
+  display: flex; align-items: center; justify-content: flex-end;
+}
+.filelist li.dir .tree-trailing { flex-basis: 44px; }
 .filelist li .tree-actions {
-  margin-left: auto;
+  position: absolute; inset: 0 0 0 auto;
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 2px;
   opacity: 0;
   transition: opacity var(--t-fast);
@@ -1914,6 +1931,7 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 /* File rows now also render the "⋯" more-menu (not just dirs), so reveal
    the action bar on hover for any row, not only directories. */
 .filelist li:hover .tree-actions { opacity: 1; }
+.filelist li:hover .size { opacity: 0; }
 .tree-action {
   background: transparent;
   border: 0;
@@ -1944,10 +1962,11 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   .filelist li .tree-actions { opacity: 0.55; }
   .filelist li .tree-actions:active,
   .filelist li.sel .tree-actions { opacity: 1; }
+  .filelist li .size { display: none !important; }
 }
 .filelist li.sel {
-  background: var(--c-accent-soft); color: var(--c-accent-fg);
-  box-shadow: inset 3px 0 0 var(--c-accent);   /* 左侧主色竖条标 active */
+  background: var(--c-accent-soft); color: var(--c-fg-0);
+  box-shadow: none;
 }
 .filelist li.sel .icon { color: var(--c-accent); }
 .filelist li.drag-over { background: var(--c-accent); color: white; box-shadow: inset 0 0 0 2px white; }
@@ -2024,7 +2043,19 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   flex: 1; font-size: var(--fs-base);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.filelist .size { color: var(--c-fg-3); font-size: var(--fs-xs); font-family: var(--font-mono); }
+.filelist .size {
+  width: 100%; overflow: hidden; text-overflow: ellipsis;
+  color: var(--c-fg-3); font-size: var(--fs-2xs);
+  font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap;
+  transition: opacity var(--t-fast);
+}
+
+/* A narrow tree should protect the filename. Exact size remains available in
+   the preview metadata strip and tooltip without adding per-row stat calls. */
+@container (max-width: 250px) {
+  .filelist li.file .tree-trailing { flex-basis: 22px; }
+  .filelist li.file .size { display: none !important; }
+}
 
 /* Search results (双区块) */
 .search-results { overflow-y: auto; flex: 1; padding: var(--sp-2) 0; }
@@ -2361,6 +2392,306 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
 .preview-find-item-snip { overflow: hidden; text-overflow: ellipsis; font-family: var(--font-mono); }
 .preview-find-item-snip mark,
 .preview-find-list mark { background: var(--c-accent-soft); color: var(--c-accent-fg); padding: 0 1px; border-radius: 2px; }
+
+/* Preview text-selection helper. Fixed positioning keeps it outside every
+   pane's overflow/scroll clipping and avoids touching the preview DOM itself. */
+.preview-selection-popover {
+  position: fixed;
+  z-index: 1450;
+  width: max-content;
+  max-width: calc(100vw - 24px);
+  transform: translateX(-50%);
+  margin-top: 8px;
+  color: var(--c-fg-1);
+  font-family: var(--font-sans);
+  font-size: var(--fs-sm);
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.32));
+  animation: preview-selection-in 120ms ease-out;
+}
+.preview-selection-popover.place-above {
+  transform: translate(-50%, -100%);
+  margin-top: -8px;
+}
+.preview-selection-popover.is-dragged {
+  transform: none;
+  margin-top: 0;
+  will-change: left, top;
+}
+.preview-selection-popover.is-dragging {
+  filter: drop-shadow(0 14px 30px rgba(0, 0, 0, 0.38));
+}
+@keyframes preview-selection-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.preview-selection-actions {
+  display: flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 3px;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-full);
+  background: var(--c-bg-2);
+}
+.preview-selection-actions button {
+  height: 30px;
+  padding: 0 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--c-fg-1);
+  font: inherit;
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast);
+}
+.preview-selection-actions button:hover,
+.preview-selection-actions button:focus-visible {
+  background: var(--c-accent-soft);
+  color: var(--c-accent-fg);
+  outline: none;
+}
+.preview-selection-actions button svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  fill: currentColor;
+}
+.preview-selection-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--c-border-strong);
+}
+.preview-selection-popover.is-asking {
+  width: min(420px, calc(100vw - 24px));
+}
+.preview-selection-ask-shell {
+  width: 100%;
+  max-height: min(560px, calc(100vh - 28px));
+  overflow: hidden;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-lg);
+  background: var(--c-bg-2);
+}
+.preview-selection-ask {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+  border: 0;
+  background: transparent;
+}
+.preview-selection-ask-head,
+.preview-selection-ask-foot,
+.preview-selection-source {
+  display: flex;
+  align-items: center;
+}
+.preview-selection-ask-head {
+  min-height: 24px;
+  gap: 8px;
+  margin-bottom: 7px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+.preview-selection-popover.is-dragging .preview-selection-ask-head {
+  cursor: grabbing;
+}
+.preview-selection-source {
+  min-width: 0;
+  flex: 1;
+  gap: 6px;
+  color: var(--c-fg-2);
+}
+.preview-selection-source > svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+.preview-selection-source > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: var(--fw-medium);
+  color: var(--c-fg-1);
+}
+.preview-selection-source small {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: var(--r-full);
+  background: var(--c-warn);
+  color: #17120a;
+  font-size: var(--fs-2xs);
+}
+.preview-selection-drag-grip {
+  width: 16px;
+  height: 22px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c-fg-4);
+  opacity: 0.72;
+  pointer-events: none;
+}
+.preview-selection-drag-grip svg {
+  width: 10px;
+  height: 16px;
+  fill: currentColor;
+}
+.preview-selection-ask-head:hover .preview-selection-drag-grip,
+.preview-selection-popover.is-dragging .preview-selection-drag-grip {
+  color: var(--c-fg-2);
+  opacity: 1;
+}
+.preview-selection-close {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--c-fg-3);
+  font: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.preview-selection-close:hover { background: var(--c-bg-3); color: var(--c-fg-0); }
+.preview-selection-excerpt {
+  max-height: 54px;
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  overflow: hidden;
+  border-left: 2px solid var(--c-accent);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  background: var(--c-bg-1);
+  color: var(--c-fg-3);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+}
+.preview-selection-ask textarea {
+  display: block;
+  width: 100%;
+  min-height: 62px;
+  max-height: 150px;
+  resize: vertical;
+  box-sizing: border-box;
+  padding: 8px 9px;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-md);
+  outline: none;
+  background: var(--c-bg-1);
+  color: var(--c-fg-0);
+  font: inherit;
+  line-height: 1.45;
+}
+.preview-selection-ask textarea::placeholder { color: var(--c-fg-3); }
+.preview-selection-ask textarea:focus {
+  border-color: var(--c-accent);
+  box-shadow: 0 0 0 2px var(--c-accent-soft);
+}
+.preview-selection-ask-foot {
+  min-height: 30px;
+  gap: 8px;
+  margin-top: 8px;
+}
+.preview-selection-ask-foot > span {
+  flex: 1;
+  color: var(--c-fg-3);
+  font-size: var(--fs-xs);
+}
+.preview-selection-send {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--c-btn-primary-bg);
+  color: var(--c-on-accent);
+  cursor: pointer;
+}
+.preview-selection-send:hover:not(:disabled) { background: var(--c-btn-primary-hover); }
+.preview-selection-send:disabled { opacity: 0.42; cursor: default; }
+.preview-selection-send svg { width: 15px; height: 15px; }
+.preview-selection-send .spinner-sm { width: 13px; height: 13px; }
+.preview-selection-answer {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+}
+.preview-selection-question {
+  margin: 0 0 8px;
+  padding: 7px 9px;
+  border-radius: var(--r-md);
+  background: var(--c-bg-1);
+  color: var(--c-fg-2);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+.preview-selection-answer-loading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 72px;
+  color: var(--c-fg-3);
+  font-size: var(--fs-xs);
+}
+.preview-selection-answer-body {
+  max-height: min(360px, calc(100vh - 210px));
+  overflow: auto;
+  padding: 2px 3px 6px;
+  color: var(--c-fg-1);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+.preview-selection-answer-body > :first-child { margin-top: 0; }
+.preview-selection-answer-body > :last-child { margin-bottom: 0; }
+.preview-selection-error {
+  margin-top: 7px;
+  color: var(--c-danger);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+.preview-selection-open {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 9px;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-md);
+  background: var(--c-bg-1);
+  color: var(--c-fg-1);
+  font: inherit;
+  font-size: var(--fs-xs);
+  cursor: pointer;
+}
+.preview-selection-open:hover {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+}
+.preview-selection-open svg { width: 13px; height: 13px; }
+@media (pointer: coarse) {
+  .preview-selection-actions { min-height: 44px; }
+  .preview-selection-actions button { height: 38px; padding: 0 14px; }
+  .preview-selection-close,
+  .preview-selection-send { width: 36px; height: 36px; }
+  .preview-selection-open { min-height: 36px; }
+  .preview-selection-ask textarea { font-size: 16px; }
+}
 
 /* Injected highlight marks in the live preview content. */
 .preview-body mark.find-hit {
@@ -4723,6 +5054,58 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   display: flex; flex-wrap: wrap; gap: 6px;
   padding: 6px 4px;
 }
+.selection-quote-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: min(310px, 100%);
+  min-height: 48px;
+  box-sizing: border-box;
+  padding: 6px 30px 6px 9px;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-md);
+  background: var(--c-bg-1);
+}
+.selection-quote-icon {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  background: var(--c-accent-soft);
+  color: var(--c-accent);
+}
+.selection-quote-icon svg { width: 14px; height: 14px; }
+.selection-quote-body { min-width: 0; line-height: 1.25; }
+.selection-quote-source {
+  color: var(--c-fg-1);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+}
+.selection-quote-text {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--c-fg-3);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.selection-quote-x {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--c-fg-3);
+}
+.selection-quote-x:hover { background: var(--c-bg-3); color: var(--c-fg-0); }
+.selection-quote-x svg { width: 11px; height: 11px; }
 .img-chip {
   position: relative;
   width: 64px; height: 64px;
@@ -5202,6 +5585,37 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   .img-editor-toolbar { padding: 8px 10px; gap: 12px; }
   .img-editor-foot { padding: 10px; }
 }
+.user-msg-quotes {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 7px;
+}
+.user-msg-quote {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: var(--r-md);
+  background: rgba(255, 255, 255, 0.12);
+}
+.user-msg-quote > svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+.user-msg-quote > div { min-width: 0; }
+.user-msg-quote strong,
+.user-msg-quote span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.user-msg-quote strong { font-size: var(--fs-xs); font-weight: var(--fw-semibold); }
+.user-msg-quote span { margin-top: 1px; opacity: 0.78; font-size: var(--fs-xs); }
 .user-msg-imgs {
   display: flex; flex-wrap: wrap; gap: 6px;
   margin-bottom: 6px;
@@ -6490,6 +6904,30 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
 }
 .queued-act:hover { background: rgba(255, 255, 255, 0.18); color: white; }
 .queued-act svg { width: 12px; height: 12px; }
+.queued-quote-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+.queued-quote-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 5px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: var(--r-sm);
+  background: rgba(255, 255, 255, 0.1);
+  font-size: var(--fs-xs);
+}
+.queued-quote-chip svg { width: 12px; height: 12px; flex: 0 0 auto; }
+.queued-quote-chip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .queued-text {
   white-space: pre-wrap; word-break: break-word;
   font-size: var(--fs-sm);
@@ -8957,6 +9395,8 @@ html[data-theme="dark"] .bubble :not(pre) > code:not(.has-file-link) * {
     padding-top: 6px;
     padding-bottom: 6px;
   }
+  .filelist li.file .tree-trailing { flex-basis: 36px; height: 36px; }
+  .filelist li.dir .tree-trailing { flex-basis: 74px; height: 36px; }
   .tree-action,
   .root-action {
     min-width: 36px;

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -49,6 +49,49 @@ def test_memory_shortcut_opens_memory_settings_page(
     expect(page.locator(".memory-settings-section")).to_be_visible()
 
 
+def test_session_rename_updates_loaded_activity_row_immediately(
+    page: Page, backend_url, auth_token
+):
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const before = app.sessions.find(row => row.id === sid)?.name || '';
+          app.activity.events = [{
+            id: 'rename-target',
+            session_id: sid,
+            session_name: before,
+            task_summary: 'Keep task summary',
+            workspace: app.currentWorkspacePath(),
+            workspace_name: 'e2e',
+            state: 'completed',
+            read: true,
+            started_at: 1,
+            finished_at: 2,
+            updated_at: 2,
+          }];
+          app.renamingPickerSid = sid;
+          app.pickerRenameDraft = 'Renamed activity row';
+          await app.pickerCommitInlineRename();
+          return {
+            sessionName: app.sessions.find(row => row.id === sid)?.name,
+            activityName: app.activity.events[0]?.session_name,
+            taskSummary: app.activity.events[0]?.task_summary,
+            updatedAt: app.activity.events[0]?.updated_at,
+          };
+        }"""
+    )
+
+    assert result == {
+        "sessionName": "Renamed activity row",
+        "activityName": "Renamed activity row",
+        "taskSummary": "Keep task summary",
+        "updatedAt": 2,
+    }
+
+
 def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_token):
     page.add_init_script("localStorage.removeItem('muselab_activity_view')")
     _login(page, backend_url, auth_token)

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -261,6 +261,189 @@ def _bootstrap_session_for_real_load(page: Page, sid: str, name: str) -> None:
     )
 
 
+def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
+    page: Page, backend_url, auth_token,
+):
+    """User/assistant正文 share the preview selection helper safely."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    sid = "selection-chat-source"
+    _bootstrap_session_for_real_load(page, sid, "Selection source")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st._loaded = true;
+        st.messages = [
+          {
+            role: "user", text: "USER_SELECTION_MARKER user selected sentence",
+            uuid: "selection-user", _k: "selection-user", _noAnim: true,
+          },
+          {
+            role: "assistant",
+            text: "ASSISTANT_SELECTION_MARKER assistant selected sentence",
+            html: "<p>ASSISTANT_SELECTION_MARKER assistant selected sentence</p>",
+            uuid: "selection-assistant", _k: "selection-assistant", _noAnim: true,
+          },
+        ];
+        st.draft.input = "EXISTING_DRAFT";
+        st.draft.pendingImages = [{
+          id: "keep-image", uploading: false,
+          preview: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
+        }];
+        st.draft.pendingDocs = [{ id: "keep-doc", uploading: false }];
+        app._activateTabState(arg);
+        app.mobileTab = "chat";
+        app.lang = "zh";
+        app.availableModels = [{ model: "e2e-model", label: "E2E" }];
+        return true;
+        """,
+        sid,
+    )
+    page.wait_for_function(
+        """sid => document.querySelectorAll(
+          `.msg-pane[data-tid="${CSS.escape(sid)}"] .msg`).length === 2""",
+        arg=sid,
+    )
+
+    def select_text(selector: str) -> None:
+        page.evaluate(
+            """selector => {
+              const node = document.querySelector(selector);
+              if (!node) throw new Error(`missing selection node: ${selector}`);
+              const range = document.createRange();
+              range.selectNodeContents(node);
+              const selection = window.getSelection();
+              selection.removeAllRanges();
+              selection.addRange(range);
+              document.dispatchEvent(new Event('selectionchange'));
+            }""",
+            selector,
+        )
+
+    select_text(
+        f'.msg-pane[data-tid="{sid}"] .msg.assistant .bubble p'
+    )
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.previewQuote.show && app.previewQuote.source === 'chat'
+            && app.previewQuote.role === 'assistant';
+        }"""
+    )
+    expect(page.locator(".preview-selection-actions")).to_be_visible()
+    page.locator(".preview-selection-actions button").first.click()
+    quoted = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(app.currentId);
+        return {
+          input: st.draft.input,
+          quotes: st.draft.pendingQuotes.map(item => ({
+            text: item.text, role: item.role, messageId: item.messageId,
+          })),
+          images: st.draft.pendingImages.map(item => item.id),
+          docs: st.draft.pendingDocs.map(item => item.id),
+        };
+        """,
+    )
+    assert quoted["input"] == "EXISTING_DRAFT"
+    assert len(quoted["quotes"]) == 1
+    assert quoted["quotes"][0]["role"] == "assistant"
+    assert quoted["quotes"][0]["messageId"] == "selection-assistant"
+    assert "ASSISTANT_SELECTION_MARKER" in quoted["quotes"][0]["text"]
+    assert quoted["images"] == ["keep-image"]
+    assert quoted["docs"] == ["keep-doc"]
+
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(app.currentId);
+        st.draft.input = "ASK_DRAFT_MUST_SURVIVE";
+        st.draft.pendingQuotes.splice(0);
+        app._activateComposerState(app.currentId);
+        window.__selectionAskOriginalCreate = app._createPreviewSelectionAskSession;
+        app._createPreviewSelectionAskSession = async (snapshot, question) => {
+          const meta = {
+            id: "chat-side-question", name: "Chat side question",
+            model: app.model, permission: "default", active: false,
+            cwd: app.currentWorkspacePath(),
+          };
+          app.sessions = [meta, ...app.sessions.filter(s => s.id !== meta.id)];
+          const child = app._ensureTabState(meta.id);
+          child._loaded = true;
+          window.__selectionAskCreate = {snapshot, question};
+          return meta;
+        };
+        app.send = async opts => {
+          window.__selectionAskSend = opts;
+          const child = app._ensureTabState(opts.sessionId);
+          child.messages.splice(0, child.messages.length,
+            {role: "user", text: opts.detachedText},
+            {role: "assistant", text: "CHAT_SIDE_ANSWER"});
+          child.streaming = false;
+          return true;
+        };
+        """,
+    )
+    select_text(
+        f'.msg-pane[data-tid="{sid}"] .msg.user .user-msg-text'
+    )
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.previewQuote.show && app.previewQuote.source === 'chat'
+            && app.previewQuote.role === 'user';
+        }"""
+    )
+    page.locator(".preview-selection-actions button").nth(1).click()
+    ask = page.locator(".preview-selection-ask textarea")
+    expect(ask).to_be_focused()
+    ask.fill("这里的结论为什么成立？")
+    page.locator(".preview-selection-send").click()
+    page.wait_for_function("() => !!window.__selectionAskSend")
+    expect(page.locator(".preview-selection-answer-body")).to_contain_text(
+        "CHAT_SIDE_ANSWER"
+    )
+    sent = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app._ensureTabState(app.currentId);
+          return {
+            opts: window.__selectionAskSend,
+            create: window.__selectionAskCreate,
+            currentId: app.currentId,
+            draft: st.draft.input,
+            images: st.draft.pendingImages.map(item => item.id),
+            docs: st.draft.pendingDocs.map(item => item.id),
+            popover: app.previewQuote.show,
+            askSessionId: app.previewQuote.askSessionId,
+          };
+        }"""
+    )
+    assert sent["opts"]["sessionId"] == "chat-side-question"
+    assert sent["opts"]["permissionMode"] == "default"
+    assert "引用自我的消息：" in sent["opts"]["detachedText"]
+    assert "USER_SELECTION_MARKER" in sent["opts"]["detachedText"]
+    assert "这里的结论为什么成立？" in sent["opts"]["detachedText"]
+    assert sent["create"]["snapshot"]["sessionId"] == sid
+    assert sent["create"]["snapshot"]["messageId"] == "selection-user"
+    assert sent["currentId"] == sid
+    assert sent["draft"] == "ASK_DRAFT_MUST_SURVIVE"
+    assert sent["images"] == ["keep-image"]
+    assert sent["docs"] == ["keep-doc"]
+    assert sent["popover"] is True
+    assert sent["askSessionId"] == "chat-side-question"
+    _app_eval(
+        page,
+        """
+        app._createPreviewSelectionAskSession = window.__selectionAskOriginalCreate;
+        return true;
+        """,
+    )
+    _assert_no_browser_errors(page, errors)
+
+
 def test_effort_fast_capabilities_and_session_restore(
     page: Page, backend_url, auth_token,
 ):
@@ -2727,6 +2910,100 @@ def test_background_completion_no_active_fallback_never_blanks_visible_messages(
     assert result["sameNode"] is True, result
     assert result["key"] == f"{sid}:live:2"
     assert result["finalVisible"] is True, result
+    _assert_no_browser_errors(page, errors)
+
+
+def test_incomplete_background_continuation_keeps_user_queue_runnable(
+    page: Page, backend_url, auth_token,
+):
+    """A missed auto-reaction is not a failure of the queued user prompt."""
+    errors = _capture_browser_errors(page)
+    _install_fake_event_source(page)
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"continuation-queue-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    sid = "continuation-queue-runnable"
+    _bootstrap_session_for_real_load(page, sid, "Continuation queue")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st._loaded = true;
+        st.messages = [{
+          role: "assistant", text: "BACKGROUND RESULT",
+          html: "<p>BACKGROUND RESULT</p>",
+          uuid: "continuation-queue-assistant",
+          _k: "continuation-queue-assistant", _noAnim: true,
+        }];
+        st.pendingQueue = [{
+          id: "queued-user-followup", text: "USER FOLLOWUP",
+          pendingImages: [], pendingDocs: [],
+        }];
+        st._queuePaused = false;
+        app._activateTabState(arg);
+        app.model = "e2e-model";
+        app._syncSessionListQuiet = () => {};
+        app._syncQueueFromServer = async () => {};
+        app._reconcileCompletedContinuation = () => {};
+        app.ackCurrentActivity = () => {};
+        app.highlightCode = async () => {};
+        app._ensureBgContPoller = () => {};
+        app._drainPendingQueue = (drainSid, turnId) => {
+          window.__continuationQueueDrain = { sid: drainSid, turnId };
+        };
+        return true;
+        """,
+        sid,
+    )
+
+    _app_eval(
+        page,
+        """
+        return app.send({
+          reconnect: true, continuation: true, sessionId: arg,
+          turnId: "continuation-queue-turn", startedAt: Date.now() / 1000,
+        });
+        """,
+        sid,
+    )
+    page.wait_for_function(
+        "() => window.__fakeChatStreams && window.__fakeChatStreams().length === 1"
+    )
+    page.evaluate(
+        """() => window.__emitSse("done", {
+          is_error: true,
+          kind: "background_continuation_incomplete",
+          error: "background task completed but no final auto-reaction arrived",
+          continuation: true,
+          background_tasks_pending: 0,
+          turn_id: "continuation-queue-turn",
+          event_seq: 1,
+        })"""
+    )
+    page.wait_for_function("() => !!window.__continuationQueueDrain")
+    result = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        return {
+          paused: st._queuePaused,
+          pending: st.pendingQueue.map(item => item.text),
+          drain: window.__continuationQueueDrain,
+        };
+        """,
+        sid,
+    )
+    assert result == {
+        "paused": False,
+        "pending": ["USER FOLLOWUP"],
+        "drain": {"sid": sid, "turnId": "continuation-queue-turn"},
+    }
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -6,6 +6,7 @@ that aborts, reactive tab state, and editor buffers settle on the right owner.
 from __future__ import annotations
 
 from collections import Counter
+import json
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -28,6 +29,916 @@ def _login(page: Page, base: str, token: str) -> None:
           return app && app.authed && app.appReady && app._sessionsInitialized;
         }"""
     )
+
+
+def _select_rendered_preview_text(page: Page) -> str:
+    return page.evaluate(
+        """() => {
+          const roots = Array.from(document.querySelectorAll(
+            '.pane.preview .markdown, .pane.preview pre.text, '
+            + '.pane.preview .xlsx-preview'
+          )).filter(el => el.getClientRects().length && el.textContent.trim());
+          const root = roots[0];
+          if (!root) throw new Error('no visible selectable preview');
+          const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+              return node.data.trim().length >= 8
+                ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+            },
+          });
+          const node = walker.nextNode();
+          if (!node) throw new Error('no preview text node');
+          const leading = node.data.length - node.data.trimStart().length;
+          const length = Math.min(32, node.data.trim().length);
+          const range = document.createRange();
+          range.setStart(node, leading);
+          range.setEnd(node, leading + length);
+          const selection = window.getSelection();
+          selection.removeAllRanges();
+          selection.addRange(range);
+          document.dispatchEvent(new Event('selectionchange'));
+          return selection.toString();
+        }"""
+    )
+
+
+def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.desktopFullPane = '';
+          app.leftOpen = true;
+          app.previewOpen = true;
+          app.leftWidth = 280;
+          app.previewWidth = 440;
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+
+          const files = document.querySelector('.pane.files');
+          const chat = document.querySelector('.pane.chat');
+          const preview = document.querySelector('.pane.preview');
+          const chatNode = chat;
+          const rect = node => {
+            const r = node.getBoundingClientRect();
+            return {left: r.left, right: r.right, width: r.width};
+          };
+          const before = {
+            files: rect(files), chat: rect(chat), preview: rect(preview),
+            orders: [files, chat, preview].map(node => getComputedStyle(node).order),
+          };
+
+          app.togglePreviewPane();
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+          const hidden = {
+            previewDisplay: getComputedStyle(preview).display,
+            chat: rect(chat),
+            sameChatNode: document.querySelector('.pane.chat') === chatNode,
+          };
+
+          app.togglePreviewPane();
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+          const restored = {
+            previewDisplay: getComputedStyle(preview).display,
+            chat: rect(chat), preview: rect(preview),
+            sameChatNode: document.querySelector('.pane.chat') === chatNode,
+          };
+          const prefs = JSON.parse(localStorage.getItem('muselab_prefs') || '{}');
+          localStorage.setItem('muselab_prefs', JSON.stringify({
+            schema: 7, rightOpen: false, rightWidth: 512,
+          }));
+          app.previewOpen = true;
+          app.previewWidth = 440;
+          app.loadPrefs();
+          const migration = {
+            previewOpen: app.previewOpen,
+            previewWidth: app.previewWidth,
+          };
+          app.previewOpen = false;
+          app.toggleDesktopFull('preview');
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+          const previewFullscreen = {
+            previewOpen: app.previewOpen,
+            preview: rect(preview),
+            chatDisplay: getComputedStyle(chat).display,
+          };
+          app.toggleDesktopFull('preview');
+          await new Promise(resolve => app.$nextTick(resolve));
+          app.toggleDesktopFull('chat');
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+          const chatFullscreen = {
+            chat: rect(chat),
+            previewDisplay: getComputedStyle(preview).display,
+            sameChatNode: document.querySelector('.pane.chat') === chatNode,
+          };
+          app.toggleDesktopFull('chat');
+          return {
+            before, hidden, restored, prefs, migration,
+            previewFullscreen, chatFullscreen,
+          };
+        }"""
+    )
+
+    before = result["before"]
+    assert before["files"]["right"] <= before["chat"]["left"]
+    assert before["chat"]["right"] <= before["preview"]["left"]
+    assert before["chat"]["width"] > before["preview"]["width"]
+    assert before["orders"] == ["1", "3", "5"]
+
+    assert result["hidden"]["previewDisplay"] == "none"
+    assert result["hidden"]["chat"]["width"] > before["chat"]["width"]
+    assert result["hidden"]["sameChatNode"] is True
+    assert result["restored"]["previewDisplay"] == "flex"
+    assert result["restored"]["chat"]["right"] <= result["restored"]["preview"]["left"]
+    assert result["restored"]["sameChatNode"] is True
+    assert result["prefs"]["schema"] == 8
+    assert result["prefs"]["previewOpen"] is True
+    assert result["prefs"]["previewWidth"] == 440
+    assert "rightOpen" not in result["prefs"]
+    assert "rightWidth" not in result["prefs"]
+    assert result["migration"] == {"previewOpen": True, "previewWidth": 512}
+    assert result["previewFullscreen"]["previewOpen"] is True
+    assert result["previewFullscreen"]["preview"]["width"] == 1440
+    assert result["previewFullscreen"]["chatDisplay"] == "none"
+    assert result["chatFullscreen"]["chat"]["width"] == 1440
+    assert result["chatFullscreen"]["previewDisplay"] == "none"
+    assert result["chatFullscreen"]["sameChatNode"] is True
+
+
+def test_file_metadata_layout_is_compact_and_human_readable(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.selected === 'README.md' && app.selectedMeta?.path === 'README.md';
+        }"""
+    )
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.lang = 'zh';
+          const now = Date.now();
+          app.fileMetaClock = now;
+          await new Promise(resolve => app.$nextTick(resolve));
+          const row = document.querySelector('.filelist li[data-path="README.md"]');
+          const size = row.querySelector('.size');
+          const meta = document.querySelector('.pane-fileinfo-meta');
+          return {
+            sizes: [0, 1024, 1536, 1024 ** 3, 1024 ** 4].map(n => app.fmtSize(n)),
+            relative: app.fmtRelativeMtime((now - 5 * 60_000) / 1000),
+            breadcrumb: app.fileBreadcrumb('one/two/three/four/file.md'),
+            rowHeight: row.getBoundingClientRect().height,
+            sizeText: size.textContent.trim(),
+            sizeFont: getComputedStyle(size).fontFamily,
+            metaText: meta.textContent.replace(/\\s+/g, ' ').trim(),
+            metaTitle: meta.title,
+          };
+        }"""
+    )
+
+    assert result["sizes"] == ["0 B", "1 KB", "1.5 KB", "1 GB", "1 TB"]
+    assert result["relative"] == "5 分钟前"
+    assert result["breadcrumb"] == "… › two › three › four"
+    assert result["rowHeight"] >= 28
+    assert result["sizeText"].endswith(" B")
+    assert "mono" not in result["sizeFont"].lower()
+    assert "B" in result["metaText"]
+    assert "修改于" in result["metaTitle"]
+
+
+def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const visible = Array.from(document.querySelectorAll(
+            '.pane.preview .markdown'
+          )).some(el => el.getClientRects().length && el.textContent.trim());
+          return app.selected === 'README.md' && app.previewMode === 'md' && visible;
+        }"""
+    )
+
+    before = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.lang = 'zh';
+          app.input = 'alphaomega';
+          await new Promise(resolve => app.$nextTick(resolve));
+          app._captureComposerState(app.currentId);
+          const ta = app.$refs.chatInput;
+          ta.setSelectionRange(5, 5);
+          return {
+            session: app.currentId,
+            sessionCount: app.sessions.length,
+            openTabs: [...app.openTabIds],
+            messageCount: app.messages.length,
+          };
+        }"""
+    )
+    selected = _select_rendered_preview_text(page)
+    expect(page.locator(".preview-selection-actions")).to_be_visible(timeout=3000)
+    page.locator(".preview-selection-actions button").nth(0).click()
+    expect(page.locator(".preview-selection-popover")).to_be_hidden()
+
+    quoted = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const quote = app.pendingQuotes[0];
+          return {
+            input: app.input,
+            draft: app.tabState[app.currentId].draft.input,
+            quoteCount: app.pendingQuotes.length,
+            quoteText: quote && quote.text,
+            quotePath: quote && quote.path,
+            session: app.currentId,
+            sessionCount: app.sessions.length,
+            openTabs: [...app.openTabIds],
+            messageCount: app.messages.length,
+          };
+        }"""
+    )
+    assert quoted["input"] == quoted["draft"]
+    assert quoted["input"] == "alphaomega"
+    assert quoted["quoteCount"] == 1
+    assert quoted["quoteText"] == selected
+    assert quoted["quotePath"] == "README.md"
+    assert quoted["session"] == before["session"]
+    assert quoted["sessionCount"] == before["sessionCount"]
+    assert quoted["openTabs"] == before["openTabs"]
+    assert quoted["messageCount"] == before["messageCount"]
+
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.input = 'KEEP EXISTING DRAFT';
+          app.pendingImages = [{id: 'keep-image'}];
+          app.pendingDocs = [{id: 'keep-doc'}];
+          app.pendingQuotes.splice(0);
+          app._captureComposerState(app.currentId);
+          window.__previewAskOriginalSend = app.send;
+          window.__previewAskOriginalCreate = app._createPreviewSelectionAskSession;
+          app._createPreviewSelectionAskSession = async (snapshot, question) => {
+            const meta = {
+              id: 'preview-side-question', name: 'Preview side question',
+              model: app.model, permission: 'default', active: false,
+              cwd: app.currentWorkspacePath(),
+            };
+            app.sessions = [meta, ...app.sessions.filter(s => s.id !== meta.id)];
+            const st = app._ensureTabState(meta.id);
+            st._loaded = true;
+            window.__previewAskCreate = {snapshot, question};
+            return meta;
+          };
+          app.send = async opts => {
+            window.__previewAskOptions = JSON.parse(JSON.stringify(opts));
+            const st = app._ensureTabState(opts.sessionId);
+            st.messages.splice(0, st.messages.length,
+              {role: 'user', text: opts.detachedText},
+              {role: 'assistant', text: 'SIDE_ANSWER_MARKER'});
+            st.streaming = false;
+            return true;
+          };
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+    selected_for_ask = _select_rendered_preview_text(page)
+    expect(page.locator(".preview-selection-actions")).to_be_visible(timeout=3000)
+    page.locator(".preview-selection-actions button").nth(1).click()
+    ask = page.locator(".preview-selection-ask")
+    expect(ask).to_be_visible()
+    ask.locator("textarea").fill("这段内容的核心是什么？")
+    ask.locator('button[type="submit"]').click()
+    expect(page.locator(".preview-selection-answer")).to_be_visible()
+    expect(page.locator(".preview-selection-answer-body")).to_contain_text(
+        "SIDE_ANSWER_MARKER"
+    )
+
+    asked = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const opts = window.__previewAskOptions;
+          app.send = window.__previewAskOriginalSend;
+          app._createPreviewSelectionAskSession = window.__previewAskOriginalCreate;
+          return {
+            opts,
+            create: window.__previewAskCreate,
+            input: app.input,
+            draft: app.tabState[app.currentId].draft.input,
+            images: app.pendingImages.map(item => item.id),
+            docs: app.pendingDocs.map(item => item.id),
+            quotes: app.pendingQuotes.length,
+            session: app.currentId,
+            sessionCount: app.sessions.length,
+            openTabs: [...app.openTabIds],
+            messageCount: app.messages.length,
+            askSessionId: app.previewQuote.askSessionId,
+            popover: app.previewQuote.show,
+          };
+        }"""
+    )
+    assert asked["opts"]["sessionId"] == "preview-side-question"
+    assert asked["opts"]["permissionMode"] == "default"
+    assert "引用自 `README.md`" in asked["opts"]["detachedText"]
+    assert selected_for_ask in asked["opts"]["detachedText"]
+    assert "这段内容的核心是什么？" in asked["opts"]["detachedText"]
+    assert asked["create"]["snapshot"]["sessionId"] == before["session"]
+    assert asked["create"]["question"] == "这段内容的核心是什么？"
+    assert asked["input"] == asked["draft"] == "KEEP EXISTING DRAFT"
+    assert asked["images"] == ["keep-image"]
+    assert asked["docs"] == ["keep-doc"]
+    assert asked["quotes"] == 0
+    assert asked["session"] == before["session"]
+    assert asked["sessionCount"] == before["sessionCount"] + 1
+    assert asked["openTabs"] == before["openTabs"]
+    assert asked["messageCount"] == before["messageCount"]
+    assert asked["askSessionId"] == "preview-side-question"
+    assert asked["popover"] is True
+
+
+def test_selection_side_session_forks_without_opening_or_switching_tab(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    source = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId"
+    )
+    child = "11111111-2222-4333-8444-555555555555"
+    fork_bodies: list[dict] = []
+
+    def handle_fork(route) -> None:
+        fork_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "id": child,
+                "session_id": child,
+                "name": "Source · 独立侧问：why",
+                "model": "e2e-model",
+                "permission": "bypassPermissions",
+                "cwd": "/e2e-workspace",
+                "forked_from": source,
+                "forked_from_message_id": "assistant-boundary",
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{source}/fork", handle_fork)
+    result = page.evaluate(
+        """async arg => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.lang = 'zh';
+          const beforeTabs = [...app.openTabIds];
+          const meta = await app._createPreviewSelectionAskSession({
+            source: 'chat', role: 'assistant', sessionId: arg.source,
+            messageId: 'assistant-boundary', path: '', text: 'selected',
+            truncated: false,
+          }, 'why');
+          return {
+            id: meta.id,
+            currentId: app.currentId,
+            openTabs: [...app.openTabIds],
+            beforeTabs,
+            stateLoaded: app.tabState[meta.id]._loaded,
+            statePermission: app.tabState[meta.id].permission,
+          };
+        }""",
+        {"source": source},
+    )
+
+    assert fork_bodies == [{
+        "up_to_message_id": "assistant-boundary",
+        "title": fork_bodies[0]["title"],
+    }]
+    assert "独立侧问" in fork_bodies[0]["title"]
+    assert result["id"] == child
+    assert result["currentId"] == source
+    assert result["openTabs"] == result["beforeTabs"]
+    assert child not in result["openTabs"]
+    assert result["stateLoaded"] is True
+    assert result["statePermission"] == "default"
+
+
+def test_selection_side_question_window_drags_by_header_and_stays_in_view(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 1000, "height": 720})
+    _login(page, backend_url, auth_token)
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.selected === 'README.md' && app.previewMode === 'md';
+        }"""
+    )
+    _select_rendered_preview_text(page)
+    actions = page.locator(".preview-selection-actions")
+    expect(actions).to_be_visible(timeout=3000)
+    actions.locator("button").nth(1).click()
+
+    popover = page.locator(".preview-selection-popover")
+    form_head = page.locator(
+        ".preview-selection-ask:not([style*='display: none']) "
+        ".preview-selection-ask-head"
+    )
+    expect(form_head).to_be_visible()
+    before = popover.bounding_box()
+    head_box = form_head.bounding_box()
+    assert before is not None and head_box is not None
+    start_x = head_box["x"] + 32
+    start_y = head_box["y"] + head_box["height"] / 2
+    target_left = 80
+    target_top = 120
+    page.mouse.move(start_x, start_y)
+    page.mouse.down()
+    page.mouse.move(
+        start_x + target_left - before["x"],
+        start_y + target_top - before["y"],
+        steps=8,
+    )
+    page.mouse.up()
+
+    after = popover.bounding_box()
+    assert after is not None
+    assert abs(after["x"] - target_left) < 2
+    assert abs(after["y"] - target_top) < 2
+    state = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const el = document.querySelector('.preview-selection-popover');
+          return {
+            dragged: app.previewQuote.dragged,
+            dragging: app.previewQuote.dragging,
+            transform: getComputedStyle(el).transform,
+            x: app.previewQuote.x,
+            y: app.previewQuote.y,
+          };
+        }"""
+    )
+    assert state["dragged"] is True
+    assert state["dragging"] is False
+    assert state["transform"] == "none"
+    assert abs(state["x"] - after["x"]) < 1
+    assert abs(state["y"] - after["y"]) < 1
+
+    # Pointer capture keeps the drag alive when the cursor leaves the header;
+    # the position is clamped to a 12 px viewport margin in both directions.
+    head_box = form_head.bounding_box()
+    assert head_box is not None
+    page.mouse.move(head_box["x"] + 32, head_box["y"] + 12)
+    page.mouse.down()
+    page.mouse.move(995, 715, steps=8)
+    page.mouse.up()
+    lower_right = popover.bounding_box()
+    assert lower_right is not None
+    assert lower_right["x"] + lower_right["width"] <= 988.5
+    assert lower_right["y"] + lower_right["height"] <= 708.5
+
+    head_box = form_head.bounding_box()
+    assert head_box is not None
+    page.mouse.move(head_box["x"] + 32, head_box["y"] + 12)
+    page.mouse.down()
+    page.mouse.move(1, 1, steps=8)
+    page.mouse.up()
+    upper_left = popover.bounding_box()
+    assert upper_left is not None
+    assert upper_left["x"] >= 11.5
+    assert upper_left["y"] >= 11.5
+
+    # The answer-state header remains the same drag handle after the form is
+    # replaced by the compact branch response.
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = 'drag-side-answer';
+          const state = app._ensureTabState(sid);
+          state._loaded = true;
+          state.messages.splice(0, state.messages.length,
+            {role: 'user', text: 'drag prompt'},
+            {role: 'assistant', text: 'DRAG ANSWER'});
+          app.previewQuote.question = 'drag question';
+          app.previewQuote.askPrompt = 'drag prompt';
+          app.previewQuote.askSessionId = sid;
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+    answer = page.locator(".preview-selection-answer")
+    answer_head = answer.locator(".preview-selection-ask-head")
+    expect(answer_head).to_be_visible()
+    answer_before = popover.bounding_box()
+    answer_head_box = answer_head.bounding_box()
+    assert answer_before is not None and answer_head_box is not None
+    page.mouse.move(answer_head_box["x"] + 32, answer_head_box["y"] + 12)
+    page.mouse.down()
+    page.mouse.move(
+        answer_head_box["x"] + 170,
+        answer_head_box["y"] + 100,
+        steps=8,
+    )
+    page.mouse.up()
+    answer_after = popover.bounding_box()
+    assert answer_after is not None
+    assert answer_after["x"] > answer_before["x"] + 80
+    assert answer_after["y"] > answer_before["y"] + 45
+
+    answer.locator(".preview-selection-close").click()
+    expect(popover).to_be_hidden()
+    reset = page.evaluate(
+        """() => {
+          const q = document.querySelector('#app')._x_dataStack[0].previewQuote;
+          return {x: q.x, y: q.y, dragged: q.dragged, dragging: q.dragging};
+        }"""
+    )
+    assert reset == {"x": 0, "y": 0, "dragged": False, "dragging": False}
+
+
+def test_selection_side_question_window_supports_touch_drag(
+        page: Page, browser_name, backend_url, auth_token):
+    if browser_name != "chromium":
+        pytest.skip("touch input dispatch runs on Chromium")
+    page.set_viewport_size({"width": 390, "height": 844})
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Emulation.setTouchEmulationEnabled", {
+        "enabled": True,
+        "maxTouchPoints": 5,
+    })
+    _login(page, backend_url, auth_token)
+    page.evaluate(
+        """() => document.querySelector('#app')._x_dataStack[0]
+          .setMobileTab('files')"""
+    )
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.mobileTab === 'preview' && app.selected === 'README.md'
+            && app.previewMode === 'md';
+        }"""
+    )
+    _select_rendered_preview_text(page)
+    actions = page.locator(".preview-selection-actions")
+    expect(actions).to_be_visible(timeout=3000)
+    actions.locator("button").nth(1).click()
+    popover = page.locator(".preview-selection-popover")
+    head = page.locator(".preview-selection-ask .preview-selection-ask-head")
+    expect(head).to_be_visible()
+    before = popover.bounding_box()
+    head_box = head.bounding_box()
+    assert before is not None and head_box is not None
+    start = {
+        "x": head_box["x"] + 40,
+        "y": head_box["y"] + head_box["height"] / 2,
+    }
+    target = {
+        "x": start["x"],
+        "y": min(760, start["y"] + 170),
+    }
+    cdp.send("Input.dispatchTouchEvent", {
+        "type": "touchStart",
+        "touchPoints": [{**start, "id": 1}],
+    })
+    cdp.send("Input.dispatchTouchEvent", {
+        "type": "touchMove",
+        "touchPoints": [{**target, "id": 1}],
+    })
+    cdp.send("Input.dispatchTouchEvent", {
+        "type": "touchEnd",
+        "touchPoints": [],
+    })
+    page.wait_for_function(
+        """() => {
+          const q = document.querySelector('#app')._x_dataStack[0].previewQuote;
+          return q.dragged && !q.dragging;
+        }"""
+    )
+    after = popover.bounding_box()
+    assert after is not None
+    assert after["y"] > before["y"] + 70
+    assert after["x"] >= 11.5
+    assert after["x"] + after["width"] <= 378.5
+    assert after["y"] + after["height"] <= 832.5
+
+
+def test_detached_preview_question_uses_send_pipeline_without_touching_draft(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    ticket_bodies: list[dict] = []
+
+    def handle_ticket(route) -> None:
+        ticket_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "preview-detached-ticket"}),
+        )
+
+    page.route("**/api/chat/stream/start", handle_ticket)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          class FakeEventSource extends EventTarget {
+            constructor(url) {
+              super();
+              this.url = url;
+              this.readyState = 0;
+              setTimeout(() => {
+                this.readyState = 1;
+                if (this.onopen) this.onopen(new Event('open'));
+              }, 0);
+            }
+            close() { this.readyState = 2; }
+          }
+          const originalEventSource = window.EventSource;
+          const originalBusy = app._confirmSessionBusy;
+          const originalRuntimeWait = app._awaitRuntimeSettingPatches;
+          const originalCommit = app._commitChatRecoveryDraft;
+          window.EventSource = FakeEventSource;
+          app._confirmSessionBusy = async () => false;
+          app._awaitRuntimeSettingPatches = async () => true;
+          let recoveryCommits = 0;
+          app._commitChatRecoveryDraft = () => { recoveryCommits += 1; };
+          try {
+            const sid = app.currentId;
+            const image = {id: 'draft-image', uploading: false};
+            const doc = {id: 'draft-doc', uploading: false};
+            app.input = 'PRESERVE THIS DRAFT';
+            app.pendingImages = [image];
+            app.pendingDocs = [doc];
+            app._captureComposerState(sid);
+            const messageCount = app.messages.length;
+            const sendResult = await app.send({
+              sessionId: sid,
+              detachedText: 'DETACHED PREVIEW QUESTION',
+            });
+            await new Promise(resolve => setTimeout(resolve, 20));
+            const state = app.tabState[sid];
+            return {
+              sendResult: sendResult === undefined ? 'undefined' : sendResult,
+              input: app.input,
+              draft: state.draft.input,
+              images: state.draft.pendingImages.map(item => item.id),
+              docs: state.draft.pendingDocs.map(item => item.id),
+              lastMessage: state.messages.at(-1)?.text,
+              messageDelta: state.messages.length - messageCount,
+              recoveryCommits,
+              recovery: app._chatDraftRecord(sid),
+            };
+          } finally {
+            if (app.es) app.es.close();
+            window.EventSource = originalEventSource;
+            app._confirmSessionBusy = originalBusy;
+            app._awaitRuntimeSettingPatches = originalRuntimeWait;
+            app._commitChatRecoveryDraft = originalCommit;
+          }
+        }"""
+    )
+
+    assert len(ticket_bodies) == 1
+    assert ticket_bodies[0]["prompt"] == "DETACHED PREVIEW QUESTION"
+    assert ticket_bodies[0]["image_ids"] == ""
+    assert result["sendResult"] == "undefined"
+    assert result["input"] == result["draft"] == "PRESERVE THIS DRAFT"
+    assert result["images"] == ["draft-image"]
+    assert result["docs"] == ["draft-doc"]
+    assert result["lastMessage"] == "DETACHED PREVIEW QUESTION"
+    assert result["messageDelta"] == 1
+    assert result["recoveryCommits"] == 0
+    assert result["recovery"]["text"] == "PRESERVE THIS DRAFT"
+    assert result["recovery"]["pending"] == ""
+
+
+def test_composer_quote_sends_context_without_rewriting_visible_text(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    ticket_bodies: list[dict] = []
+
+    def handle_ticket(route) -> None:
+        ticket_bodies.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "selection-quote-ticket"}),
+        )
+
+    page.route("**/api/chat/stream/start", handle_ticket)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          class FakeEventSource extends EventTarget {
+            constructor(url) {
+              super();
+              this.url = url;
+              this.readyState = 0;
+              setTimeout(() => {
+                this.readyState = 1;
+                if (this.onopen) this.onopen(new Event('open'));
+              }, 0);
+            }
+            close() { this.readyState = 2; }
+          }
+          const originalEventSource = window.EventSource;
+          const originalBusy = app._confirmSessionBusy;
+          const originalRuntimeWait = app._awaitRuntimeSettingPatches;
+          window.EventSource = FakeEventSource;
+          app._confirmSessionBusy = async () => false;
+          app._awaitRuntimeSettingPatches = async () => true;
+          try {
+            const sid = app.currentId;
+            app.lang = 'zh';
+            app.input = 'VISIBLE QUESTION';
+            app.pendingQuotes = [{
+              id: 'quote-context', source: 'preview', role: '',
+              sessionId: sid, messageId: '', path: 'README.md',
+              text: 'SELECTED CONTEXT', truncated: false,
+            }];
+            app._captureComposerState(sid);
+            const before = app.messages.length;
+            const sendResult = await app.send();
+            await new Promise(resolve => setTimeout(resolve, 20));
+            const state = app.tabState[sid];
+            const user = state.messages.slice(before).find(m => m.role === 'user');
+            return {
+              sendResult: sendResult === undefined ? 'undefined' : sendResult,
+              input: app.input,
+              draft: state.draft.input,
+              pendingQuotes: state.draft.pendingQuotes.length,
+              promptText: user && user.text,
+              displayText: user && user.displayText,
+              quoteText: user && user.selectionQuotes[0].text,
+            };
+          } finally {
+            if (app.es) app.es.close();
+            window.EventSource = originalEventSource;
+            app._confirmSessionBusy = originalBusy;
+            app._awaitRuntimeSettingPatches = originalRuntimeWait;
+          }
+        }"""
+    )
+
+    assert len(ticket_bodies) == 1
+    prompt = ticket_bodies[0]["prompt"]
+    assert "引用自 `README.md`" in prompt
+    assert "SELECTED CONTEXT" in prompt
+    assert prompt.endswith("VISIBLE QUESTION")
+    assert result["sendResult"] == "undefined"
+    assert result["input"] == result["draft"] == ""
+    assert result["pendingQuotes"] == 0
+    assert result["promptText"] == prompt
+    assert result["displayText"] == "VISIBLE QUESTION"
+    assert result["quoteText"] == "SELECTED CONTEXT"
+
+
+def test_preview_selection_quote_fits_mobile_and_reveals_chat(
+        page: Page, browser_name, backend_url, auth_token):
+    if browser_name != "chromium":
+        pytest.skip("touch media emulation runs on Chromium")
+    page.set_viewport_size({"width": 390, "height": 844})
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Emulation.setTouchEmulationEnabled", {
+        "enabled": True,
+        "maxTouchPoints": 5,
+    })
+    _login(page, backend_url, auth_token)
+    page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.lang = 'zh';
+          app.input = '';
+          app._captureComposerState(app.currentId);
+          app.setMobileTab('files');
+        }"""
+    )
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.mobileTab === 'preview' && app.selected === 'README.md'
+            && app.previewMode === 'md';
+        }"""
+    )
+    selected = _select_rendered_preview_text(page)
+    actions = page.locator(".preview-selection-actions")
+    expect(actions).to_be_visible(timeout=3000)
+    geometry = actions.evaluate(
+        """el => {
+          const box = el.getBoundingClientRect();
+          return {
+            left: box.left,
+            right: box.right,
+            top: box.top,
+            bottom: box.bottom,
+            buttonHeights: Array.from(el.querySelectorAll('button'))
+              .map(button => button.getBoundingClientRect().height),
+          };
+        }"""
+    )
+    assert geometry["left"] >= 0
+    assert geometry["right"] <= 390
+    assert geometry["top"] >= 0
+    assert geometry["bottom"] <= 844
+    assert min(geometry["buttonHeights"]) >= 38
+
+    actions.locator("button").nth(0).click()
+    page.wait_for_function(
+        """expected => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.mobileTab === 'chat'
+            && app.input === ''
+            && app.pendingQuotes.length === 1
+            && app.pendingQuotes[0].path === 'README.md'
+            && app.pendingQuotes[0].text.includes(expected);
+        }""",
+        arg=selected,
+    )
+    result = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            mobileTab: app.mobileTab,
+            input: app.input,
+            quoteCount: app.pendingQuotes.length,
+            quoteText: app.pendingQuotes[0]?.text || '',
+            popover: app.previewQuote.show,
+            chatDisplay: getComputedStyle(document.querySelector('.pane.chat')).display,
+            chipDisplay: getComputedStyle(document.querySelector('.selection-quote-chip')).display,
+          };
+        }"""
+    )
+    assert result["mobileTab"] == "chat"
+    assert result["popover"] is False
+    assert result["chatDisplay"] == "flex"
+    assert result["input"] == ""
+    assert result["quoteCount"] == 1
+    assert selected in result["quoteText"]
+    assert result["chipDisplay"] in {"flex", "inline-flex"}
+
+
+def test_file_metadata_stays_inside_mobile_header(
+        page: Page, browser_name, backend_url, auth_token):
+    if browser_name != "chromium":
+        pytest.skip("touch media emulation runs on Chromium")
+    page.set_viewport_size({"width": 390, "height": 844})
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Emulation.setTouchEmulationEnabled", {
+        "enabled": True,
+        "maxTouchPoints": 5,
+    })
+    _login(page, backend_url, auth_token)
+    page.evaluate(
+        """() => document.querySelector('#app')._x_dataStack[0]
+          .setMobileTab('files')"""
+    )
+    file_row_height = page.locator(
+        '.filelist li[data-path="README.md"]'
+    ).evaluate("row => row.getBoundingClientRect().height")
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.selected === 'README.md' && !!app.selectedMeta;
+        }"""
+    )
+    page.evaluate(
+        """() => document.querySelector('#app')._x_dataStack[0]
+          .setMobileTab('preview')"""
+    )
+
+    geometry = page.evaluate(
+        """() => {
+          const head = document.querySelector('.pane.preview .pane-head');
+          const meta = head.querySelector('.pane-fileinfo-meta');
+          const headBox = head.getBoundingClientRect();
+          const metaBox = meta.getBoundingClientRect();
+          return {
+            headTop: headBox.top,
+            headBottom: headBox.bottom,
+            metaTop: metaBox.top,
+            metaBottom: metaBox.bottom,
+            metaHeight: metaBox.height,
+            themeDisplay: getComputedStyle(
+              document.querySelector('.files-theme-toggle')).display,
+            hiddenDisplay: getComputedStyle(
+              document.querySelector('.files-hidden-toggle')).display,
+          };
+        }"""
+    )
+
+    assert geometry["metaTop"] >= geometry["headTop"]
+    assert geometry["metaBottom"] <= geometry["headBottom"]
+    assert geometry["metaHeight"] < 20
+    assert file_row_height >= 40
+    assert geometry["themeDisplay"] != "none"
+    assert geometry["hiddenDisplay"] == "none"
 
 
 def test_directory_can_be_mentioned_from_search_and_tree_action(
@@ -1814,6 +2725,8 @@ def test_hidden_toggle_does_not_replay_expanded_directories(page: Page,
                                                             backend_url,
                                                             auth_token):
     _login(page, backend_url, auth_token)
+    expect(page.locator(".pane.files .files-hidden-toggle")).to_be_visible()
+    expect(page.locator(".pane.files .files-tools")).to_have_count(0)
     result = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -170,6 +170,47 @@ def test_pin_persists_without_rewriting_activity_time(tmp_path, monkeypatch):
     assert restarted.set_pin("missing", True) is None
 
 
+@pytest.mark.asyncio
+async def test_rename_persists_and_pushes_without_reordering_task(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    ticks = iter([1, 2, 3, 4])
+    monkeypatch.setattr("backend.activity.time.time", lambda: next(ticks))
+    first = service.start("s1", summary="older task")
+    service.finish("s1", "completed")
+    service.start("s2", summary="newer task")
+    service.finish("s2", "completed")
+    before = dict(next(row for row in service.list()
+                       if row["session_id"] == "s1"))
+
+    async with service.subscribe() as queue:
+        update = await asyncio.to_thread(
+            service.rename_session, "s1", "Renamed conversation",
+        )
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert update is not None
+    assert update["item"]["id"] == first["id"]
+    assert update["item"]["session_name"] == "Renamed conversation"
+    assert payload["item"]["session_name"] == "Renamed conversation"
+    assert payload["revision"] == update["revision"] == service.revision
+    after = next(row for row in service.list() if row["session_id"] == "s1")
+    for field in (
+        "updated_at", "started_at", "finished_at", "state", "read",
+        "task_summary", "turn_count",
+    ):
+        assert after[field] == before[field]
+    assert [row["session_id"] for row in service.list()] == ["s2", "s1"]
+
+    restarted = ActivityService(tmp_path)
+    restored = next(row for row in restarted.list()
+                    if row["session_id"] == "s1")
+    assert restored["session_name"] == "Renamed conversation"
+    assert service.rename_session("missing", "No row") is None
+
+
 def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
     service = _service(tmp_path, monkeypatch)
     service.start("s1", summary="long task")

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -108,6 +108,35 @@ def test_reset_all_empty_pool(chat_mod, client):
     assert r.json() == {"ok": True, "reset": []}
 
 
+def test_session_rename_updates_activity_ledger(chat_mod, client, monkeypatch):
+    from backend import activity as activity_module
+
+    created = client.post(
+        "/api/chat/sessions",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "Before rename"},
+    )
+    assert created.status_code == 200, created.text
+    sid = created.json()["id"]
+    calls = []
+
+    def rename_activity(target_sid, name):
+        calls.append((target_sid, name))
+
+    monkeypatch.setattr(activity_module.activity, "rename_session", rename_activity)
+    monkeypatch.setattr(chat_mod, "sdk_rename_session", lambda *_args, **_kwargs: None)
+
+    response = client.patch(
+        f"/api/chat/sessions/{sid}",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "After rename"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert chat_mod.sess.get_session(sid)["name"] == "After rename"
+    assert calls == [(sid, "After rename")]
+
+
 def test_session_effort_and_fast_patch_persist_and_rebuild(
     chat_mod, client, monkeypatch,
 ):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -214,7 +214,15 @@ def _mint_session(client, auth) -> str:
     return r.json()["id"]
 
 
-def test_queue_endpoint_enqueue_and_get(client, auth):
+@pytest.fixture()
+def queue_autodrain_disabled(monkeypatch):
+    """Keep CRUD endpoint tests from launching a real headless SDK turn."""
+    from backend import chat
+
+    monkeypatch.setattr(chat, "_schedule_queue_drain", lambda _sid: None)
+
+
+def test_queue_endpoint_enqueue_and_get(client, auth, queue_autodrain_disabled):
     sid = _mint_session(client, auth)
     r = client.post(f"/api/chat/sessions/{sid}/queue", headers=auth,
                     json={"text": "hello"})
@@ -225,17 +233,70 @@ def test_queue_endpoint_enqueue_and_get(client, auth):
     assert r.status_code == 200
     body = r.json()
     assert [it["text"] for it in body["items"]] == ["hello"]
+    assert [it["display_text"] for it in body["items"]] == ["hello"]
     assert body["paused"] is False
 
 
-def test_queue_endpoint_rejects_empty_message(client, auth):
+def test_queue_endpoint_preserves_bounded_selection_quote_presentation(
+    client, auth, queue_autodrain_disabled,
+):
+    sid = _mint_session(client, auth)
+    quote = {
+        "id": "quote-1",
+        "source": "preview",
+        "role": "",
+        "sessionId": sid,
+        "messageId": "",
+        "path": "README.md",
+        "text": "selected context",
+        "truncated": False,
+    }
+    response = client.post(
+        f"/api/chat/sessions/{sid}/queue",
+        headers=auth,
+        json={
+            "text": "引用自 `README.md`：\n\n> selected context\n\nquestion",
+            "display_text": "question",
+            "selection_quotes": [quote],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    item = client.get(
+        f"/api/chat/sessions/{sid}/queue", headers=auth,
+    ).json()["items"][0]
+    assert item["display_text"] == "question"
+    assert item["selection_quotes"] == [quote]
+
+
+def test_queue_endpoint_schedules_drain_kick(client, auth, monkeypatch):
+    from backend import chat
+
+    kicks = []
+    monkeypatch.setattr(chat, "_schedule_queue_drain", kicks.append)
+    sid = _mint_session(client, auth)
+    response = client.post(
+        f"/api/chat/sessions/{sid}/queue",
+        headers=auth,
+        json={"text": "wake me"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert kicks == [sid]
+
+
+def test_queue_endpoint_rejects_empty_message(
+    client, auth, queue_autodrain_disabled,
+):
     sid = _mint_session(client, auth)
     r = client.post(f"/api/chat/sessions/{sid}/queue", headers=auth,
                     json={"text": "   "})
     assert r.status_code == 400
 
 
-def test_queue_endpoint_full_returns_409(client, auth):
+def test_queue_endpoint_full_returns_409(
+    client, auth, queue_autodrain_disabled,
+):
     sid = _mint_session(client, auth)
     from backend import sessions as sess
     for i in range(sess._QUEUE_MAX):
@@ -247,7 +308,9 @@ def test_queue_endpoint_full_returns_409(client, auth):
     assert over.status_code == 409
 
 
-def test_queue_endpoint_reorder_roundtrip(client, auth):
+def test_queue_endpoint_reorder_roundtrip(
+    client, auth, queue_autodrain_disabled,
+):
     sid = _mint_session(client, auth)
     ids = []
     for t in ("a", "b", "c"):
@@ -261,7 +324,7 @@ def test_queue_endpoint_reorder_roundtrip(client, auth):
     assert [it["id"] for it in r.json()["items"]] == new_order
 
 
-def test_queue_endpoint_remove_item(client, auth):
+def test_queue_endpoint_remove_item(client, auth, queue_autodrain_disabled):
     sid = _mint_session(client, auth)
     r = client.post(f"/api/chat/sessions/{sid}/queue", headers=auth,
                     json={"text": "doomed"})
@@ -271,7 +334,7 @@ def test_queue_endpoint_remove_item(client, auth):
     assert r.json()["items"] == []
 
 
-def test_queue_endpoint_clear(client, auth):
+def test_queue_endpoint_clear(client, auth, queue_autodrain_disabled):
     sid = _mint_session(client, auth)
     client.post(f"/api/chat/sessions/{sid}/queue", headers=auth,
                 json={"text": "m1"})
@@ -284,7 +347,9 @@ def test_queue_endpoint_clear(client, auth):
                       headers=auth).json()["items"] == []
 
 
-def test_queue_endpoint_pause_toggle(client, auth, monkeypatch):
+def test_queue_endpoint_pause_toggle(
+    client, auth, monkeypatch, queue_autodrain_disabled,
+):
     from backend import chat
 
     drains = []
@@ -318,6 +383,105 @@ def test_queue_endpoint_requires_auth(client):
     """At least one route enforces the token — no header → 401."""
     r = client.get("/api/chat/sessions/whatever/queue")
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_late_enqueue_after_empty_completion_check_kicks_idle_queue(
+    app_module, monkeypatch,
+):
+    """Closing the exact lost-wakeup window starts the just-enqueued item."""
+    import asyncio
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    starts = []
+    started = asyncio.Event()
+
+    async def fake_start_turn(session_id, prompt, **kwargs):
+        starts.append((session_id, prompt, kwargs))
+        started.set()
+
+    monkeypatch.setattr(chat, "_start_turn", fake_start_turn)
+
+    # The previous turn/background watcher has just run its final drain and
+    # observed no work. A stale browser then posts while it still renders the
+    # session as streaming — this used to leave the item stranded forever.
+    await chat._maybe_drain_queue(sid)
+    response = await chat.enqueue_api(sid, chat.QueueEnqueueReq(text="late"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    task = chat._queue_drain_tasks.get(sid)
+    if task is not None:
+        await task
+
+    assert response["ok"] is True
+    assert [(item[0], item[1]) for item in starts] == [(sid, "late")]
+    assert sess.get_queue(sid)["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_drain_kicks_serialize_dequeue_and_preserve_fifo(
+    app_module, monkeypatch,
+):
+    import asyncio
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    sess.enqueue_message(sid, "first")
+    sess.enqueue_message(sid, "second")
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+    starts = []
+
+    async def fake_start_turn(_sid, prompt, **_kwargs):
+        starts.append(prompt)
+        if prompt == "first":
+            first_entered.set()
+            await release_first.wait()
+        else:
+            second_entered.set()
+
+    monkeypatch.setattr(chat, "_start_turn", fake_start_turn)
+    first = asyncio.create_task(chat._maybe_drain_queue(sid))
+    await asyncio.wait_for(first_entered.wait(), timeout=1)
+    second = asyncio.create_task(chat._maybe_drain_queue(sid))
+    await asyncio.sleep(0)
+    assert not second_entered.is_set()
+
+    release_first.set()
+    await asyncio.gather(first, second)
+    assert starts == ["first", "second"]
+    assert sess.get_queue(sid)["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_scheduled_drain_restores_accepted_message(
+    app_module, monkeypatch,
+):
+    import asyncio
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    sess.enqueue_message(sid, "survive restart")
+    entered = asyncio.Event()
+
+    async def stalled_start(*_args, **_kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(chat, "_start_turn", stalled_start)
+    task = asyncio.create_task(chat._maybe_drain_queue(sid))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    queue = sess.get_queue(sid)
+    assert [item["text"] for item in queue["items"]] == ["survive restart"]
+    assert queue["paused"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -379,6 +379,117 @@ def test_done_is_published_before_slow_post_turn_bookkeeping(
     asyncio.run(exercise())
 
 
+def test_activity_stays_running_until_background_continuation_finishes(
+        stream_env, client, monkeypatch):
+    """A main ResultMessage is not the logical end while a task is detached.
+
+    The tab derives its yellow dot from the task pin.  Activity Center must keep
+    the same session running until that pin settles and the CLI's continuation
+    reaches its own ResultMessage; otherwise opening the center shows no running
+    indicator for work that is visibly still active in the tab strip.
+    """
+    from backend import activity as activity_module
+
+    chat_mod = stream_env
+    sid = _make_session(client)
+
+    async def exercise():
+        watcher_attached = asyncio.Event()
+        release_watcher = asyncio.Event()
+        activity_transitions = []
+
+        started = TaskStartedMessage(
+            subtype="task_started", data={}, task_id="task_deferred",
+            description="sleep 20", uuid="task-start", session_id=sid,
+            tool_use_id="tu-bg", task_type="bash",
+        )
+        main_result = ResultMessage(
+            subtype="success", duration_ms=10, duration_api_ms=9,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0,
+            usage={"input_tokens": 1, "output_tokens": 1},
+        )
+        notification = TaskNotificationMessage(
+            subtype="task_notification", data={}, task_id="task_deferred",
+            status="completed", output_file="/tmp/task.out", summary="done",
+            uuid="task-finish", session_id=sid, tool_use_id="tu-bg",
+        )
+        reaction = AssistantMessage(
+            content=[TextBlock(text="后台任务已经完成。")],
+            model="claude-sonnet-4-6", usage={}, uuid="continuation-asst",
+        )
+        continuation_result = ResultMessage(
+            subtype="success", duration_ms=12, duration_api_ms=10,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0, usage={},
+        )
+
+        class _DeferredBackgroundClient(_FakeStreamClient):
+            async def receive_messages(self):
+                watcher_attached.set()
+                await release_watcher.wait()
+                for message in (notification, reaction, continuation_result):
+                    yield message
+
+        fake = _DeferredBackgroundClient([started, main_result])
+
+        async def fake_get_client(*_args, **_kwargs):
+            return fake
+
+        monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+        monkeypatch.setattr(
+            activity_module.activity,
+            "start",
+            lambda activity_sid, *, summary="": activity_transitions.append(
+                ("start", activity_sid, summary)),
+        )
+        monkeypatch.setattr(
+            activity_module.activity,
+            "finish",
+            lambda activity_sid, status: activity_transitions.append(
+                ("finish", activity_sid, status)),
+        )
+
+        broadcast = await chat_mod._start_turn(sid, "run a background task")
+        await asyncio.wait_for(watcher_attached.wait(), timeout=1)
+
+        assert any(
+            event.get("event") == "done"
+            for event in broadcast.replay_events()
+        )
+        assert activity_transitions == [
+            ("start", sid, "run a background task"),
+        ]
+        assert chat_mod._sessions_with_inflight_tasks[sid] == {
+            "task_deferred",
+        }
+        assert chat_mod._background_activity_finishes[sid] == "completed"
+
+        await asyncio.wait_for(broadcast.task, timeout=1)
+        watcher = chat_mod._task_watchers[sid]
+        release_watcher.set()
+        await asyncio.wait_for(watcher, timeout=1)
+
+        assert activity_transitions == [
+            ("start", sid, "run a background task"),
+            ("finish", sid, "completed"),
+        ]
+        assert sid not in chat_mod._sessions_with_inflight_tasks
+        assert sid not in chat_mod._background_activity_finishes
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        chat_mod._sessions_with_inflight_tasks.pop(sid, None)
+        chat_mod._background_activity_finishes.pop(sid, None)
+        chat_mod._task_watchers.pop(sid, None)
+        chat_mod._active_turns.pop(sid, None)
+        recent = chat_mod._recent_turns.pop(sid, None)
+        if recent is not None:
+            recent.close()
+        chat_mod._delete_active_turn_sidecar(sid)
+
+
 def test_stream_drops_prior_turn_replay_but_keeps_late_task_lifecycle(
         stream_env, client, monkeypatch):
     """A pooled SDK queue may start with the preceding turn's delayed tail.

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -191,6 +191,98 @@ def test_preview_tabs_persist_reading_positions_and_html_frames():
     assert "this._htmlPreviewMessageOwner(e.source)" in app
 
 
+def test_preview_selection_quote_attachment_and_side_question_are_safely_wired():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    assert "PREVIEW_QUOTE_MAX_CHARS: 6000" in app
+    assert "this._initPreviewSelection();" in app
+    assert '_previewSelectionHost(node)' in app
+    assert '_chatSelectionHost(node)' in app
+    assert 'el.closest(".markdown, pre.text, .xlsx-preview")' in app
+    assert 'pane.dataset.tid !== this.currentId' in app
+    assert 'message.classList.contains("user")' in app
+    assert 'message.classList.contains("assistant")' in app
+    assert "sessionId: this.currentId" in app
+    assert 'snapshot.source === "chat"' in app
+    assert '"引用自我的消息："' in app
+    assert '"引用自 Muse 回复："' in app
+    assert 'this.previewMode === "md"' in app
+    assert 'this.previewMode === "text"' in app
+    assert 'this.previewMode === "csv"' in app
+    assert 'this.previewMode === "xlsx"' in app
+    assert 'host.closest(".editor-live-preview")' in app
+    assert 'previewMode === "html"' not in app[
+        app.index("_previewSelectionHost(node)"):
+        app.index("_syncPreviewSelection()")
+    ]
+    assert 'previewMode === "pdf"' not in app[
+        app.index("_previewSelectionHost(node)"):
+        app.index("_syncPreviewSelection()")
+    ]
+
+    assert 'class="preview-selection-popover"' in html
+    assert '@click="quotePreviewSelection()"' in html
+    assert '@click="openPreviewSelectionAsk()"' in html
+    assert '@submit.prevent="sendPreviewSelectionQuestion()"' in html
+    assert 'x-ref="previewQuoteInput"' in html
+    assert ':href="previewQuoteSourceIcon()"' in html
+    assert 'class="selection-quote-chip"' in html
+    assert '@click="removePendingQuote(i)"' in html
+    assert "将展开为独立侧问" in html
+    assert "不写入当前会话" in html
+    assert '@click="openPreviewSelectionAskSession()"' in html
+    assert 'x-ref="previewSelectionPopover"' in html
+    assert '@pointerdown="startPreviewQuoteDrag($event)"' in html
+    assert '@pointermove="movePreviewQuoteDrag($event)"' in html
+    assert '@pointerup="finishPreviewQuoteDrag($event)"' in html
+    assert 'class="preview-selection-drag-grip"' in html
+    assert ".preview-selection-popover" in css
+    assert "position: fixed" in css[css.index(".preview-selection-popover"):][0:300]
+    assert ".preview-selection-popover.is-dragged" in css
+    assert "touch-action: none" in css
+    assert "_clampPreviewQuotePosition(left, top, width, height)" in app
+    assert "startPreviewQuoteDrag(ev)" in app
+    assert "movePreviewQuoteDrag(ev)" in app
+    assert "finishPreviewQuoteDrag(ev)" in app
+    assert "window.visualViewport.addEventListener" in app
+    assert "new ResizeObserver" in app
+
+    quote_start = app.index("quotePreviewSelection()")
+    quote_end = app.index("\n\n    removePendingQuote", quote_start)
+    quote = app[quote_start:quote_end]
+    assert "draft.pendingQuotes.push" in quote
+    assert "draft.input" not in quote
+    assert "_insertComposerTextAtCaret" not in app
+
+    send_start = app.index("async send(opts = {})")
+    send_end = app.index("\n    async stop(", send_start)
+    send = app[send_start:send_end]
+    assert 'const hasDetachedText = typeof opts.detachedText === "string"' in send
+    assert 'const composerInput = hasDetachedText ? opts.detachedText' in send
+    assert 'const composerImages = hasDetachedText ? []' in send
+    assert 'const composerDocs = hasDetachedText ? []' in send
+    assert 'const composerQuotes = hasDetachedText ? []' in send
+    assert "this._composerPromptText(composerInput, composerQuotes)" in send
+    assert "opts.permissionMode || inheritedPermission" in send
+    assert "if (hasDetachedText) return;" in send
+    assert "if (!hasDetachedText) this._cancelMentionLookup();" in send
+    assert "if (hasDetachedText || isReconnect || resumed" in send
+    assert "if (!hasDetachedText && !isReconnect && !resumed)" in send
+    ask_start = app.index("async sendPreviewSelectionQuestion()")
+    ask_end = app.index("\n\n    // A11y:", ask_start)
+    ask = app[ask_start:ask_end]
+    assert "_createPreviewSelectionAskSession" in app
+    assert "/fork`" in app
+    assert 'fetch("/api/chat/sessions"' in app
+    assert "sessionId: target.id" in ask
+    assert "detachedText: prompt" in ask
+    assert 'permissionMode: "default"' in ask
+    assert "this.dismissPreviewQuote(true)" not in ask
+    assert "newSession" not in ask
+
+
 def test_mobile_preview_captures_before_hiding_and_pins_tree_taps():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
@@ -332,6 +424,48 @@ def test_pane_popups_escape_clipping_but_stay_below_global_overlays():
     assert "position: fixed; inset: 0; z-index: 200" in css
     assert "position: fixed; z-index: 800" in css
     assert "position: fixed; inset: 0; z-index: 900" in css
+
+
+def test_desktop_layout_is_files_chat_preview_with_one_canonical_chat_dom():
+    """Chat is the flexible center; preview is the optional right rail."""
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+    i18n = (FRONTEND / "i18n" / "index.js").read_text(encoding="utf-8")
+
+    assert html.count('<aside class="pane chat"') == 1
+    assert html.count('<section class="pane preview"') == 1
+    assert ".layout > .pane.files { order: 1; }" in css
+    assert ".layout > .files-resizer { order: 2; }" in css
+    assert ".layout > .pane.chat { order: 3; }" in css
+    assert ".layout > .preview-resizer { order: 4; }" in css
+    assert ".layout > .pane.preview { order: 5;" in css
+
+    preview_start = html.index('<section class="pane preview"')
+    preview_head = html.index("<header", preview_start)
+    assert "'pane-hidden': !previewOpen" in html[preview_start:preview_head]
+    chat_start = html.index('<aside class="pane chat"')
+    chat_head = html.index("<header", chat_start)
+    assert "pane-hidden" not in html[chat_start:chat_head]
+
+    assert "previewOpen: true" in app
+    assert "previewWidth: 440" in app
+    assert "togglePreviewPane()" in app
+    assert "rightOpen: true" not in app
+    assert "rightWidth: 440" not in app
+    assert "leftOpen: this.leftOpen, previewOpen: this.previewOpen" in app
+    assert "leftWidth: this.leftWidth, previewWidth: this.previewWidth" in app
+    assert 'schema: 8' in app
+    assert 'else if (typeof p.rightWidth === "number")' in app
+    assert 'if (next === "preview") this.previewOpen = true;' in app
+    assert "btn.hide_preview" in i18n and "btn.show_preview" in i18n
+
+    nav = html[html.index('<nav class="mobile-tab-bar"'):
+               html.index("</nav>", html.index('<nav class="mobile-tab-bar"'))]
+    # This is a desktop-only layout change; preserve the established mobile
+    # navigation order and its muscle memory.
+    assert nav.index("mobileTab==='files'") < nav.index(
+        "mobileTab==='preview'") < nav.index("mobileTab==='chat'")
 
 
 def test_multi_workspace_ui_and_folder_browser_are_wired_end_to_end():
@@ -548,6 +682,54 @@ def test_file_tree_uses_a_bounded_viewport_window():
     assert '@scroll.passive="onFileTreeScroll($event)"' in html
     assert html.count("filelist-virtual-spacer") == 2
     assert ".filelist li.filelist-virtual-spacer" in css
+
+
+def test_session_rename_patches_activity_without_reloading_chat():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    helper_start = app.index("_applyRenamedSession(sid, name) {")
+    helper = app[helper_start:app.index("\n    async pickerCommitInlineRename()", helper_start)]
+    modal_start = app.index("async renameSession() {")
+    modal = app[modal_start:app.index("\n    // ===== settings modal", modal_start)]
+
+    assert "item.session_name = name" in helper
+    assert "this.activity.events = [...this.activity.events]" in helper
+    assert app.count("this._applyRenamedSession(") == 2
+    assert "refreshSessions" not in modal
+    assert "loadSession" not in helper
+    assert "fetchActivity" not in helper
+
+
+def test_file_tree_metadata_is_adaptive_and_human_readable():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    assert 'const units = ["B", "KB", "MB", "GB", "TB"]' in app
+    assert "fmtRelativeMtime(ts)" in app
+    assert "fileMetaTitle(meta)" in app
+    assert 'class="tree-trailing"' in html
+    assert 'class="pane-fileinfo-meta"' in html
+    assert "fileBreadcrumb(selected)" in html
+    assert ".filelist li:hover .size { opacity: 0; }" in css
+    assert "@container (max-width: 250px)" in css
+    assert "font-variant-numeric: tabular-nums" in css
+
+
+def test_file_header_keeps_theme_and_hidden_toggles_as_direct_actions():
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    files_head_start = html.index('<aside class="pane files"')
+    files_head_end = html.index("</header>", files_head_start)
+    files_head = html[files_head_start:files_head_end]
+
+    assert files_head.count('@click="toggleTheme()"') == 1
+    assert files_head.count('@click="toggleHidden()"') == 1
+    assert 'class="icon-btn files-keep-mobile files-theme-toggle"' in files_head
+    assert 'class="icon-btn files-hidden-toggle"' in files_head
+    assert "filesToolsOpen" not in html
+    assert ".files-tools" not in css
+    assert ".files-theme-mobile" not in css
 
 
 def test_hidden_toggle_collapses_before_reloading_root():
@@ -1168,6 +1350,8 @@ def test_stream_done_errors_share_failed_message_state_and_actions():
 
     assert "markUserFailed(_detail, d.kind, d.cta, d.retryable)" in done
     assert "if (d.is_error)" in done
+    assert "const queueBlockingError = !!d.is_error && !isContinuation" in done
+    assert "if (queueBlockingError)" in done
     assert "_drainPendingQueue(streamSid, completedTurnId)" in done
     assert "d.turn_id || streamState.activeTurnId || expectedTurnId" in done
     assert "turnId === completedTurnId" in app
@@ -1338,8 +1522,8 @@ def test_send_pins_owner_waits_before_enqueue_and_blocks_failed_attachments():
     assert "const sendMeta = (this.sessions || []).find(s => s.id === sendSid)" in send
     assert "sendSid === this.currentId" in send
     assert "const sendDraft = sendState.draft" in send
-    assert "const composerImages = sendDraft.pendingImages.slice()" in send
-    assert "const composerDocs = sendDraft.pendingDocs.slice()" in send
+    assert "const composerImages = hasDetachedText ? [] : sendDraft.pendingImages.slice()" in send
+    assert "const composerDocs = hasDetachedText ? [] : sendDraft.pendingDocs.slice()" in send
     assert "const clearSubmittedComposer = ({ preserveForHandshake = false } = {}) =>" in send
     assert "removeOwned(sendDraft.pendingImages" in send
     busy_branch = "await this._confirmSessionBusy(sendSid, sendState)"
@@ -1392,9 +1576,9 @@ def test_chat_draft_survives_refresh_and_failed_stream_start():
     assert "this.tabState[id].draft.input = this._consumePersistedChatDraft(id)" in app
     assert 'window.addEventListener("pagehide"' in app
     assert "this._schedulePersistChatDraft(this.currentId, this.input" in app
-    assert "this._stageChatRecoveryDraft(sendSid, composerText)" in send
+    assert "this._stageChatRecoveryDraft(sendSid, composerInput)" in send
     assert "clearSubmittedComposer({ preserveForHandshake: true })" in send
-    assert "this._commitChatRecoveryDraft(sendSid, composerText)" in send
+    assert "this._commitChatRecoveryDraft(sendSid, composerInput)" in send
     assert "const rollbackUnstartedSend = () =>" in send
     assert "restoreSubmittedComposer(true)" in send
     assert "restoreOwned(sendDraft.pendingImages, composerImages)" in send
@@ -1425,7 +1609,8 @@ def test_queue_edit_does_not_borrow_active_composer_and_prompt_menu_is_removed()
     queue_start = app.index("async editPendingQueueItem")
     queue_edit = app[queue_start:app.index("async resumeQueueDrain", queue_start)]
 
-    assert "draft.input = text" in queue_edit
+    assert "draft.input = displayText" in queue_edit
+    assert "draft.pendingQuotes.splice" in queue_edit
     assert "draft.pendingImages.splice" in queue_edit
     assert "draft.pendingDocs.splice" in queue_edit
     assert "if (sid !== this.currentId) return" not in queue_edit

--- a/tests/test_plan_mode.py
+++ b/tests/test_plan_mode.py
@@ -237,6 +237,12 @@ def test_queue_endpoint_preserves_plan_return_capability(
 ):
     from backend import chat
 
+    # This case deliberately exercises the persisted item through one manual
+    # drain below. Enqueue now schedules an immediate background kick for idle
+    # sessions, so disable that production wakeup here or it can consume the
+    # item before the test installs its fake _start_turn.
+    monkeypatch.setattr(chat, "_schedule_queue_drain", lambda _sid: None)
+
     created = client.post(
         "/api/chat/sessions",
         headers=auth,


### PR DESCRIPTION
## 变更类型
- [x] 新功能 (feature)
- [x] 修复 (bugfix)
- [ ] 重构 (refactor)
- [ ] 文档 (docs)

## 变更说明

### 会话与任务状态
- 会话改名后通过现有 Activity SSE 立即同步任务中心，不改变排序、已读状态或任务时间。
- 后台任务存在时延后完成任务中心活动，直到最后一次续接真正结束。
- 为排队消息增加串行 drain 与完成竞态补偿，避免后台完成窗口内的新消息被遗漏或重复出队。

### 文件区与主布局
- 桌面布局调整为文件区、居中会话区、右侧预览区，突出主要对话。
- 优化文件路径、大小、修改时间等元信息展示，并让显示隐藏文件保持为直接操作。

### 选区引用与独立侧问
- 预览区和对话区选中文字后，可作为可移除的文本附件加入输入框，不改写正文。
- “询问”创建独立轻量分支，回答留在浮动面板中，不写入当前会话。
- 独立侧问浮窗支持标题栏自由拖动、鼠标和触屏 Pointer Events、视口边界约束、内容增长回弹与关闭重置。
- 排队展示保留正文与引用附件的结构化元数据，实际模型提示仍使用完整可读上下文。

## 隐私与安全
- 本 PR 没有新增 DUCC 配置或协议改动。
- 新增行扫描未发现凭证、私钥、个人主目录或邮箱信息。
- 独立侧问使用 default 权限，并明确要求不调用工具、不修改文件。

## 测试情况
- `tests/test_frontend_lint.py`: 100 passed
- `tests/test_chat_queue.py`: 30 passed
- `tests/test_activity.py`: 15 passed
- 任务中心/后台活动 targeted pytest: 2 passed
- 选区、布局、文件元信息、后台续接桌面与触屏 E2E: 13 passed
- `ruff check`、`node --check frontend/app.js`、`git diff --check` 通过

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 未包含敏感信息
