### PR TITLE
fix(chat): 稳定会话状态并完善独立侧问体验

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -821,6 +821,17 @@ class TurnBroadcast:
         self.user_text: str = ""
         self.user_images: list[dict] = []
         self.user_docs: list[dict] = []
+        # Display-only recovery boundary for an explicitly interrupted turn.
+        # The Claude CLI may abort before it flushes this turn to JSONL, while
+        # the browser has already rendered text/thinking/tool cards.  Capture
+        # the transcript coordinate immediately before query() so a durable
+        # MuseLab snapshot can later be inserted at the same visual position
+        # without writing partial assistant output back into model context.
+        self.transcript_boundary: dict[str, Any] = {}
+        self.canonical_terminal_published = False
+        self.cancelled_snapshot_persisted = False
+        self.cancelled_snapshot_suppressed = False
+        self.cancelled_snapshot_lock = threading.Lock()
         # True for a HEADLESS CONTINUATION turn: the cross-turn task watcher
         # opens one of these (no user prompt) when an SDK background task
         # finishes after its originating turn ended. It carries the task's
@@ -4711,6 +4722,58 @@ def _session_message_uuids(sid: str, model: str) -> frozenset[str]:
         return frozenset()
 
 
+def _turn_transcript_boundary(
+    sid: str,
+    model: str,
+) -> tuple[frozenset[str], dict[str, Any]]:
+    """Return the SDK replay boundary plus a display-history anchor.
+
+    The UUID set continues to protect the pooled SDK receive queue from
+    replaying a previous response.  The compact coordinate is retained on the
+    ``TurnBroadcast`` only for the lifetime of this turn and, if the user
+    interrupts before a canonical ResultMessage, is copied into the private
+    cancelled-turn display snapshot.
+    """
+    existing = _session_message_uuids(sid, model)
+    boundary: dict[str, Any] = {
+        "record_count": 0,
+        "source_dev": 0,
+        "source_inode": 0,
+        "normal_uuid": "",
+        "normal_total": 0,
+        "full_uuid": "",
+        "full_total": 0,
+    }
+    try:
+        indexed = _ensure_transcript_index(sid)
+        if indexed is None:
+            return existing, boundary
+        _, index = indexed
+        records = index.get("records") or []
+        source = index.get("source") or {}
+        boundary.update({
+            "record_count": len(records),
+            "source_dev": int(source.get("dev") or 0),
+            "source_inode": int(source.get("inode") or 0),
+        })
+        for order in ("normal", "full"):
+            record_ids = (index.get("orders") or {}).get(order) or []
+            prefix = (index.get("bubble_prefix") or {}).get(order) or [0]
+            if record_ids:
+                rec = records[record_ids[-1]]
+                boundary[f"{order}_uuid"] = str(rec.get("uuid") or "")
+            boundary[f"{order}_total"] = int(prefix[-1] if prefix else 0)
+    except Exception as exc:
+        # Recovery metadata is best-effort.  Failing to establish an anchor
+        # must never stop the actual model request; an unanchored snapshot is
+        # still safely appended to the display history if cancellation occurs.
+        sys.stderr.write(
+            f"[chat-stream] transcript boundary skipped sid={sid[:8]} "
+            f"exc={type(exc).__name__}\n")
+        sys.stderr.flush()
+    return existing, boundary
+
+
 class _TurnResponseBoundary:
     """Classify pooled-SDK messages relative to one ``query()`` call."""
 
@@ -4793,21 +4856,20 @@ def get_session_api(
     outline / export / jump-to-pre-compact back-compat — those need the whole
     list. Windowing is ignored when `full` is set.
 
-    Mid-turn fallback: SDK CLI only writes the JSONL on turn completion,
-    so a reload while a reply is streaming would otherwise return an
-    empty list. When an active TurnBroadcast exists for `sid`, we
-    reconstruct the in-flight messages from its event buffer (user
-    prompt + every SSE event yielded so far) so the user sees the
-    partial reply instead of a blank session."""
+    Explicit-interrupt recovery: if the CLI was force-stopped before it could
+    flush this turn to JSONL, merge MuseLab's private display snapshot at its
+    original transcript anchor. The snapshot is presentation-only and is
+    never passed back into model context."""
     meta = sess.get_session_meta(sid)
     if meta is None:
         raise HTTPException(404, "session not found")
     model = meta.get("model", "")
+    snapshots, snapshot_generation = _load_cancelled_turn_snapshots(sid)
     # Any bounded request uses the byte-offset index, including bounded
     # ``full``-order paging after an outline jump.  Keeping normal/full as an
     # explicit response coordinate prevents a full-order offset from later
     # being sent to the default normal-order endpoint.
-    uses_index = bool(around_uuid or tail > 0 or offset >= 0)
+    uses_index = bool(around_uuid or tail > 0 or offset >= 0 or snapshots)
     generation = ""
     has_later = False
     pre_total = 0
@@ -4816,13 +4878,25 @@ def get_session_api(
     if uses_index:
         indexed = _ensure_transcript_index(sid)
         if indexed is None:
-            messages: list[dict] = []
-            total = 0
-            win_offset = 0
-            window = []
+            generation = _combined_history_generation(
+                "", snapshot_generation)
+            if history_generation and history_generation != generation:
+                raise HTTPException(409, detail={
+                    "error": "history_generation_mismatch",
+                    "history_generation": generation,
+                })
+            if around_uuid:
+                raise HTTPException(404, "message uuid not found")
+            window, total, win_offset, has_later = _interrupted_history_window(
+                None, None, snapshots, {}, history_order,
+                tail=tail, offset=offset, limit=limit)
+            messages = window
         else:
             transcript_path, index = indexed
-            generation = str(index.get("history_generation") or "")
+            generation = _combined_history_generation(
+                str(index.get("history_generation") or ""),
+                snapshot_generation,
+            )
             # Bubbles stranded before the visible chain's root (post-/compact,
             # or a fork). Reported in FULL-order units in every response so the
             # client can offer "Load earlier" even when the normal-order window
@@ -4871,35 +4945,58 @@ def get_session_api(
             else:
                 order = "full" if full else "normal"
                 history_order = order
-                total = index["bubble_prefix"][order][-1]
-                if offset >= 0:
-                    start = max(0, min(offset, total))
-                    end = total if limit <= 0 else min(total, start + limit)
+                if snapshots:
+                    window, total, win_offset, has_later = (
+                        _interrupted_history_window(
+                            transcript_path,
+                            index,
+                            snapshots,
+                            annotations,
+                            order,
+                            tail=tail,
+                            offset=offset,
+                            limit=limit,
+                        )
+                    )
                 else:
-                    start = max(0, total - tail)
-                    end = total
-                record_ids, inner_start, _ = (
-                    transcript_idx.record_indices_for_bubble_window(
-                        index, order, start, end))
-                shaped = _indexed_ui_records(
-                    transcript_path, index, record_ids, annotations)
-                window = shaped[inner_start:inner_start + (end - start)]
-                win_offset = start
-                has_later = end < total
+                    total = index["bubble_prefix"][order][-1]
+                    if offset >= 0:
+                        start = max(0, min(offset, total))
+                        end = total if limit <= 0 else min(total, start + limit)
+                    else:
+                        start = max(0, total - tail)
+                        end = total
+                    record_ids, inner_start, _ = (
+                        transcript_idx.record_indices_for_bubble_window(
+                            index, order, start, end))
+                    shaped = _indexed_ui_records(
+                        transcript_path, index, record_ids, annotations)
+                    window = shaped[inner_start:inner_start + (end - start)]
+                    win_offset = start
+                    has_later = end < total
             messages = window
 
             # The index already has the exact normal-order bubble total, so
             # window requests can self-heal message_count without shaping the
             # entire transcript.
-            normal_total = index["bubble_prefix"]["normal"][-1]
+            if snapshots:
+                normal_total, turns = _interrupted_history_stats(
+                    index, snapshots, "normal")
+            else:
+                normal_total = index["bubble_prefix"]["normal"][-1]
+                records = index["records"]
+                turns = sum(
+                    1 for rec_i in index["orders"]["normal"]
+                    if records[rec_i].get("real_user_prompt")
+                )
             if not full and meta.get("message_count", 0) != normal_total:
                 try:
-                    records = index["records"]
-                    turns = sum(
-                        1 for rec_i in index["orders"]["normal"]
-                        if records[rec_i].get("real_user_prompt")
-                    )
                     sess.set_message_count(sid, normal_total, turn_count=turns)
+                    meta = {
+                        **meta,
+                        "message_count": normal_total,
+                        "turn_count": turns,
+                    }
                 except Exception:
                     pass
     else:
@@ -4972,10 +5069,15 @@ def get_session_outline_api(sid: str) -> dict:
     meta = sess.get_session_meta(sid)
     if meta is None:
         raise HTTPException(404, "session not found")
+    _, snapshot_generation = _load_cancelled_turn_snapshots(sid)
     try:
         indexed = _ensure_transcript_index(sid)
         if indexed is None:
-            return {"outline": [], "history_generation": ""}
+            return {
+                "outline": [],
+                "history_generation": _combined_history_generation(
+                    "", snapshot_generation),
+            }
         _, index = indexed
         records = index["records"]
         items = [
@@ -4988,24 +5090,25 @@ def get_session_outline_api(sid: str) -> dict:
         ]
         return {
             "outline": items,
-            "history_generation": index.get("history_generation") or "",
+            "history_generation": _combined_history_generation(
+                index.get("history_generation") or "", snapshot_generation),
         }
     except Exception:
-        return {"outline": [], "history_generation": ""}
+        return {
+            "outline": [],
+            "history_generation": _combined_history_generation(
+                "", snapshot_generation),
+        }
 
 
 def _broadcast_to_ui_messages(bc: "TurnBroadcast") -> list[dict]:
-    """Reconstruct a UI-shaped message list from an in-flight broadcast.
-    Lossy by design: this is shown only mid-turn while SDK JSONL is
-    empty. Once the turn finishes the regular SDK→UI path takes over
-    and we drop this view.
+    """Reconstruct the browser-visible portion of one broadcast.
 
-    Events fold like the streaming-handler's openAsst/closeAsst dance:
-    consecutive 'text' deltas form one assistant bubble; thinking
-    deltas accumulate into one thinking message; tool_use / tool_result
-    push their own messages. Non-render events (done / error / etc.)
-    are ignored here — the UI's `done` handler only matters in live
-    streaming, not in a reload-rebuild."""
+    This is the display record used when an explicit interrupt prevents the
+    CLI from committing a canonical JSONL turn.  It deliberately contains no
+    hidden protocol payloads and is never fed back to the model: only the same
+    bounded text/thinking/tool fields already sent to the browser are kept.
+    """
     out: list[dict] = []
     if bc.user_text or bc.user_images or bc.user_docs:
         out.append({
@@ -5016,6 +5119,23 @@ def _broadcast_to_ui_messages(bc: "TurnBroadcast") -> list[dict]:
         })
     cur_text_msg: dict | None = None
     cur_thinking_msg: dict | None = None
+
+    def close_segment() -> None:
+        nonlocal cur_text_msg, cur_thinking_msg
+        cur_text_msg = None
+        cur_thinking_msg = None
+
+    def apply_task_status(tool_use_id: str, task_id: str, **patch: Any) -> None:
+        for message in reversed(out):
+            if message.get("role") != "tool_use":
+                continue
+            status = message.get("task_status") or {}
+            if (tool_use_id and message.get("id") == tool_use_id) or (
+                task_id and status.get("task_id") == task_id
+            ):
+                message["task_status"] = {**status, "task_id": task_id, **patch}
+                return
+
     for ev in bc.replay_events():
         kind = ev.get("event") or ""
         data_str = ev.get("data") or "{}"
@@ -5041,30 +5161,487 @@ def _broadcast_to_ui_messages(bc: "TurnBroadcast") -> list[dict]:
             else:
                 cur_thinking_msg["text"] += chunk
         elif kind == "tool_use":
-            cur_text_msg = None
-            cur_thinking_msg = None
-            out.append({
+            close_segment()
+            message = {
                 "role": "tool_use",
                 "name": data.get("name"),
+                "id": data.get("id"),
                 "summary": data.get("summary"),
-                "input": data.get("input"),
+                "input": data.get("input") or {},
+                "task_status": None,
+                "_approvalSuperseded": False,
                 **({"todos": data["todos"]} if "todos" in data else {}),
                 **({"task": data["task"]} if "task" in data else {}),
                 **({"plan": data["plan"]} if "plan" in data else {}),
-            })
+            }
+            out.append(message)
         elif kind == "tool_result":
-            cur_text_msg = None
-            cur_thinking_msg = None
+            close_segment()
             out.append({
                 "role": "tool_result",
+                "id": data.get("id"),
+                "tool_name": data.get("tool_name") or "",
                 "preview": data.get("preview"),
+                "text": data.get("text") or "",
                 "truncated": data.get("truncated"),
+                "text_truncated": data.get("text_truncated"),
                 "is_error": data.get("is_error"),
+                "bash": data.get("bash"),
             })
-        # ask_user_question / permission_request not reconstructed here —
-        # they're interactive blocks whose answer state lives in the
-        # ask/perm queues, not in the broadcast buffer.
+        elif kind == "task_started":
+            apply_task_status(
+                str(data.get("tool_use_id") or ""),
+                str(data.get("task_id") or ""),
+                state="running",
+                description=data.get("description") or "",
+            )
+        elif kind == "task_progress":
+            apply_task_status(
+                str(data.get("tool_use_id") or ""),
+                str(data.get("task_id") or ""),
+                state="running",
+                usage=data.get("usage") or {},
+                last_tool_name=data.get("last_tool_name") or "",
+            )
+        elif kind == "task_notification":
+            raw_state = str(data.get("status") or "")
+            state = raw_state if raw_state in {
+                "completed", "failed", "stopped"
+            } else "done"
+            apply_task_status(
+                str(data.get("tool_use_id") or ""),
+                str(data.get("task_id") or ""),
+                state=state,
+                summary=data.get("summary") or "",
+                output_file=data.get("output_file") or "",
+            )
+        elif kind == "ask_user_question":
+            close_segment()
+            questions = data.get("questions") or []
+            out.append({
+                "role": "ask_user_question",
+                "id": data.get("id"),
+                "questions": questions,
+                "pendingAnswers": {
+                    str(question.get("question") or ""): (
+                        [] if question.get("multiSelect") else None
+                    )
+                    for question in questions
+                    if isinstance(question, dict)
+                },
+                # The stream is terminal: never resurrect an actionable card
+                # whose backend Future was cancelled with the turn.
+                "submitted": True,
+                "askOtherOpen": False,
+                "askOtherText": "",
+            })
+        elif kind == "permission_request":
+            close_segment()
+            out.append({
+                "role": "permission_request",
+                "id": data.get("id"),
+                "tool": data.get("tool"),
+                "summary": data.get("summary"),
+                "kind": data.get("kind") or "tool",
+                "suggestions": data.get("suggestions") or [],
+                "return_mode": data.get("return_mode") or "",
+                "title": data.get("title") or "",
+                "display_name": data.get("display_name") or "",
+                "description": data.get("description") or "",
+                "input": data.get("input") or {},
+                "tool_use_id": data.get("tool_use_id") or data.get("toolUseId") or "",
+                "plan": data.get("plan") or "",
+                "resolved": True,
+                "decision": "expired",
+                "mode": None,
+                "submitting": False,
+                "awaitingTransition": False,
+                "_decisionAcknowledged": True,
+                "failure_message": "",
+            })
     return out
+
+
+_CANCELLED_TURN_SNAPSHOT_SCHEMA = 1
+
+
+def _canonical_uuid_component(value: str) -> str | None:
+    """Return a filesystem-safe canonical UUID or ``None``."""
+    try:
+        parsed = uuid.UUID(str(value or ""))
+    except (ValueError, AttributeError, TypeError):
+        return None
+    canonical = str(parsed)
+    return canonical if canonical == str(value or "").lower() else None
+
+
+def _cancelled_turn_session_dir(sid: str) -> Path | None:
+    safe_sid = _canonical_uuid_component(sid)
+    if safe_sid is None:
+        return None
+    return sess.SESS_DIR / "cancelled_turns" / safe_sid
+
+
+def _cancelled_turn_snapshot_path(sid: str, turn_id: str) -> Path | None:
+    directory = _cancelled_turn_session_dir(sid)
+    safe_turn = _canonical_uuid_component(turn_id)
+    if directory is None or safe_turn is None:
+        return None
+    return directory / f"{safe_turn}.json"
+
+
+def _delete_cancelled_turn_snapshots(sid: str) -> None:
+    directory = _cancelled_turn_session_dir(sid)
+    if directory is None or not directory.exists():
+        return
+    shutil.rmtree(directory, ignore_errors=True)
+
+
+def _load_cancelled_turn_snapshots(sid: str) -> tuple[list[dict], str]:
+    """Load private display-only interrupted-turn snapshots.
+
+    The generation hashes filenames and stat data only; private message text is
+    never copied into an ETag, log line, or other externally observable cache
+    key.
+    """
+    directory = _cancelled_turn_session_dir(sid)
+    if directory is None or not directory.exists():
+        return [], ""
+    snapshots: list[dict] = []
+    digest = hashlib.blake2b(digest_size=12)
+    for path in sorted(directory.glob("*.json")):
+        try:
+            stat = path.stat()
+            digest.update(path.name.encode("ascii", errors="ignore"))
+            digest.update(f":{stat.st_mtime_ns}:{stat.st_size};".encode("ascii"))
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("snapshot root must be an object")
+            if data.get("schema") != _CANCELLED_TURN_SNAPSHOT_SCHEMA:
+                raise ValueError("unsupported snapshot schema")
+            if data.get("sid") != sid or not isinstance(data.get("messages"), list):
+                raise ValueError("snapshot ownership mismatch")
+            snapshots.append(data)
+        except Exception as exc:
+            # Never log payloads: a cancelled turn can contain private source,
+            # prompts, or tool output. Filename + exception class is enough for
+            # an operator to find a corrupt local artifact.
+            sys.stderr.write(
+                f"[chat] cancelled snapshot skipped file={path.name} "
+                f"exc={type(exc).__name__}\n")
+    snapshots.sort(key=lambda item: (
+        int(item.get("started_at_ms") or 0), str(item.get("turn_id") or "")))
+    return snapshots, digest.hexdigest() if snapshots else ""
+
+
+def _combined_history_generation(base: str, snapshot_generation: str) -> str:
+    if not snapshot_generation:
+        return base
+    return f"{base or 'none'}~cancelled-{snapshot_generation}"
+
+
+def _persist_cancelled_turn_snapshot(bc: "TurnBroadcast") -> bool:
+    """Serialize the pump/watchdog race and persist one stable snapshot."""
+    with bc.cancelled_snapshot_lock:
+        return _persist_cancelled_turn_snapshot_locked(bc)
+
+
+def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
+    """Atomically persist the browser-visible part of a non-canonical turn."""
+    if bc.cancelled_snapshot_persisted:
+        return True
+    if (bc.cancelled_snapshot_suppressed
+            or bc.canonical_terminal_published
+            or not bc.cancelled):
+        return False
+    path = _cancelled_turn_snapshot_path(bc.session_id, bc.turn_id)
+    if path is None:
+        return False
+    messages = _broadcast_to_ui_messages(bc)
+    if not messages:
+        return False
+
+    now_ms = int(time.time() * 1000)
+    elapsed_s = max(0.0, now_ms / 1000.0 - float(bc.started_at or 0))
+    for index, message in enumerate(messages):
+        message["_key"] = f"cancelled:{bc.turn_id}:{index}"
+        message["_interrupted"] = True
+        message["_interrupted_turn_id"] = bc.turn_id
+    for message in reversed(messages):
+        if message.get("role") != "user":
+            message.setdefault("ts", now_ms)
+            if elapsed_s >= 1:
+                message.setdefault("elapsed", round(elapsed_s, 1))
+            break
+
+    boundary = dict(bc.transcript_boundary or {})
+    hidden_uuids: list[str] = []
+    try:
+        indexed = _ensure_transcript_index(bc.session_id)
+        if indexed is not None:
+            _, index = indexed
+            source = index.get("source") or {}
+            same_source = (
+                int(source.get("dev") or 0) == int(boundary.get("source_dev") or 0)
+                and int(source.get("inode") or 0)
+                    == int(boundary.get("source_inode") or 0)
+            )
+            start = int(boundary.get("record_count") or 0)
+            records = index.get("records") or []
+            if same_source and 0 <= start <= len(records):
+                hidden_uuids = list(dict.fromkeys(
+                    str(record.get("uuid") or "")
+                    for record in records[start:]
+                    if record.get("uuid")
+                ))
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] cancelled snapshot boundary scan skipped "
+            f"sid={bc.session_id[:8]} exc={type(exc).__name__}\n")
+
+    payload = {
+        "schema": _CANCELLED_TURN_SNAPSHOT_SCHEMA,
+        "sid": bc.session_id,
+        "turn_id": bc.turn_id,
+        "model": bc.model,
+        "started_at_ms": int(float(bc.started_at or 0) * 1000),
+        "interrupted_at_ms": now_ms,
+        "anchors": {
+            "normal": {
+                "uuid": boundary.get("normal_uuid") or "",
+                "total": int(boundary.get("normal_total") or 0),
+            },
+            "full": {
+                "uuid": boundary.get("full_uuid") or "",
+                "total": int(boundary.get("full_total") or 0),
+            },
+        },
+        "hidden_uuids": hidden_uuids,
+        "messages": messages,
+    }
+    try:
+        # Keep the atomic writer's temporary file and the final snapshot in a
+        # session-private directory. Interrupted prompts and tool output must
+        # not be readable by another local account during the rename-sized
+        # window before the final file chmod below.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with suppress(OSError):
+            path.parent.chmod(0o700)
+        atomic_write_text(
+            path,
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+        )
+        with suppress(OSError):
+            path.chmod(0o600)
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] cancelled snapshot write failed sid={bc.session_id[:8]} "
+            f"exc={type(exc).__name__}\n")
+        sys.stderr.flush()
+        return False
+
+    # The durable display record is already committed. Metadata is a
+    # self-healing cache (the history endpoint recomputes it), so a failure to
+    # bump the list row must not tell the browser that snapshot persistence
+    # failed and leave the just-rendered pane exposed to an older reload.
+    bc.cancelled_snapshot_persisted = True
+    try:
+        snapshots, _ = _load_cancelled_turn_snapshots(bc.session_id)
+        indexed = _ensure_transcript_index(bc.session_id)
+        index = indexed[1] if indexed is not None else None
+        total, turns = _interrupted_history_stats(index, snapshots, "normal")
+        sess.bump_session(
+            bc.session_id,
+            message_count=total,
+            turn_count=turns,
+            auto_rename_from=bc.user_text,
+        )
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] cancelled snapshot metadata sync failed "
+            f"sid={bc.session_id[:8]} "
+            f"exc={type(exc).__name__}\n")
+        sys.stderr.flush()
+    return True
+
+
+def _interrupted_history_segments(
+    index: dict | None,
+    snapshots: list[dict],
+    order: str,
+) -> tuple[list[dict], int]:
+    """Build a virtual bubble stream of canonical records + snapshots."""
+    records = (index or {}).get("records") or []
+    orders = (index or {}).get("orders") or {}
+    record_ids = list(orders.get(order) or [])
+    positions: dict[str, int] = {}
+    for position, record_id in enumerate(record_ids):
+        uid = str(records[record_id].get("uuid") or "")
+        if uid:
+            positions[uid] = position
+    full_uuids = {
+        str(records[record_id].get("uuid") or "")
+        for record_id in orders.get("full") or []
+    }
+    prefix = ((index or {}).get("bubble_prefix") or {}).get(order) or [0]
+
+    placed: dict[int, list[dict]] = {}
+    included: list[dict] = []
+    for snapshot in snapshots:
+        anchors = snapshot.get("anchors") or {}
+        anchor = anchors.get(order) or {}
+        anchor_uuid = str(anchor.get("uuid") or "")
+        if anchor_uuid and anchor_uuid in positions:
+            position = positions[anchor_uuid]
+        elif order == "normal" and anchor_uuid and anchor_uuid in full_uuids:
+            # The interrupted turn sits before the current compact/fork root.
+            # Keep it in full-history mode but do not punch it back into the
+            # normal post-compact view.
+            continue
+        else:
+            target = max(0, int(anchor.get("total") or 0))
+            position = -1
+            for pos in range(len(record_ids)):
+                reached = int(prefix[pos + 1] if pos + 1 < len(prefix) else 0)
+                if reached > target:
+                    break
+                position = pos
+        placed.setdefault(position, []).append(snapshot)
+        included.append(snapshot)
+
+    for group in placed.values():
+        group.sort(key=lambda item: (
+            int(item.get("started_at_ms") or 0), str(item.get("turn_id") or "")))
+
+    hidden = {
+        str(uid)
+        for snapshot in included
+        for uid in (snapshot.get("hidden_uuids") or [])
+        if uid
+    }
+    segments: list[dict] = []
+
+    def append_snapshots(position: int) -> None:
+        for snapshot in placed.get(position, []):
+            messages = snapshot.get("messages") or []
+            if messages:
+                segments.append({
+                    "kind": "snapshot",
+                    "snapshot": snapshot,
+                    "count": len(messages),
+                })
+
+    append_snapshots(-1)
+    for position, record_id in enumerate(record_ids):
+        record = records[record_id]
+        if str(record.get("uuid") or "") not in hidden:
+            count = max(0, int(record.get("bubble_count") or 0))
+            if count:
+                segments.append({
+                    "kind": "record",
+                    "record_id": record_id,
+                    "count": count,
+                })
+        append_snapshots(position)
+    snapshot_turns = sum(
+        1
+        for snapshot in included
+        if any(
+            isinstance(message, dict) and message.get("role") == "user"
+            for message in (snapshot.get("messages") or [])
+        )
+    )
+    return segments, snapshot_turns
+
+
+def _interrupted_history_stats(
+    index: dict | None,
+    snapshots: list[dict],
+    order: str,
+) -> tuple[int, int]:
+    segments, snapshot_turns = _interrupted_history_segments(
+        index, snapshots, order)
+    total = sum(int(segment.get("count") or 0) for segment in segments)
+    records = (index or {}).get("records") or []
+    canonical_turns = sum(
+        1
+        for segment in segments
+        if segment.get("kind") == "record"
+        and records[segment["record_id"]].get("real_user_prompt")
+    )
+    return total, canonical_turns + snapshot_turns
+
+
+def _interrupted_history_window(
+    transcript_path: Path | None,
+    index: dict | None,
+    snapshots: list[dict],
+    annotations: dict[str, dict],
+    order: str,
+    *,
+    tail: int = 0,
+    offset: int = -1,
+    limit: int = 0,
+) -> tuple[list[dict], int, int, bool]:
+    """Read one window from the virtual display history.
+
+    Only canonical records that intersect the requested display window are
+    read from JSONL.  A session with a cancelled snapshot therefore retains
+    the existing long-history/windowing protections instead of falling back to
+    a full transcript parse on every open.
+    """
+    segments, _ = _interrupted_history_segments(index, snapshots, order)
+    total = sum(int(segment.get("count") or 0) for segment in segments)
+    if offset >= 0:
+        start = max(0, min(offset, total))
+        end = total if limit <= 0 else min(total, start + limit)
+    elif tail > 0:
+        start = max(0, total - tail)
+        end = total
+    else:
+        start, end = 0, total
+
+    pieces: list[tuple[str, Any, int, int]] = []
+    selected_record_ids: list[int] = []
+    cursor = 0
+    for segment in segments:
+        count = int(segment.get("count") or 0)
+        seg_start, seg_end = cursor, cursor + count
+        cursor = seg_end
+        overlap_start = max(start, seg_start)
+        overlap_end = min(end, seg_end)
+        if overlap_start >= overlap_end:
+            continue
+        local_start = overlap_start - seg_start
+        local_end = overlap_end - seg_start
+        if segment["kind"] == "record":
+            record_id = int(segment["record_id"])
+            selected_record_ids.append(record_id)
+            pieces.append(("record", record_id, local_start, local_end))
+        else:
+            pieces.append((
+                "snapshot", segment["snapshot"], local_start, local_end))
+
+    shaped_by_record: dict[int, list[dict]] = {}
+    if transcript_path is not None and index is not None and selected_record_ids:
+        shaped = _indexed_ui_records(
+            transcript_path, index, selected_record_ids, annotations)
+        shaped_cursor = 0
+        records = index.get("records") or []
+        for record_id in selected_record_ids:
+            count = max(0, int(records[record_id].get("bubble_count") or 0))
+            shaped_by_record[record_id] = shaped[
+                shaped_cursor:shaped_cursor + count]
+            shaped_cursor += count
+
+    window: list[dict] = []
+    for kind, source, local_start, local_end in pieces:
+        if kind == "record":
+            messages = shaped_by_record.get(int(source), [])
+        else:
+            messages = source.get("messages") or []
+        window.extend(messages[local_start:local_end])
+    return window, total, start, end < total
 
 
 @router.get("/sessions/{sid}/export", dependencies=[Depends(require_token_query)])
@@ -5077,13 +5654,21 @@ def export_session_markdown(sid: str) -> Response:
     if meta is None:
         raise HTTPException(404, "session not found")
     model = meta.get("model", "")
-    try:
-        sdk_msgs = _get_session_msgs(sid, model)
-    except Exception:
-        sdk_msgs = []
     annotations = sess.get_message_annotations(sid)
-    compact_uuids = _compact_summary_uuids(sid)
-    messages = _sdk_messages_to_ui(sdk_msgs, annotations, compact_uuids)
+    snapshots, _ = _load_cancelled_turn_snapshots(sid)
+    if snapshots:
+        indexed = _ensure_transcript_index(sid)
+        transcript_path = indexed[0] if indexed is not None else None
+        index = indexed[1] if indexed is not None else None
+        messages, _, _, _ = _interrupted_history_window(
+            transcript_path, index, snapshots, annotations, "normal")
+    else:
+        try:
+            sdk_msgs = _get_session_msgs(sid, model)
+        except Exception:
+            sdk_msgs = []
+        compact_uuids = _compact_summary_uuids(sid)
+        messages = _sdk_messages_to_ui(sdk_msgs, annotations, compact_uuids)
     # Bind any unbound pending image/doc attachments (those persisted
     # before the stream completed could write a uuid annotation) to the
     # user messages that have inline image refs but no thumb/url yet.
@@ -5163,6 +5748,14 @@ def _clear_session_runtime_state(sid: str) -> None:
         recent.close()
     broadcast = _active_turns.pop(sid, None)
     if broadcast is not None:
+        # Explicit session deletion owns the terminal state. Prevent the
+        # cancelled pump's finally block from recreating a private display
+        # snapshot after purge_session_storage has removed every artifact.
+        broadcast.cancelled_snapshot_suppressed = True
+        # Join any already-running to_thread writer before the caller removes
+        # the snapshot directory. A later writer observes the suppression bit.
+        with broadcast.cancelled_snapshot_lock:
+            pass
         task = getattr(broadcast, "task", None)
         if task is not None and not task.done():
             task.cancel()
@@ -5212,6 +5805,7 @@ def purge_session_storage(sid: str) -> bool:
     _interrupted_at_startup.pop(sid, None)
     _clear_session_runtime_state(sid)
     _delete_active_turn_sidecar(sid)
+    _delete_cancelled_turn_snapshots(sid)
     return removed
 
 
@@ -7468,7 +8062,12 @@ async def _force_stop_after_grace(
             if _active_turns.get(session_id) is bc:
                 _active_turns.pop(session_id, None)
         if not bc.done:
-            bc.publish({"event": "cancelled", "data": "{}"})
+            snapshot_ready = await asyncio.to_thread(
+                _persist_cancelled_turn_snapshot, bc)
+            bc.publish({
+                "event": "cancelled",
+                "data": json.dumps({"snapshot_ready": snapshot_ready}),
+            })
             bc.finish()
         _delete_active_turn_sidecar(session_id)
     except Exception as e:
@@ -9793,7 +10392,12 @@ async def _finish_cancelled_startup(
 ) -> TurnBroadcast:
     """Finish a turn cancelled before its SDK client/query was ready."""
     if not broadcast.done:
-        broadcast.publish({"event": "cancelled", "data": "{}"})
+        snapshot_ready = await asyncio.to_thread(
+            _persist_cancelled_turn_snapshot, broadcast)
+        broadcast.publish({
+            "event": "cancelled",
+            "data": json.dumps({"snapshot_ready": snapshot_ready}),
+        })
         broadcast.finish()
     async with _lock:
         if _active_turns.get(session_id) is broadcast:
@@ -9961,6 +10565,11 @@ async def _start_turn(
                 raise _TurnBusy()
             broadcast = TurnBroadcast(session_id=session_id, model=model or MODEL)
             _active_turns[session_id] = broadcast
+    # The Stop button can race cold CLI/MCP startup before attachment parsing
+    # and the final model resolution below. Retain the already-submitted text
+    # as soon as this broadcast owns the session so startup cancellation can
+    # persist the same user bubble the browser is displaying.
+    broadcast.user_text = prompt
     # Clear a completed watcher defensively. A live watcher must never be
     # cancelled here: it still owns the stream and its continuation belongs to
     # the previous turn.
@@ -10555,8 +11164,9 @@ async def _start_turn(
                 # Snapshot AFTER preflight compact (which may write a new compact
                 # boundary) and immediately BEFORE this user query. A cache hit is
                 # cheap; to_thread keeps a long-session parse off the event loop.
-                existing_uuids = await asyncio.to_thread(
-                    _session_message_uuids, session_id, model_to_use)
+                existing_uuids, transcript_boundary = await asyncio.to_thread(
+                    _turn_transcript_boundary, session_id, model_to_use)
+                broadcast.transcript_boundary = transcript_boundary
                 boundary = _TurnResponseBoundary(existing_uuids)
                 # mem0 recall is supplied by the UserPromptSubmit hook configured
                 # on this client. The canonical query remains exactly `prompt` so
@@ -11674,6 +12284,26 @@ async def _start_turn(
                                 turn_errored = True
                         except (ValueError, TypeError):
                             pass
+                        # ResultMessage is the canonical transcript boundary.
+                        # Even a graceful done(cancelled=true) must not get a
+                        # duplicate display snapshot layered over JSONL.
+                        broadcast.canonical_terminal_published = True
+                    if (isinstance(ev, dict)
+                            and ev.get("event") == "cancelled"
+                            and broadcast.cancelled):
+                        snapshot_ready = await asyncio.to_thread(
+                            _persist_cancelled_turn_snapshot, broadcast)
+                        try:
+                            cancelled_data = json.loads(ev.get("data") or "{}")
+                        except (TypeError, ValueError):
+                            cancelled_data = {}
+                        if not isinstance(cancelled_data, dict):
+                            cancelled_data = {}
+                        cancelled_data["snapshot_ready"] = snapshot_ready
+                        ev = {
+                            **ev,
+                            "data": json.dumps(cancelled_data),
+                        }
                     broadcast.publish(ev)
                     if isinstance(ev, dict) and ev.get("event") == "done":
                         terminal_published = True
@@ -11718,6 +12348,11 @@ async def _start_turn(
                         "".join(assistant_acc),
                         turn_error_text or "turn stream failed",
                         broadcast.turn_id)
+            if (broadcast.cancelled
+                    and not broadcast.canonical_terminal_published
+                    and not broadcast.cancelled_snapshot_persisted):
+                await asyncio.to_thread(
+                    _persist_cancelled_turn_snapshot, broadcast)
             _activity_status = ("cancelled" if broadcast.cancelled else
                                 "failed" if turn_errored else "completed")
             await _finish_activity(

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -16,7 +16,7 @@ import urllib.parse
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Iterable, get_args
+from typing import Any, Iterable, Literal, get_args
 from fastapi import APIRouter, Depends, Query, HTTPException, UploadFile, File, Request, Response
 from fastapi.responses import FileResponse
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
@@ -796,6 +796,14 @@ class TurnBroadcast:
         # queue rather than charging into the next item — the user stopped on
         # purpose, almost never "just this one, send the rest."
         self.cancelled = False
+        # Exact persisted assistant boundary observed from AssistantMessage.
+        # Keep it on the broadcast as well as in event_gen's local accumulator:
+        # a forced interrupt can prevent ResultMessage from arriving, but the
+        # CLI may still flush that AssistantMessage to JSONL several seconds
+        # later.  The cancellation cleanup can then annotate the precise UUID
+        # instead of racing a "latest transcript row" scan.
+        self.last_assistant_uuid = ""
+        self.cancelled_at_ms = 0
         self.started_at = time.time()
         # Immutable identity for this exact assistant turn. Session id alone
         # cannot distinguish the classic ABA race where turn A finishes and
@@ -862,6 +870,7 @@ class TurnBroadcast:
         # session, before cold client/MCP startup. Startup failure/cancellation
         # uses this bit to close only rows that were actually created.
         self.activity_started = False
+        self.activity_hidden = False
 
     def publish(self, event: dict) -> None:
         """Route one SSE event to the record channel, the live channel, or both.
@@ -2222,6 +2231,9 @@ async def _build_and_connect_client(
     for serialising concurrent misses on the same key via _creation_lock_for().
     """
     sess_data = sess.get_session(session_id) or {}
+    side_question_runtime = (
+        sess_data.get("runtime_profile") == "side_question"
+    )
     effort = _normalize_effort(effort)
     service_tier = (service_tier or "").strip()
     if effort not in _VALID_EFFORT:
@@ -2275,8 +2287,11 @@ async def _build_and_connect_client(
     skills_off = os.environ.get("MUSELAB_DISABLE_SKILLS", "").lower() in (
         "1", "true", "yes",
     )
-    user_prompt_hooks = [mem0.build_recall_hook(session_id)]
-    if (effort == "ultra" and _is_codex_gateway_model(model)
+    user_prompt_hooks = (
+        [] if side_question_runtime else [mem0.build_recall_hook(session_id)]
+    )
+    if (not side_question_runtime and effort == "ultra"
+            and _is_codex_gateway_model(model)
             and not skills_off):
         user_prompt_hooks.append(_build_ultra_skill_hook())
     opts_kwargs = dict(
@@ -2362,6 +2377,19 @@ async def _build_and_connect_client(
             )],
         },
     )
+    if side_question_runtime:
+        # Side questions are deliberately narrower than ordinary workspace
+        # agents.  `tools` removes every built-in except public web lookup;
+        # the explicit allow rules make those two tools usable from the compact
+        # floating window without an approval card it cannot render.  Remove
+        # workspace/user instruction sources, plugins and recall hooks as well:
+        # a web query must not gain unrelated private context behind the user's
+        # back.  The selected excerpt + forked transcript remain available.
+        opts_kwargs["tools"] = ["WebSearch", "WebFetch"]
+        opts_kwargs["allowed_tools"] = ["WebSearch", "WebFetch"]
+        opts_kwargs["setting_sources"] = []
+        opts_kwargs["plugins"] = []
+        opts_kwargs["hooks"].pop("UserPromptSubmit", None)
     if is_ducc:
         # Keep the SDK's mature stream-json/control/MCP/session machinery, but
         # swap the executable to MuseLab's sanitising wrapper. The wrapper then
@@ -2392,7 +2420,7 @@ async def _build_and_connect_client(
     # users expect an explicitly named local skill (e.g. galatea) to be usable
     # regardless of the selected model. Operators who hit vendor payload limits
     # can still opt out globally via MUSELAB_DISABLE_SKILLS=1.
-    if not skills_off:
+    if not skills_off and not side_question_runtime:
         opts_kwargs["skills"] = "all"
     # Optional model params from env (UI-editable via /api/settings).
     mt = env_int("MUSELAB_MAX_TURNS", 0, min_value=0)
@@ -2492,35 +2520,39 @@ async def _build_and_connect_client(
     #     user already added via `claude mcp add` "just works" without
     #     re-entering — muselab is positioned as a Claude Code replacement.
     # See backend/api_settings.py _load_mcp_merged for the merge rules.
-    mcp_dict: dict = {"muselab": build_server_for_session(session_id)}
-    try:
-        from .api_settings import _load_mcp_merged
-        for name, spec in _load_mcp_merged().items():
-            if not isinstance(spec, dict):
-                continue
-            # Skip disabled servers (UI toggle OR override stub).
-            if spec.get("disabled"):
-                continue
-            # Strip muselab-local metadata keys before handing to SDK —
-            # `_source` / `_overridden_by_muselab` / `disabled` are
-            # display/control fields, not part of the MCP spec.
-            clean = {k: v for k, v in spec.items()
-                     if not k.startswith("_") and k != "disabled"}
-            # Defensive: external sources may have entries without
-            # `command` (e.g. broken Claude Code config). Skip rather
-            # than hand the SDK an unconnectable spec.
-            if "command" not in clean and "url" not in clean:
-                continue
-            mcp_dict[name] = clean
-    except Exception as e:
-        # Don't silently drop EVERY MCP server because one source had a
-        # parse error — log + carry on with the built-in. _load_mcp_merged
-        # already swallows per-file errors and stderr's them; this catch
-        # is for unexpected programmer errors only.
-        sys.stderr.write(
-            f"[chat] mcp merge failed for sid={session_id[:8]}: "
-            f"{type(e).__name__}: {e}; only muselab built-in MCP active\n")
-        sys.stderr.flush()
+    mcp_dict: dict = (
+        {} if side_question_runtime
+        else {"muselab": build_server_for_session(session_id)}
+    )
+    if not side_question_runtime:
+        try:
+            from .api_settings import _load_mcp_merged
+            for name, spec in _load_mcp_merged().items():
+                if not isinstance(spec, dict):
+                    continue
+                # Skip disabled servers (UI toggle OR override stub).
+                if spec.get("disabled"):
+                    continue
+                # Strip muselab-local metadata keys before handing to SDK —
+                # `_source` / `_overridden_by_muselab` / `disabled` are
+                # display/control fields, not part of the MCP spec.
+                clean = {k: v for k, v in spec.items()
+                         if not k.startswith("_") and k != "disabled"}
+                # Defensive: external sources may have entries without
+                # `command` (e.g. broken Claude Code config). Skip rather
+                # than hand the SDK an unconnectable spec.
+                if "command" not in clean and "url" not in clean:
+                    continue
+                mcp_dict[name] = clean
+        except Exception as e:
+            # Don't silently drop EVERY MCP server because one source had a
+            # parse error — log + carry on with the built-in. _load_mcp_merged
+            # already swallows per-file errors and stderr's them; this catch
+            # is for unexpected programmer errors only.
+            sys.stderr.write(
+                f"[chat] mcp merge failed for sid={session_id[:8]}: "
+                f"{type(e).__name__}: {e}; only muselab built-in MCP active\n")
+            sys.stderr.flush()
     opts_kwargs["mcp_servers"] = mcp_dict
     # Enable extended thinking for models whose provider endpoint handles
     # the standard Anthropic thinking config. Some vendors (e.g. Qianfan)
@@ -2586,7 +2618,7 @@ async def _build_and_connect_client(
     # callback, so wiring it there only creates a false AskUserQuestion promise
     # plus CanUseToolShadowedWarning noise. Interactive questions use the
     # dedicated muselab MCP tool in every mode.
-    if permission != "bypassPermissions":
+    if permission != "bypassPermissions" and not side_question_runtime:
         opts_kwargs["can_use_tool"] = perm.build_callback_for_session(
             session_id,
             plan_return_permission=(
@@ -3314,6 +3346,13 @@ class CreateReq(BaseModel):
     # has open in a tab and is about to type in. Empty + closed + unpinned +
     # auto-named is the only thing eligible for cleanup.
     open_ids: list[str] | None = None
+    # Lightweight side-question branches remain normal resumable sessions but
+    # intentionally do not become rows in the global task/activity ledger.
+    activity_hidden: bool = False
+    # A side question is conversational, not a general workspace agent.  Its
+    # runtime exposes only public web lookup tools even when the branch is
+    # later opened as a full chat.
+    runtime_profile: Literal["", "side_question"] = ""
 
 
 _last_orphan_gc_at = 0.0
@@ -3782,6 +3821,8 @@ def create_session_api(req: CreateReq) -> dict:
                 permission=resolved_permission,
                 auto_named=True,
                 cwd=req.cwd or None,
+                activity_hidden=req.activity_hidden,
+                runtime_profile=req.runtime_profile,
             )
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
@@ -3792,6 +3833,8 @@ def create_session_api(req: CreateReq) -> dict:
                 model=resolved_model,
                 permission=resolved_permission,
                 cwd=req.cwd or None,
+                activity_hidden=req.activity_hidden,
+                runtime_profile=req.runtime_profile,
             )
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
@@ -4341,6 +4384,17 @@ def _sdk_messages_to_ui(sm_list: list, annotations: dict[str, dict],
         elapsed = ann.get("elapsed_s")
         if elapsed is not None and "elapsed" not in entry:
             entry["elapsed"] = elapsed
+        # Completion annotations belong to the persisted assistant UUID, but
+        # one SDK message can explode into thinking/tool/result bubbles and the
+        # footer mounts on whichever bubble is visually last.  Fan model and
+        # terminal state across that UUID just like ts/elapsed, otherwise a
+        # tool-ending turn reloads as two separator lines with no model/state.
+        model_name = ann.get("model")
+        if model_name and "model" not in entry:
+            entry["model"] = model_name
+        turn_status = ann.get("turn_status")
+        if turn_status and "turn_status" not in entry:
+            entry["turn_status"] = turn_status
         # User-msg image annotations (thumb + url for the lightbox)
         # live in the sidecar — the inline `image_refs` extracted from
         # the SDK content blocks only carry `mime`. Layer the sidecar's
@@ -4407,6 +4461,71 @@ def _ensure_transcript_index(sid: str) -> tuple[Path, dict] | None:
         sid, path, _transcript_index_path(sid), _describe_transcript_record)
 
 
+def _indexed_turn_context(
+    transcript_path: Path,
+    index: dict,
+    record_indices: list[int],
+) -> dict[str, tuple[str, int | None]]:
+    """Map selected record UUIDs to their logical turn origin and start time.
+
+    A visible assistant run may span several JSONL records (tool results), and
+    a background-task continuation starts at a zero-bubble task-notification
+    record.  A bounded tail read normally does not read that hidden ancestor,
+    so deriving footer duration from visible bubbles alone either loses the
+    value or accidentally borrows metadata from the launch turn.  The index
+    already stores parent links plus prompt/notification descriptors; walk
+    those cheap records and seek only the few unique origin lines for time.
+    """
+    records = index.get("records") or []
+    if not records or not record_indices:
+        return {}
+    by_uuid: dict[str, int] = {}
+    for record_i, record in enumerate(records):
+        uid = str(record.get("uuid") or "")
+        if uid:
+            by_uuid[uid] = record_i
+
+    origin_by_uuid: dict[str, str] = {}
+    origin_indices: set[int] = set()
+    for selected_i in record_indices:
+        if selected_i < 0 or selected_i >= len(records):
+            continue
+        selected = records[selected_i]
+        selected_uuid = str(selected.get("uuid") or "")
+        current_i = selected_i
+        origin_i = selected_i
+        seen: set[str] = set()
+        while 0 <= current_i < len(records):
+            current = records[current_i]
+            current_uuid = str(current.get("uuid") or "")
+            if current_uuid in seen:
+                break
+            if current_uuid:
+                seen.add(current_uuid)
+            origin_i = current_i
+            if (current.get("real_user_prompt")
+                    or current.get("task_notifications")):
+                break
+            parent = str(current.get("parent") or "")
+            parent_i = by_uuid.get(parent) if parent else None
+            if parent_i is None:
+                break
+            current_i = parent_i
+        origin_uuid = str(records[origin_i].get("uuid") or selected_uuid)
+        if selected_uuid:
+            origin_by_uuid[selected_uuid] = origin_uuid
+        origin_indices.add(origin_i)
+
+    origin_times: dict[str, int | None] = {}
+    for entry in transcript_idx.read_records(
+            transcript_path, index, sorted(origin_indices)):
+        origin_times[str(entry.get("uuid") or "")] = _transcript_ts_ms(entry)
+    return {
+        uid: (origin_uuid, origin_times.get(origin_uuid))
+        for uid, origin_uuid in origin_by_uuid.items()
+    }
+
+
 def _indexed_ui_records(
     transcript_path: Path,
     index: dict,
@@ -4415,6 +4534,8 @@ def _indexed_ui_records(
 ) -> list[dict]:
     """Seek/read and shape only selected records from a transcript index."""
     entries = transcript_idx.read_records(transcript_path, index, record_indices)
+    turn_context = _indexed_turn_context(
+        transcript_path, index, record_indices)
     raw = [
         _RawMsg(str(e.get("uuid") or ""), str(e.get("type") or ""),
                 e.get("message") or {}, _transcript_ts_ms(e))
@@ -4434,6 +4555,13 @@ def _indexed_ui_records(
         ordinal = ordinals.get(uid, 0)
         ordinals[uid] = ordinal + 1
         bubble["_key"] = f"{uid}:{ordinal}"
+        context = turn_context.get(uid)
+        if context is not None:
+            origin_uuid, started_at_ms = context
+            if origin_uuid:
+                bubble["_turn_origin_uuid"] = origin_uuid
+            if started_at_ms is not None:
+                bubble["turn_started_at"] = started_at_ms
         tool_id = str(bubble.get("id") or "")
         if bubble.get("role") == "tool_result" and tool_id:
             tool_name = tool_names.get(tool_id) or ""
@@ -4446,6 +4574,113 @@ def _indexed_ui_records(
         elif bubble.get("role") == "tool_use" and tool_id in task_status:
             bubble["task_status"] = task_status[tool_id]
     return bubbles
+
+
+def _complete_turn_footer_metadata(
+    messages: list[dict],
+    session_model: str,
+    *,
+    has_later: bool,
+    active_turn: "TurnBroadcast | None" = None,
+) -> None:
+    """Put one complete footer contract on every real visual turn tail.
+
+    The frontend footer lives on the last muse-side bubble before a visible
+    user bubble.  Persisted completion annotations, however, belong to the
+    exact assistant UUID that produced ResultMessage and may sit earlier than
+    a trailing tool_result.  Background continuations add another wrinkle:
+    they have no visible user separator at all.  Restrict donors to the tail's
+    indexed turn origin, then fill status/time/duration/model without leaking
+    metadata across those hidden boundaries.
+    """
+    if not messages:
+        return
+    active_uuid = ""
+    if active_turn is not None and not active_turn.done:
+        active_uuid = str(active_turn.last_assistant_uuid or "")
+
+    i = 0
+    while i < len(messages):
+        if messages[i].get("role") == "user":
+            i += 1
+            continue
+        group_start = i
+        while i < len(messages) and messages[i].get("role") != "user":
+            i += 1
+        group = messages[group_start:i]
+        tail = group[-1]
+        origin_uuid = str(tail.get("_turn_origin_uuid") or "")
+        scope = ([item for item in group
+                  if str(item.get("_turn_origin_uuid") or "") == origin_uuid]
+                 if origin_uuid else group)
+        if not scope:
+            scope = [tail]
+
+        def last_value(field: str) -> Any:
+            for item in reversed(scope):
+                if field not in item:
+                    continue
+                value = item.get(field)
+                if value is not None and value != "":
+                    return value
+            return None
+
+        status = str(last_value("turn_status") or "")
+        active_scope = bool(active_uuid and any(
+            str(item.get("uuid") or "") == active_uuid for item in scope))
+        closed_by_user = i < len(messages)
+        complete_window_tail = i == len(messages) and not has_later
+        if not status:
+            if active_scope:
+                status = "running"
+            elif closed_by_user or complete_window_tail:
+                status = "completed"
+
+        # A page ending in the middle of a turn is not a real footer boundary.
+        # Leave it without status; the frontend hides incomplete separators.
+        if not status:
+            continue
+
+        terminal_ms = last_value("ts")
+        if terminal_ms is None:
+            terminal_ms = last_value("mts")
+        try:
+            terminal_ms = int(terminal_ms) if terminal_ms is not None else None
+        except (TypeError, ValueError, OverflowError):
+            terminal_ms = None
+
+        started_ms = last_value("turn_started_at")
+        try:
+            started_ms = int(started_ms) if started_ms is not None else None
+        except (TypeError, ValueError, OverflowError):
+            started_ms = None
+
+        elapsed = last_value("elapsed")
+        try:
+            elapsed = float(elapsed) if elapsed is not None else None
+        except (TypeError, ValueError, OverflowError):
+            elapsed = None
+        if elapsed is None and started_ms is not None:
+            end_ms = (int(time.time() * 1000)
+                      if status == "running" else terminal_ms)
+            if end_ms is not None:
+                elapsed = round(max(0.0, (end_ms - started_ms) / 1000), 1)
+
+        footer_model = str(last_value("model") or "")
+        if not footer_model and active_scope and active_turn is not None:
+            footer_model = str(active_turn.model or "")
+        if not footer_model:
+            footer_model = str(session_model or "")
+
+        tail["turn_status"] = status
+        if status != "running" and terminal_ms is not None:
+            tail["ts"] = terminal_ms
+        if started_ms is not None:
+            tail["turn_started_at"] = started_ms
+        if elapsed is not None:
+            tail["elapsed"] = elapsed
+        if footer_model:
+            tail["model"] = footer_model
 
 
 def _bind_pending_attachments(sid: str, messages: list[dict]) -> None:
@@ -5024,6 +5259,16 @@ def get_session_api(
             except Exception:
                 pass
 
+    active_turn = _active_turns.get(sid)
+    if active_turn is not None and active_turn.done:
+        active_turn = None
+    _complete_turn_footer_metadata(
+        window,
+        model,
+        has_later=has_later,
+        active_turn=active_turn,
+    )
+
     return {
         **meta,
         "messages": window,
@@ -5297,6 +5542,176 @@ def _delete_cancelled_turn_snapshots(sid: str) -> None:
     shutil.rmtree(directory, ignore_errors=True)
 
 
+def _cancelled_snapshot_canonical_span(
+    transcript_path: Path,
+    index: dict,
+    snapshot: dict,
+) -> tuple[list[str], str]:
+    """Resolve a late JSONL flush back to its interrupted turn.
+
+    A force-stopped CLI can acknowledge the terminal boundary before its
+    AssistantMessage UUID is observable, then append that canonical record
+    several seconds later.  The snapshot's pre-query record coordinate plus
+    the original user-record timestamp identifies that turn without inspecting
+    or logging private message text.  Return all UUIDs in the logical turn and
+    the last assistant UUID that can own its durable footer.
+    """
+    boundary = snapshot.get("transcript_boundary") or {}
+    records = index.get("records") or []
+    try:
+        start = int(boundary.get("record_count"))
+    except (TypeError, ValueError):
+        return [], ""
+    if start < 0 or start >= len(records):
+        return [], ""
+
+    source = index.get("source") or {}
+    for field, current_field in (
+        ("source_dev", "dev"), ("source_inode", "inode"),
+    ):
+        try:
+            expected = int(boundary.get(field) or 0)
+            current = int(source.get(current_field) or 0)
+        except (TypeError, ValueError):
+            return [], ""
+        if expected and current and expected != current:
+            return [], ""
+
+    real_user_ids = [
+        record_i for record_i in range(start, len(records))
+        if records[record_i].get("real_user_prompt")
+    ]
+    if not real_user_ids:
+        return [], ""
+    entries = transcript_idx.read_records(
+        transcript_path, index, real_user_ids)
+    entry_by_uuid = {
+        str(entry.get("uuid") or ""): entry for entry in entries
+    }
+    started_ms = int(snapshot.get("started_at_ms") or 0)
+    interrupted_ms = int(snapshot.get("interrupted_at_ms") or 0)
+    canonical_terminal = bool(snapshot.get("canonical_terminal_published"))
+    origin_i: int | None = None
+    for candidate_position, record_i in enumerate(real_user_ids):
+        record_uuid = str(records[record_i].get("uuid") or "")
+        ts_ms = _transcript_ts_ms(entry_by_uuid.get(record_uuid) or {})
+        if ts_ms is None:
+            # A canonical ResultMessage means this query definitely reached
+            # the transcript even on legacy rows without timestamps.  The
+            # first real prompt after the pre-query boundary is therefore it.
+            if canonical_terminal and candidate_position == 0:
+                origin_i = record_i
+            break
+        if started_ms and ts_ms < started_ms - 5_000:
+            continue
+        if interrupted_ms and ts_ms <= interrupted_ms + 250:
+            origin_i = record_i
+            break
+        # A post-interrupt prompt belongs to a resend/new turn.  Never borrow
+        # its assistant merely because the user repeated the exact same text.
+        if interrupted_ms and ts_ms > interrupted_ms + 250:
+            break
+
+    if origin_i is None:
+        return [], ""
+    origin_uuid = str(records[origin_i].get("uuid") or "")
+    by_uuid = {
+        str(record.get("uuid") or ""): record_i
+        for record_i, record in enumerate(records)
+        if record.get("uuid")
+    }
+    origin_cache: dict[int, str] = {}
+
+    def logical_origin(record_i: int) -> str:
+        cached = origin_cache.get(record_i)
+        if cached is not None:
+            return cached
+        current_i = record_i
+        seen: set[str] = set()
+        result = ""
+        while 0 <= current_i < len(records):
+            current = records[current_i]
+            current_uuid = str(current.get("uuid") or "")
+            if current_uuid in seen:
+                break
+            if current_uuid:
+                seen.add(current_uuid)
+            # A task notification starts a separate headless continuation;
+            # cancelling the launch turn must not relabel that later reaction.
+            if current.get("task_notifications"):
+                break
+            if current.get("real_user_prompt"):
+                result = current_uuid
+                break
+            parent = str(current.get("parent") or "")
+            parent_i = by_uuid.get(parent) if parent else None
+            if parent_i is None:
+                break
+            current_i = parent_i
+        origin_cache[record_i] = result
+        return result
+
+    span: list[str] = []
+    tail_assistant_uuid = ""
+    for record_i in range(origin_i, len(records)):
+        if logical_origin(record_i) != origin_uuid:
+            continue
+        record = records[record_i]
+        record_uuid = str(record.get("uuid") or "")
+        if record_uuid:
+            span.append(record_uuid)
+        if (record.get("type") == "assistant"
+                and int(record.get("bubble_count") or 0) > 0):
+            tail_assistant_uuid = record_uuid
+    return span, tail_assistant_uuid
+
+
+def _heal_cancelled_snapshot_from_canonical(
+    sid: str,
+    path: Path,
+    snapshot: dict,
+    transcript_path: Path,
+    index: dict,
+) -> bool:
+    """Promote a late canonical assistant to the snapshot's cancelled truth.
+
+    Until an assistant exists, dynamically hide any duplicate canonical user
+    rows and keep rendering the private snapshot.  Once the assistant arrives,
+    annotate its exact UUID and retire only this validated snapshot file.
+    """
+    span, assistant_uuid = _cancelled_snapshot_canonical_span(
+        transcript_path, index, snapshot)
+    if span:
+        snapshot["hidden_uuids"] = list(dict.fromkeys([
+            *(snapshot.get("hidden_uuids") or []), *span,
+        ]))
+    if not assistant_uuid:
+        return False
+    started_ms = int(snapshot.get("started_at_ms") or 0)
+    interrupted_ms = int(snapshot.get("interrupted_at_ms") or 0)
+    elapsed_s = round(max(0, interrupted_ms - started_ms) / 1000, 1)
+    try:
+        sess.set_message_annotation(
+            sid,
+            assistant_uuid,
+            model=str(snapshot.get("model") or ""),
+            ts=interrupted_ms or None,
+            turn_status="cancelled",
+            elapsed_s=elapsed_s,
+        )
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] late cancelled footer heal failed sid={sid[:8]} "
+            f"exc={type(exc).__name__}\n")
+        return False
+    # Exact path comes from the already-validated canonical sid/turn snapshot
+    # directory.  Failure to unlink is harmless: subsequent reads resolve and
+    # exclude it again, while the sidecar remains authoritative.
+    with suppress(OSError):
+        path.unlink(missing_ok=True)
+    return True
+
+
 def _load_cancelled_turn_snapshots(sid: str) -> tuple[list[dict], str]:
     """Load private display-only interrupted-turn snapshots.
 
@@ -5307,13 +5722,9 @@ def _load_cancelled_turn_snapshots(sid: str) -> tuple[list[dict], str]:
     directory = _cancelled_turn_session_dir(sid)
     if directory is None or not directory.exists():
         return [], ""
-    snapshots: list[dict] = []
-    digest = hashlib.blake2b(digest_size=12)
+    loaded: list[tuple[Path, dict]] = []
     for path in sorted(directory.glob("*.json")):
         try:
-            stat = path.stat()
-            digest.update(path.name.encode("ascii", errors="ignore"))
-            digest.update(f":{stat.st_mtime_ns}:{stat.st_size};".encode("ascii"))
             data = json.loads(path.read_text(encoding="utf-8"))
             if not isinstance(data, dict):
                 raise ValueError("snapshot root must be an object")
@@ -5321,7 +5732,7 @@ def _load_cancelled_turn_snapshots(sid: str) -> tuple[list[dict], str]:
                 raise ValueError("unsupported snapshot schema")
             if data.get("sid") != sid or not isinstance(data.get("messages"), list):
                 raise ValueError("snapshot ownership mismatch")
-            snapshots.append(data)
+            loaded.append((path, data))
         except Exception as exc:
             # Never log payloads: a cancelled turn can contain private source,
             # prompts, or tool output. Filename + exception class is enough for
@@ -5329,8 +5740,44 @@ def _load_cancelled_turn_snapshots(sid: str) -> tuple[list[dict], str]:
             sys.stderr.write(
                 f"[chat] cancelled snapshot skipped file={path.name} "
                 f"exc={type(exc).__name__}\n")
+    indexed: tuple[Path, dict] | None = None
+    if any((data.get("transcript_boundary") or {}).get("record_count") is not None
+           for _, data in loaded):
+        try:
+            indexed = _ensure_transcript_index(sid)
+        except Exception as exc:
+            sys.stderr.write(
+                f"[chat] cancelled snapshot heal skipped sid={sid[:8]} "
+                f"exc={type(exc).__name__}\n")
+
+    snapshots: list[dict] = []
+    kept_paths: list[Path] = []
+    for path, data in loaded:
+        healed = False
+        if indexed is not None and data.get("transcript_boundary"):
+            try:
+                healed = _heal_cancelled_snapshot_from_canonical(
+                    sid, path, data, indexed[0], indexed[1])
+            except Exception as exc:
+                # Recovery must fail closed to the already-valid private
+                # snapshot; a malformed/temporarily changing transcript must
+                # never turn session history into a 500 response.
+                sys.stderr.write(
+                    f"[chat] cancelled snapshot heal deferred sid={sid[:8]} "
+                    f"exc={type(exc).__name__}\n")
+        if not healed:
+            snapshots.append(data)
+            kept_paths.append(path)
     snapshots.sort(key=lambda item: (
         int(item.get("started_at_ms") or 0), str(item.get("turn_id") or "")))
+    digest = hashlib.blake2b(digest_size=12)
+    for path in kept_paths:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        digest.update(path.name.encode("ascii", errors="ignore"))
+        digest.update(f":{stat.st_mtime_ns}:{stat.st_size};".encode("ascii"))
     return snapshots, digest.hexdigest() if snapshots else ""
 
 
@@ -5346,14 +5793,65 @@ def _persist_cancelled_turn_snapshot(bc: "TurnBroadcast") -> bool:
         return _persist_cancelled_turn_snapshot_locked(bc)
 
 
+def _cancelled_footer_values(bc: "TurnBroadcast") -> tuple[int, float]:
+    """Return one stable terminal timestamp/duration for an interrupted turn."""
+    now_ms = int(getattr(bc, "cancelled_at_ms", 0) or 0)
+    if now_ms <= 0:
+        now_ms = int(time.time() * 1000)
+        bc.cancelled_at_ms = now_ms
+    elapsed_s = max(0.0, now_ms / 1000.0 - float(bc.started_at or 0))
+    return now_ms, round(elapsed_s, 1)
+
+
+def _persist_cancelled_footer_annotation_locked(
+    bc: "TurnBroadcast", now_ms: int, elapsed_s: float,
+) -> bool:
+    """Persist footer truth even when an interrupted turn reached JSONL late.
+
+    ResultMessage normally owns this annotation.  A forced CLI teardown can
+    still emit and persist an AssistantMessage without ever producing that
+    terminal ResultMessage, which used to leave a refresh with only the raw
+    text.  AssistantMessage already gave us its exact UUID; writing a private
+    sidecar annotation is safe even if the JSONL line itself flushes shortly
+    afterwards.
+    """
+    assistant_uuid = str(getattr(bc, "last_assistant_uuid", "") or "")
+    if not assistant_uuid:
+        return False
+    try:
+        sess.set_message_annotation(
+            bc.session_id,
+            assistant_uuid,
+            model=bc.model,
+            ts=now_ms,
+            turn_status="cancelled",
+            elapsed_s=elapsed_s,
+        )
+        return True
+    except Exception as exc:
+        # No prompt/reply text in logs: UUID ownership + exception class is
+        # enough to diagnose a local sidecar failure without leaking content.
+        sys.stderr.write(
+            f"[chat] cancelled footer annotation failed "
+            f"sid={bc.session_id[:8]} exc={type(exc).__name__}\n")
+        sys.stderr.flush()
+        return False
+
+
 def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
     """Atomically persist the browser-visible part of a non-canonical turn."""
     if bc.cancelled_snapshot_persisted:
         return True
-    if (bc.cancelled_snapshot_suppressed
-            or bc.canonical_terminal_published
-            or not bc.cancelled):
+    if bc.cancelled_snapshot_suppressed or not bc.cancelled:
         return False
+    now_ms, elapsed_s = _cancelled_footer_values(bc)
+    annotation_ready = _persist_cancelled_footer_annotation_locked(
+        bc, now_ms, elapsed_s)
+    # ResultMessage made the canonical transcript authoritative.  Do not layer
+    # a duplicate display snapshot over it; the exact UUID annotation above is
+    # the only missing persistence step in this narrow done/interrupt race.
+    if bc.canonical_terminal_published and annotation_ready:
+        return annotation_ready
     path = _cancelled_turn_snapshot_path(bc.session_id, bc.turn_id)
     if path is None:
         return False
@@ -5361,8 +5859,6 @@ def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
     if not messages:
         return False
 
-    now_ms = int(time.time() * 1000)
-    elapsed_s = max(0.0, now_ms / 1000.0 - float(bc.started_at or 0))
     for index, message in enumerate(messages):
         message["_key"] = f"cancelled:{bc.turn_id}:{index}"
         message["_interrupted"] = True
@@ -5371,33 +5867,12 @@ def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
         if message.get("role") != "user":
             message.setdefault("ts", now_ms)
             if elapsed_s >= 1:
-                message.setdefault("elapsed", round(elapsed_s, 1))
+                message.setdefault("elapsed", elapsed_s)
+            message.setdefault("model", bc.model)
+            message.setdefault("turn_status", "cancelled")
             break
 
     boundary = dict(bc.transcript_boundary or {})
-    hidden_uuids: list[str] = []
-    try:
-        indexed = _ensure_transcript_index(bc.session_id)
-        if indexed is not None:
-            _, index = indexed
-            source = index.get("source") or {}
-            same_source = (
-                int(source.get("dev") or 0) == int(boundary.get("source_dev") or 0)
-                and int(source.get("inode") or 0)
-                    == int(boundary.get("source_inode") or 0)
-            )
-            start = int(boundary.get("record_count") or 0)
-            records = index.get("records") or []
-            if same_source and 0 <= start <= len(records):
-                hidden_uuids = list(dict.fromkeys(
-                    str(record.get("uuid") or "")
-                    for record in records[start:]
-                    if record.get("uuid")
-                ))
-    except Exception as exc:
-        sys.stderr.write(
-            f"[chat] cancelled snapshot boundary scan skipped "
-            f"sid={bc.session_id[:8]} exc={type(exc).__name__}\n")
 
     payload = {
         "schema": _CANCELLED_TURN_SNAPSHOT_SCHEMA,
@@ -5406,6 +5881,13 @@ def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
         "model": bc.model,
         "started_at_ms": int(float(bc.started_at or 0) * 1000),
         "interrupted_at_ms": now_ms,
+        "canonical_terminal_published": bool(
+            bc.canonical_terminal_published),
+        "transcript_boundary": {
+            "record_count": int(boundary.get("record_count") or 0),
+            "source_dev": int(boundary.get("source_dev") or 0),
+            "source_inode": int(boundary.get("source_inode") or 0),
+        },
         "anchors": {
             "normal": {
                 "uuid": boundary.get("normal_uuid") or "",
@@ -5416,7 +5898,7 @@ def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
                 "total": int(boundary.get("full_total") or 0),
             },
         },
-        "hidden_uuids": hidden_uuids,
+        "hidden_uuids": [],
         "messages": messages,
     }
     try:
@@ -5639,7 +6121,16 @@ def _interrupted_history_window(
         if kind == "record":
             messages = shaped_by_record.get(int(source), [])
         else:
-            messages = source.get("messages") or []
+            started_at_ms = int(source.get("started_at_ms") or 0)
+            turn_id = str(source.get("turn_id") or "")
+            messages = [dict(message)
+                        for message in (source.get("messages") or [])]
+            for message in messages:
+                if turn_id:
+                    message.setdefault(
+                        "_turn_origin_uuid", f"cancelled:{turn_id}")
+                if started_at_ms > 0:
+                    message.setdefault("turn_started_at", started_at_ms)
         window.extend(messages[local_start:local_end])
     return window, total, start, end < total
 
@@ -7494,6 +7985,8 @@ class ForkReq(BaseModel):
     # Omit / null = no truncation, copy the full transcript.
     up_to_message_id: str | None = None
     title: str | None = None
+    activity_hidden: bool = False
+    runtime_profile: Literal["", "side_question"] = ""
 
 
 @router.post("/sessions/{sid}/fork", dependencies=[Depends(require_token)])
@@ -7571,6 +8064,8 @@ def fork_session_api(sid: str, req: ForkReq) -> dict:
         forked_from=sid,
         forked_from_name=source_name,
         forked_from_message_id=req.up_to_message_id or "",
+        activity_hidden=req.activity_hidden,
+        runtime_profile=req.runtime_profile,
         cwd=src_meta.get("cwd") or str(ROOT),
     )
     return {
@@ -7930,6 +8425,8 @@ async def interrupt(session_id: str) -> dict:
     bc = _active_turns.get(session_id)
     if bc is not None and not bc.done:
         bc.cancelled = True
+        if not bc.cancelled_at_ms:
+            bc.cancelled_at_ms = int(time.time() * 1000)
         # Arm the hard-stop deadline from the CLICK, not after waiting for the
         # SDK control request. The old ordering added its possible 60s timeout
         # in front of the 2.5s grace period.
@@ -9796,6 +10293,11 @@ async def _watch_inflight_tasks(
     cont_state: dict | None = None
     activity_failed = False
     watcher_cancelled = False
+    # The continuation is a real assistant turn for display/accounting even
+    # though it has no user bubble.  Keep the session's public model id on its
+    # broadcast so live and persisted footers do not reload with a blank model.
+    continuation_model = str(
+        (sess.get_session_meta(session_id) or {}).get("model") or "")
 
     def _owns_generation() -> bool:
         return (generation is None
@@ -9808,7 +10310,7 @@ async def _watch_inflight_tasks(
         nonlocal cont, cont_state
         if not _owns_generation():
             return
-        b = TurnBroadcast(session_id=session_id, model="")
+        b = TurnBroadcast(session_id=session_id, model=continuation_model)
         b.started_at = _background_turn_started_at.get(
             session_id, b.started_at)
         b.parent_turn_id = _background_origin_turn_id.get(session_id, "")
@@ -9883,12 +10385,23 @@ async def _watch_inflight_tasks(
             return
         incomplete_error = (state or {}).get("incomplete_error")
         completed_at_ms = int(time.time() * 1000)
+        assistant_uuid = str((state or {}).get("assistant_uuid") or "")
+        cont_elapsed = (
+            round(duration_ms / 1000, 1)
+            if duration_ms
+            else round(max(0.0, time.time() - b.started_at), 1)
+        )
+        terminal_status = (
+            "cancelled" if cancelled else
+            "failed" if incomplete_error else
+            "completed"
+        )
         done_payload = {
             "cancelled": cancelled,
             "model": b.model,
             "continuation": True,
             "duration_ms": duration_ms,
-            "assistant_uuid": (state or {}).get("assistant_uuid") or "",
+            "assistant_uuid": assistant_uuid,
             "completed_at_ms": completed_at_ms,
             "background_tasks_pending": len(pending),
         }
@@ -9905,53 +10418,35 @@ async def _watch_inflight_tasks(
         # long JSONL cannot leave the continuation footer pulsing after the
         # SDK has already emitted its ResultMessage.
         b.publish({"event": "done", "data": json.dumps(done_payload)})
+        # AssistantMessage already supplied the exact persisted UUID.  Annotate
+        # that boundary directly in the same event-loop turn as done; rescanning
+        # "the latest assistant" raced both delayed JSONL flushes and the next
+        # user turn, which is why continuation footers disappeared on refresh.
+        if assistant_uuid:
+            try:
+                # Keep this synchronous inside the current event-loop turn:
+                # publish() only queues the frame, so subscribers cannot act
+                # on done (or refresh) until this tiny local sidecar write is
+                # durable.  Offloading here reintroduced the very race this
+                # exact-UUID path is meant to close.
+                sess.set_message_annotation(
+                    session_id,
+                    assistant_uuid,
+                    model=b.model,
+                    ts=completed_at_ms,
+                    turn_status=terminal_status,
+                    elapsed_s=cont_elapsed if cont_elapsed >= 1 else None,
+                )
+            except Exception as e:
+                sys.stderr.write(
+                    f"[chat] continuation footer annotation failed "
+                    f"sid={session_id[:8]}: {type(e).__name__}\n")
+                sys.stderr.flush()
         b.finish()
         async with _lock:
             if _active_turns.get(session_id) is b:
                 _active_turns.pop(session_id, None)
         _remember_recent_turn(session_id, b)
-        # Persist the completion time the way a normal turn does (see the
-        # set_message_annotation call in _handle_result_message). The uuid MUST
-        # come from the transcript tail because annotations are keyed by the
-        # persisted uuid. This is presentation bookkeeping, so run it after
-        # the watcher has released its stream slot; a slow transcript scan or
-        # sidecar write must not delay footer completion or queue draining.
-        async def _annotate_completion() -> None:
-            try:
-                asst_uuid, _ = await asyncio.to_thread(
-                    _recent_turn_uuids, session_id, False)
-                if asst_uuid:
-                    existing = await asyncio.to_thread(
-                        sess.get_message_annotations, session_id)
-                    # Never overwrite. A continuation that ended without a
-                    # reply of its own resolves to the previous turn's
-                    # assistant message, which already has that timestamp.
-                    if "ts" not in (existing.get(asst_uuid) or {}):
-                        cont_elapsed = (
-                            round(duration_ms / 1000, 1)
-                            if duration_ms
-                            else round(
-                                max(0.0, time.time() - b.started_at), 1)
-                        )
-                        await asyncio.to_thread(
-                            sess.set_message_annotation,
-                            session_id, asst_uuid,
-                            model=b.model,
-                            ts=completed_at_ms,
-                            elapsed_s=(
-                                cont_elapsed if cont_elapsed >= 1 else None),
-                        )
-            except Exception as e:
-                # A missing footer timestamp must never affect the continuation.
-                sys.stderr.write(
-                    f"[chat] continuation ts annotation failed "
-                    f"sid={session_id[:8]}: {type(e).__name__}: {e}\n")
-                sys.stderr.flush()
-
-        annotation_task = asyncio.create_task(_annotate_completion())
-        _maintenance_tasks.add(annotation_task)
-        annotation_task.add_done_callback(_maintenance_tasks.discard)
-
     async def _request_explicit_resume(reason: str) -> bool:
         """Ask the existing SDK session to finish the originating request.
 
@@ -10081,6 +10576,27 @@ async def _watch_inflight_tasks(
                         _mark_incomplete()
                     break
                 if msg is _STREAM_EOF:
+                    if pending:
+                        # A definitive stream EOF means the owning CLI is gone:
+                        # no terminal TaskNotification can ever arrive for the
+                        # still-pinned subprocesses.  Keeping those pins made
+                        # /active and Activity Center report a ghost running
+                        # task after an interrupted turn had already vanished
+                        # from the chat pane.  Watcher replacement/shutdown
+                        # arrives as CancelledError instead and deliberately
+                        # retains ownership, so releasing only on EOF is safe.
+                        deferred_status = _background_activity_finishes.get(
+                            session_id)
+                        activity_failed = deferred_status != "cancelled"
+                        sys.stderr.write(
+                            f"[chat] task watcher: stream ended with "
+                            f"{len(pending)} pending task(s) "
+                            f"sid={session_id[:8]}; releasing dead pins\n")
+                        _release_task_pins(session_id, pending)
+                        for task_id in pending:
+                            _bg_task_descriptions.pop(task_id, None)
+                        pending.clear()
+                        break
                     if await _request_explicit_resume("message stream ended"):
                         _reopen_stream()
                         continue
@@ -10414,6 +10930,8 @@ async def _start_activity_early(
     prompt: str,
 ) -> None:
     """Expose a reserved turn while its SDK client is still starting."""
+    if broadcast.activity_hidden:
+        return
     try:
         from .activity import activity as _activity
         await asyncio.to_thread(
@@ -10594,6 +11112,7 @@ async def _start_turn(
     # prevents the "I tried to switch but it didn't take" class of bugs and
     # avoids cross-vendor thinking-signature corruption.
     s = sess.get_session(session_id) or {}
+    broadcast.activity_hidden = bool(s.get("activity_hidden", False))
     locked = (s.get("model") or "").strip()
     if locked:
         healed = _heal_unreachable_locked_model(session_id, locked, model)
@@ -11279,7 +11798,7 @@ async def _start_turn(
         async def _prepare_side_event(payload):
             if isinstance(payload, dict) and payload.get("event") in {
                 "ask_user_question", "permission_request"
-            }:
+            } and not broadcast.activity_hidden:
                 try:
                     from .activity import activity as _activity
                     await asyncio.to_thread(
@@ -11353,6 +11872,7 @@ async def _start_turn(
             assistant_uuid = getattr(msg, "uuid", None)
             if assistant_uuid:
                 last_assistant_uuid = str(assistant_uuid)
+                broadcast.last_assistant_uuid = last_assistant_uuid
             a_usage = getattr(msg, "usage", None) or {}
             if a_usage:
                 in_t = int(a_usage.get("input_tokens", 0) or 0)
@@ -11731,11 +12251,36 @@ async def _start_turn(
                 await _finish_activity(
                     session_id, broadcast, _activity_status)
             # Capture once at the SDK's authoritative terminal boundary. The
-            # sidecar write happens after slower context/transcript work, but it
-            # must persist the same completion instant the browser saw in done.
+            # exact assistant UUID is already known from AssistantMessage, so
+            # persist the footer BEFORE yielding done.  A hard refresh or a new
+            # turn can otherwise arrive while the slower context/transcript
+            # bookkeeping below is still running and observe a bare assistant
+            # record with no status/model/duration.
             _completed_at_ms = int(time.time() * 1000)
+            _msg_duration_ms = getattr(msg, "duration_ms", None)
+            _elapsed_s = (round(_msg_duration_ms / 1000, 1)
+                          if _msg_duration_ms else None)
+            _footer_annotation_uuid = ""
+            if last_assistant_uuid:
+                try:
+                    await asyncio.to_thread(
+                        sess.set_message_annotation,
+                        session_id,
+                        last_assistant_uuid,
+                        cost=f"${cost:.4f}",
+                        model=model_to_use,
+                        ts=_completed_at_ms,
+                        turn_status=_activity_status,
+                        elapsed_s=_elapsed_s,
+                    )
+                    _footer_annotation_uuid = last_assistant_uuid
+                except Exception as exc:
+                    sys.stderr.write(
+                        f"[chat] terminal footer annotation failed "
+                        f"sid={session_id[:8]} exc={type(exc).__name__}\n")
+                    sys.stderr.flush()
             yield {"event": "done", "data": json.dumps({
-                "duration_ms": getattr(msg, "duration_ms", None),
+                "duration_ms": _msg_duration_ms,
                 "assistant_uuid": last_assistant_uuid,
                 "completed_at_ms": _completed_at_ms,
                 "total_cost_usd": cost,
@@ -11871,8 +12416,12 @@ async def _start_turn(
             # fallback branch, which previously left it unbound on the fast path
             # → UnboundLocalError at every turn's end.
             all_msgs: list | None = None
-            new_asst_uuid, new_user_uuid = await asyncio.to_thread(
+            scanned_asst_uuid, new_user_uuid = await asyncio.to_thread(
                 _recent_turn_uuids, session_id, bool(persisted_imgs))
+            # AssistantMessage is the exact boundary for this turn.  A scan of
+            # the mutable transcript tail can already see a continuation or a
+            # fast next turn, so it is fallback-only.
+            new_asst_uuid = last_assistant_uuid or scanned_asst_uuid
             if not (new_asst_uuid and new_user_uuid):
                 try:
                     all_msgs = await asyncio.to_thread(
@@ -11901,7 +12450,7 @@ async def _start_turn(
                             new_user_uuid = sm.uuid
                     if new_asst_uuid and new_user_uuid:
                         break
-            if new_asst_uuid:
+            if new_asst_uuid and new_asst_uuid != _footer_annotation_uuid:
                 # ts (ms epoch) stamps the turn's completion time. The
                 # frontend's turn-footer (.turn-footer in index.html)
                 # reads it via fmtHM() → "HH:MM" under the last muse
@@ -11914,13 +12463,11 @@ async def _start_turn(
                 # "13:42 · 2m50s" footer (FE-side stamping only survives
                 # within the live session). None when SDK didn't fill
                 # duration_ms.
-                _msg_duration_ms = getattr(msg, "duration_ms", None)
-                _elapsed_s = (round(_msg_duration_ms / 1000, 1)
-                              if _msg_duration_ms else None)
                 sess.set_message_annotation(
                     session_id, new_asst_uuid,
                     cost=f"${cost:.4f}", model=model_to_use,
                     ts=_completed_at_ms,
+                    turn_status=_activity_status,
                     elapsed_s=_elapsed_s)
             if new_user_uuid and (persisted_imgs or persisted_docs):
                 sess.set_message_annotation(
@@ -12391,7 +12938,11 @@ async def _start_turn(
                 elif broadcast.cancelled:
                     # User explicitly stopped this turn — pause the queue so
                     # the remaining items don't auto-fire. They resume manually.
-                    sess.set_queue_paused(session_id, True)
+                    # Keep the empty-queue invariant atomic.  A late terminal
+                    # cleanup used to create ``{items: [], paused: true}``;
+                    # the next message then entered a queue that could never
+                    # drain, which looked like an intermittent send failure.
+                    sess.pause_queue_if_nonempty(session_id)
                 else:
                     await _maybe_drain_queue(session_id)
             except Exception as e:

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2290,9 +2290,8 @@ async def _build_and_connect_client(
     user_prompt_hooks = (
         [] if side_question_runtime else [mem0.build_recall_hook(session_id)]
     )
-    if (not side_question_runtime and effort == "ultra"
-            and _is_codex_gateway_model(model)
-            and not skills_off):
+    if (effort == "ultra" and _is_codex_gateway_model(model)
+            and not side_question_runtime and not skills_off):
         user_prompt_hooks.append(_build_ultra_skill_hook())
     opts_kwargs = dict(
         cwd=str(workspace_root),

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -130,6 +130,17 @@ def _normalize_session_permission_fields(row: dict) -> dict:
     normalized["service_tier"] = (
         "fast" if normalized.get("service_tier") == "fast" else ""
     )
+    normalized["activity_hidden"] = bool(
+        normalized.get("activity_hidden", False)
+    )
+    # Runtime profiles are deliberately closed rather than free-form.  The
+    # side-question profile narrows the SDK tool surface to public web lookup;
+    # an unknown/legacy value must fall back to the ordinary session runtime.
+    normalized["runtime_profile"] = (
+        "side_question"
+        if normalized.get("runtime_profile") == "side_question"
+        else ""
+    )
     return normalized
 
 
@@ -424,6 +435,16 @@ def _merge_sdk_with_index(
         "forked_from": m.get("forked_from", ""),
         "forked_from_name": m.get("forked_from_name", ""),
         "forked_from_message_id": m.get("forked_from_message_id", ""),
+        # Lightweight side-question branches are real resumable sessions, but
+        # they are deliberately absent from the global task ledger. Keep that
+        # distinction in durable session metadata so reloads and later turns
+        # do not accidentally promote them into Task Center.
+        "activity_hidden": bool(m.get("activity_hidden", False)),
+        "runtime_profile": (
+            "side_question"
+            if m.get("runtime_profile") == "side_question"
+            else ""
+        ),
         # Every conversation is bound to the directory the Claude SDK was
         # started in.  Keep it in the sidecar so history, files and previews
         # switch as one workspace instead of silently falling back to ROOT.
@@ -579,11 +600,15 @@ def create_session(
     cwd: str | Path | None = None,
     permission: str = "",
     plan_return_permission: str | None = None,
+    activity_hidden: bool = False,
+    runtime_profile: str = "",
 ) -> dict:
     return register_session(str(uuid.uuid4()), name=name, model=model,
                             permission=permission,
                             plan_return_permission=plan_return_permission,
-                            auto_named=True, cwd=cwd)
+                            auto_named=True, cwd=cwd,
+                            activity_hidden=activity_hidden,
+                            runtime_profile=runtime_profile)
 
 
 def register_session(sid: str, *, name: str = "", model: str = "",
@@ -598,12 +623,16 @@ def register_session(sid: str, *, name: str = "", model: str = "",
                      forked_from: str = "",
                      forked_from_name: str = "",
                      forked_from_message_id: str = "",
+                     activity_hidden: bool = False,
+                     runtime_profile: str = "",
                      cwd: str | Path | None = None) -> dict:
     """Add a session that already has a UUID (e.g. one minted by SDK
     fork_session) to the muselab index. Same shape as create_session
     but without generating a fresh UUID."""
     now = time.time()
     workspace = workspace_registry.resolve(cwd)
+    if runtime_profile not in ("", "side_question"):
+        raise ValueError("invalid runtime profile")
     meta = {
         "id": sid,
         "name": name or _default_session_name(),
@@ -625,6 +654,8 @@ def register_session(sid: str, *, name: str = "", model: str = "",
         "effort": str(effort or "").strip() or "auto",
         "service_tier": "fast" if service_tier == "fast" else "",
         "thinking": bool(thinking),
+        "activity_hidden": bool(activity_hidden),
+        "runtime_profile": runtime_profile,
         "cwd": str(workspace),
     }
     if forked_from:
@@ -1037,8 +1068,20 @@ def set_message_annotation(sid: str, msg_uuid: str, **fields: Any) -> None:
         data = _load_sidecar(sid, use_cache=False)
         msgs = data.setdefault("messages", {})
         cur = msgs.setdefault(msg_uuid, {})
+        # Explicit user cancellation is monotonic truth.  A force-stopped CLI
+        # can append its AssistantMessage/ResultMessage late; generic terminal
+        # bookkeeping then attempts to write ``completed`` for the same UUID.
+        # Preserve both the status and the click-time footer metrics in that
+        # race, while still allowing the cancellation healer to replace an
+        # earlier inferred ``completed`` with ``cancelled``.
+        sticky_cancelled = (
+            cur.get("turn_status") == "cancelled"
+            and fields.get("turn_status") not in (None, "cancelled")
+        )
         for k, v in fields.items():
             if v is None:
+                continue
+            if sticky_cancelled and k in {"turn_status", "ts", "elapsed_s"}:
                 continue
             cur[k] = v
         _save_sidecar(sid, data)
@@ -1303,6 +1346,13 @@ def _load_queue(sid: str) -> dict:
                 if isinstance(item, dict) else item
                 for item in d["items"]
             ]
+        # ``paused`` describes queued work that must wait for an explicit
+        # resume.  With no work it has no referent and becomes a trap for the
+        # *next* enqueue: dequeue_message would refuse that fresh item forever.
+        # Normalize legacy/stale ``{items: [], paused: true}`` files on read so
+        # an already-affected installation recovers immediately after upgrade.
+        if not d["items"]:
+            d["paused"] = False
         return d
     except Exception:
         return {"items": [], "paused": False}
@@ -1317,6 +1367,10 @@ def _save_queue(sid: str, data: dict) -> None:
             if isinstance(item, dict) else item
             for item in items
         ]
+    # Enforce the same invariant on every write.  This also removes stale
+    # empty-paused files the next time any queue mutation touches them.
+    if not canonical.get("items"):
+        canonical["paused"] = False
     # An empty, un-paused queue leaves no file behind (avoids littering
     # sessions/ with thousands of empty queue.json files over time).
     if not canonical.get("items") and not canonical.get("paused"):
@@ -1433,7 +1487,7 @@ def set_queue_paused(sid: str, paused: bool) -> dict:
     (paused=False) does NOT itself drain — the caller kicks the drain."""
     with _QUEUE_LOCK:
         data = _load_queue(sid)
-        data["paused"] = bool(paused)
+        data["paused"] = bool(paused) and bool(data["items"])
         _save_queue(sid, data)
         return data
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1164,6 +1164,11 @@ function portal() {
           && focused && focused.closest && focused.closest(".terminal-host")) {
         return;
       }
+      // Composition candidate navigation/confirmation belongs wholly to the
+      // IME. Some WebViews report the commit Enter as an ordinary keydown
+      // immediately after compositionend; the per-element lifecycle guard
+      // below keeps global shortcuts from treating it as a real command.
+      if (this._isImeComposingEvent(ev)) return;
       // ---- Command palette ----
       // Cmd/Ctrl+K from anywhere opens it. While open, palette owns
       // ↑/↓/Enter; everything else falls through to the input.
@@ -1651,7 +1656,8 @@ function portal() {
     // shrinks the layout with no keyboard present → a big blank band appears
     // at the bottom of the chat. Zeroing the inset here keeps the two CSS
     // inputs (.kb-open class + --kb-inset) in lockstep, exactly like update().
-    onChatInputBlur() {
+    onChatInputBlur(ev) {
+      this._resetImeCompositionState(ev);
       document.body.classList.remove("kb-open");
       document.documentElement.style.setProperty("--kb-inset", "0px");
       this._scheduleMobileRootReset();
@@ -5068,9 +5074,40 @@ function portal() {
     // candidate; it must not also submit the surrounding prompt or rename.
     // `isComposing` is the standard signal, while keyCode/which 229 and
     // key="Process" cover older Safari/WebView and Windows IME variants.
+    //
+    // Chromium WebViews and Safari can emit compositionend just BEFORE the
+    // very same candidate-confirming Enter, with isComposing=false and
+    // keyCode=13. Track the textarea lifecycle directly and treat an Enter in
+    // that short event window as part of the commit. DOM-local fields avoid
+    // reactive writes while the native IME buffer is live.
+    onImeCompositionStart(ev) {
+      const target = ev && (ev.target || ev.currentTarget);
+      if (!target) return;
+      target._museImeComposing = true;
+      target._museImeEndedAt = 0;
+    },
+    onImeCompositionEnd(ev) {
+      const target = ev && (ev.target || ev.currentTarget);
+      if (!target) return;
+      target._museImeComposing = false;
+      target._museImeEndedAt = Number(ev.timeStamp) || 0;
+    },
+    _resetImeCompositionState(ev) {
+      const target = ev && (ev.target || ev.currentTarget);
+      if (!target) return;
+      target._museImeComposing = false;
+      target._museImeEndedAt = 0;
+    },
     _isImeComposingEvent(ev) {
-      return !!(ev && (ev.isComposing || ev.keyCode === 229 || ev.which === 229
-        || ev.key === "Process"));
+      if (!ev) return false;
+      const target = ev.target || ev.currentTarget;
+      const endedAt = Number(target && target._museImeEndedAt) || 0;
+      const eventAt = Number(ev.timeStamp) || 0;
+      const commitEnter = ev.key === "Enter" && endedAt > 0
+        && eventAt >= endedAt && eventAt - endedAt <= 80;
+      return !!(ev.isComposing || ev.keyCode === 229 || ev.which === 229
+        || ev.key === "Process" || (target && target._museImeComposing)
+        || commitEnter);
     },
     _claimNonImeEnter(ev) {
       if (!ev || this._isImeComposingEvent(ev)) return false;
@@ -25583,10 +25620,33 @@ function portal() {
           }
         }, delay);
       });
-      es.addEventListener("cancelled", () => {
+      es.addEventListener("cancelled", ev => {
         flushRender();
+        let d = {};
+        try { d = JSON.parse(ev.data || "{}"); } catch (_) { d = {}; }
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
         es.close(); _markDone(true, false, true); _stopTimer();
+        // A force-stopped CLI may never commit this turn to canonical JSONL.
+        // The backend writes the already-rendered SSE record to a private,
+        // display-only snapshot BEFORE emitting snapshot_ready. Reconcile that
+        // snapshot quietly now so a list poll / tab switch / page reload sees
+        // the same content and Alpine can retain matching live objects + keys.
+        // If persistence failed, keep the live pane and clear its old revision
+        // baseline so stop()'s delayed list refresh cannot replace it with an
+        // older transcript immediately after the user clicks Stop.
+        streamState._seenUpdated = undefined;
+        if (streamSid === this.currentId) this._openSeenUpdated = undefined;
+        if (d && d.snapshot_ready) {
+          this.loadSession(streamSid, {
+            quiet: true,
+            probeActive: false,
+          }).then(loaded => {
+            if (loaded && this.tabState[streamSid] === streamState) {
+              streamState._loaded = true;
+              streamState._pendingExternalUpdate = false;
+            }
+          });
+        }
         // User explicitly stopped — pause the queue too. Auto-draining
         // here would be surprising (they cancelled for a reason, almost
         // never "just this one but please send the rest"). The paused

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3883,6 +3883,12 @@ function portal() {
       // stamp turn_status.  A canonical historical footer already has ts, so
       // never relabel such a prior turn just because a newer stream is active.
       if (pane && pane.streaming && m && !m.ts) return "running";
+      // Compatibility for cached/front-end-injected records created before
+      // turn_status became part of the footer contract.  Their terminal `ts`
+      // is already durable proof that the turn closed; keep the footer and
+      // point-fork action available until the next canonical reload enriches
+      // the record with an explicit status.
+      if (m && m.ts) return "completed";
       return "";
     },
     turnStatusLabel(status) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -315,6 +315,10 @@ function portal() {
     // and the drop falls through to the browser, which opens the file
     // as a navigation away from muselab). See init() for the listeners.
     osFileDragging: false,
+    // The whole app is an OS-file drop surface.  Empty means workspace root;
+    // only a real directory row may set a nested destination.
+    osFileDropDir: "",
+    osFileDropOnDirectory: false,
     _dragCounter: 0,
     // Right-click context menu on a preview tab. { path, x, y } when open.
     previewTabCtxMenu: null,
@@ -393,9 +397,10 @@ function portal() {
     // contexts are sandboxed/browser-owned.
     previewQuote: {
       show: false, mode: "actions", source: "", role: "", sessionId: "",
-      messageId: "", text: "", path: "", question: "",
+      messageId: "", text: "", path: "", question: "", followup: "",
       x: 0, y: 0, above: false, truncated: false, sending: false,
       askSessionId: "", askSessionName: "", askPrompt: "", askError: "",
+      askAutoScroll: true,
       // Ask mode starts anchored to the selection. The first title-bar drag
       // converts x/y to viewport-relative top/left coordinates until close.
       dragged: false, dragging: false,
@@ -880,7 +885,7 @@ function portal() {
     // Desktop's secondary right rail is the preview. Chat is the primary,
     // always-mounted center pane and therefore has no open/closed flag.
     previewOpen: true,
-    leftWidth: 280,
+    leftWidth: 340,
     previewWidth: 440,
     showHidden: false,
     // ===== Trash =====
@@ -1382,7 +1387,7 @@ function portal() {
       this.$watch("currentId", (tid) => {
         if (this.previewQuote.show && this.previewQuote.sessionId
             && this.previewQuote.sessionId !== tid) {
-          this.dismissPreviewQuote(true);
+          this.dismissTransientPreviewQuote(true);
         }
         if (!tid) return;
         this.$nextTick(() => this._scrollTabIntoView(tid));
@@ -1444,16 +1449,21 @@ function portal() {
       };
       document.addEventListener("dragenter", (e) => {
         if (!_hasFileType(e.dataTransfer)) return;
+        e.preventDefault();
+        e.stopPropagation();
         this._dragCounter++;
-        if (this._dragCounter === 1) this.osFileDragging = true;
-      });
+        this._setOsFileDropTarget(e.target);
+      }, true);
       document.addEventListener("dragleave", (e) => {
         // Some browsers (Firefox) don't expose types on dragleave; we
         // decrement unconditionally because every leave matches an
         // earlier enter and the counter floor at 0 prevents drift.
+        if (this._dragCounter <= 0) return;
+        e.preventDefault();
+        e.stopPropagation();
         if (this._dragCounter > 0) this._dragCounter--;
-        if (this._dragCounter === 0) this.osFileDragging = false;
-      });
+        if (this._dragCounter === 0) this._resetOsFileDragState();
+      }, true);
       // Required for drop to fire: dragover MUST be preventDefault'd at
       // some level. The preview overlay does this when visible, but for
       // areas of the page that aren't drop targets we also need a
@@ -1463,14 +1473,22 @@ function portal() {
       document.addEventListener("dragover", (e) => {
         if (!_hasFileType(e.dataTransfer)) return;
         e.preventDefault();
-      });
+        e.stopPropagation();
+        this._setOsFileDropTarget(e.target);
+        if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+      }, true);
       document.addEventListener("drop", (e) => {
-        // If the drop wasn't handled by an explicit zone (preview /
-        // chat input), suppress browser default and reset state.
-        if (_hasFileType(e.dataTransfer)) e.preventDefault();
-        this._dragCounter = 0;
-        this.osFileDragging = false;
-      });
+        if (!_hasFileType(e.dataTransfer)) return;
+        // Capture before the composer/preview/tree handlers: an OS file is a
+        // workspace upload, never an implicit chat attachment.  Internal tab
+        // and tree drags carry custom MIME types and never enter this branch.
+        e.preventDefault();
+        e.stopPropagation();
+        const dropTarget = this._externalFileDropTarget(e.target);
+        const files = Array.from((e.dataTransfer && e.dataTransfer.files) || []);
+        this._resetOsFileDragState();
+        if (files.length) void this._uploadFilesToDir(dropTarget.dir, files);
+      }, true);
 
       // HTML preview bridge. Each live sandboxed frame reports image clicks,
       // readiness and internal scrolling through postMessage.
@@ -1576,7 +1594,7 @@ function portal() {
         console.groupEnd();
       });
       this.$watch("editing", v => {
-        this.dismissPreviewQuote(true);
+        this.dismissTransientPreviewQuote(true);
         v ? this.mountCM() : this.unmountCM();
       });
       // Removed: pane-open toast — the panel opening is self-evident.
@@ -1587,7 +1605,7 @@ function portal() {
       // boot restore). Fire once now too in case `selected` was restored
       // before this watcher attached.
       this.$watch("selected", (p) => {
-        this.dismissPreviewQuote(true);
+        this.dismissTransientPreviewQuote(true);
         this.loadSelectedMeta(p);
       });
       this.loadSelectedMeta(this.selected);
@@ -3074,7 +3092,8 @@ function portal() {
     },
     async onAttachDrop(ev) {
       const files = Array.from((ev.dataTransfer && ev.dataTransfer.files) || []);
-      for (const f of files) await this._attachFile(f);
+      this._resetOsFileDragState();
+      await this._uploadFilesToDir("", files);
     },
     async onImagePaste(ev) {
       // Only handle pasted image data; let normal text paste through.
@@ -3826,8 +3845,11 @@ function portal() {
     // Compact, no decimals at minute granularity — second-precision past
     // ~30s adds visual noise without information value.
     fmtStreamElapsed(secs) {
-      if (!secs || secs < 1) return "";
-      const s = Math.floor(secs);
+      if (secs === null || secs === undefined || secs === "") return "";
+      const numeric = Number(secs);
+      if (!Number.isFinite(numeric) || numeric < 0) return "";
+      if (numeric < 1) return "<1s";
+      const s = Math.floor(numeric);
       if (s < 60) return `${s}s`;
       const m = Math.floor(s / 60);
       const rs = s % 60;
@@ -3851,6 +3873,48 @@ function portal() {
       const D = String(d.getDate()).padStart(2, "0");
       if (d.getFullYear() === now.getFullYear()) return `${M}-${D} ${hh}:${mm}`;
       return `${d.getFullYear()}-${M}-${D} ${hh}:${mm}`;
+    },
+    turnFooterStatus(m, pane) {
+      const stored = String((m && m.turn_status)
+        || (m && m._interrupted ? "cancelled" : "")
+        || (m && m._failed ? "failed" : ""));
+      if (stored) return stored;
+      // Fresh live bubbles are created before the terminal done payload can
+      // stamp turn_status.  A canonical historical footer already has ts, so
+      // never relabel such a prior turn just because a newer stream is active.
+      if (pane && pane.streaming && m && !m.ts) return "running";
+      return "";
+    },
+    turnStatusLabel(status) {
+      const value = String(status || "");
+      if (value === "running") return this.lang === "zh" ? "运行中" : "Running";
+      if (value === "completed") return this.lang === "zh" ? "已完成" : "Completed";
+      if (value === "failed") return this.lang === "zh" ? "失败" : "Failed";
+      return this.lang === "zh" ? "已中断" : "Interrupted";
+    },
+    turnFooterTime(m, pane) {
+      const status = this.turnFooterStatus(m, pane);
+      if (status === "running") {
+        return Number((m && m.turn_started_at)
+          || (pane && pane._streamStartedAt) || (m && m.mts) || 0);
+      }
+      return Number((m && (m.ts || m.mts || m.turn_started_at)) || 0);
+    },
+    turnFooterElapsed(m, pane) {
+      const value = this.turnFooterStatus(m, pane) === "running"
+        ? Math.max(
+            Number((m && m.elapsed) || 0),
+            Number((pane && pane.streamElapsed) || 0),
+          )
+        : Number(m && m.elapsed);
+      return Number.isFinite(value) && value >= 0 ? value : null;
+    },
+    turnFooterModel(m, pane, sid) {
+      const live = String((m && m.model)
+        || (pane && pane.streamingModel) || "");
+      if (live) return live;
+      const meta = (this.sessions || []).find(session => session.id === sid);
+      return String((meta && meta.model) || "");
     },
     // True when index i in messages[] is the tail of a turn — i.e. it
     // is muse-side AND the next message is either nonexistent or
@@ -5085,17 +5149,58 @@ function portal() {
       if (!target) return;
       target._museImeComposing = true;
       target._museImeEndedAt = 0;
+
+      // Alpine's x-model effect is allowed to write `textarea.value` whenever
+      // the root `input` value changes.  That is normally harmless, but a
+      // programmatic draft/session reconciliation that lands while Windows
+      // Pinyin / macOS marked text is active makes Chromium replace the
+      // native composition buffer without emitting compositionend.  The
+      // textarea then remains the IME's stale target: plain Latin input still
+      // works, while switching back to Chinese can stay broken until the page
+      // is restarted.
+      //
+      // Keep the DOM-owned marked text authoritative for this short window.
+      // Input events still update Alpine's model; only model -> DOM writes are
+      // deferred.  We restore Alpine's original hook and synchronize the
+      // committed DOM value in compositionend/blur below.
+      if (!target._museImeOriginalForceModelUpdate
+          && typeof target._x_forceModelUpdate === "function") {
+        const original = target._x_forceModelUpdate;
+        target._museImeOriginalForceModelUpdate = original;
+        target._x_forceModelUpdate = value => {
+          if (target._museImeComposing) {
+            target._museImeDeferredModelValue = value;
+            return;
+          }
+          original(value);
+        };
+      }
     },
     onImeCompositionEnd(ev) {
       const target = ev && (ev.target || ev.currentTarget);
       if (!target) return;
-      target._museImeComposing = false;
+      this._finishImeComposition(target);
       target._museImeEndedAt = Number(ev.timeStamp) || 0;
+    },
+    _finishImeComposition(target) {
+      if (!target) return;
+      target._museImeComposing = false;
+      const original = target._museImeOriginalForceModelUpdate;
+      if (typeof original === "function") {
+        target._x_forceModelUpdate = original;
+      }
+      delete target._museImeOriginalForceModelUpdate;
+      delete target._museImeDeferredModelValue;
+      // Safari/WebView may fire compositionend before its final non-composing
+      // input event.  Commit the DOM value now; the later input is idempotent.
+      // This also deliberately lets the user's marked text win over a stale
+      // programmatic draft write that was deferred above.
+      if (this.input !== target.value) this.input = target.value;
     },
     _resetImeCompositionState(ev) {
       const target = ev && (ev.target || ev.currentTarget);
       if (!target) return;
-      target._museImeComposing = false;
+      this._finishImeComposition(target);
       target._museImeEndedAt = 0;
     },
     _isImeComposingEvent(ev) {
@@ -5203,7 +5308,7 @@ function portal() {
       // the exact files the user was looking at — matches the chat-tab strip's
       // behavior via openTabIds.
       this._setLS("muselab_prefs", JSON.stringify({
-        schema: 8,          // v8 makes chat center + preview the right rail
+        schema: 9,          // v9 gives the desktop file manager useful room
         model: this.model, defaultModel: this.defaultModel,
         permission: this.permission, defaultPermission: this.defaultPermission,
         currentId: this.currentId,
@@ -5277,7 +5382,14 @@ function portal() {
           this.workspaceSurfaces = p.workspaceSurfaces;
         }
         if (typeof p.leftOpen === "boolean") this.leftOpen = p.leftOpen;
-        if (typeof p.leftWidth === "number") this.leftWidth = p.leftWidth;
+        if (typeof p.leftWidth === "number") {
+          // v8 shipped the file manager at 280px.  Migrating only that exact
+          // old default gives existing users the roomier desktop layout while
+          // preserving any width they deliberately resized themselves.
+          this.leftWidth = this._loadedPrefsSchema < 9
+            && Math.abs(p.leftWidth - 280) <= 1
+            ? 340 : p.leftWidth;
+        }
         // v7's rightOpen/rightWidth described the CHAT rail. In v8 chat is the
         // always-visible center pane and PREVIEW owns the right rail. Preserve
         // a useful old width, but never turn an old hidden-chat preference into
@@ -6594,6 +6706,11 @@ function portal() {
         // quota/auth error and confuse the user). Cleared by explicit
         // resume-queue or discard-queue actions on the failed user bubble.
         _queuePaused: false,
+        // Durable queue mutations are async.  Track them per action/item so a
+        // double-click cannot issue duplicate DELETE/resume requests, and so
+        // an edit is never copied back into the composer unless the server
+        // actually removed the queued original.
+        _queueMutating: {},
         // True only during _attachToServerTurn's poll window (between a turn's
         // done and the server starting the next queued turn) — suppresses the
         // idle "Queue waiting" banner so it doesn't flash mid-drain.
@@ -6687,6 +6804,9 @@ function portal() {
         st._sessionActivityExpected = null;
       }
       if (!Array.isArray(st.draft.pendingQuotes)) st.draft.pendingQuotes = [];
+      if (!st._queueMutating || typeof st._queueMutating !== "object") {
+        st._queueMutating = {};
+      }
       return st;
     },
 
@@ -6759,7 +6879,7 @@ function portal() {
       if ((previous === "preview" && next !== "preview")
           || (previous === "chat" && next !== "chat"
               && this.previewQuote.source === "chat")) {
-        this.dismissPreviewQuote(true);
+        this.dismissTransientPreviewQuote(true);
       }
       const ownerPath = this.selected;
       const ownerLoadSeq = this._previewLoadSeq;
@@ -6878,6 +6998,35 @@ function portal() {
     _currentQueueLen() {
       const st = this.tabState[this.currentId];
       return (st && st.pendingQueue) ? st.pendingQueue.length : 0;
+    },
+    queueActionBusy(sid, key) {
+      const st = sid && this.tabState[sid];
+      return !!(st && st._queueMutating && st._queueMutating[key]);
+    },
+    _setQueueActionBusy(st, key, busy) {
+      if (!st || !key) return;
+      const next = { ...(st._queueMutating || {}) };
+      if (busy) next[key] = true;
+      else delete next[key];
+      // Replace the object so Alpine sees keys introduced after mount.
+      st._queueMutating = next;
+    },
+    async _runQueueMutation(sid, st, key, url, options, failureZh, failureEn) {
+      if (!sid || !st || this.tabState[sid] !== st
+          || this.queueActionBusy(sid, key)) return null;
+      this._setQueueActionBusy(st, key, true);
+      try {
+        const r = await fetch(url, options);
+        if (!r.ok) throw new Error(`queue mutation failed: HTTP ${r.status}`);
+        return r;
+      } catch (_e) {
+        if (this.tabState[sid] === st) {
+          this.toast(this.lang === "zh" ? failureZh : failureEn, "error", 3500);
+        }
+        return null;
+      } finally {
+        if (this.tabState[sid] === st) this._setQueueActionBusy(st, key, false);
+      }
     },
     async _enqueueMessage(sid, item) {
       this._ensureTabState(sid);
@@ -7346,10 +7495,15 @@ function portal() {
       if (!st || !st.pendingQueue) return;
       const item = st.pendingQueue[idx];
       if (!item) return;
-      try {
-        await fetch("/api/chat/sessions/" + sid + "/queue/" + encodeURIComponent(item.id),
-                    { method: "DELETE", headers: this.hdr() });
-      } catch (_e) {}
+      const key = "remove:" + item.id;
+      const r = await this._runQueueMutation(
+        sid, st, key,
+        "/api/chat/sessions/" + sid + "/queue/" + encodeURIComponent(item.id),
+        { method: "DELETE", headers: this.hdr() },
+        "移除排队消息失败，原消息仍保留",
+        "Could not remove the queued message; it is still queued",
+      );
+      if (!r) return;
       await this._syncQueueFromServer(sid);
     },
     async editPendingQueueItem(sid, idx) {
@@ -7369,10 +7523,18 @@ function portal() {
       const quotes = (item.pendingQuotes || []).slice();
       const imgs = (item.images || []).slice();
       const docs = (item.docs || []).slice();
-      try {
-        await fetch("/api/chat/sessions/" + sid + "/queue/" + encodeURIComponent(item.id),
-                    { method: "DELETE", headers: this.hdr() });
-      } catch (_e) {}
+      const key = "edit:" + item.id;
+      const r = await this._runQueueMutation(
+        sid, st, key,
+        "/api/chat/sessions/" + sid + "/queue/" + encodeURIComponent(item.id),
+        { method: "DELETE", headers: this.hdr() },
+        "编辑排队消息失败，原消息仍保留",
+        "Could not edit the queued message; the original is still queued",
+      );
+      // Never create an editable duplicate when DELETE failed.  Previously the
+      // draft was restored unconditionally, so re-send could execute both the
+      // untouched queue item and its apparent replacement.
+      if (!r) return;
       await this._syncQueueFromServer(sid);
       if (this.tabState[sid] !== st) return;
       const draft = st.draft;
@@ -7404,21 +7566,34 @@ function portal() {
       // turn it starts. Also the manual "kick" for the post-restart case —
       // the server intentionally does NOT auto-resume draining on boot, so
       // dormant items wait here until the user hits Resume.
-      try {
-        await fetch("/api/chat/sessions/" + sid + "/queue/pause", {
+      const st = this.tabState[sid];
+      if (!st) return;
+      const r = await this._runQueueMutation(
+        sid, st, "resume",
+        "/api/chat/sessions/" + sid + "/queue/pause",
+        {
           method: "POST",
           headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
           body: JSON.stringify({ paused: false }),
-        });
-      } catch (_e) {}
+        },
+        "继续队列失败，请检查连接后重试",
+        "Could not resume the queue; check the connection and retry",
+      );
+      if (!r) return;
       await this._syncQueueFromServer(sid);
       this._drainPendingQueue(sid);
     },
     async discardQueue(sid) {
-      try {
-        await fetch("/api/chat/sessions/" + sid + "/queue",
-                    { method: "DELETE", headers: this.hdr() });
-      } catch (_e) {}
+      const st = this.tabState[sid];
+      if (!st) return;
+      const r = await this._runQueueMutation(
+        sid, st, "discard",
+        "/api/chat/sessions/" + sid + "/queue",
+        { method: "DELETE", headers: this.hdr() },
+        "清空队列失败，消息仍保留",
+        "Could not discard the queue; messages are still queued",
+      );
+      if (!r) return;
       await this._syncQueueFromServer(sid);
     },
     // Pull the per-session context meter (input/output tokens, limit, %)
@@ -11114,9 +11289,7 @@ function portal() {
     },
 
     async onPreviewDrop(ev) {
-      this.previewDragHover = false;
-      this.osFileDragging = false;
-      this._dragCounter = 0;
+      this._resetOsFileDragState();
       const files = Array.from((ev.dataTransfer && ev.dataTransfer.files) || []);
       if (!files.length) return;
       const ownerWorkspace = this.fileWorkspacePath();
@@ -12823,7 +12996,12 @@ function portal() {
       if (!existing.length || !(incoming && incoming.length)) return incoming || [];
       const existingTail = existing[existing.length - 1];
       const liveFooter = existingTail && existingTail.role !== "user"
-        ? { ts: existingTail.ts, elapsed: existingTail.elapsed }
+        ? {
+            ts: existingTail.ts,
+            elapsed: existingTail.elapsed,
+            model: existingTail.model,
+            turn_status: existingTail.turn_status,
+          }
         : null;
       const candidates = new Map();
       for (const message of existing) {
@@ -12858,6 +13036,8 @@ function portal() {
         const liveFields = mountedKey.includes(":live:") ? {
           ts: matched.ts,
           elapsed: matched.elapsed,
+          model: matched.model,
+          turn_status: matched.turn_status,
           memoryRecall: matched.memoryRecall,
         } : null;
         const canonicalFields = { ...canonical };
@@ -12866,6 +13046,10 @@ function portal() {
         if (liveFields) {
           if (liveFields.ts) matched.ts = liveFields.ts;
           if (liveFields.elapsed) matched.elapsed = liveFields.elapsed;
+          if (liveFields.model && !matched.model) matched.model = liveFields.model;
+          if (liveFields.turn_status && !matched.turn_status) {
+            matched.turn_status = liveFields.turn_status;
+          }
           if (liveFields.memoryRecall) matched.memoryRecall = liveFields.memoryRecall;
         }
         matched._k = mountedKey;
@@ -12881,6 +13065,12 @@ function portal() {
         if (!canonicalTail.ts && liveFooter.ts) canonicalTail.ts = liveFooter.ts;
         if (!canonicalTail.elapsed && liveFooter.elapsed) {
           canonicalTail.elapsed = liveFooter.elapsed;
+        }
+        if (!canonicalTail.model && liveFooter.model) {
+          canonicalTail.model = liveFooter.model;
+        }
+        if (!canonicalTail.turn_status && liveFooter.turn_status) {
+          canonicalTail.turn_status = liveFooter.turn_status;
         }
       }
       return result;
@@ -12915,6 +13105,13 @@ function portal() {
       if (!Object.prototype.hasOwnProperty.call(m, "forkUuid")) m.forkUuid = "";
       if (!Object.prototype.hasOwnProperty.call(m, "ts")) m.ts = null;
       if (!Object.prototype.hasOwnProperty.call(m, "elapsed")) m.elapsed = 0;
+      if (!Object.prototype.hasOwnProperty.call(m, "model")) m.model = "";
+      if (!Object.prototype.hasOwnProperty.call(m, "turn_status")) {
+        m.turn_status = "";
+      }
+      if (!Object.prototype.hasOwnProperty.call(m, "memoryRecall")) {
+        m.memoryRecall = null;
+      }
       this._assignLiveKey(st, m);
       const target = (st._laterMessages && st._laterMessages.length)
         ? st._laterMessages : st.messages;
@@ -17517,7 +17714,7 @@ function portal() {
       return saved;
     },
     onPreviewViewportScroll() {
-      if (this.previewQuote.show) this.dismissPreviewQuote(true);
+      this.dismissTransientPreviewQuote(true);
       clearTimeout(this._previewViewSaveTimer);
       const ownerPath = this.selected;
       const ownerLoadSeq = this._previewLoadSeq;
@@ -19005,7 +19202,7 @@ function portal() {
 
     async openFile(n, opts = {}) {
       if (!n || !n.path) return false;
-      this.dismissPreviewQuote(true);
+      this.dismissTransientPreviewQuote(true);
       if (this.previewSurface === "terminal") this._teardownTerminalView();
       this.previewSurface = "file";
       // Clicking / double-clicking the file that already owns the editor is a
@@ -20145,7 +20342,7 @@ function portal() {
       document.addEventListener("selectionchange", () => {
         // Focusing the inline question field collapses the document selection.
         // The selected source has already been snapshotted, so retain the ask
-        // panel until the user sends, cancels or changes preview ownership.
+        // panel until the user explicitly closes it or opens the full branch.
         if (this.previewQuote.show && this.previewQuote.mode === "ask") return;
         clearTimeout(this._previewSelectionTimer);
         this._previewSelectionTimer = setTimeout(() => {
@@ -20156,7 +20353,7 @@ function portal() {
       document.addEventListener("pointerdown", (ev) => {
         const inPopover = ev.target && ev.target.closest
           && ev.target.closest(".preview-selection-popover");
-        if (!inPopover && this.previewQuote.show) this.dismissPreviewQuote(false);
+        if (!inPopover) this.dismissTransientPreviewQuote(false);
       }, true);
       const onViewportResize = () => {
         // Mobile keyboards can resize the visual viewport while the question
@@ -20438,6 +20635,7 @@ function portal() {
         text: selectedText,
         path: source === "preview" ? this.selected : "",
         question: "",
+        followup: "",
         x: Math.min(viewportWidth - popoverHalf - 12,
           Math.max(popoverHalf + 12, rect.left + rect.width / 2)),
         y: above ? rect.top : rect.bottom,
@@ -20448,9 +20646,23 @@ function portal() {
         askSessionName: "",
         askPrompt: "",
         askError: "",
+        askAutoScroll: true,
         dragged: false,
         dragging: false,
       });
+    },
+
+    dismissTransientPreviewQuote(clearSelection = false) {
+      // The tiny selection-actions bubble is contextual and should disappear
+      // when its selection loses ownership. Once expanded into an independent
+      // question, however, it is a real floating window: page clicks, file or
+      // chat switches, scrolling and editor changes must not close it. Only
+      // its close button, Escape, or "open full chat" dismisses that state.
+      if (!this.previewQuote.show || this.previewQuote.mode === "ask") {
+        return false;
+      }
+      this.dismissPreviewQuote(clearSelection);
+      return true;
     },
 
     dismissPreviewQuote(clearSelection = false) {
@@ -20459,10 +20671,10 @@ function portal() {
       this._cancelPreviewQuoteDrag();
       Object.assign(this.previewQuote, {
         show: false, mode: "actions", source: "", role: "", sessionId: "",
-        messageId: "", text: "", path: "", question: "",
+        messageId: "", text: "", path: "", question: "", followup: "",
         x: 0, y: 0, above: false, truncated: false, sending: false,
         dragged: false, dragging: false, askSessionId: "",
-        askSessionName: "", askPrompt: "", askError: "",
+        askSessionName: "", askPrompt: "", askError: "", askAutoScroll: true,
       });
       if (clearSelection) {
         try {
@@ -20587,10 +20799,12 @@ function portal() {
       this.previewQuote.mode = "ask";
       this.previewQuote.dragged = false;
       this.previewQuote.question = "";
+      this.previewQuote.followup = "";
       this.previewQuote.askSessionId = "";
       this.previewQuote.askSessionName = "";
       this.previewQuote.askPrompt = "";
       this.previewQuote.askError = "";
+      this.previewQuote.askAutoScroll = true;
       this.$nextTick(() => {
         // x-ref inside an x-if template is not guaranteed to join Alpine's
         // root $refs collection on the same tick in every browser build.
@@ -20634,6 +20848,8 @@ function portal() {
               up_to_message_id: snapshot.source === "chat"
                 ? (snapshot.messageId || null) : null,
               title,
+              activity_hidden: true,
+              runtime_profile: "side_question",
             }),
           },
         );
@@ -20655,6 +20871,8 @@ function portal() {
             permission: "default",
             cwd: (source && source.cwd) || this.currentWorkspacePath(),
             open_ids: this.openTabIds || [],
+            activity_hidden: true,
+            runtime_profile: "side_question",
           }),
         });
         if (!response.ok) throw new Error(`selection session ${response.status}`);
@@ -20671,6 +20889,8 @@ function portal() {
         cwd: payload.cwd || (source && source.cwd) || this.currentWorkspacePath(),
         _selectionAsk: true,
         _selectionAskForked: forked,
+        activity_hidden: true,
+        runtime_profile: "side_question",
       };
       this.sessions = [meta, ...this.sessions.filter(s => s.id !== id)];
       this._sessionsEtag = "";
@@ -20698,7 +20918,31 @@ function portal() {
           break;
         }
       }
-      return messages.slice(userIndex + 1);
+      // Keep the branch-local user turns as well as assistant replies so the
+      // floating window can behave like a compact multi-turn conversation.
+      // Inherited fork history stays before the exact first side-question
+      // prompt and is therefore intentionally excluded.
+      return messages.slice(Math.max(0, userIndex));
+    },
+
+    previewSelectionAskConversation() {
+      return this.previewSelectionAskMessages().filter(message => (
+        message && message.text
+        && (message.role === "user" || message.role === "assistant")
+      ));
+    },
+
+    previewSelectionAskUserText(message) {
+      if (!message) return "";
+      if (message.text === this.previewQuote.askPrompt) {
+        return this.previewQuote.question || "";
+      }
+      return this.userVisibleText(message);
+    },
+
+    previewSelectionAskMessageHtml(message) {
+      const text = String((message && message.text) || "").trim();
+      return text ? this.mdRender(text) : "";
     },
 
     previewSelectionAskText() {
@@ -20709,9 +20953,44 @@ function portal() {
         .trim();
     },
 
-    previewSelectionAskHtml() {
-      const text = this.previewSelectionAskText();
+    previewSelectionAskHtml(message = null) {
+      const text = message ? String(message.text || "").trim()
+        : this.previewSelectionAskText();
       return text ? this.mdRender(text) : "";
+    },
+
+    previewSelectionAskSearching() {
+      if (!this.previewSelectionAskRunning()) return false;
+      const messages = this.previewSelectionAskMessages();
+      let lastUser = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i] && messages[i].role === "user") {
+          lastUser = i;
+          break;
+        }
+      }
+      return messages.slice(lastUser + 1).some(message => (
+        message && message.role === "tool_use"
+        && (message.name === "WebSearch" || message.name === "WebFetch")
+      ));
+    },
+
+    onPreviewSelectionAskScroll(ev) {
+      const el = ev && ev.currentTarget;
+      if (!el) return;
+      this.previewQuote.askAutoScroll = (
+        el.scrollHeight - el.scrollTop - el.clientHeight < 48
+      );
+    },
+
+    scrollPreviewSelectionAskConversation(force = false) {
+      if (!force && !this.previewQuote.askAutoScroll) return false;
+      const el = document.querySelector(
+        ".preview-selection-popover .preview-selection-conversation",
+      );
+      if (!el || !el.getClientRects().length) return false;
+      el.scrollTop = el.scrollHeight;
+      return true;
     },
 
     previewSelectionAskRunning() {
@@ -20745,6 +21024,63 @@ function portal() {
       return true;
     },
 
+    _previewSelectionAskPrompt(question, snapshot = null) {
+      const instruction = this.lang === "zh"
+        ? "这是一个独立侧问。请基于这个侧问分支已有的上下文回答。必要时可以使用 WebSearch 或 WebFetch 核实公开信息；不得调用其他工具或修改文件。搜索时不要把文件路径、凭证、私人信息或选中原文直接放入查询词或 URL，应先抽象成最少必要的公开关键词。"
+        : "This is an independent side question. Answer from the context already present in this side branch. You may use WebSearch or WebFetch when public information needs verification; do not use other tools or modify files. Never put file paths, credentials, private data, or the selected passage verbatim into a query or URL; reduce it to the minimum necessary public keywords first.";
+      const label = this.lang === "zh"
+        ? (snapshot ? "问题：" : "追问：")
+        : (snapshot ? "Question:" : "Follow-up:");
+      const parts = [];
+      if (snapshot) parts.push(this._previewQuoteBlock(snapshot));
+      parts.push(instruction, `${label}\n${question}`);
+      return parts.join("\n\n");
+    },
+
+    onPreviewQuoteFollowupEnter(ev) {
+      if (!ev || ev.isComposing || ev.keyCode === 229) return;
+      const isTouch = (window.matchMedia
+        && window.matchMedia("(pointer: coarse)").matches) || window.innerWidth < 768;
+      if (isTouch || ev.shiftKey || ev.ctrlKey || ev.metaKey) return;
+      ev.preventDefault();
+      this.sendPreviewSelectionFollowup();
+    },
+
+    async sendPreviewSelectionFollowup() {
+      const sid = this.previewQuote.askSessionId;
+      const question = String(this.previewQuote.followup || "").trim();
+      if (!sid || !question || this.previewSelectionAskRunning()
+          || this.workspaceSwitching) return false;
+      const prompt = this._previewSelectionAskPrompt(question);
+      this.previewQuote.sending = true;
+      this.previewQuote.askError = "";
+      this.previewQuote.askAutoScroll = true;
+      try {
+        const result = await this.send({
+          sessionId: sid,
+          detachedText: prompt,
+          detachedDisplayText: question,
+          permissionMode: "default",
+        });
+        if (result === false) {
+          this.previewQuote.askError = this.lang === "zh"
+            ? "追问发送失败，请重试"
+            : "Could not send the follow-up; please retry";
+          return false;
+        }
+        this.previewQuote.followup = "";
+        this.$nextTick(() => this.scrollPreviewSelectionAskConversation(true));
+        return true;
+      } catch (_) {
+        this.previewQuote.askError = this.lang === "zh"
+          ? "追问发送失败，请重试"
+          : "Could not send the follow-up; please retry";
+        return false;
+      } finally {
+        this.previewQuote.sending = false;
+      }
+    },
+
     async sendPreviewSelectionQuestion() {
       if (!this.previewQuote.show || this.previewQuote.mode !== "ask"
           || this.previewQuote.sending) return false;
@@ -20769,11 +21105,7 @@ function portal() {
         text: this.previewQuote.text,
         truncated: this.previewQuote.truncated,
       };
-      const prompt = this._previewQuoteBlock(snapshot)
-        + "\n\n" + (this.lang === "zh"
-          ? "这是一个独立侧问。请只基于已有上下文和上面的选中内容回答，不调用工具、不修改文件。\n问题："
-          : "This is an independent side question. Answer only from the existing context and selection; do not use tools or modify files.\nQuestion:")
-        + "\n" + question;
+      const prompt = this._previewSelectionAskPrompt(question, snapshot);
       this.previewQuote.sending = true;
       this.previewQuote.askError = "";
       try {
@@ -20784,6 +21116,7 @@ function portal() {
         const result = await this.send({
           sessionId: target.id,
           detachedText: prompt,
+          detachedDisplayText: question,
           permissionMode: "default",
         });
         if (result === false) {
@@ -21463,6 +21796,37 @@ function portal() {
     },
 
     // ===== upload / drag-drop / mkdir =====
+    _externalFileDropTarget(target) {
+      const el = target && target.nodeType === 1
+        ? target
+        : (target && target.parentElement);
+      const row = el && el.closest
+        ? el.closest(".filelist li.dir[data-path]")
+        : null;
+      return {
+        dir: row ? String(row.dataset.path || "") : "",
+        explicitDirectory: !!row,
+      };
+    },
+    _setOsFileDropTarget(target) {
+      const drop = this._externalFileDropTarget(target);
+      this.osFileDragging = true;
+      this.osFileDropDir = drop.dir;
+      this.osFileDropOnDirectory = drop.explicitDirectory;
+      this.dragOver = drop.explicitDirectory ? drop.dir : "";
+      this.dragOverRoot = !drop.explicitDirectory;
+      return drop;
+    },
+    _resetOsFileDragState() {
+      this._dragCounter = 0;
+      this.osFileDragging = false;
+      this.osFileDropDir = "";
+      this.osFileDropOnDirectory = false;
+      this.dragOver = "";
+      this.dragOverRoot = false;
+      this.previewDragHover = false;
+      this.dragHover = false;
+    },
     async upload(ev) {
       // Multi-file picker: upload all selected files in parallel to the
       // workspace root and refresh the tree ONCE, mirroring onPreviewDrop.
@@ -21657,6 +22021,17 @@ function portal() {
       this._lpStart = null;
     },
     onTreeNodeDragOver(ev, n) {
+      const types = Array.from(ev.dataTransfer?.types || []);
+      if (types.includes("Files")
+          && !types.includes(this._DRAG_MIME_INTERNAL)) {
+        // External files are deliberately stricter than tree moves: only a
+        // directory row is an explicit nested destination.  A file row is
+        // just another part of the window and therefore means workspace root.
+        this.dragOver = n.is_dir ? n.path : "";
+        this.dragOverRoot = !n.is_dir;
+        ev.dataTransfer.dropEffect = "copy";
+        return;
+      }
       // Target dir = the node itself when it's a folder, or its parent
       // directory when it's a file. Dropping onto a file lands the
       // item next to that file (matches Finder / VSCode behavior).
@@ -21703,10 +22078,11 @@ function portal() {
         return;
       }
 
-      // OS file upload — dropping onto a file uploads into that file's
-      // parent dir (same dir-resolution as internal moves).
+      // OS file upload — only a directory row is a nested target. Dropping on
+      // a file row follows the app-wide default and uploads to workspace root.
       const files = Array.from(ev.dataTransfer?.files || []);
-      await this._uploadFilesToDir(targetDir, files);
+      this._resetOsFileDragState();
+      await this._uploadFilesToDir(n.is_dir ? n.path : "", files);
     },
     // Parallel-upload a set of OS files into `targetDir` (empty string =
     // workspace root), then refresh the tree once and surface a single
@@ -21781,6 +22157,7 @@ function portal() {
       }
       // OS file upload → workspace root.
       const files = Array.from(ev.dataTransfer?.files || []);
+      this._resetOsFileDragState();
       await this._uploadFilesToDir("", files);
     },
     async moveTreeItem(srcPath, targetDir) {
@@ -23707,6 +24084,18 @@ function portal() {
       if (!sendSid) return false;
       if (sendSid === this.currentId) this._captureComposerState(sendSid);
       const sendState = this._ensureTabState(sendSid);
+      // Stop is an acknowledged control handshake, not an idle gap.  Sending
+      // while it is still settling used to enqueue a fresh message between the
+      // interrupt endpoint's atomic pause and the turn cleanup's second pause;
+      // that new item then appeared accepted but remained paused.  Keep the
+      // draft intact and make the short wait explicit instead.
+      if (sendState._stopping && !opts.reconnect && !opts.resumedItem) {
+        this.toast(this.lang === "zh"
+          ? "正在中断上一条任务，请稍候再发送"
+          : "The previous turn is still stopping; send again in a moment",
+        "warn", 2200);
+        return false;
+      }
       // Do not start a new turn between the optimistic selector change and
       // its persisted session update. Otherwise Plan Mode could launch with a
       // stale/missing return capability. Reconnects and queued snapshots own
@@ -23730,6 +24119,8 @@ function portal() {
       // lifecycle. This also makes ticket failure recovery a no-op for the
       // unrelated composer.
       const hasDetachedText = typeof opts.detachedText === "string";
+      const detachedDisplayText = typeof opts.detachedDisplayText === "string"
+        ? opts.detachedDisplayText : opts.detachedText;
       // Snapshot the pinned session's draft before any await. Every later read,
       // clear, upload wait and enqueue remains owned by this exact state object.
       const composerInput = hasDetachedText ? opts.detachedText : (sendDraft.input || "");
@@ -23980,7 +24371,7 @@ function portal() {
         this._capLiveMessages(sendState);
         sentUserBubble = this._appendLiveMessage(sendState, {
           role: "user", text,
-          displayText: hasDetachedText ? text : composerInput,
+          displayText: hasDetachedText ? detachedDisplayText : composerInput,
           selectionQuotes: composerQuotes.map(q => ({ ...q })),
           images: readyImages.map(im => ({
             preview: im.preview,
@@ -25147,6 +25538,11 @@ function portal() {
         const completedAtMs = Number(meta.completedAtMs) || 0;
         const durationMs = Number(meta.durationMs) || 0;
         const assistantUuid = String(meta.assistantUuid || "");
+        const completedModel = String(
+          meta.model || streamState.streamingModel || modelForBubble || "",
+        );
+        const turnStatus = String(meta.turnStatus || "");
+        const memoryRecall = meta.memoryRecall || null;
         const _now = completedAtMs > 0 ? completedAtMs : Date.now();
         const _elapsed = durationMs > 0
           ? durationMs / 1000
@@ -25155,14 +25551,23 @@ function portal() {
         const _stamp = (m) => {
           if (!m.ts) m.ts = _now;
           if (!m.elapsed && _elapsed >= 1) m.elapsed = _elapsed;
+          if (!m.model && completedModel) m.model = completedModel;
+          if ((!m.turn_status || m.turn_status === "running") && turnStatus) {
+            m.turn_status = turnStatus;
+          }
+          if (!m.memoryRecall && memoryRecall) m.memoryRecall = memoryRecall;
         };
         // Tail-most muse-side message of THIS turn, used when the turn has no
         // assistant text bubble of its own to hang the footer on.
         let tailCandidate = null;
         let stampedAssistant = null;
+        let lastUserCandidate = null;
         for (let k = turnMessages.length - 1; k >= 0; k--) {
           const m = turnMessages[k];
-          if (m.role === "user") break;          // entered the previous turn
+          if (m.role === "user") {
+            lastUserCandidate = m;
+            break;                               // entered the previous turn
+          }
           if (tailCandidate === null) tailCandidate = m;
           // Skip tool blocks / standalone thinking; they're not the
           // "reply" the user reads time off.
@@ -25173,6 +25578,13 @@ function portal() {
           _stamp(m);                              // found the tail text bubble
           stampedAssistant = m;
           break;                                  // stop after the first one (most recent)
+        }
+        // An interrupt/error can land before the SDK emits any muse-side
+        // block.  Stamp that turn's user envelope so the terminal footer does
+        // not vanish with the pending bubble; the template explicitly allows
+        // a status-bearing user tail for this one exceptional shape.
+        if (!tailCandidate && lastUserCandidate && turnStatus) {
+          tailCandidate = lastUserCandidate;
         }
         // The footer is mounted on the actual turn-tail node. Stamp that node
         // regardless of whether an assistant bubble was found above; otherwise
@@ -25318,6 +25730,10 @@ function portal() {
           assistantUuid: d.assistant_uuid,
           completedAtMs: d.completed_at_ms,
           durationMs: d.duration_ms,
+          model: d.model,
+          turnStatus: d.cancelled
+            ? "cancelled" : (d.is_error ? "failed" : "completed"),
+          memoryRecall: d.memory_recall,
         });
         _stopTimer();
         if (isContinuation && !d.cancelled) {
@@ -25479,7 +25895,12 @@ function portal() {
             markUserFailed(serverError, errKind, errCta, errRetryable);
           }
           restoreSubmittedComposer(false);
-          es.close(); _markDone(false, false, true); _stopTimer();
+          es.close();
+          _markDone(false, false, true, {
+            model: modelForBubble,
+            turnStatus: "failed",
+          });
+          _stopTimer();
           // Pause auto-drain — same context likely fails the next message
           // too (quota / auth / cross-vendor signature). The failed user
           // bubble surfaces a "resume queue (N)" CTA so the user can
@@ -25625,7 +26046,12 @@ function portal() {
         let d = {};
         try { d = JSON.parse(ev.data || "{}"); } catch (_) { d = {}; }
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
-        es.close(); _markDone(true, false, true); _stopTimer();
+        es.close();
+        _markDone(true, false, true, {
+          model: modelForBubble,
+          turnStatus: "cancelled",
+        });
+        _stopTimer();
         // A force-stopped CLI may never commit this turn to canonical JSONL.
         // The backend writes the already-rendered SSE record to a private,
         // display-only snapshot BEFORE emitting snapshot_ready. Reconcile that

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -991,7 +991,7 @@
              x-show="previewSurface==='file' && (previewDragHover || osFileDragging)"
              x-transition.opacity
              @dragover.prevent
-             @drop.prevent="onPreviewDrop($event); previewDragHover = false; osFileDragging = false; _dragCounter = 0">
+             @drop.prevent="onPreviewDrop($event)">
           <div class="preview-drop-inner">
             <svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
@@ -2806,24 +2806,38 @@
                    the bottom, and keeping both would pulse two sets of dots
                    ~20px apart. -->
               <div class="turn-footer"
-                   x-show="m.role !== 'user'
+                   x-show="(m.role !== 'user' || m.turn_status || m._interrupted || m._failed)
                      && (i === paneMsgs.length - 1 || (paneMsgs[i + 1] && paneMsgs[i + 1].role === 'user'))
+                     && turnFooterStatus(m, pane)
                      && (
-                       m.ts
-                       || m.elapsed
+                       turnFooterTime(m, pane)
+                       || turnFooterElapsed(m, pane) !== null
+                       || turnFooterModel(m, pane, tid)
+                       || turnFooterStatus(m, pane)
+                       || m._interrupted
                        || (turnForkMessageId(paneMsgs, i) && !(pane && pane.streaming))
                      )">
-                <span x-show="m.ts"
-                      class="msg-ts" :title="m.model || ''"
-                      x-text="fmtTurnTime(m.ts)"></span>
+                <span class="turn-status"
+                      x-show="turnFooterStatus(m, pane)"
+                      :class="turnFooterStatus(m, pane)"
+                      x-text="turnStatusLabel(turnFooterStatus(m, pane))"></span>
+                <!-- Old transcripts may predate completion annotations.  Their
+                     last record still carries mts, which is a close and stable
+                     fallback instead of rendering a separator with no time. -->
+                <span x-show="turnFooterTime(m, pane)"
+                      class="msg-ts"
+                      x-text="fmtTurnTime(turnFooterTime(m, pane))"></span>
                 <!-- Total elapsed kept after done so the user can
                      reference back how long the turn took (esp. useful
                      for long agentic runs). Stamped in _markDone next
                      to .ts; only shown when both exist and m.elapsed
                      >= 1s (sub-second replies don't need the noise). -->
-                <span x-show="m.elapsed && m.ts"
+                <span x-show="turnFooterElapsed(m, pane) !== null && turnFooterTime(m, pane)"
                       class="msg-elapsed"
-                      x-text="'· ' + fmtStreamElapsed(m.elapsed)"></span>
+                      x-text="'· ' + fmtStreamElapsed(turnFooterElapsed(m, pane))"></span>
+                <span x-show="turnFooterModel(m, pane, tid)" class="turn-model"
+                      :title="turnFooterModel(m, pane, tid)"
+                      x-text="'· ' + modelLabel(turnFooterModel(m, pane, tid))"></span>
                 <details class="memory-recall-trace"
                          x-show="m.memoryRecall && m.memoryRecall.count">
                   <summary x-text="lang==='zh'
@@ -2986,11 +3000,13 @@
                     <span style="flex:1"></span>
                     <button class="queued-act icon-btn sm"
                             @click="editPendingQueueItem(currentId, qi)"
+                            :disabled="queueActionBusy(currentId, 'edit:' + q.id)"
                             :title="lang==='zh' ? '编辑' : 'Edit'">
                       <svg><use href="#i-edit"/></svg>
                     </button>
                     <button class="queued-act icon-btn sm"
                             @click="removePendingQueueItem(currentId, qi)"
+                            :disabled="queueActionBusy(currentId, 'remove:' + q.id)"
                             :title="lang==='zh' ? '移除' : 'Remove'">
                       <svg><use href="#i-x"/></svg>
                     </button>
@@ -3073,9 +3089,11 @@
                           + (lang==='zh' ? ' 条）' : ' waiting)')"></span>
             <button class="queue-paused-btn primary"
                     @click="resumeQueueDrain(currentId)"
+                    :disabled="queueActionBusy(currentId, 'resume')"
                     x-text="lang==='zh' ? '继续执行' : 'Resume'"></button>
             <button class="queue-paused-btn"
                     @click="discardQueue(currentId)"
+                    :disabled="queueActionBusy(currentId, 'discard')"
                     x-text="lang==='zh' ? '清空队列' : 'Discard'"></button>
           </div>
 
@@ -3551,10 +3569,14 @@
                  shows while streaming. Same shape + size + fill — they
                  read as a sibling pair (blue send / red stop). -->
             <button @click="send()"
-                    :disabled="workspaceSwitching || !availableModels.length || tabState[currentId]?._permissionChangePending || runtimeSettingsPending() || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingQuotes.length && !pendingImages.length && !pendingDocs.length)"
+                    :disabled="workspaceSwitching || !availableModels.length || tabState[currentId]?._stopping || tabState[currentId]?._permissionChangePending || runtimeSettingsPending() || _sendWaitingForUpload || pendingImages.some(im => im.uploading) || pendingDocs.some(d => d.uploading) || (!input.trim() && !pendingQuotes.length && !pendingImages.length && !pendingDocs.length)"
                     class="btn-primary chat-toolbar-send chat-toolbar-queue"
-                    :aria-label="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')"
-                    :title="_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')">
+                    :aria-label="tabState[currentId]?._stopping
+                      ? (lang==='zh' ? '正在中断' : 'Stopping')
+                      : (_isBusy(currentId) ? t('queue.button_hint') : t('btn.send'))"
+                    :title="tabState[currentId]?._stopping
+                      ? (lang==='zh' ? '等待上一条任务完成中断' : 'Waiting for the previous turn to stop')
+                      : (_isBusy(currentId) ? t('queue.button_hint') : t('btn.send'))">
               <span class="icon"><svg><use href="#i-send"/></svg></span>
               <span class="chat-toolbar-queue-badge"
                     x-show="_currentQueueLen() > 0"
@@ -3695,20 +3717,50 @@
                     @click="dismissPreviewQuote(true)"
                     :title="lang === 'zh' ? '关闭' : 'Close'">×</button>
           </div>
-          <div class="preview-selection-question" x-text="previewQuote.question"></div>
-          <div class="preview-selection-answer-loading"
-               x-show="previewSelectionAskRunning() && !previewSelectionAskText()">
-            <span class="spinner-sm"></span>
-            <span x-text="lang === 'zh' ? '正在回答…' : 'Answering…'"></span>
+          <div class="preview-selection-conversation"
+               @scroll.passive="onPreviewSelectionAskScroll($event)"
+               x-effect="previewSelectionAskText(); $nextTick(() => scrollPreviewSelectionAskConversation())">
+            <template x-for="(message, index) in previewSelectionAskConversation()"
+                      :key="message._key || message.id || message.uuid || index">
+              <div class="preview-selection-turn"
+                   :class="message.role === 'user' ? 'is-user' : 'is-assistant'">
+                <template x-if="message.role === 'user'">
+                  <div class="preview-selection-question"
+                       x-text="previewSelectionAskUserText(message)"></div>
+                </template>
+                <template x-if="message.role === 'assistant'">
+                  <div class="preview-selection-answer-body markdown"
+                       x-html="previewSelectionAskMessageHtml(message)"></div>
+                </template>
+              </div>
+            </template>
+            <div class="preview-selection-answer-loading"
+                 x-show="previewSelectionAskRunning()">
+              <span class="spinner-sm"></span>
+              <span x-text="previewSelectionAskSearching()
+                ? (lang === 'zh' ? '正在检索网页…' : 'Searching the web…')
+                : (lang === 'zh' ? '正在回答…' : 'Answering…')"></span>
+            </div>
           </div>
-          <div class="preview-selection-answer-body markdown"
-               x-show="previewSelectionAskText()"
-               x-html="previewSelectionAskHtml()"></div>
           <div class="preview-selection-error"
                x-show="previewQuote.askError || previewSelectionAskFailed()"
                x-text="previewQuote.askError || (lang === 'zh' ? '侧问没有完成，可打开会话重试' : 'The side question did not finish; open the chat to retry')"></div>
+          <form class="preview-selection-followup"
+                @submit.prevent="sendPreviewSelectionFollowup()">
+            <textarea x-model="previewQuote.followup"
+                      rows="2"
+                      autocomplete="off"
+                      :placeholder="lang === 'zh' ? '继续追问…' : 'Ask a follow-up…'"
+                      @keydown.enter="onPreviewQuoteFollowupEnter($event)"
+                      @keydown.escape.stop.prevent="dismissPreviewQuote(true)"></textarea>
+            <button type="submit" class="preview-selection-followup-send"
+                    :disabled="!previewQuote.followup.trim() || previewSelectionAskRunning() || workspaceSwitching"
+                    :title="lang === 'zh' ? '发送追问' : 'Send follow-up'">
+              <svg aria-hidden="true"><use href="#i-send"/></svg>
+            </button>
+          </form>
           <div class="preview-selection-ask-foot">
-            <span x-text="lang === 'zh' ? '不写入当前会话' : 'Kept out of the current chat'"></span>
+            <span x-text="lang === 'zh' ? '独立多轮 · 可网页搜索' : 'Independent thread · Web search enabled'"></span>
             <button type="button" class="preview-selection-open"
                     @click="openPreviewSelectionAskSession()"
                     :title="lang === 'zh' ? '打开完整分支会话' : 'Open the full branch chat'">
@@ -3719,6 +3771,27 @@
         </div>
       </div>
     </template>
+  </div>
+
+  <!-- One predictable OS-file drop surface for the whole application.
+       Pointer events stay on the content underneath so a directory row can
+       be the only explicit nested destination; every other location routes
+       to the current workspace root. -->
+  <div class="global-file-drop-overlay"
+       x-show="authed && osFileDragging"
+       x-transition.opacity
+       x-cloak
+       :class="{ 'into-directory': osFileDropOnDirectory }"
+       role="status" aria-live="polite">
+    <div class="global-file-drop-card">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
+      </svg>
+      <strong x-text="osFileDropOnDirectory
+        ? (lang === 'zh' ? '上传到 /' + osFileDropDir : 'Upload to /' + osFileDropDir)
+        : (lang === 'zh' ? '上传到工作区根目录' : 'Upload to workspace root')"></strong>
+      <span x-text="lang === 'zh' ? '松开鼠标以上传' : 'Release to upload'"></span>
+    </div>
   </div>
 
   <!-- ============ Message outline modal ============
@@ -5668,6 +5741,13 @@
                   :class="{ active: activity.view === 'timeline' }"
                   x-text="lang==='zh' ? '时间倒序' : 'By time'"></button>
         </div>
+        <!-- Fixed-size slot: refresh visibility changes without moving the
+             view switch or close button. -->
+        <span class="activity-refreshing" :class="{ active: activity.loading }"
+              :title="lang==='zh' ? '正在刷新' : 'Refreshing'"
+              :aria-hidden="!activity.loading">
+          <span class="spinner-sm"></span>
+        </span>
         <button class="modal-close" @click="activity.show=false" aria-label="Close">×</button>
       </div>
       <!-- One chip per attention group, in the same order as the sections below:
@@ -5697,8 +5777,15 @@
                 x-text="lang==='zh' ? '清除筛选' : 'Clear filter'"></button>
         <button class="btn-ghost sm" x-show="activity.summary.unread" @click="ackAllActivity()" x-text="lang==='zh' ? '全部标为已读' : 'Mark all read'"></button>
       </div>
-      <div class="modal-body activity-body">
-        <div class="hint-row" x-show="activity.loading" x-text="lang==='zh' ? '加载中…' : 'Loading…'"></div>
+      <div class="modal-body activity-body" :aria-busy="activity.loading">
+        <!-- Loading is an overlay, not a list row.  A normal-flow hint used to
+             disappear above the mounted rows when fetchActivity settled,
+             shifting the entire ledger (and modal height) in one frame. -->
+        <div class="activity-loading-overlay" x-show="activity.loading && !activity.events.length"
+             role="status" aria-live="polite">
+          <span class="spinner-sm"></span>
+          <span x-text="lang==='zh' ? '正在加载任务…' : 'Loading tasks…'"></span>
+        </div>
         <template x-for="group in activityVisibleGroups()" :key="group.key">
           <section class="activity-group" x-show="activityEvents(group).length"
                    :class="{ 'is-timeline': group.key === 'timeline' }">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3361,10 +3361,12 @@
                     @keydown.meta.x="onCutLine($event)"
                     @keydown.up="onChatArrowUp($event)"
                     @keydown.down="onChatArrowDown($event)"
+                    @compositionstart="onImeCompositionStart($event)"
+                    @compositionend="onImeCompositionEnd($event)"
                     @input="onChatInput($event); autoGrow($event.target)"
                     @paste="onImagePaste($event)"
                     @focus="onChatInputFocus($event)"
-                    @blur="onChatInputBlur()"
+                    @blur="onChatInputBlur($event)"
                     @click="onChatInputClick($event)"
                     :placeholder="t('chat.placeholder')"></textarea>
           </form>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -585,7 +585,7 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
    ========================================================================== */
 .layout {
   display: grid;
-  grid-template-columns: 280px 1fr 440px;
+  grid-template-columns: 340px 1fr 440px;
   /* dvh = dynamic viewport height — matches the actually-visible area on
      mobile Safari (where the address bar collapses/expands), preventing the
      chat input from getting hidden behind browser chrome. Falls back to vh
@@ -2578,7 +2578,8 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   font-size: var(--fs-xs);
   line-height: 1.45;
 }
-.preview-selection-ask textarea {
+.preview-selection-ask textarea,
+.preview-selection-followup textarea {
   display: block;
   width: 100%;
   min-height: 62px;
@@ -2594,8 +2595,10 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   font: inherit;
   line-height: 1.45;
 }
-.preview-selection-ask textarea::placeholder { color: var(--c-fg-3); }
-.preview-selection-ask textarea:focus {
+.preview-selection-ask textarea::placeholder,
+.preview-selection-followup textarea::placeholder { color: var(--c-fg-3); }
+.preview-selection-ask textarea:focus,
+.preview-selection-followup textarea:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 2px var(--c-accent-soft);
 }
@@ -2609,7 +2612,8 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   color: var(--c-fg-3);
   font-size: var(--fs-xs);
 }
-.preview-selection-send {
+.preview-selection-send,
+.preview-selection-followup-send {
   width: 30px;
   height: 30px;
   padding: 0;
@@ -2622,40 +2626,69 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   color: var(--c-on-accent);
   cursor: pointer;
 }
-.preview-selection-send:hover:not(:disabled) { background: var(--c-btn-primary-hover); }
-.preview-selection-send:disabled { opacity: 0.42; cursor: default; }
-.preview-selection-send svg { width: 15px; height: 15px; }
+.preview-selection-send:hover:not(:disabled),
+.preview-selection-followup-send:hover:not(:disabled) { background: var(--c-btn-primary-hover); }
+.preview-selection-send:disabled,
+.preview-selection-followup-send:disabled { opacity: 0.42; cursor: default; }
+.preview-selection-send svg,
+.preview-selection-followup-send svg { width: 15px; height: 15px; }
 .preview-selection-send .spinner-sm { width: 13px; height: 13px; }
 .preview-selection-answer {
   width: 100%;
   box-sizing: border-box;
   padding: 10px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(560px, calc(100vh - 28px));
+  min-height: 0;
+}
+.preview-selection-conversation {
+  min-height: 72px;
+  max-height: min(350px, calc(100vh - 230px));
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 2px 3px 7px;
+  overscroll-behavior: contain;
+}
+.preview-selection-turn {
+  display: flex;
+  width: 100%;
+}
+.preview-selection-turn.is-user { justify-content: flex-end; }
+.preview-selection-turn.is-assistant { justify-content: flex-start; }
+.preview-selection-turn.is-user .preview-selection-question {
+  width: fit-content;
+  max-width: 88%;
 }
 .preview-selection-question {
-  margin: 0 0 8px;
+  margin: 0;
   padding: 7px 9px;
   border-radius: var(--r-md);
-  background: var(--c-bg-1);
-  color: var(--c-fg-2);
-  font-size: var(--fs-xs);
+  background: var(--c-accent-soft);
+  color: var(--c-fg-1);
+  font-size: var(--fs-sm);
   line-height: 1.45;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 .preview-selection-answer-loading {
   display: flex;
   align-items: center;
   gap: 7px;
-  min-height: 72px;
+  min-height: 32px;
   color: var(--c-fg-3);
   font-size: var(--fs-xs);
 }
 .preview-selection-answer-body {
-  max-height: min(360px, calc(100vh - 210px));
-  overflow: auto;
-  padding: 2px 3px 6px;
+  min-width: 0;
+  max-width: 100%;
+  padding: 2px 3px;
   color: var(--c-fg-1);
   font-size: var(--fs-sm);
   line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 .preview-selection-answer-body > :first-child { margin-top: 0; }
 .preview-selection-answer-body > :last-child { margin-bottom: 0; }
@@ -2664,6 +2697,25 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   color: var(--c-danger);
   font-size: var(--fs-xs);
   line-height: 1.4;
+}
+.preview-selection-followup {
+  display: flex;
+  align-items: flex-end;
+  gap: 7px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--c-border);
+}
+.preview-selection-followup textarea {
+  flex: 1;
+  min-width: 0;
+  min-height: 38px;
+  max-height: 96px;
+  resize: vertical;
+  padding: 7px 8px;
+}
+.preview-selection-followup .preview-selection-followup-send {
+  flex: 0 0 auto;
 }
 .preview-selection-open {
   min-height: 30px;
@@ -2688,9 +2740,11 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   .preview-selection-actions { min-height: 44px; }
   .preview-selection-actions button { height: 38px; padding: 0 14px; }
   .preview-selection-close,
-  .preview-selection-send { width: 36px; height: 36px; }
+  .preview-selection-send,
+  .preview-selection-followup-send { width: 36px; height: 36px; }
   .preview-selection-open { min-height: 36px; }
-  .preview-selection-ask textarea { font-size: 16px; }
+  .preview-selection-ask textarea,
+  .preview-selection-followup textarea { font-size: 16px; }
 }
 
 /* Injected highlight marks in the live preview content. */
@@ -2724,6 +2778,65 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   font-size: var(--fs-md); font-weight: var(--fw-semibold);
   display: flex; flex-direction: column; align-items: center; gap: 10px;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+.global-file-drop-overlay {
+  position: fixed;
+  inset: 10px;
+  z-index: 1180;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--c-accent);
+  border-radius: var(--r-xl);
+  background: color-mix(in srgb, var(--c-accent-soft) 72%, transparent);
+  box-shadow: inset 0 0 0 1px var(--c-accent-soft);
+  backdrop-filter: blur(1.5px);
+}
+.global-file-drop-overlay.into-directory {
+  border-color: var(--c-success);
+  background: color-mix(in srgb, var(--c-success) 10%, transparent);
+}
+.global-file-drop-card {
+  min-width: min(360px, calc(100vw - 48px));
+  max-width: calc(100vw - 48px);
+  padding: 22px 28px;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-lg);
+  background: var(--c-bg-1);
+  color: var(--c-fg-0);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+  text-align: center;
+}
+.global-file-drop-card svg {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 3px;
+  fill: none;
+  stroke: var(--c-accent);
+  stroke-width: 1.7;
+}
+.global-file-drop-overlay.into-directory .global-file-drop-card svg {
+  stroke: var(--c-success);
+}
+.global-file-drop-card strong {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+}
+.global-file-drop-card span {
+  color: var(--c-fg-2);
+  font-size: var(--fs-sm);
+}
+@media (max-width: 700px) {
+  .global-file-drop-overlay { inset: 6px; }
+  .global-file-drop-card { padding: 18px 20px; }
 }
 .editor {
   width: 100%; height: 100%; padding: var(--sp-5);
@@ -3567,7 +3680,41 @@ pre.text {
 .activity-chip.is-empty { opacity:0.42; }
 .activity-chip.is-empty:hover { opacity:0.85; }
 @media (prefers-reduced-motion:reduce) { .activity-chip .activity-chip-dot { animation:none; } }
-.activity-body { max-height:min(70vh,680px); overflow:auto; padding:10px 14px 18px; }
+.activity-body { position:relative; max-height:min(70vh,680px); overflow:auto; padding:10px 14px 18px; }
+/* Keep the desktop ledger geometry stable across cold load → rows.  The
+   loading/refresh indicators are absolutely positioned, so neither their
+   appearance nor disappearance can push a mounted row or resize the modal. */
+@media (min-width:721px) {
+  .activity-body { min-height:min(46vh,420px); }
+}
+.activity-loading-overlay {
+  position:absolute;
+  inset:0;
+  z-index:2;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  color:var(--c-fg-3);
+  font-size:var(--fs-sm);
+  background:var(--c-bg-1);
+}
+.activity-refreshing {
+  width:20px;
+  height:20px;
+  flex:0 0 20px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  pointer-events:none;
+  color:var(--c-accent);
+  visibility:hidden;
+  opacity:0;
+  transition:opacity var(--t-fast);
+}
+.activity-refreshing.active { visibility:visible; opacity:1; }
+.activity-refreshing .spinner-sm,
+.activity-loading-overlay .spinner-sm { flex:0 0 auto; }
 .activity-group h3 { margin:10px 4px 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
 .activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
 .activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
@@ -4257,6 +4404,28 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
   height: 1px;
   background: var(--c-border);
 }
+.turn-status,
+.turn-model {
+  flex:0 0 auto;
+  color:var(--c-fg-3);
+  font-size:var(--fs-xs);
+  white-space:nowrap;
+}
+.turn-status {
+  min-width: 48px;
+  text-align: right;
+}
+.turn-status.running { color:var(--c-accent-fg); }
+.turn-status.completed { color:var(--c-success); }
+.turn-status.failed { color:var(--c-danger); }
+.turn-status.cancelled { color:var(--c-warn); }
+.turn-model {
+  flex:0 1 auto;
+  min-width:0;
+  max-width:120px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
 .turn-fork-btn {
   width: 22px;
   height: 22px;
@@ -4296,8 +4465,10 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
      width on every breakpoint. Just tighten the vertical rhythm. */
   .turn-footer {
     margin: 4px 0 2px;
+    gap: 5px;
     min-height: 14px;
   }
+  .turn-model { max-width:90px; }
   .turn-fork-btn {
     width: 30px;
     height: 30px;
@@ -6508,6 +6679,8 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   font-family: var(--font-mono);
   letter-spacing: 0.2px;
   flex-shrink: 0;
+  min-width: 46px;
+  text-align: center;
 }
 /* "· 2m50s" total-elapsed pill stamped next to .msg-ts after the turn
    finishes. Same mono / muted treatment as .msg-ts so they read as one
@@ -6518,6 +6691,7 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
   font-family: var(--font-mono);
   letter-spacing: 0.2px;
   flex-shrink: 0;
+  min-width: 52px;
 }
 
 .jump-bottom {

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -88,6 +88,10 @@ def test_cached_activity_refresh_does_not_shift_rows_or_modal(
     expect(page.locator(".activity-refreshing")).to_be_visible()
     row = page.locator(".activity-row").filter(has_text="Stable activity row")
     expect(row).to_be_visible()
+    # Measure only the loading/refresh transition.  The modal has its own
+    # short open scale transition; CI can reach this assertion while that
+    # unrelated animation is still changing geometry by ~1-2px.
+    page.wait_for_timeout(250)
 
     before = page.evaluate(
         """async () => {

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -49,6 +49,85 @@ def test_memory_shortcut_opens_memory_settings_page(
     expect(page.locator(".memory-settings-section")).to_be_visible()
 
 
+def test_cached_activity_refresh_does_not_shift_rows_or_modal(
+    page: Page, backend_url, auth_token,
+):
+    """The loading indicator must be out of flow when cached rows exist."""
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
+          app.activity.viewLoaded = true;
+          app.activity.view = 'timeline';
+          app.activity.events = [{
+            id: 'stable-refresh-row', kind: 'turn',
+            session_id: 'stable-refresh-session',
+            session_name: 'Stable activity row',
+            task_summary: 'Must not jump when loading disappears',
+            workspace: '/tmp/e2e', workspace_name: 'e2e',
+            state: 'running', read: true,
+            started_at: 100, finished_at: 0, updated_at: 100,
+          }];
+          app.activity.summary = {
+            running: 1, unread: 0, attention: 0,
+            groups: {review: 0, running: 1, failed: 0, history: 0},
+            group_unread: {review: 0, running: 0, failed: 0, history: 0},
+            workspaces: [],
+          };
+          app.fetchActivity = () => new Promise(resolve => {
+            window.__finishStableActivityRefresh = resolve;
+          });
+          void app.openActivityCenter();
+        }"""
+    )
+    expect(page.locator(".activity-modal")).to_be_visible()
+    expect(page.locator(".activity-refreshing")).to_be_visible()
+    row = page.locator(".activity-row").filter(has_text="Stable activity row")
+    expect(row).to_be_visible()
+
+    before = page.evaluate(
+        """async () => {
+          await new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)));
+          const modal = document.querySelector('.activity-modal');
+          const body = document.querySelector('.activity-body');
+          const row = Array.from(document.querySelectorAll('.activity-row'))
+            .find(node => node.textContent.includes('Stable activity row'));
+          return {
+            modalHeight: modal.getBoundingClientRect().height,
+            bodyHeight: body.getBoundingClientRect().height,
+            rowTop: row.getBoundingClientRect().top,
+          };
+        }"""
+    )
+    page.evaluate("() => window.__finishStableActivityRefresh(true)")
+    page.wait_for_function(
+        "() => !document.querySelector('#app')._x_dataStack[0].activity.loading"
+    )
+    after = page.evaluate(
+        """async () => {
+          await new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)));
+          const modal = document.querySelector('.activity-modal');
+          const body = document.querySelector('.activity-body');
+          const row = Array.from(document.querySelectorAll('.activity-row'))
+            .find(node => node.textContent.includes('Stable activity row'));
+          return {
+            modalHeight: modal.getBoundingClientRect().height,
+            bodyHeight: body.getBoundingClientRect().height,
+            rowTop: row.getBoundingClientRect().top,
+          };
+        }"""
+    )
+
+    for key in ("modalHeight", "bodyHeight", "rowTop"):
+        assert abs(after[key] - before[key]) < 1, (before, after)
+
+
 def test_session_rename_updates_loaded_activity_row_immediately(
     page: Page, backend_url, auth_token
 ):

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -261,6 +261,94 @@ def _bootstrap_session_for_real_load(page: Page, sid: str, name: str) -> None:
     )
 
 
+def test_chat_ime_commit_enter_keeps_chinese_text_and_next_enter_sends(
+    page: Page, backend_url, auth_token,
+):
+    """WebView compositionend→plain Enter must commit, not submit, Chinese."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    sid = "ime-composition-chat"
+    _bootstrap_session_for_real_load(page, sid, "IME composition")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st._loaded = true;
+        st.draft.input = "";
+        app._activateTabState(arg);
+        window.__imeSendCalls = 0;
+        app.send = () => { window.__imeSendCalls += 1; return true; };
+        return true;
+        """,
+        sid,
+    )
+    textarea = page.locator(".chat-input-textarea")
+    expect(textarea).to_be_visible(timeout=5000)
+    textarea.focus()
+
+    result = page.evaluate(
+        """async () => {
+          const textarea = document.querySelector(".chat-input-textarea");
+          textarea.dispatchEvent(new CompositionEvent("compositionstart", {
+            bubbles: true, data: "ni",
+          }));
+          textarea.value = "你";
+          textarea.dispatchEvent(new InputEvent("input", {
+            bubbles: true,
+            inputType: "insertCompositionText",
+            data: "你",
+            isComposing: true,
+          }));
+          textarea.dispatchEvent(new CompositionEvent("compositionend", {
+            bubbles: true, data: "你",
+          }));
+          // Chromium WebView/Safari ordering: the final model input lands,
+          // then the candidate-confirming Enter is reported as a plain key.
+          textarea.dispatchEvent(new InputEvent("input", {
+            bubbles: true,
+            inputType: "insertText",
+            data: "你",
+            isComposing: false,
+          }));
+          const commitEnter = new KeyboardEvent("keydown", {
+            key: "Enter", code: "Enter", bubbles: true, cancelable: true,
+          });
+          textarea.dispatchEvent(commitEnter);
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const committed = {
+            sendCalls: window.__imeSendCalls,
+            input: app.input,
+            value: textarea.value,
+            prevented: commitEnter.defaultPrevented,
+          };
+
+          await new Promise(resolve => setTimeout(resolve, 100));
+          const sendEnter = new KeyboardEvent("keydown", {
+            key: "Enter", code: "Enter", bubbles: true, cancelable: true,
+          });
+          textarea.dispatchEvent(sendEnter);
+          return {
+            committed,
+            sendCalls: window.__imeSendCalls,
+            sendPrevented: sendEnter.defaultPrevented,
+            composing: !!textarea._museImeComposing,
+          };
+        }"""
+    )
+
+    assert result["committed"] == {
+        "sendCalls": 0,
+        "input": "你",
+        "value": "你",
+        "prevented": False,
+    }
+    assert result["sendCalls"] == 1
+    assert result["sendPrevented"] is True
+    assert result["composing"] is False
+    _assert_no_browser_errors(page, errors)
+
+
 def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
     page: Page, backend_url, auth_token,
 ):
@@ -2046,6 +2134,221 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     assert result["frames"]
     assert all(frame["ready"] and not frame["loading"] for frame in result["frames"]), result
     assert all(frame["visible"] and frame["count"] > 0 for frame in result["frames"]), result
+    _assert_no_browser_errors(page, errors)
+
+
+def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_nodes(
+    page: Page, backend_url, auth_token,
+):
+    """A forced interrupt quietly adopts its durable display snapshot."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _install_fake_event_source(page)
+    sid = "perf-cancelled-snapshot-identity"
+    prompt = "CANCELLED_SNAPSHOT_USER_PROMPT"
+    first_text = "CANCELLED_SNAPSHOT_FIRST_REPLY " + ("kept before tool " * 20)
+    thinking = "CANCELLED_SNAPSHOT_THINKING"
+    tool_result = "CANCELLED_SNAPSHOT_TOOL_RESULT\nsecond line"
+    final_text = "CANCELLED_SNAPSHOT_FINAL_SEGMENT " + ("still visible " * 20)
+    snapshot_messages: list[dict] = []
+    requests = _route_windowed_session(page, sid, snapshot_messages)
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"cancelled-snapshot-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.refreshSessions = async () => {};
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._ensureSessionRegistered = async () => true;
+        app._confirmSessionBusy = async () => false;
+        app.appReady = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.sessions = [{
+          id: sid, name: "Cancelled snapshot", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st._seenUpdated = 1;
+        app.currentId = sid;
+        app._residentTabIds = [sid];
+        app._activateTabState(sid);
+        app.messagesReady = true;
+        app.messagesLoading = false;
+        app.mobileTab = "chat";
+        app.input = arg.prompt;
+        app.atBottom = true;
+        return true;
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+
+    _app_eval(page, "app.send(); return true;")
+    page.wait_for_function(
+        "() => window.__fakeChatStreams && window.__fakeChatStreams().length === 1"
+    )
+    page.evaluate(
+        """payload => {
+          window.__emitSse("text", {
+            text: payload.first, turn_id: "cancelled-snapshot-turn", event_seq: 1,
+          });
+          window.__emitSse("thinking", {
+            text: payload.thinking, turn_id: "cancelled-snapshot-turn", event_seq: 2,
+          });
+          window.__emitSse("tool_use", {
+            id: "toolu_cancelled_snapshot", name: "Read",
+            summary: "cancelled snapshot fixture",
+            input: {file_path: "fixture.txt"},
+            turn_id: "cancelled-snapshot-turn", event_seq: 3,
+          });
+          window.__emitSse("tool_result", {
+            id: "toolu_cancelled_snapshot", tool_name: "Read",
+            preview: payload.toolResult, text: payload.toolResult,
+            truncated: false, text_truncated: false, is_error: false,
+            turn_id: "cancelled-snapshot-turn", event_seq: 4,
+          });
+          window.__emitSse("text", {
+            text: payload.final, turn_id: "cancelled-snapshot-turn", event_seq: 5,
+          });
+        }""",
+        {
+            "first": first_text,
+            "thinking": thinking,
+            "toolResult": tool_result,
+            "final": final_text,
+        },
+    )
+    page.wait_for_function(
+        """expected => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const pane = Array.from(document.querySelectorAll(".msg-pane"))
+            .find(el => getComputedStyle(el).display !== "none");
+          return app.streaming && app.messages.length === 6
+            && pane?.textContent.includes(expected.first)
+            && pane?.textContent.includes(expected.final);
+        }""",
+        arg={"first": first_text, "final": final_text},
+        timeout=10000,
+    )
+    before = page.evaluate(
+        """() => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const pane = Array.from(document.querySelectorAll(".msg-pane"))
+            .find(el => getComputedStyle(el).display !== "none");
+          const nodes = Array.from(pane.querySelectorAll(".msg"));
+          window.__cancelledSnapshotNodes = nodes;
+          window.__cancelledSnapshotKeys = app.messages.map(m => m._k);
+          window.__cancelledSnapshotMinCount = nodes.length;
+          window.__cancelledSnapshotObserver = new MutationObserver(() => {
+            const visible = Array.from(document.querySelectorAll(".msg-pane"))
+              .find(el => getComputedStyle(el).display !== "none");
+            const count = visible ? visible.querySelectorAll(".msg").length : 0;
+            window.__cancelledSnapshotMinCount = Math.min(
+              window.__cancelledSnapshotMinCount, count);
+          });
+          window.__cancelledSnapshotObserver.observe(
+            document.querySelector("#app"), {childList: true, subtree: true});
+          return {count: nodes.length, keys: window.__cancelledSnapshotKeys};
+        }"""
+    )
+    assert before["count"] == 6
+    assert all(":live:" in key for key in before["keys"])
+
+    snapshot_messages.extend([
+        {
+            "role": "user", "text": prompt,
+            "_key": "cancelled:cancelled-snapshot-turn:0", "_interrupted": True,
+        },
+        {
+            "role": "assistant", "text": first_text, "model": "e2e-model",
+            "_key": "cancelled:cancelled-snapshot-turn:1", "_interrupted": True,
+        },
+        {
+            "role": "thinking", "text": thinking,
+            "_key": "cancelled:cancelled-snapshot-turn:2", "_interrupted": True,
+        },
+        {
+            "role": "tool_use", "id": "toolu_cancelled_snapshot", "name": "Read",
+            "summary": "cancelled snapshot fixture", "input": {"file_path": "fixture.txt"},
+            "_key": "cancelled:cancelled-snapshot-turn:3", "_interrupted": True,
+        },
+        {
+            "role": "tool_result", "id": "toolu_cancelled_snapshot", "tool_name": "Read",
+            "preview": tool_result, "text": tool_result, "is_error": False,
+            "_key": "cancelled:cancelled-snapshot-turn:4", "_interrupted": True,
+        },
+        {
+            "role": "assistant", "text": final_text, "model": "e2e-model",
+            "_key": "cancelled:cancelled-snapshot-turn:5", "_interrupted": True,
+        },
+    ])
+    page.evaluate(
+        """() => window.__emitSse("cancelled", {
+          snapshot_ready: true,
+          turn_id: "cancelled-snapshot-turn",
+          event_seq: 6,
+        })"""
+    )
+    page.wait_for_function(
+        """expected => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(expected.sid);
+          return !app.streaming && !st.streaming && st._loaded
+            && st.messages.length === expected.count
+            && st.messages.every(message => message._interrupted === true);
+        }""",
+        arg={"sid": sid, "count": len(snapshot_messages)},
+        timeout=10000,
+    )
+    result = page.evaluate(
+        """async ({ first, final }) => {
+          await new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)));
+          window.__cancelledSnapshotObserver.disconnect();
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const pane = Array.from(document.querySelectorAll(".msg-pane"))
+            .find(el => getComputedStyle(el).display !== "none");
+          const nodes = Array.from(pane.querySelectorAll(".msg"));
+          return {
+            minCount: window.__cancelledSnapshotMinCount,
+            count: nodes.length,
+            sameNodes: nodes.every(
+              (node, index) => node === window.__cancelledSnapshotNodes[index]),
+            keys: app.messages.map(message => message._k),
+            ready: app.messagesReady,
+            loading: app.messagesLoading,
+            firstVisible: pane.textContent.includes(first),
+            finalVisible: pane.textContent.includes(final),
+          };
+        }""",
+        {"first": first_text, "final": final_text},
+    )
+
+    assert requests, "cancelled reconciliation did not request the display snapshot"
+    assert result["minCount"] == before["count"], result
+    assert result["count"] == before["count"]
+    assert result["sameNodes"] is True, result
+    assert result["keys"] == before["keys"]
+    assert result["ready"] is True and result["loading"] is False
+    assert result["firstVisible"] is True and result["finalVisible"] is True
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -349,6 +349,96 @@ def test_chat_ime_commit_enter_keeps_chinese_text_and_next_enter_sends(
     _assert_no_browser_errors(page, errors)
 
 
+def test_native_ime_buffer_survives_reactive_composer_reconciliation(
+    page: Page, backend_url, auth_token,
+):
+    """Alpine model writes must not replace Chromium's native marked text."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    sid = "ime-native-reconciliation"
+    _bootstrap_session_for_real_load(page, sid, "Native IME reconciliation")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st._loaded = true;
+        st.draft.input = "";
+        app._activateTabState(arg);
+        return true;
+        """,
+        sid,
+    )
+    textarea = page.locator(".chat-input-textarea")
+    expect(textarea).to_be_visible(timeout=5000)
+    textarea.click()
+    page.wait_for_function(
+        "() => document.activeElement === document.querySelector('.chat-input-textarea')"
+    )
+
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Input.imeSetComposition", {
+        "text": "ni",
+        "selectionStart": 2,
+        "selectionEnd": 2,
+        "replacementStart": 0,
+        "replacementEnd": 0,
+    })
+    composing = _app_eval(
+        page,
+        """
+        const ta = document.querySelector('.chat-input-textarea');
+        return { value: ta.value, input: app.input,
+          composing: !!ta._museImeComposing,
+          guarded: typeof ta._museImeOriginalForceModelUpdate === 'function' };
+        """,
+    )
+    assert composing == {
+        "value": "ni", "input": "ni", "composing": True, "guarded": True,
+    }
+
+    # This is the rare real-world race: a tab/draft reconciliation writes the
+    # root x-model while native marked text is still active. Before the guard,
+    # Alpine immediately assigned textarea.value and Chromium emitted no
+    # compositionend, leaving the OS IME attached to stale editor state.
+    protected = _app_eval(
+        page,
+        """
+        app.input = 'reconciled draft';
+        return new Promise(resolve => queueMicrotask(() => {
+          const ta = document.querySelector('.chat-input-textarea');
+          resolve({ value: ta.value, input: app.input,
+            composing: !!ta._museImeComposing });
+        }));
+        """,
+    )
+    assert protected == {
+        "value": "ni", "input": "reconciled draft", "composing": True,
+    }
+
+    cdp.send("Input.imeSetComposition", {
+        "text": "你",
+        "selectionStart": 1,
+        "selectionEnd": 1,
+        "replacementStart": 0,
+        "replacementEnd": 2,
+    })
+    cdp.send("Input.insertText", {"text": "你"})
+    committed = _app_eval(
+        page,
+        """
+        const ta = document.querySelector('.chat-input-textarea');
+        return { value: ta.value, input: app.input,
+          composing: !!ta._museImeComposing,
+          guarded: !!ta._museImeOriginalForceModelUpdate };
+        """,
+    )
+    assert committed == {
+        "value": "你", "input": "你", "composing": False, "guarded": False,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
 def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
     page: Page, backend_url, auth_token,
 ):
@@ -2150,6 +2240,7 @@ def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_node
     thinking = "CANCELLED_SNAPSHOT_THINKING"
     tool_result = "CANCELLED_SNAPSHOT_TOOL_RESULT\nsecond line"
     final_text = "CANCELLED_SNAPSHOT_FINAL_SEGMENT " + ("still visible " * 20)
+    cancelled_at_ms = int(time.time() * 1000)
     snapshot_messages: list[dict] = []
     requests = _route_windowed_session(page, sid, snapshot_messages)
     page.route(
@@ -2297,6 +2388,8 @@ def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_node
         },
         {
             "role": "assistant", "text": final_text, "model": "e2e-model",
+            "ts": cancelled_at_ms, "elapsed": 5.0,
+            "turn_status": "cancelled",
             "_key": "cancelled:cancelled-snapshot-turn:5", "_interrupted": True,
         },
     ])
@@ -2327,6 +2420,8 @@ def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_node
           const pane = Array.from(document.querySelectorAll(".msg-pane"))
             .find(el => getComputedStyle(el).display !== "none");
           const nodes = Array.from(pane.querySelectorAll(".msg"));
+          const tail = app.messages[app.messages.length - 1];
+          const footer = nodes[nodes.length - 1]?.querySelector('.turn-footer');
           return {
             minCount: window.__cancelledSnapshotMinCount,
             count: nodes.length,
@@ -2337,6 +2432,12 @@ def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_node
             loading: app.messagesLoading,
             firstVisible: pane.textContent.includes(first),
             finalVisible: pane.textContent.includes(final),
+            tailStatus: tail.turn_status,
+            tailModel: tail.model,
+            tailTs: tail.ts,
+            tailElapsed: tail.elapsed,
+            footerVisible: !!footer?.getClientRects().length,
+            footerText: footer?.textContent.replace(/\\s+/g, ' ').trim() || '',
           };
         }""",
         {"first": first_text, "final": final_text},
@@ -2349,6 +2450,18 @@ def test_desktop_cancelled_snapshot_reconcile_never_blanks_or_replaces_live_node
     assert result["keys"] == before["keys"]
     assert result["ready"] is True and result["loading"] is False
     assert result["firstVisible"] is True and result["finalVisible"] is True
+    assert result["tailStatus"] == "cancelled"
+    assert result["tailModel"] == "e2e-model"
+    # The live terminal timestamp is deliberately preserved during a quiet
+    # same-DOM reconcile; a cold reload reads the durable value asserted by
+    # the backend snapshot test. Both must remain populated here.
+    assert result["tailTs"] > 0
+    assert result["tailElapsed"] >= 1
+    assert result["footerVisible"] is True
+    assert ("E2E model" in result["footerText"]
+            or "e2e-model" in result["footerText"])
+    assert ("已中断" in result["footerText"]
+            or "Interrupted" in result["footerText"])
     _assert_no_browser_errors(page, errors)
 
 
@@ -2547,6 +2660,11 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
               completed_at_ms: arg.completedAtMs,
               duration_ms: arg.durationMs,
               total_cost_usd: 0.001,
+              model: 'e2e-model',
+              memory_recall: {
+                id: 'tool-tail-memory-trace', count: 1,
+                latency_ms: 8, status: 'ok', items: [],
+              },
               session_usage: {
                 context_used_pct: 5,
                 context_used: 500,
@@ -2575,6 +2693,9 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
             && tail?.role === 'tool_result'
             && tail.ts === arg.completedAtMs
             && tail.elapsed === arg.durationMs / 1000
+            && tail.model === 'e2e-model'
+            && tail.turn_status === 'completed'
+            && tail.memoryRecall?.id === 'tool-tail-memory-trace'
             && tail.forkUuid === arg.assistantUuid
             && tailNode?.classList.contains('tool_result')
             && footer?.getClientRects().length
@@ -2599,8 +2720,14 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     expected_time = _app_eval(
         page, "return app.fmtTurnTime(arg);", completed_at_ms
     )
+    expected_status = _app_eval(
+        page, "return app.lang === 'zh' ? '已完成' : 'Completed';"
+    )
     expect(footer.locator(".msg-ts")).to_have_text(expected_time)
     expect(footer.locator(".msg-elapsed")).to_have_text("· 2m05s")
+    expect(footer.locator(".turn-model")).to_have_text("· E2E model")
+    expect(footer.locator(".turn-status")).to_have_text(expected_status)
+    expect(footer.locator(".memory-recall-trace")).to_be_visible()
     expect(footer.locator(".turn-fork-btn")).to_be_visible()
 
     state = _app_eval(
@@ -2618,6 +2745,9 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
             app.messages, app.messages.length - 1),
           ts: tail.ts,
           elapsed: tail.elapsed,
+          model: tail.model,
+          turnStatus: tail.turn_status,
+          memoryRecallId: tail.memoryRecall?.id || '',
           liveKey: tail._k,
           streaming: app.streaming,
         };
@@ -2633,6 +2763,9 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
         "forkBoundary": assistant_uuid,
         "ts": completed_at_ms,
         "elapsed": duration_ms / 1000,
+        "model": "e2e-model",
+        "turnStatus": "completed",
+        "memoryRecallId": "tool-tail-memory-trace",
         "streaming": False,
     }
     assert ":live:" in live_key
@@ -2793,6 +2926,139 @@ def test_canonical_reload_stays_quiet_when_background_tab_becomes_current(
     assert all(frame["visibleCount"] > 0 for frame in result["frames"]), result
     assert result["finalVisible"] is True, result
     _assert_no_browser_errors(page, errors)
+
+
+def test_mobile_turn_footer_keeps_complete_metadata_inside_chat(
+    page: Page, backend_url, auth_token,
+):
+    """Status/time/duration/model/fork all fit at the 320px floor."""
+    page.set_viewport_size({"width": 320, "height": 700})
+    _login(page, backend_url, auth_token)
+    page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          st.messages.splice(0, st.messages.length, ...app._historyEnvelopes(sid, [{
+            role: 'assistant', text: 'MOBILE_FOOTER_COMPLETE',
+            html: '<p>MOBILE_FOOTER_COMPLETE</p>',
+            uuid: 'mobile-footer-assistant',
+            forkUuid: 'mobile-footer-assistant',
+            ts: Date.now(), elapsed: 3725,
+            model: 'codex:a-very-long-model-name-for-footer',
+            turn_status: 'completed',
+          }]));
+          st._loaded = true;
+          st.messagesReady = true;
+          st.streaming = false;
+          app._activateTabState(sid);
+          app.messagesReady = true;
+          app.mobileTab = 'chat';
+        }"""
+    )
+    footer = page.locator(".msg-pane:visible .turn-footer")
+    expect(footer).to_be_visible()
+    expect(footer.locator(".turn-status")).to_be_visible()
+    expect(footer.locator(".msg-ts")).to_be_visible()
+    expect(footer.locator(".msg-elapsed")).to_be_visible()
+    expect(footer.locator(".turn-model")).to_be_visible()
+    expect(footer.locator(".turn-fork-btn")).to_be_visible()
+
+    geometry = footer.evaluate(
+        """node => {
+          const body = node.closest('.chat-body').getBoundingClientRect();
+          const rect = node.getBoundingClientRect();
+          const visible = Array.from(node.children)
+            .filter(child => child.getClientRects().length)
+            .map(child => {
+              const r = child.getBoundingClientRect();
+              return {left: r.left, right: r.right};
+            });
+          return {
+            bodyLeft: body.left, bodyRight: body.right,
+            left: rect.left, right: rect.right,
+            clientWidth: node.clientWidth, scrollWidth: node.scrollWidth,
+            visible,
+          };
+        }"""
+    )
+    assert geometry["left"] >= geometry["bodyLeft"] - 1, geometry
+    assert geometry["right"] <= geometry["bodyRight"] + 1, geometry
+    assert geometry["scrollWidth"] <= geometry["clientWidth"] + 1, geometry
+    assert all(
+        child["left"] >= geometry["bodyLeft"] - 1
+        and child["right"] <= geometry["bodyRight"] + 1
+        for child in geometry["visible"]
+    ), geometry
+
+
+def test_failed_queue_edit_never_duplicates_and_stopping_turn_rejects_send(
+    page: Page, backend_url, auth_token,
+):
+    """Exercise both queue failure guards through Alpine's live state."""
+    _login(page, backend_url, auth_token)
+    sid = page.evaluate(
+        "() => document.querySelector('#app')._x_dataStack[0].currentId"
+    )
+    mutations: list[str] = []
+
+    def fail_queue_mutation(route):
+        mutations.append(route.request.method)
+        route.fulfill(
+            status=503,
+            content_type="application/json",
+            body='{"detail":"temporary queue failure"}',
+        )
+
+    page.route(
+        f"**/api/chat/sessions/{sid}/queue/q-edit-failure",
+        fail_queue_mutation,
+    )
+    result = page.evaluate(
+        """async sid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app._ensureTabState(sid);
+          app._syncQueueFromServer = async () => {};
+          st.pendingQueue = [{
+            id: 'q-edit-failure', text: 'SERVER ORIGINAL',
+            displayText: 'SERVER ORIGINAL', pendingQuotes: [],
+            images: [], docs: [],
+          }];
+          st.draft.input = '';
+          app._activateComposerState(sid);
+          await app.editPendingQueueItem(sid, 0);
+          const afterEdit = {
+            queueLength: st.pendingQueue.length,
+            queueText: st.pendingQueue[0]?.text || '',
+            draft: st.draft.input,
+            busy: Object.keys(st._queueMutating || {}),
+          };
+
+          st._stopping = true;
+          st.streaming = true;
+          st.draft.input = 'SEND DURING STOP';
+          app._activateComposerState(sid);
+          const sendResult = await app.send();
+          return {
+            afterEdit,
+            sendResult,
+            stoppingDraft: st.draft.input,
+            pendingAfterStop: st.pendingQueue.length,
+          };
+        }""",
+        sid,
+    )
+
+    assert mutations == ["DELETE"]
+    assert result["afterEdit"] == {
+        "queueLength": 1,
+        "queueText": "SERVER ORIGINAL",
+        "draft": "",
+        "busy": [],
+    }
+    assert result["sendResult"] is False
+    assert result["stoppingDraft"] == "SEND DURING STOP"
+    assert result["pendingAfterStop"] == 1
 
 
 def test_background_task_gap_leaves_composer_usable_without_empty_reconnect(

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -32,6 +32,15 @@ def _login(page: Page, base: str, token: str) -> None:
 
 
 def _select_rendered_preview_text(page: Page) -> str:
+    # Alpine can publish ``previewMode`` one render tick before the Markdown
+    # body is mounted.  Wait for the actual selectable surface so callers do
+    # not race an otherwise healthy preview on slower CI runners.
+    page.wait_for_function(
+        """() => Array.from(document.querySelectorAll(
+          '.pane.preview .markdown, .pane.preview pre.text, '
+          + '.pane.preview .xlsx-preview'
+        )).some(el => el.getClientRects().length && el.textContent.trim())"""
+    )
     return page.evaluate(
         """() => {
           const roots = Array.from(document.querySelectorAll(

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -119,6 +119,12 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
           };
           const prefs = JSON.parse(localStorage.getItem('muselab_prefs') || '{}');
           localStorage.setItem('muselab_prefs', JSON.stringify({
+            schema: 8, leftWidth: 280, previewWidth: 440,
+          }));
+          app.leftWidth = 280;
+          app.loadPrefs();
+          const fileWidthMigration = app.leftWidth;
+          localStorage.setItem('muselab_prefs', JSON.stringify({
             schema: 7, rightOpen: false, rightWidth: 512,
           }));
           app.previewOpen = true;
@@ -149,7 +155,7 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
           };
           app.toggleDesktopFull('chat');
           return {
-            before, hidden, restored, prefs, migration,
+            before, hidden, restored, prefs, migration, fileWidthMigration,
             previewFullscreen, chatFullscreen,
           };
         }"""
@@ -167,11 +173,12 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
     assert result["restored"]["previewDisplay"] == "flex"
     assert result["restored"]["chat"]["right"] <= result["restored"]["preview"]["left"]
     assert result["restored"]["sameChatNode"] is True
-    assert result["prefs"]["schema"] == 8
+    assert result["prefs"]["schema"] == 9
     assert result["prefs"]["previewOpen"] is True
     assert result["prefs"]["previewWidth"] == 440
     assert "rightOpen" not in result["prefs"]
     assert "rightWidth" not in result["prefs"]
+    assert result["fileWidthMigration"] == 340
     assert result["migration"] == {"previewOpen": True, "previewWidth": 512}
     assert result["previewFullscreen"]["previewOpen"] is True
     assert result["previewFullscreen"]["preview"]["width"] == 1440
@@ -179,6 +186,147 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
     assert result["chatFullscreen"]["chat"]["width"] == 1440
     assert result["chatFullscreen"]["previewDisplay"] == "none"
     assert result["chatFullscreen"]["sameChatNode"] is True
+
+
+def test_os_file_drop_uses_whole_window_root_except_explicit_directory(
+        page: Page, backend_url, auth_token):
+    """Composer/tree blank/file rows are root; only a dir row is nested."""
+    errors: list[str] = []
+    page.on("pageerror", lambda exc: errors.append(str(exc)))
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const uploads = [];
+          const attachments = [];
+          const internalMoves = [];
+          app._uploadFilesToDir = async (dir, files) => {
+            uploads.push({dir, names: Array.from(files, file => file.name)});
+          };
+          app._attachFile = async file => attachments.push(file.name);
+          app.moveTreeItems = async (paths, dir) => {
+            internalMoves.push({paths: Array.from(paths), dir});
+          };
+
+          const list = document.querySelector('.filelist');
+          const dirRow = document.createElement('li');
+          dirRow.className = 'dir';
+          dirRow.dataset.path = 'drop-target-dir';
+          dirRow.innerHTML = '<span class="name">drop-target-dir</span>';
+          const dirNode = {is_dir: true, path: 'drop-target-dir'};
+          dirRow.addEventListener('dragover', event => {
+            event.preventDefault();
+            app.onTreeNodeDragOver(event, dirNode);
+          });
+          dirRow.addEventListener('drop', event => {
+            event.preventDefault();
+            void app.onDrop(event, dirNode);
+          });
+          list.appendChild(dirRow);
+          const fileRow = document.createElement('li');
+          fileRow.className = 'file';
+          fileRow.dataset.path = 'drop-target-dir/existing.txt';
+          fileRow.innerHTML = '<span class="name">existing.txt</span>';
+          list.appendChild(fileRow);
+
+          const overlay = document.querySelector('.global-file-drop-overlay');
+          const settle = () => new Promise(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(resolve)));
+          const transfer = name => {
+            const dt = new DataTransfer();
+            dt.items.add(new File(['fixture'], name, {type: 'text/plain'}));
+            return dt;
+          };
+          const enter = async (target, name) => {
+            const dt = transfer(name);
+            target.dispatchEvent(new DragEvent('dragenter', {
+              bubbles: true, cancelable: true, dataTransfer: dt,
+            }));
+            target.dispatchEvent(new DragEvent('dragover', {
+              bubbles: true, cancelable: true, dataTransfer: dt,
+            }));
+            await settle();
+            return dt;
+          };
+          const drop = async (target, dt) => {
+            target.dispatchEvent(new DragEvent('drop', {
+              bubbles: true, cancelable: true, dataTransfer: dt,
+            }));
+            await settle();
+          };
+
+          const chat = document.querySelector('.chat-input-wrap');
+          let dt = await enter(chat, 'chat-root.txt');
+          const rootOverlay = {
+            visible: !!overlay.getClientRects().length,
+            directory: app.osFileDropOnDirectory,
+            text: overlay.textContent.replace(/\\s+/g, ' ').trim(),
+          };
+          await drop(chat, dt);
+
+          dt = await enter(list, 'tree-blank-root.txt');
+          await drop(list, dt);
+
+          dt = await enter(dirRow.querySelector('.name'), 'nested.txt');
+          const dirOverlay = {
+            visible: !!overlay.getClientRects().length,
+            directory: app.osFileDropOnDirectory,
+            dir: app.osFileDropDir,
+            text: overlay.textContent.replace(/\\s+/g, ' ').trim(),
+          };
+          await drop(dirRow.querySelector('.name'), dt);
+
+          dt = await enter(fileRow.querySelector('.name'), 'file-row-root.txt');
+          await drop(fileRow.querySelector('.name'), dt);
+
+          // The document capture route must ignore MuseLab's own tree drag.
+          const internal = new DataTransfer();
+          internal.setData(app._DRAG_MIME_INTERNAL, 'README.md');
+          internal.setData('text/plain', 'README.md');
+          app._dragSrcPath = 'README.md';
+          dirRow.querySelector('.name').dispatchEvent(new DragEvent('dragover', {
+            bubbles: true, cancelable: true, dataTransfer: internal,
+          }));
+          dirRow.querySelector('.name').dispatchEvent(new DragEvent('drop', {
+            bubbles: true, cancelable: true, dataTransfer: internal,
+          }));
+          await settle();
+          const internalOverlay = app.osFileDragging;
+          dirRow.remove();
+          fileRow.remove();
+          return {
+            uploads, attachments, internalMoves, internalOverlay,
+            rootOverlay, dirOverlay,
+            dragging: app.osFileDragging,
+            dropDir: app.osFileDropDir,
+          };
+        }"""
+    )
+
+    assert result["uploads"] == [
+        {"dir": "", "names": ["chat-root.txt"]},
+        {"dir": "", "names": ["tree-blank-root.txt"]},
+        {"dir": "drop-target-dir", "names": ["nested.txt"]},
+        {"dir": "", "names": ["file-row-root.txt"]},
+    ]
+    assert result["attachments"] == []
+    assert result["internalMoves"] == [
+        {"paths": ["README.md"], "dir": "drop-target-dir"},
+    ]
+    assert result["internalOverlay"] is False
+    assert result["rootOverlay"]["visible"] is True
+    assert result["rootOverlay"]["directory"] is False
+    assert ("工作区根目录" in result["rootOverlay"]["text"]
+            or "workspace root" in result["rootOverlay"]["text"])
+    assert result["dirOverlay"]["visible"] is True
+    assert result["dirOverlay"]["directory"] is True
+    assert result["dirOverlay"]["dir"] == "drop-target-dir"
+    assert "/drop-target-dir" in result["dirOverlay"]["text"]
+    assert result["dragging"] is False
+    assert result["dropDir"] == ""
+    assert errors == []
 
 
 def test_file_metadata_layout_is_compact_and_human_readable(
@@ -312,11 +460,15 @@ def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
             return meta;
           };
           app.send = async opts => {
-            window.__previewAskOptions = JSON.parse(JSON.stringify(opts));
+            window.__previewAskOptions = window.__previewAskOptions || [];
+            window.__previewAskOptions.push(JSON.parse(JSON.stringify(opts)));
             const st = app._ensureTabState(opts.sessionId);
-            st.messages.splice(0, st.messages.length,
-              {role: 'user', text: opts.detachedText},
-              {role: 'assistant', text: 'SIDE_ANSWER_MARKER'});
+            const turn = window.__previewAskOptions.length;
+            if (turn === 1) st.messages.splice(0, st.messages.length);
+            st.messages.push(
+              {role: 'user', text: opts.detachedText,
+               displayText: opts.detachedDisplayText},
+              {role: 'assistant', text: `SIDE_ANSWER_MARKER_${turn}`});
             st.streaming = false;
             return true;
           };
@@ -332,7 +484,16 @@ def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
     ask.locator('button[type="submit"]').click()
     expect(page.locator(".preview-selection-answer")).to_be_visible()
     expect(page.locator(".preview-selection-answer-body")).to_contain_text(
-        "SIDE_ANSWER_MARKER"
+        "SIDE_ANSWER_MARKER_1"
+    )
+    followup = page.locator(".preview-selection-followup textarea")
+    followup.fill("能再举一个例子吗？")
+    page.locator(".preview-selection-followup-send").click()
+    expect(page.locator(".preview-selection-conversation")).to_contain_text(
+        "SIDE_ANSWER_MARKER_2"
+    )
+    expect(page.locator(".preview-selection-conversation")).to_contain_text(
+        "能再举一个例子吗？"
     )
 
     asked = page.evaluate(
@@ -358,11 +519,17 @@ def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
           };
         }"""
     )
-    assert asked["opts"]["sessionId"] == "preview-side-question"
-    assert asked["opts"]["permissionMode"] == "default"
-    assert "引用自 `README.md`" in asked["opts"]["detachedText"]
-    assert selected_for_ask in asked["opts"]["detachedText"]
-    assert "这段内容的核心是什么？" in asked["opts"]["detachedText"]
+    assert len(asked["opts"]) == 2
+    first, followup_opts = asked["opts"]
+    assert first["sessionId"] == followup_opts["sessionId"] == "preview-side-question"
+    assert first["permissionMode"] == followup_opts["permissionMode"] == "default"
+    assert "引用自 `README.md`" in first["detachedText"]
+    assert selected_for_ask in first["detachedText"]
+    assert "这段内容的核心是什么？" in first["detachedText"]
+    assert first["detachedDisplayText"] == "这段内容的核心是什么？"
+    assert "追问：" in followup_opts["detachedText"]
+    assert "能再举一个例子吗？" in followup_opts["detachedText"]
+    assert followup_opts["detachedDisplayText"] == "能再举一个例子吗？"
     assert asked["create"]["snapshot"]["sessionId"] == before["session"]
     assert asked["create"]["question"] == "这段内容的核心是什么？"
     assert asked["input"] == asked["draft"] == "KEEP EXISTING DRAFT"
@@ -429,6 +596,8 @@ def test_selection_side_session_forks_without_opening_or_switching_tab(
     assert fork_bodies == [{
         "up_to_message_id": "assistant-boundary",
         "title": fork_bodies[0]["title"],
+        "activity_hidden": True,
+        "runtime_profile": "side_question",
     }]
     assert "独立侧问" in fork_bodies[0]["title"]
     assert result["id"] == child
@@ -437,6 +606,70 @@ def test_selection_side_session_forks_without_opening_or_switching_tab(
     assert child not in result["openTabs"]
     assert result["stateLoaded"] is True
     assert result["statePermission"] == "default"
+
+
+def test_side_question_window_stays_floating_until_explicit_close(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 1200, "height": 800})
+    _login(page, backend_url, auth_token)
+    page.locator('.filelist li[data-path="README.md"]').click()
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.selected === 'README.md' && app.previewMode === 'md';
+        }"""
+    )
+    _select_rendered_preview_text(page)
+    page.locator(".preview-selection-actions button").nth(1).click()
+    popover = page.locator(".preview-selection-popover")
+    textarea = page.locator(".preview-selection-ask:visible textarea")
+    expect(textarea).to_be_visible()
+    textarea.fill("FLOATING_QUESTION_DRAFT")
+
+    # An ordinary click elsewhere used to close the window in capture phase.
+    page.locator(".filelist").click(position={"x": 6, "y": 6})
+    expect(popover).to_be_visible()
+    expect(textarea).to_have_value("FLOATING_QUESTION_DRAFT")
+
+    # File selection, chat-tab ownership and preview scrolling are all page
+    # navigation, not an implicit close command for an independent question.
+    state = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const source = app.currentId;
+          const other = '22222222-3333-4444-8555-666666666666';
+          app.sessions = [...app.sessions, {
+            id: other, name: 'Other chat', model: app.model,
+            permission: 'default', cwd: app.currentWorkspacePath(),
+          }];
+          app.openTabIds = [...app.openTabIds, other];
+          app._ensureTabState(other)._loaded = true;
+          app.selected = 'notes/a.md';
+          app.currentId = other;
+          app.onPreviewViewportScroll();
+          await new Promise(resolve => app.$nextTick(resolve));
+          const switched = {
+            show: app.previewQuote.show,
+            mode: app.previewQuote.mode,
+            question: app.previewQuote.question,
+          };
+          app.currentId = source;
+          app.openTabIds = app.openTabIds.filter(id => id !== other);
+          app.sessions = app.sessions.filter(row => row.id !== other);
+          delete app.tabState[other];
+          await new Promise(resolve => app.$nextTick(resolve));
+          return switched;
+        }"""
+    )
+    assert state == {
+        "show": True,
+        "mode": "ask",
+        "question": "FLOATING_QUESTION_DRAFT",
+    }
+    expect(popover).to_be_visible()
+
+    page.locator(".preview-selection-ask:visible .preview-selection-close").click()
+    expect(popover).to_be_hidden()
 
 
 def test_selection_side_question_window_drags_by_header_and_stays_in_view(

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -5,6 +5,7 @@ with fake clients, so the route logic (4-tuple key handling, disconnect
 fan-out, response shape) runs for real without spawning a CLI.
 """
 import asyncio
+import json
 import os
 from types import SimpleNamespace
 
@@ -378,7 +379,7 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
     """Stop must work before get_client() has produced a cached client."""
     from backend import activity as activity_module
 
-    sid = "sid-cold-start"
+    sid = "00000000-0000-4000-8000-000000000042"
     startup_entered = asyncio.Event()
     activity_transitions = []
 
@@ -397,6 +398,7 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
         lambda _sid: {"model": "glm-5.2-internal", "effort": ""},
     )
     monkeypatch.setattr(chat_mod.sess, "update_permission", lambda *_a: True)
+    monkeypatch.setattr(chat_mod.sess, "bump_session", lambda *_a, **_kw: True)
     monkeypatch.setattr(
         activity_module.activity,
         "start",
@@ -424,6 +426,10 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
     assert broadcast.cancelled is True
     assert broadcast.done is True
     assert [event["event"] for event in broadcast.replay_events()] == ["cancelled"]
+    cancelled_payload = json.loads(next(broadcast.replay_events())["data"])
+    assert cancelled_payload["snapshot_ready"] is True
+    snapshots, _ = chat_mod._load_cancelled_turn_snapshots(sid)
+    assert [message["text"] for message in snapshots[0]["messages"]] == ["stop me"]
     assert sid not in chat_mod._active_turns
     assert sid not in chat_mod._clients
     assert activity_transitions == [
@@ -433,6 +439,7 @@ async def test_interrupt_cancels_cold_client_startup_immediately(
     recent = chat_mod._recent_turns.pop(sid, None)
     if recent is not None:
         recent.close()
+    chat_mod._delete_cancelled_turn_snapshots(sid)
 
 
 def test_interrupt_pauses_nonempty_queue_before_sdk_call(chat_mod, client):
@@ -526,6 +533,90 @@ async def test_force_stop_noop_when_turn_drained_naturally(chat_mod):
     # _active_turns no longer holds it (the pump's finally popped it).
     await chat_mod._force_stop_after_grace(sid, bc, grace=0.01)
     assert c.disconnected is False
+
+
+def test_cancelled_turn_snapshot_survives_reload_export_and_delete(
+    chat_mod, client, auth,
+):
+    """A force-stopped turn is display history even when no CLI JSONL exists."""
+    created = client.post(
+        "/api/chat/sessions",
+        headers=auth,
+        json={"name": "cancel snapshot", "model": "claude-sonnet-4-6"},
+    )
+    assert created.status_code == 200, created.text
+    sid = created.json()["id"]
+    bc = chat_mod.TurnBroadcast(sid, model="claude-sonnet-4-6")
+    bc.user_text = "keep this interrupted prompt"
+    bc.cancelled = True
+    bc.publish({
+        "event": "text",
+        "data": '{"text":"partial assistant text"}',
+    })
+    bc.publish({
+        "event": "thinking",
+        "data": '{"text":"partial reasoning"}',
+    })
+    bc.publish({
+        "event": "tool_use",
+        "data": (
+            '{"name":"Read","id":"toolu_cancelled",'
+            '"summary":"notes.md","input":{"file_path":"notes.md"}}'
+        ),
+    })
+    bc.publish({
+        "event": "tool_result",
+        "data": (
+            '{"id":"toolu_cancelled","tool_name":"Read",'
+            '"preview":"line one","text":"line one\\nline two",'
+            '"truncated":false,"text_truncated":false,"is_error":false}'
+        ),
+    })
+
+    try:
+        assert chat_mod._persist_cancelled_turn_snapshot(bc) is True
+        path = chat_mod._cancelled_turn_snapshot_path(sid, bc.turn_id)
+        assert path is not None and path.exists()
+        assert path.parent.stat().st_mode & 0o777 == 0o700
+        assert path.stat().st_mode & 0o777 == 0o600
+
+        first = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+        assert first.status_code == 200, first.text
+        body = first.json()
+        messages = body["messages"]
+        assert [message["role"] for message in messages] == [
+            "user", "assistant", "thinking", "tool_use", "tool_result",
+        ]
+        assert messages[0]["text"] == "keep this interrupted prompt"
+        assert messages[1]["text"] == "partial assistant text"
+        assert messages[3]["id"] == "toolu_cancelled"
+        assert messages[4]["text"] == "line one\nline two"
+        assert all(message["_interrupted"] is True for message in messages)
+        assert len({message["_key"] for message in messages}) == len(messages)
+        assert "~cancelled-" in body["history_generation"]
+        assert body["message_count"] == len(messages)
+        assert body["turn_count"] == 1
+
+        # Disk, not _active_turns/_recent_turns, is the recovery source.
+        chat_mod._active_turns.pop(sid, None)
+        chat_mod._recent_turns.pop(sid, None)
+        second = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+        assert second.status_code == 200, second.text
+        assert second.json()["messages"] == messages
+
+        exported = client.get(
+            f"/api/chat/sessions/{sid}/export?token={TEST_TOKEN}")
+        assert exported.status_code == 200, exported.text
+        assert "keep this interrupted prompt" in exported.text
+        assert "partial assistant text" in exported.text
+
+        deleted = client.delete(f"/api/chat/sessions/{sid}", headers=auth)
+        assert deleted.status_code == 200, deleted.text
+        assert not path.exists()
+    finally:
+        bc.close()
 
 
 # ====== probe_provider ======

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -813,6 +813,7 @@ def test_fork_inherits_session_settings_and_records_lineage(
     )
     assert source.status_code == 200, source.text
     sid = source.json()["id"]
+    assert source.json()["activity_hidden"] is False
     chat_mod.sess.update_permission(sid, "plan")
     chat_mod.sess.update_effort(sid, "high")
     chat_mod.sess.update_service_tier(sid, "fast")
@@ -828,7 +829,12 @@ def test_fork_inherits_session_settings_and_records_lineage(
     response = client.post(
         f"/api/chat/sessions/{sid}/fork",
         headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
-        json={"up_to_message_id": boundary, "title": "source chat · 分支"},
+        json={
+            "up_to_message_id": boundary,
+            "title": "source chat · 分支",
+            "activity_hidden": True,
+            "runtime_profile": "side_question",
+        },
     )
 
     assert response.status_code == 200, response.text
@@ -849,6 +855,8 @@ def test_fork_inherits_session_settings_and_records_lineage(
     assert body["forked_from"] == sid
     assert body["forked_from_name"] == "source chat"
     assert body["forked_from_message_id"] == boundary
+    assert body["activity_hidden"] is True
+    assert body["runtime_profile"] == "side_question"
     assert body["cwd"] == source.json()["cwd"]
 
 

--- a/tests/test_chat_options.py
+++ b/tests/test_chat_options.py
@@ -162,6 +162,37 @@ def test_non_bypass_runtime_installs_permission_resolver(
     assert callable(captured["can_use_tool"])
 
 
+def test_side_question_runtime_exposes_only_public_web_tools(
+    app_module, monkeypatch, tmp_path,
+):
+    from backend import chat as chat_mod
+    from backend import endpoints, sessions as sess
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    monkeypatch.delenv("MUSELAB_DISABLE_SKILLS", raising=False)
+    monkeypatch.setattr(endpoints, "_VENDOR_CONFIG_DIR", tmp_path / "vendor-cfg")
+    side = sess.create_session(
+        "side question",
+        model="deepseek-v4-pro",
+        permission="default",
+        activity_hidden=True,
+        runtime_profile="side_question",
+    )
+    captured = _capture_build_options(chat_mod, monkeypatch)
+
+    asyncio.run(chat_mod._build_and_connect_client(
+        side["id"], "deepseek-v4-pro", "default", ""))
+
+    assert captured["tools"] == ["WebSearch", "WebFetch"]
+    assert captured["allowed_tools"] == ["WebSearch", "WebFetch"]
+    assert captured["setting_sources"] == []
+    assert captured["plugins"] == []
+    assert captured["mcp_servers"] == {}
+    assert "skills" not in captured
+    assert "can_use_tool" not in captured
+    assert "UserPromptSubmit" not in captured["hooks"]
+
+
 def test_plan_runtime_can_return_to_bypass_and_installs_exit_hooks(
     app_module, monkeypatch, tmp_path,
 ):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -130,13 +130,26 @@ def test_set_queue_paused_toggles(app_module):
     assert sess.set_queue_paused(sid, False)["paused"] is False
 
 
-def test_pause_empty_queue_persists_flag(app_module):
-    """Pausing an empty queue still records paused=True (the file is written
-    because paused is truthy even with no items)."""
+def test_pause_empty_queue_is_a_noop(app_module):
+    """A pause cannot outlive (or predate) the work it protects."""
     sess = _sess(app_module)
     sid = "s-pause-empty"
-    sess.set_queue_paused(sid, True)
-    assert sess.get_queue(sid)["paused"] is True
+    assert sess.set_queue_paused(sid, True)["paused"] is False
+    assert sess.get_queue(sid) == {"items": [], "paused": False}
+    assert not sess._queue_path(sid).exists()
+
+
+def test_legacy_empty_paused_queue_is_normalized_before_next_enqueue(app_module):
+    """Upgrade an already-stranded queue instead of only preventing new ones."""
+    sess = _sess(app_module)
+    sid = "s-legacy-empty-paused"
+    sess._queue_path(sid).write_text(
+        '{"items": [], "paused": true}', encoding="utf-8",
+    )
+
+    assert sess.get_queue(sid) == {"items": [], "paused": False}
+    sess.enqueue_message(sid, "fresh after upgrade")
+    assert sess.dequeue_message(sid)["text"] == "fresh after upgrade"
 
 
 def test_remove_queue_item(app_module):

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -239,6 +239,7 @@ def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypa
     annotations = chat_mod.sess.get_message_annotations(sid)
     assert annotations["assistant-final-uuid"]["ts"] == done["completed_at_ms"]
     assert annotations["assistant-final-uuid"]["elapsed_s"] == 1.5
+    assert annotations["assistant-final-uuid"]["turn_status"] == "completed"
 
     # Turn reservation released after completion.
     assert sid not in chat_mod._active_turns
@@ -295,6 +296,125 @@ def test_tool_only_turn_persists_completion_annotation(
     annotations = chat_mod.sess.get_message_annotations(sid)
     assert annotations[assistant_uuid]["ts"] == done["completed_at_ms"]
     assert annotations[assistant_uuid]["elapsed_s"] == 2.5
+    assert annotations[assistant_uuid]["turn_status"] == "completed"
+    persisted = chat_mod._RawMsg(
+        assistant_uuid,
+        "assistant",
+        {"content": [{
+            "type": "tool_use", "id": "tu_tool_only", "name": "Read",
+            "input": {"file_path": "/tmp/tool-only.txt"},
+        }]},
+    )
+    shaped = chat_mod._sdk_messages_to_ui([persisted], annotations)
+    assert shaped[-1]["role"] == "tool_use"
+    assert shaped[-1]["model"] == "claude-sonnet-4-6"
+    assert shaped[-1]["turn_status"] == "completed"
+
+
+def test_forced_interrupt_persists_refreshable_footer_and_private_snapshot(
+        stream_env, client):
+    """A Result-less forced stop must retain its footer after a reload."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    bc = chat_mod.TurnBroadcast(
+        session_id=sid, model="codex:gpt-5.6-sol")
+    bc.user_text = "interrupt fixture"
+    bc.cancelled = True
+    bc.last_assistant_uuid = "assistant-interrupted-exact-uuid"
+    bc.started_at = 1_700_000_000.0
+    bc.cancelled_at_ms = 1_700_000_004_200
+    bc.publish({
+        "event": "text",
+        "data": json.dumps({"text": "partial answer"}),
+    })
+
+    assert chat_mod._persist_cancelled_turn_snapshot(bc) is True
+
+    annotations = chat_mod.sess.get_message_annotations(sid)
+    footer = annotations[bc.last_assistant_uuid]
+    assert footer == {
+        "model": "codex:gpt-5.6-sol",
+        "ts": bc.cancelled_at_ms,
+        "turn_status": "cancelled",
+        "elapsed_s": 4.2,
+    }
+    snapshots, generation = chat_mod._load_cancelled_turn_snapshots(sid)
+    assert generation
+    assert len(snapshots) == 1
+    tail = snapshots[0]["messages"][-1]
+    assert tail["role"] == "assistant"
+    assert tail["text"] == "partial answer"
+    assert tail["model"] == "codex:gpt-5.6-sol"
+    assert tail["turn_status"] == "cancelled"
+    assert tail["ts"] == bc.cancelled_at_ms
+    assert tail["elapsed"] == 4.2
+
+    path = chat_mod._cancelled_turn_snapshot_path(sid, bc.turn_id)
+    assert path is not None and path.exists()
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_activity_hidden_turn_never_enters_global_task_center(
+        stream_env, client, monkeypatch):
+    """A lightweight side branch streams normally without ledger mutations."""
+    from backend import activity as activity_module
+
+    chat_mod = stream_env
+    created = client.post(
+        "/api/chat/sessions",
+        headers={
+            "X-Auth-Token": TEST_TOKEN,
+            "Content-Type": "application/json",
+        },
+        json={
+            "name": "side question fixture",
+            "model": "claude-sonnet-4-6",
+            "activity_hidden": True,
+        },
+    )
+    assert created.status_code == 200, created.text
+    sid = created.json()["id"]
+    assistant_uuid = "activity-hidden-assistant"
+    messages = [
+        AssistantMessage(
+            content=[TextBlock(text="lightweight answer")],
+            model="claude-sonnet-4-6",
+            usage={},
+            uuid=assistant_uuid,
+        ),
+        ResultMessage(
+            subtype="success", duration_ms=1100, duration_api_ms=1000,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0, usage={},
+        ),
+    ]
+
+    async def fake_get_client(
+        session_id, model, permission="bypassPermissions", effort="", service_tier="",
+    ):
+        return _FakeStreamClient(messages)
+
+    def forbidden_activity(*_args, **_kwargs):
+        raise AssertionError("activity ledger must ignore lightweight branch")
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        chat_mod,
+        "_recent_turn_uuids",
+        lambda _sid, _want_image_user: (assistant_uuid, "hidden-user"),
+    )
+    monkeypatch.setattr(activity_module.activity, "start", forbidden_activity)
+    monkeypatch.setattr(activity_module.activity, "finish", forbidden_activity)
+    monkeypatch.setattr(activity_module.activity, "set_state", forbidden_activity)
+
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        f"&prompt=ask&model=claude-sonnet-4-6&permission=default"
+    )
+    assert response.status_code == 200, response.text
+    assert any(event == "done" for event, _ in _parse_sse(response.text))
+    assert chat_mod.sess.get_session(sid)["activity_hidden"] is True
 
 
 def test_done_is_published_before_slow_post_turn_bookkeeping(
@@ -487,6 +607,60 @@ def test_activity_stays_running_until_background_continuation_finishes(
         recent = chat_mod._recent_turns.pop(sid, None)
         if recent is not None:
             recent.close()
+        chat_mod._delete_active_turn_sidecar(sid)
+
+
+@pytest.mark.parametrize(
+    ("deferred_status", "expected_status"),
+    [("completed", "failed"), ("cancelled", "cancelled")],
+)
+def test_background_stream_eof_releases_dead_task_and_closes_activity(
+        stream_env, monkeypatch, deferred_status, expected_status):
+    """A closed CLI can never deliver the pending task's terminal marker.
+
+    This is the force-teardown path behind the stale yellow tab / Activity
+    Center row: unlike watcher replacement, the watcher is not cancelled; its
+    shared stream ends cleanly with EOF while the task pin is still present.
+    """
+    from backend import activity as activity_module
+
+    chat_mod = stream_env
+    sid = f"sid-eof-{deferred_status}"
+    task_id = f"task-eof-{deferred_status}"
+    transitions = []
+
+    class _ClosedClient:
+        async def receive_messages(self):
+            if False:  # pragma: no cover - make this an async generator
+                yield None
+
+    async def exercise():
+        chat_mod._pin_background_task(sid, task_id)
+        chat_mod._bg_task_descriptions[task_id] = "sleep 30"
+        chat_mod._background_activity_finishes[sid] = deferred_status
+        await chat_mod._watch_inflight_tasks(
+            sid, _ClosedClient(), {task_id: "sleep 30"})
+
+    monkeypatch.setattr(
+        activity_module.activity,
+        "finish",
+        lambda activity_sid, status: transitions.append(
+            (activity_sid, status)),
+    )
+    try:
+        asyncio.run(exercise())
+        assert transitions == [(sid, expected_status)]
+        assert sid not in chat_mod._sessions_with_inflight_tasks
+        assert sid not in chat_mod._background_activity_finishes
+        assert task_id not in chat_mod._bg_task_descriptions
+        assert task_id not in chat_mod._bg_task_pinned_at
+    finally:
+        chat_mod._sessions_with_inflight_tasks.pop(sid, None)
+        chat_mod._background_activity_finishes.pop(sid, None)
+        chat_mod._bg_task_descriptions.pop(task_id, None)
+        chat_mod._bg_task_pinned_at.pop(task_id, None)
+        chat_mod._background_turn_started_at.pop(sid, None)
+        chat_mod._background_origin_turn_id.pop(sid, None)
         chat_mod._delete_active_turn_sidecar(sid)
 
 
@@ -1037,7 +1211,7 @@ def test_watcher_opens_continuation_turn_and_unpins(stream_env):
         model="claude-sonnet-4-6", usage={},
         uuid="continuation-assistant-uuid")
     result = ResultMessage(
-        subtype="success", duration_ms=120, duration_api_ms=100,
+        subtype="success", duration_ms=1120, duration_api_ms=1100,
         is_error=False, num_turns=1, session_id=sid,
         total_cost_usd=0.0, usage={})
     fake_client = _FakeWatchClient([notif, reaction, result])
@@ -1061,7 +1235,7 @@ def test_watcher_opens_continuation_turn_and_unpins(stream_env):
         assert kinds[-1] == "done", f"missing terminal done: {kinds}"
         done_ev = next(e for e in bc.events if e.get("event") == "done")
         done = json.loads(done_ev["data"])
-        assert done["duration_ms"] == 120
+        assert done["duration_ms"] == 1120
         assert done["assistant_uuid"] == "continuation-assistant-uuid"
         assert isinstance(done["completed_at_ms"], int)
         assert done["completed_at_ms"] > 0
@@ -1074,6 +1248,13 @@ def test_watcher_opens_continuation_turn_and_unpins(stream_env):
         assert payload["tool_use_id"] == "tu"
         assert payload["status"] == "completed"
         assert payload["output_file"] == "/tmp/o.md"
+        annotations = chat_mod.sess.get_message_annotations(sid)
+        assert annotations["continuation-assistant-uuid"] == {
+            "model": done["model"],
+            "ts": done["completed_at_ms"],
+            "turn_status": "completed",
+            "elapsed_s": 1.1,
+        }
         # All pending settled → pin released, client reclaimable.
         assert sid not in chat_mod._sessions_with_inflight_tasks
         assert sid not in chat_mod._task_watchers
@@ -1087,14 +1268,20 @@ def test_watcher_opens_continuation_turn_and_unpins(stream_env):
 
 
 def test_continuation_terminal_precedes_annotation_bookkeeping(stream_env):
-    """The footer terminal event must not wait for transcript sidecars."""
+    """Queue done, annotate its exact UUID, then release the event loop."""
     import inspect
 
     source = inspect.getsource(stream_env._watch_inflight_tasks)
     done_at = source.index(
         'b.publish({"event": "done", "data": json.dumps(done_payload)})')
-    annotate_at = source.index("_recent_turn_uuids, session_id, False")
+    annotate_at = source.index("sess.set_message_annotation(", done_at)
+    finish_at = source.index("b.finish()", annotate_at)
     assert done_at < annotate_at
+    assert annotate_at < finish_at
+    close_source = source[source.index("async def _close_continuation"):finish_at]
+    assert "_recent_turn_uuids" not in close_source
+    assert "asyncio.to_thread" not in close_source
+    assert '(state or {}).get("assistant_uuid")' in close_source
     assert stream_env._CONTINUATION_GRACE <= 8
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -231,7 +231,7 @@ def test_preview_selection_quote_attachment_and_side_question_are_safely_wired()
     assert 'class="selection-quote-chip"' in html
     assert '@click="removePendingQuote(i)"' in html
     assert "将展开为独立侧问" in html
-    assert "不写入当前会话" in html
+    assert "独立多轮 · 可网页搜索" in html
     assert '@click="openPreviewSelectionAskSession()"' in html
     assert 'x-ref="previewSelectionPopover"' in html
     assert '@pointerdown="startPreviewQuoteDrag($event)"' in html
@@ -281,6 +281,48 @@ def test_preview_selection_quote_attachment_and_side_question_are_safely_wired()
     assert 'permissionMode: "default"' in ask
     assert "this.dismissPreviewQuote(true)" not in ask
     assert "newSession" not in ask
+
+
+def test_side_question_stays_floating_and_is_hidden_from_activity_center():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    chat = (BACKEND / "chat.py").read_text(encoding="utf-8")
+    sessions = (BACKEND / "sessions.py").read_text(encoding="utf-8")
+
+    transient_start = app.index("\n    dismissTransientPreviewQuote(") + 1
+    transient_end = app.index("\n    dismissPreviewQuote(", transient_start)
+    transient = app[transient_start:transient_end]
+    assert 'this.previewQuote.mode === "ask"' in transient
+    assert "return false" in transient
+
+    selection_start = app.index("_initPreviewSelection()")
+    selection_end = app.index("\n    _previewQuoteElement()", selection_start)
+    selection = app[selection_start:selection_end]
+    assert "if (!inPopover) this.dismissTransientPreviewQuote(false)" in selection
+    assert "if (!inPopover && this.previewQuote.show) this.dismissPreviewQuote" not in selection
+    for owner_change in (
+        'this.$watch("currentId"',
+        'this.$watch("selected"',
+        "onPreviewViewportScroll()",
+        "async openFile(n, opts = {})",
+    ):
+        start = app.index(owner_change)
+        assert "dismissTransientPreviewQuote" in app[start:start + 700]
+
+    create_start = app.index("async _createPreviewSelectionAskSession(")
+    create_end = app.index("\n    previewSelectionAskMessages()", create_start)
+    create = app[create_start:create_end]
+    assert create.count("activity_hidden: true") >= 3
+    assert create.count('runtime_profile: "side_question"') >= 3
+    assert "sendPreviewSelectionFollowup()" in app
+    assert "previewSelectionAskConversation()" in app
+    assert "WebSearch or WebFetch" in app
+    assert "preview-selection-followup" in html
+    assert "activity_hidden: bool = False" in chat
+    assert "broadcast.activity_hidden = bool" in chat
+    assert "if broadcast.activity_hidden:" in chat
+    assert "and not broadcast.activity_hidden" in chat
+    assert '"activity_hidden": bool(m.get("activity_hidden", False))' in sessions
 
 
 def test_mobile_preview_captures_before_hiding_and_pins_tree_taps():
@@ -361,6 +403,10 @@ def test_enter_submission_waits_for_ime_composition():
     assert "target._museImeEndedAt" in ime
     assert "eventAt - endedAt <= 80" in ime
     assert helper.index("return false") < helper.index("ev.preventDefault()")
+    assert "_museImeOriginalForceModelUpdate" in app
+    assert "target._x_forceModelUpdate = value =>" in app
+    assert "this._finishImeComposition(target)" in app
+    assert "if (this.input !== target.value) this.input = target.value" in app
 
     assert '@keydown.enter="confirmModalOnEnter($event)"' in html
     assert '@keydown.enter="commitRenameTabOnEnter($event)"' in html
@@ -461,10 +507,48 @@ def test_desktop_layout_is_files_chat_preview_with_one_canonical_chat_dom():
     assert "rightWidth: 440" not in app
     assert "leftOpen: this.leftOpen, previewOpen: this.previewOpen" in app
     assert "leftWidth: this.leftWidth, previewWidth: this.previewWidth" in app
-    assert 'schema: 8' in app
+    assert 'leftWidth: 340' in app
+    assert 'schema: 9' in app
+    assert 'Math.abs(p.leftWidth - 280) <= 1' in app
     assert 'else if (typeof p.rightWidth === "number")' in app
     assert 'if (next === "preview") this.previewOpen = true;' in app
     assert "btn.hide_preview" in i18n and "btn.show_preview" in i18n
+
+
+def test_external_file_drop_is_global_root_by_default_and_directory_explicit():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    listener_start = app.index("// Document-level OS-file-drag detection")
+    listener_end = app.index("// HTML preview bridge", listener_start)
+    listeners = app[listener_start:listener_end]
+    assert 'document.addEventListener("drop", (e) =>' in listeners
+    assert "this._externalFileDropTarget(e.target)" in listeners
+    assert "this._uploadFilesToDir(dropTarget.dir, files)" in listeners
+    assert "e.stopPropagation()" in listeners
+    assert "}, true);" in listeners
+
+    target_start = app.index("_externalFileDropTarget(target)")
+    target_end = app.index("\n    async upload(ev)", target_start)
+    target = app[target_start:target_end]
+    assert '.closest(".filelist li.dir[data-path]")' in target
+    assert 'dir: row ? String(row.dataset.path || "") : ""' in target
+
+    attach_start = app.index("async onAttachDrop(ev)")
+    attach_end = app.index("\n    async onImagePaste", attach_start)
+    attach = app[attach_start:attach_end]
+    assert 'this._uploadFilesToDir("", files)' in attach
+    assert "_attachFile" not in attach
+
+    drop_start = app.index("async onDrop(ev, n)")
+    drop_end = app.index("\n    // Parallel-upload", drop_start)
+    tree_drop = app[drop_start:drop_end]
+    assert 'this._uploadFilesToDir(n.is_dir ? n.path : "", files)' in tree_drop
+    assert 'class="global-file-drop-overlay"' in html
+    assert "上传到工作区根目录" in html
+    assert ".global-file-drop-overlay" in css
+    assert "pointer-events: none" in css
 
     nav = html[html.index('<nav class="mobile-tab-bar"'):
                html.index("</nav>", html.index('<nav class="mobile-tab-bar"'))]
@@ -1412,7 +1496,9 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
 
     assert 'x-show="isTabStreaming(currentId)"' in html
     assert "chat-toolbar-stop" in html
-    assert ':title="_isBusy(currentId) ? t(\'queue.button_hint\')' in html
+    assert "tabState[currentId]?._stopping" in html
+    assert "等待上一条任务完成中断" in html
+    assert "_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')" in html
     assert "撤回队尾" not in html
     assert "removePendingQueueItem" not in stop
     assert "if (st._stopping) return" in stop
@@ -1428,7 +1514,8 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     cancelled_start = app.index('es.addEventListener("cancelled"')
     cancelled_end = app.index("\n      });", cancelled_start)
     cancelled = app[cancelled_start:cancelled_end]
-    assert "_markDone(true, false, true)" in cancelled
+    assert "_markDone(true, false, true, {" in cancelled
+    assert 'turnStatus: "cancelled"' in cancelled
     assert "d.snapshot_ready" in cancelled
     assert "streamState._seenUpdated = undefined" in cancelled
     assert "quiet: true" in cancelled
@@ -2388,7 +2475,8 @@ def test_chat_send_and_stop_buttons_are_icon_only_but_accessible():
     buttons = html[toolbar_start:toolbar_end]
     assert 'x-text="t(\'btn.send\')"' not in buttons
     assert 'x-text="t(\'btn.stop\')"' not in buttons
-    assert ':aria-label="_isBusy(currentId) ? t(\'queue.button_hint\') : t(\'btn.send\')"' in buttons
+    assert "tabState[currentId]?._stopping" in buttons
+    assert "_isBusy(currentId) ? t('queue.button_hint') : t('btn.send')" in buttons
     assert ':aria-label="t(\'btn.stop\')"' in buttons
     assert ".chat-toolbar-send { width: 44px; padding: 0; }" in css
     assert ".chat-toolbar-send > span:nth-child(2)" not in css
@@ -2634,6 +2722,65 @@ def test_turn_footer_is_a_separator_and_no_longer_hosts_streaming_dots():
     # full width.
     assert "padding: 4px 0 6px 40px;" not in css
     assert "padding: 2px 0 3px 34px;" not in css
+
+
+def test_turn_footer_falls_back_to_transcript_time_and_shows_model_and_state():
+    """Historic/tool-ending turns must not render as an empty separator."""
+    chat = (BACKEND / "chat.py").read_text(encoding="utf-8")
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    footer = html[html.index('<div class="turn-footer"'):]
+    footer = footer[:footer.index('<button class="turn-fork-btn"')]
+    assert "turnFooterTime(m, pane)" in footer
+    assert "turnFooterElapsed(m, pane)" in footer
+    assert "turnFooterStatus(m, pane)" in footer
+    assert 'class="turn-model"' in footer
+    assert 'class="turn-status"' in footer
+    assert "modelLabel(turnFooterModel(m, pane, tid))" in footer
+    assert 'entry["model"] = model_name' in chat
+    assert 'entry["turn_status"] = turn_status' in chat
+    assert "turn_status=_activity_status" in chat
+    assert "def _complete_turn_footer_metadata(" in chat
+    assert 'tail["turn_status"] = status' in chat
+
+    mark_start = app.index("const _markDone = (")
+    mark_end = app.index("\n      const markUserFailed", mark_start)
+    mark = app[mark_start:mark_end]
+    assert "if (!m.model && completedModel) m.model = completedModel" in mark
+    assert 'm.turn_status === "running"' in mark
+    assert "m.turn_status = turnStatus" in mark
+    assert "if (!m.memoryRecall && memoryRecall)" in mark
+    assert "if (!tailCandidate && lastUserCandidate && turnStatus)" in mark
+    assert "m.role !== 'user' || m.turn_status || m._interrupted || m._failed" in footer
+
+
+def test_queue_controls_validate_mutations_and_block_send_during_interrupt():
+    """A failed DELETE must not become an editable duplicate."""
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    chat = (BACKEND / "chat.py").read_text(encoding="utf-8")
+
+    helper_start = app.index("async _runQueueMutation(")
+    helper_end = app.index("\n    async _enqueueMessage", helper_start)
+    helper = app[helper_start:helper_end]
+    assert "if (!r.ok) throw" in helper
+    assert "queueActionBusy(sid, key)" in helper
+
+    edit_start = app.index("async editPendingQueueItem(")
+    edit_end = app.index("\n    async resumeQueueDrain", edit_start)
+    edit = app[edit_start:edit_end]
+    assert "if (!r) return;" in edit
+    assert edit.index("if (!r) return;") < edit.index("draft.input = displayText")
+
+    send_start = app.index("async send(opts = {})")
+    send_end = app.index("\n    // ====== ask_user_question", send_start)
+    send = app[send_start:send_end]
+    assert "if (sendState._stopping && !opts.reconnect && !opts.resumedItem)" in send
+    assert "tabState[currentId]?._stopping" in html
+    assert "queueActionBusy(currentId, 'edit:' + q.id)" in html
+    assert "queueActionBusy(currentId, 'remove:' + q.id)" in html
+    assert "sess.pause_queue_if_nonempty(session_id)" in chat
 
 
 def test_per_message_timestamps_are_plumbed_but_only_shown_on_expand():

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -350,19 +350,25 @@ def test_enter_submission_waits_for_ime_composition():
     helper_start = app.index("_claimNonImeEnter(ev)")
     helper_end = app.index("\n    },", helper_start)
     helper = app[helper_start:helper_end]
-    ime_start = app.index("_isImeComposingEvent(ev)")
+    ime_start = app.index("    _isImeComposingEvent(ev) {")
     ime_end = app.index("\n    },", ime_start)
     ime = app[ime_start:ime_end]
     assert "ev.isComposing" in ime
     assert "ev.keyCode === 229" in ime
     assert "ev.which === 229" in ime
     assert 'ev.key === "Process"' in ime
+    assert "target._museImeComposing" in ime
+    assert "target._museImeEndedAt" in ime
+    assert "eventAt - endedAt <= 80" in ime
     assert helper.index("return false") < helper.index("ev.preventDefault()")
 
     assert '@keydown.enter="confirmModalOnEnter($event)"' in html
     assert '@keydown.enter="commitRenameTabOnEnter($event)"' in html
     assert '@keydown.enter="pickerCommitInlineRenameOnEnter($event)"' in html
     assert '@keydown.enter="onEnter($event)"' in html
+    assert '@compositionstart="onImeCompositionStart($event)"' in html
+    assert '@compositionend="onImeCompositionEnd($event)"' in html
+    assert '@blur="onChatInputBlur($event)"' in html
     assert '@keydown.enter.prevent="commitRenameTab()"' not in html
     assert '@keydown.enter.prevent="pickerCommitInlineRename()"' not in html
     assert '@keydown.enter.prevent.stop="onEnter($event)"' not in html
@@ -1421,7 +1427,12 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     assert "if (!waitForTerminalEvent || !st.streaming)" in stop
     cancelled_start = app.index('es.addEventListener("cancelled"')
     cancelled_end = app.index("\n      });", cancelled_start)
-    assert "_markDone(true, false, true)" in app[cancelled_start:cancelled_end]
+    cancelled = app[cancelled_start:cancelled_end]
+    assert "_markDone(true, false, true)" in cancelled
+    assert "d.snapshot_ready" in cancelled
+    assert "streamState._seenUpdated = undefined" in cancelled
+    assert "quiet: true" in cancelled
+    assert "probeActive: false" in cancelled
     mark_done_start = app.index("const _markDone = (")
     mark_done_end = app.index("\n      };", mark_done_start)
     assert "streamState._stopping = false" in app[

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -427,6 +427,33 @@ def test_annotation_partial_update_preserves_other_fields(app_module):
     assert anns["uuid-x"]["images"] == [{"mime": "image/png"}]
 
 
+def test_cancelled_annotation_is_not_downgraded_by_late_completion(app_module):
+    """User cancellation and its click-time metrics are monotonic truth."""
+    from backend import sessions as sess
+
+    sid = sess.create_session()["id"]
+    sess.set_message_annotation(
+        sid, "uuid-late",
+        turn_status="cancelled", ts=1_700_000_002_000, elapsed_s=2.0,
+        model="codex:gpt-5.6-sol",
+    )
+    # A late ResultMessage may still contribute cost/model, but it cannot turn
+    # the footer green or move its boundary several seconds past the click.
+    sess.set_message_annotation(
+        sid, "uuid-late",
+        cost="$0.0100", model="codex:gpt-5.6-sol",
+        ts=1_700_000_009_000, turn_status="completed", elapsed_s=9.0,
+    )
+    annotation = sess.get_message_annotations(sid)["uuid-late"]
+    assert annotation == {
+        "turn_status": "cancelled",
+        "ts": 1_700_000_002_000,
+        "elapsed_s": 2.0,
+        "model": "codex:gpt-5.6-sol",
+        "cost": "$0.0100",
+    }
+
+
 def test_session_usage_endpoint_returns_meter_data(client, auth, app_module):
     r = client.get("/api/chat/usage/never-existed?model=claude-opus-4-7",
                     headers=auth)
@@ -673,6 +700,37 @@ def test_create_session_leaves_model_empty_when_no_provider(app_module, monkeypa
     monkeypatch.setattr(endpoints, "has_anthropic_auth", lambda: False)
     meta = chat.create_session_api(chat.CreateReq(name="fresh", model=""))
     assert (meta.get("model") or "") == ""
+
+
+def test_lightweight_session_persists_activity_hidden(app_module):
+    from backend import sessions as sess
+
+    hidden = sess.create_session("side question", activity_hidden=True)
+    normal = sess.create_session("normal chat")
+
+    assert hidden["activity_hidden"] is True
+    assert sess.get_session(hidden["id"])["activity_hidden"] is True
+    listed = {row["id"]: row for row in sess.list_sessions()}
+    assert listed[hidden["id"]]["activity_hidden"] is True
+    assert normal["activity_hidden"] is False
+    assert listed[normal["id"]]["activity_hidden"] is False
+
+
+def test_side_question_runtime_profile_is_durable_and_closed(app_module):
+    from backend import sessions as sess
+
+    side = sess.create_session(
+        "side question",
+        activity_hidden=True,
+        runtime_profile="side_question",
+    )
+    assert side["runtime_profile"] == "side_question"
+    assert sess.get_session(side["id"])["runtime_profile"] == "side_question"
+    listed = {row["id"]: row for row in sess.list_sessions()}
+    assert listed[side["id"]]["runtime_profile"] == "side_question"
+
+    with pytest.raises(ValueError, match="invalid runtime profile"):
+        sess.create_session("unsafe", runtime_profile="workspace_agent")
 
 
 def test_reset_session_endpoint(client, auth):

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -385,6 +385,134 @@ def test_window_endpoint_interleaves_cancelled_snapshot_at_original_anchor(
     ]
 
 
+def test_late_canonical_flush_keeps_interrupted_footer_after_refresh(
+    client, auth, app_module, tmp_path,
+):
+    """A delayed AssistantMessage must inherit the earlier interrupt truth.
+
+    This reproduces the live race: Stop renders an interrupted footer while
+    the CLI is being torn down, the browser refreshes, and only then does the
+    canonical assistant row reach JSONL.  It must not be inferred completed
+    merely because a later user turn now follows it.
+    """
+    from backend import chat as chat_mod
+
+    initial = [
+        _entry("u0", "user", "before",
+               timestamp="2024-01-01T00:00:00.000Z"),
+        _entry("a0", "assistant", "before answer", "u0",
+               timestamp="2024-01-01T00:00:00.500Z"),
+    ]
+    sid, transcript = _make_endpoint_session(
+        client, auth, chat_mod, tmp_path, initial)
+    _, boundary = chat_mod._turn_transcript_boundary(
+        sid, "claude-sonnet-4-6")
+    bc = chat_mod.TurnBroadcast(
+        session_id=sid, model="codex:gpt-5.6-sol")
+    bc.user_text = "repeatable prompt"
+    bc.started_at = 1_704_067_201.0
+    bc.cancelled_at_ms = 1_704_067_202_500
+    bc.cancelled = True
+    bc.canonical_terminal_published = True
+    bc.transcript_boundary = boundary
+    bc.publish({
+        "event": "text",
+        "data": json.dumps({"text": "live partial"}),
+    })
+
+    try:
+        # No AssistantMessage UUID exists yet.  The canonical-terminal flag
+        # must no longer suppress the temporary interrupted snapshot.
+        assert chat_mod._persist_cancelled_turn_snapshot(bc) is True
+        snapshot_path = chat_mod._cancelled_turn_snapshot_path(sid, bc.turn_id)
+        assert snapshot_path is not None and snapshot_path.exists()
+
+        _append(
+            transcript,
+            _entry("u-cancel", "user", "repeatable prompt", "a0",
+                   timestamp="2024-01-01T00:00:01.200Z"),
+            _entry("a-cancel", "assistant", "late canonical partial", "u-cancel",
+                   timestamp="2024-01-01T00:00:05.000Z"),
+            _entry("u-after", "user", "repeatable prompt", "a-cancel",
+                   timestamp="2024-01-01T00:00:06.000Z"),
+            _entry("a-after", "assistant", "later success", "u-after",
+                   timestamp="2024-01-01T00:00:07.000Z"),
+        )
+
+        response = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 20})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert [(item["uuid"], item["role"]) for item in body["messages"]] == [
+            ("u0", "user"), ("a0", "assistant"),
+            ("u-cancel", "user"), ("a-cancel", "assistant"),
+            ("u-after", "user"), ("a-after", "assistant"),
+        ]
+        cancelled = next(
+            item for item in body["messages"] if item["uuid"] == "a-cancel")
+        assert cancelled["turn_status"] == "cancelled"
+        assert cancelled["ts"] == bc.cancelled_at_ms
+        assert cancelled["elapsed"] == 1.5
+        assert cancelled["model"] == "codex:gpt-5.6-sol"
+        assert not snapshot_path.exists()
+        assert chat_mod.sess.get_message_annotations(sid)["a-cancel"][
+            "turn_status"] == "cancelled"
+    finally:
+        bc.close()
+
+
+def test_interrupted_snapshot_never_steals_post_interrupt_resend(
+    client, auth, app_module, tmp_path,
+):
+    """A result-less stop must not mark a fast same-text resend cancelled."""
+    from backend import chat as chat_mod
+
+    sid, transcript = _make_endpoint_session(
+        client, auth, chat_mod, tmp_path, [
+            _entry("u0", "user", "before",
+                   timestamp="2024-01-01T00:00:00.000Z"),
+            _entry("a0", "assistant", "before answer", "u0",
+                   timestamp="2024-01-01T00:00:00.500Z"),
+        ])
+    _, boundary = chat_mod._turn_transcript_boundary(
+        sid, "claude-sonnet-4-6")
+    bc = chat_mod.TurnBroadcast(
+        session_id=sid, model="codex:gpt-5.6-sol")
+    bc.user_text = "same prompt"
+    bc.started_at = 1_704_067_201.0
+    bc.cancelled_at_ms = 1_704_067_202_000
+    bc.cancelled = True
+    bc.transcript_boundary = boundary
+    bc.publish({
+        "event": "text", "data": json.dumps({"text": "stopped partial"}),
+    })
+
+    try:
+        assert chat_mod._persist_cancelled_turn_snapshot(bc) is True
+        snapshot_path = chat_mod._cancelled_turn_snapshot_path(sid, bc.turn_id)
+        assert snapshot_path is not None and snapshot_path.exists()
+        # The interrupted query wrote no canonical user row.  A new turn with
+        # identical text starts after the click and must remain completed.
+        _append(
+            transcript,
+            _entry("u-resend", "user", "same prompt", "a0",
+                   timestamp="2024-01-01T00:00:03.000Z"),
+            _entry("a-resend", "assistant", "successful resend", "u-resend",
+                   timestamp="2024-01-01T00:00:04.000Z"),
+        )
+        response = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 20})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        resend = next(
+            item for item in body["messages"] if item.get("uuid") == "a-resend")
+        assert resend["turn_status"] == "completed"
+        assert snapshot_path.exists()
+        assert "a-resend" not in chat_mod.sess.get_message_annotations(sid)
+    finally:
+        bc.close()
+
+
 def test_endpoint_reports_pre_total_and_zeroes_it_in_full_order(
     client, auth, app_module, tmp_path,
 ):
@@ -481,6 +609,123 @@ def test_cross_window_tool_context_task_status_generation_and_around(
     )
     assert stale.status_code == 409
     assert stale.json()["detail"]["error"] == "history_generation_mismatch"
+
+
+def test_reload_footer_recovers_hidden_continuation_start_and_four_fields(
+    client, auth, app_module, tmp_path,
+):
+    """A zero-bubble task notification is the continuation's turn boundary."""
+    from backend import chat as chat_mod
+
+    notification = (
+        "<task-notification><tool-use-id>toolu_bg</tool-use-id>"
+        "<task-id>bg1</task-id><status>completed</status>"
+        "<summary>done</summary></task-notification>"
+    )
+    entries = [
+        _entry("u1", "user", "launch", timestamp="2026-08-07T10:35:20Z"),
+        _entry("a1", "assistant", [{
+            "type": "tool_use", "id": "toolu_bg", "name": "Bash",
+            "input": {"command": "sleep 20", "run_in_background": True},
+        }], "u1", timestamp="2026-08-07T10:35:22Z"),
+        _entry("tr1", "user", [{
+            "type": "tool_result", "tool_use_id": "toolu_bg",
+            "content": "started",
+        }], "a1", timestamp="2026-08-07T10:35:23Z"),
+        # This record renders no user bubble and therefore is outside a normal
+        # bubble-window read, but it is the true start of the auto-continuation.
+        _entry("notify1", "user", notification, "tr1",
+               timestamp="2026-08-07T10:35:34Z"),
+        _entry("a2", "assistant", "background task finished", "notify1",
+               timestamp="2026-08-07T10:35:40Z"),
+        _entry("u2", "user", "next", "a2",
+               timestamp="2026-08-07T10:37:26Z"),
+        _entry("a3", "assistant", "next answer", "u2",
+               timestamp="2026-08-07T10:37:29Z"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+    assert response.status_code == 200, response.text
+    messages = response.json()["messages"]
+    continuation_tail = next(item for item in messages if item["uuid"] == "a2")
+
+    assert continuation_tail["turn_status"] == "completed"
+    assert continuation_tail["ts"] == 1_786_098_940_000
+    assert continuation_tail["elapsed"] == 6.0
+    assert continuation_tail["model"] == "claude-sonnet-4-6"
+    assert continuation_tail["turn_started_at"] == 1_786_098_934_000
+    assert continuation_tail["_turn_origin_uuid"] == "notify1"
+
+
+def test_reload_footer_moves_cancel_annotation_to_actual_tool_result_tail(
+    client, auth, app_module, tmp_path,
+):
+    """The footer mounts after tool_result, not on the annotated assistant."""
+    from backend import chat as chat_mod
+
+    entries = [
+        _entry("u1", "user", "run", timestamp="2026-08-07T11:34:00Z"),
+        _entry("a1", "assistant", [{
+            "type": "tool_use", "id": "toolu_stop", "name": "Bash",
+            "input": {"command": "sleep 30"},
+        }], "u1", timestamp="2026-08-07T11:34:01Z"),
+        _entry("tr1", "user", [{
+            "type": "tool_result", "tool_use_id": "toolu_stop",
+            "content": "stopped",
+        }], "a1", timestamp="2026-08-07T11:34:06Z"),
+        _entry("u2", "user", "after", "tr1",
+               timestamp="2026-08-07T11:35:00Z"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    chat_mod.sess.set_message_annotation(
+        sid, "a1",
+        model="codex:gpt-5.6-sol",
+        ts=1_786_102_446_000,
+        turn_status="cancelled",
+        elapsed_s=6.0,
+    )
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+    assert response.status_code == 200, response.text
+    tail = next(item for item in response.json()["messages"]
+                if item["uuid"] == "tr1")
+
+    assert tail["turn_status"] == "cancelled"
+    assert tail["ts"] == 1_786_102_446_000
+    assert tail["elapsed"] == 6.0
+    assert tail["model"] == "codex:gpt-5.6-sol"
+
+
+def test_reload_footer_exposes_four_fields_for_active_canonical_tail(
+    client, auth, app_module, tmp_path,
+):
+    from backend import chat as chat_mod
+
+    entries = [
+        _entry("u1", "user", "run", timestamp="2026-08-07T11:34:00Z"),
+        _entry("a1", "assistant", "partial", "u1",
+               timestamp="2026-08-07T11:34:02Z"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    active = chat_mod.TurnBroadcast(sid, model="codex:gpt-5.6-sol")
+    active.last_assistant_uuid = "a1"
+    chat_mod._active_turns[sid] = active
+    try:
+        response = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+        assert response.status_code == 200, response.text
+        tail = response.json()["messages"][-1]
+
+        assert tail["turn_status"] == "running"
+        assert tail["turn_started_at"] == 1_786_102_440_000
+        assert tail["elapsed"] >= 0
+        assert tail["model"] == "codex:gpt-5.6-sol"
+    finally:
+        chat_mod._active_turns.pop(sid, None)
+        active.close()
 
 
 def test_around_uuid_limit_is_in_bubbles_and_keeps_target(

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -305,6 +305,86 @@ def test_window_endpoint_matches_full_oracle_and_adds_stable_keys(
     assert len({m["_key"] for m in body["messages"]}) == len(body["messages"])
 
 
+def test_window_endpoint_interleaves_cancelled_snapshot_at_original_anchor(
+    client, auth, app_module, tmp_path,
+):
+    """Partial JSONL rows are replaced by one durable display-only snapshot."""
+    from backend import chat as chat_mod
+
+    entries = [
+        _entry("u0", "user", "before"),
+        _entry("a0", "assistant", "before answer", "u0"),
+        # The CLI managed to append part of the interrupted turn before its
+        # process was force-stopped. These UUIDs must be hidden, not duplicated.
+        _entry("u-cancel", "user", "cancel prompt", "a0"),
+        _entry("a-cancel", "assistant", "canonical partial", "u-cancel"),
+        # A later successful turn remains after the interrupted display layer.
+        _entry("u-after", "user", "after prompt", "a-cancel"),
+        _entry("a-after", "assistant", "after answer", "u-after"),
+    ]
+    sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    turn_id = "00000000-0000-4000-8000-000000000099"
+    path = chat_mod._cancelled_turn_snapshot_path(sid, turn_id)
+    assert path is not None
+    chat_mod.atomic_write_text(path, json.dumps({
+        "schema": chat_mod._CANCELLED_TURN_SNAPSHOT_SCHEMA,
+        "sid": sid,
+        "turn_id": turn_id,
+        "started_at_ms": 1_700_000_000_000,
+        "interrupted_at_ms": 1_700_000_001_000,
+        "anchors": {
+            "normal": {"uuid": "a0", "total": 2},
+            "full": {"uuid": "a0", "total": 2},
+        },
+        "hidden_uuids": ["u-cancel", "a-cancel"],
+        "messages": [
+            {
+                "role": "user", "text": "cancel prompt",
+                "_key": f"cancelled:{turn_id}:0", "_interrupted": True,
+            },
+            {
+                "role": "assistant", "text": "live partial survives",
+                "_key": f"cancelled:{turn_id}:1", "_interrupted": True,
+            },
+        ],
+    }, ensure_ascii=False))
+
+    response = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 20})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [(item["role"], item.get("text")) for item in body["messages"]] == [
+        ("user", "before"),
+        ("assistant", "before answer"),
+        ("user", "cancel prompt"),
+        ("assistant", "live partial survives"),
+        ("user", "after prompt"),
+        ("assistant", "after answer"),
+    ]
+    assert body["total"] == 6
+    assert body["message_count"] == 6
+    assert body["turn_count"] == 3
+    assert "canonical partial" not in response.text
+    assert "~cancelled-" in body["history_generation"]
+
+    page = client.get(
+        f"/api/chat/sessions/{sid}",
+        headers=auth,
+        params={
+            "offset": 1,
+            "limit": 4,
+            "history_generation": body["history_generation"],
+        },
+    )
+    assert page.status_code == 200, page.text
+    assert [(item["role"], item.get("text")) for item in page.json()["messages"]] == [
+        ("assistant", "before answer"),
+        ("user", "cancel prompt"),
+        ("assistant", "live partial survives"),
+        ("user", "after prompt"),
+    ]
+
+
 def test_endpoint_reports_pre_total_and_zeroes_it_in_full_order(
     client, auth, app_module, tmp_path,
 ):

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -644,6 +644,10 @@ def test_reload_footer_recovers_hidden_continuation_start_and_four_fields(
                timestamp="2026-08-07T10:37:29Z"),
     ]
     sid, _ = _make_endpoint_session(client, auth, chat_mod, tmp_path, entries)
+    # Session creation intentionally leaves an unreachable requested model
+    # unlocked on credential-free installations.  This footer scenario needs
+    # a deterministic session model regardless of developer login / CI auth.
+    chat_mod.sess.update_model(sid, "claude-sonnet-4-6")
 
     response = client.get(
         f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})


### PR DESCRIPTION
## 变更类型

- [x] 修复（bugfix）
- [x] 功能（feature）

## 变更说明

- 将中断、失败、后台延续和工具尾部回合统一为完整 footer 契约，持久化状态、时间、运行时长和模型；迟到的完成事件不再覆盖用户已中断状态。
- 修复后台任务 EOF 的幽灵运行状态，以及中断握手、队列暂停和编辑/删除操作之间的竞态；失败的队列操作不会再制造重复消息。
- 保持任务中心加载与刷新时的几何尺寸稳定，并扩大桌面文件管理区的默认宽度。
- 支持把 OS 文件拖到整个窗口上传到工作区根目录；只有明确拖到目录行时才进入该目录。
- 将独立侧问升级为始终悬浮、可拖动、可多轮追问的轻量会话，并从全局任务中心隐藏。
- 独立侧问只开放 `WebSearch` / `WebFetch`，禁用工作区工具、MCP、Skills、插件、记忆召回及用户/项目设置源。
- 保护原生输入法 composition 缓冲区，避免响应式草稿或会话对账破坏中文输入状态。

## 隐私与权限边界

- 未新增 DUCC 配置、端点、凭证或私有标识；PR 差异中没有本机用户路径。
- 侧问的网页检索提示明确禁止把文件路径、凭证、私人信息或选中原文直接写入查询词或 URL。
- 中断快照继续使用会话私有目录/文件权限，日志只记录截断会话标识和异常类型，不输出消息正文。

## 本地验证

- 分批回归：`91 + 100 + 124 = 315 passed`。
- Chromium E2E：`7 passed`，覆盖任务中心无位移、IME、移动 footer、停止/队列、全窗口拖放、独立侧问多轮与持续悬浮。
- `ruff check backend/ tests/`：通过。
- `bash scripts/lint.sh`：通过（含编码、class 冲突和隐私扫描）。
- 全部前端 JS `node --check`、manifest JSON、`git diff --check`：通过。
- 本机仅 2 GiB 内存，因此完整单进程 pytest 改为分批执行；远端 CI 继续运行完整测试矩阵。

## 审查检查项

- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 本地关键路径验证通过
- [x] 已检查敏感信息、私有路径与 DUCC 边界
- [x] 远端完整 CI 全部通过后再合入