### PR TITLE
fix(chat): 修复中文输入法偶发失效

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1676,6 +1676,19 @@ function portal() {
     // inputs (.kb-open class + --kb-inset) in lockstep, exactly like update().
     onChatInputBlur(ev) {
       this._resetImeCompositionState(ev);
+      const target = ev && (ev.target || ev.currentTarget);
+      const settledOwner = target && target._museImeSettledOwnerSid;
+      // The composer bridge intentionally ignores model writes while focused.
+      // When focus leaves (for example, the user clicks Send), commit exactly
+      // what is visibly in the native control before the click handler reads
+      // the draft. A composition settled for a different tab is excluded.
+      if (target && (!settledOwner || settledOwner === this.currentId)) {
+        if (this.input !== target.value) this.input = target.value;
+        const state = this.currentId && this.tabState && this.tabState[this.currentId];
+        if (state && state.draft) state.draft.input = target.value;
+        if (this.currentId) this._persistChatDraft(this.currentId, target.value);
+      }
+      if (target) delete target._museImeSettledOwnerSid;
       document.body.classList.remove("kb-open");
       document.documentElement.style.setProperty("--kb-inset", "0px");
       this._scheduleMobileRootReset();
@@ -5145,41 +5158,36 @@ function portal() {
     // `isComposing` is the standard signal, while keyCode/which 229 and
     // key="Process" cover older Safari/WebView and Windows IME variants.
     //
-    // Chromium WebViews and Safari can emit compositionend just BEFORE the
-    // very same candidate-confirming Enter, with isComposing=false and
-    // keyCode=13. Track the textarea lifecycle directly and treat an Enter in
-    // that short event window as part of the commit. DOM-local fields avoid
-    // reactive writes while the native IME buffer is live.
-    onImeCompositionStart(ev) {
-      const target = ev && (ev.target || ev.currentTarget);
+    // The chat textarea deliberately has no x-model. While it owns focus,
+    // native DOM text is authoritative and reactive model effects do not
+    // write `textarea.value`. This is essential for Windows Pinyin and
+    // macOS marked text. Reassigning value during an active composition can
+    // detach Chromium from the OS IME; afterwards Latin keys still work but a
+    // newly selected Chinese IME produces no text until the page is rebuilt.
+    // Programmatic composer edits go through _setChatInput(), which also
+    // refuses DOM writes for the short marked-text window.
+    _markImeComposition(target) {
       if (!target) return;
       target._museImeComposing = true;
       target._museImeEndedAt = 0;
-
-      // Alpine's x-model effect is allowed to write `textarea.value` whenever
-      // the root `input` value changes.  That is normally harmless, but a
-      // programmatic draft/session reconciliation that lands while Windows
-      // Pinyin / macOS marked text is active makes Chromium replace the
-      // native composition buffer without emitting compositionend.  The
-      // textarea then remains the IME's stale target: plain Latin input still
-      // works, while switching back to Chinese can stay broken until the page
-      // is restarted.
-      //
-      // Keep the DOM-owned marked text authoritative for this short window.
-      // Input events still update Alpine's model; only model -> DOM writes are
-      // deferred.  We restore Alpine's original hook and synchronize the
-      // committed DOM value in compositionend/blur below.
-      if (!target._museImeOriginalForceModelUpdate
-          && typeof target._x_forceModelUpdate === "function") {
-        const original = target._x_forceModelUpdate;
-        target._museImeOriginalForceModelUpdate = original;
-        target._x_forceModelUpdate = value => {
-          if (target._museImeComposing) {
-            target._museImeDeferredModelValue = value;
-            return;
-          }
-          original(value);
-        };
+      delete target._museImeSettledOwnerSid;
+      if (!target._museImeOwnerSid) {
+        target._museImeOwnerSid = this.currentId || "";
+      }
+    },
+    onImeCompositionStart(ev) {
+      const target = ev && (ev.target || ev.currentTarget);
+      if (!target) return;
+      this._markImeComposition(target);
+    },
+    onChatBeforeInput(ev) {
+      const target = ev && (ev.target || ev.currentTarget);
+      if (!target) return;
+      // A few embedded Chromium builds omit compositionstart but still expose
+      // the standard beforeinput signal. Marking here closes that gap before
+      // Alpine or any app handler can reconcile the draft.
+      if (ev.isComposing || ev.inputType === "insertCompositionText") {
+        this._markImeComposition(target);
       }
     },
     onImeCompositionEnd(ev) {
@@ -5190,18 +5198,32 @@ function portal() {
     },
     _finishImeComposition(target) {
       if (!target) return;
+      // Chromium can emit compositionend and then blur for the same commit.
+      // onChatInput's missing-compositionend fallback can also run first. A
+      // second settlement must be a no-op; otherwise the shared textarea's
+      // old value is copied into whichever session became current meanwhile.
+      if (!target._museImeComposing && !target._museImeOwnerSid) return;
+      const ownerSid = target._museImeOwnerSid || this.currentId || "";
       target._museImeComposing = false;
-      const original = target._museImeOriginalForceModelUpdate;
-      if (typeof original === "function") {
-        target._x_forceModelUpdate = original;
-      }
-      delete target._museImeOriginalForceModelUpdate;
-      delete target._museImeDeferredModelValue;
+      delete target._museImeOwnerSid;
+      target._museImeSettledOwnerSid = ownerSid;
       // Safari/WebView may fire compositionend before its final non-composing
       // input event.  Commit the DOM value now; the later input is idempotent.
-      // This also deliberately lets the user's marked text win over a stale
-      // programmatic draft write that was deferred above.
+      // If a tab switch completed first, save the commit back to the textarea's
+      // original draft instead of leaking it into the newly active session.
+      if (ownerSid && ownerSid !== this.currentId) {
+        const ownerState = this.tabState && this.tabState[ownerSid];
+        if (ownerState && ownerState.draft) {
+          ownerState.draft.input = target.value;
+          this._persistChatDraft(ownerSid, target.value);
+        }
+        this.$nextTick(() => this._syncChatInputDom(this.input));
+        return;
+      }
       if (this.input !== target.value) this.input = target.value;
+      const state = ownerSid && this.tabState && this.tabState[ownerSid];
+      if (state && state.draft) state.draft.input = target.value;
+      if (ownerSid) this._persistChatDraft(ownerSid, target.value);
     },
     _resetImeCompositionState(ev) {
       const target = ev && (ev.target || ev.currentTarget);
@@ -5219,6 +5241,24 @@ function portal() {
       return !!(ev.isComposing || ev.keyCode === 229 || ev.which === 229
         || ev.key === "Process" || (target && target._museImeComposing)
         || commitEnter);
+    },
+    _syncChatInputDom(value = this.input, options = {}) {
+      const target = options.target || (this.$refs && this.$refs.chatInput);
+      if (!target || target._museImeComposing) return false;
+      // Ordinary reactive reconciliation must never replace a focused native
+      // editor. Explicit user-facing app actions call with force=true below.
+      if (!options.force && document.activeElement === target) return false;
+      const next = value == null ? "" : String(value);
+      if (target.value !== next) target.value = next;
+      return true;
+    },
+    _setChatInput(value) {
+      const next = value == null ? "" : String(value);
+      this.input = next;
+      // Explicit app actions (history, @ mention, clear, tab activation) may
+      // update a focused textarea, but still never overwrite marked text.
+      this._syncChatInputDom(next, { force: true });
+      return next;
     },
     _claimNonImeEnter(ev) {
       if (!ev || this._isImeComposingEvent(ev)) return false;
@@ -7645,7 +7685,17 @@ function portal() {
       const st = this._ensureTabState(id);
       const draft = st.draft;
       draft._activated = true;
-      this.input = draft.input || "";
+      const ta = this.$refs && this.$refs.chatInput;
+      // Switching ownership while an IME buffer is live must end the old
+      // editor session before the shared textarea receives the new draft.
+      // blur normally emits compositionend; the explicit reset is a fallback
+      // for WebViews that omit it when focus moves programmatically.
+      if (ta && ta._museImeComposing && ta._museImeOwnerSid
+          && ta._museImeOwnerSid !== id) {
+        ta.blur();
+        if (ta._museImeComposing) this._resetImeCompositionState({ target: ta });
+      }
+      this._setChatInput(draft.input || "");
       this.pendingImages = draft.pendingImages;
       this.pendingDocs = draft.pendingDocs;
       this.pendingQuotes = draft.pendingQuotes;
@@ -22963,7 +23013,8 @@ function portal() {
     insertFileMention(path, isDir = false) {
       const mentionPath = this._mentionPath(path, isDir);
       const mention = "@" + mentionPath + " ";
-      this.input = (this.input || "") + (this.input && !this.input.endsWith(" ") ? " " : "") + mention;
+      this._setChatInput((this.input || "")
+        + (this.input && !this.input.endsWith(" ") ? " " : "") + mention);
       if (this.$refs.chatInput) this.$refs.chatInput.focus();
       this.toast(this.t("toast.mention_added", { path: mentionPath }), "success", 1500);
       // Mobile: @ mention is a chat-side action, jump to the chat pane
@@ -23055,13 +23106,14 @@ function portal() {
       const c = this.slashResults[i];
       if (!c) return;
       // Replace current input with the canonical form so user sees what's submitted
-      this.input = "/" + c.name + (c.name === "model" || c.name === "resume" ? " " : "");
+      this._setChatInput("/" + c.name
+        + (c.name === "model" || c.name === "resume" ? " " : ""));
       this.slashShow = false;
       if (this.$refs.chatInput) this.$refs.chatInput.focus();
       // For commands with NO argument needed, auto-execute on selection
       if (!["model", "resume"].includes(c.name)) {
         this._runSlash(c.name, "");
-        this.input = "";
+        this._setChatInput("");
       }
     },
 
@@ -23140,7 +23192,7 @@ function portal() {
           this._activateTabState(meta.id);
           await this.loadSession(meta.id);
           // Pre-fill input with the compact prompt — user reviews then sends
-          this.input = this.t("slash.compact_prompt");
+          this._setChatInput(this.t("slash.compact_prompt"));
           this.toast(this.t("slash.compact_ok"), "success", 2500);
           return;
         }
@@ -23241,7 +23293,7 @@ function portal() {
       if (this.settings && this.settings.show) this.settings.show = false;
       // Close skills drawer if open
       if (this.skillsDrawerOpen) this.skillsDrawerOpen = false;
-      this.input = prompt;
+      this._setChatInput(prompt);
       this.$nextTick(() => {
         const ta = this.$refs.chatInput;
         if (ta) {
@@ -23315,7 +23367,7 @@ function portal() {
         || (zh ? `用 ${s.name} MCP 帮我：` : `Use the ${s.name} MCP to: `);
       this.mcpDrawerOpen = false;
       if (this.settings && this.settings.show) this.settings.show = false;
-      this.input = prompt;
+      this._setChatInput(prompt);
       this.$nextTick(() => {
         const ta = this.$refs.chatInput;
         if (ta) {
@@ -23573,7 +23625,7 @@ function portal() {
       draft._historyDraft = "";
     },
     _showChatHistoryInput(text, ev) {
-      this.input = text;
+      this._setChatInput(text);
       ev.preventDefault();
       this.$nextTick(() => {
         const ta = this.$refs.chatInput;
@@ -23644,12 +23696,25 @@ function portal() {
       this.mentionShow = false;
     },
     onChatInput(ev) {
+      const ta = ev.target;
+      // Do not depend on Alpine directive listener order. The native control
+      // is the source of truth while focused, especially during composition.
+      if (this.input !== ta.value) this.input = ta.value;
+      if (ev.isComposing || ev.inputType === "insertCompositionText") {
+        this._markImeComposition(ta);
+      } else if (ta._museImeComposing
+                 && ev.inputType !== "insertCompositionText") {
+        // Some Android/embedded Chromium builds commit through input without
+        // a compositionend event (and may label the final event insertText,
+        // not insertFromComposition). Clear the guard after consuming it.
+        this._finishImeComposition(ta);
+        ta._museImeEndedAt = Number(ev.timeStamp) || 0;
+      }
       // A real edit forks away from the recalled entry. Programmatic history
-      // navigation updates x-model directly and does not emit an input event.
+      // navigation goes through _setChatInput and does not emit an input event.
       this._resetChatInputHistory();
       this._captureComposerState(this.currentId, { persist: false });
       this._schedulePersistChatDraft(this.currentId, this.input || "");
-      const ta = ev.target;
       const pos = ta.selectionStart;
       const text = this.input.slice(0, pos);
 
@@ -23753,7 +23818,7 @@ function portal() {
       const before = this.input.slice(0, this.mentionAnchor);
       const after = this.input.slice(ta.selectionStart);
       const mentionPath = this._mentionPath(item.path, !!item.is_dir);
-      this.input = before + "@" + mentionPath + " " + after;
+      this._setChatInput(before + "@" + mentionPath + " " + after);
       this._cancelMentionLookup();
       this.$nextTick(() => {
         const newPos = (before + "@" + mentionPath + " ").length;
@@ -23783,13 +23848,13 @@ function portal() {
         const ta = this.$refs.chatInput;
         if (ta) {
           const s = ta.selectionStart, e = ta.selectionEnd;
-          this.input = this.input.slice(0, s) + "\n" + this.input.slice(e);
+          this._setChatInput(this.input.slice(0, s) + "\n" + this.input.slice(e));
           this.$nextTick(() => {
             ta.setSelectionRange(s + 1, s + 1);
             this.autoGrow(ta);
           });
         } else {
-          this.input += "\n";
+          this._setChatInput(this.input + "\n");
         }
         return;
       }
@@ -24248,7 +24313,7 @@ function portal() {
           if (ownsSendDraft() && sendDraft.input === composerInput) {
             sendDraft.input = "";
             this._resetChatInputHistory(sendDraft);
-            if (this.currentId === sendSid) this.input = "";
+            if (this.currentId === sendSid) this._setChatInput("");
             this._persistChatDraft(sendSid, "");
           }
           this.$nextTick(() => { if (this.currentId === sendSid && this.$refs.chatInput) this.autoGrow(this.$refs.chatInput); });
@@ -26449,7 +26514,7 @@ function portal() {
       // Drop the failed bubble, put text back in input, and send.
       const idx = this.messages.indexOf(m);
       if (idx >= 0) this.messages.splice(idx, 1);
-      this.input = this.userVisibleText(m);
+      this._setChatInput(this.userVisibleText(m));
       this.pendingQuotes.splice(
         0, this.pendingQuotes.length,
         ...this.userSelectionQuotes(m).map(q => ({ ...q, id: this._uuid() })),
@@ -26510,7 +26575,7 @@ function portal() {
       const msgs = this.messages;
       const idx = msgs.indexOf(m);
       if (idx >= 0) msgs.splice(idx);
-      this.input = newText;
+      this._setChatInput(newText);
       this.$nextTick(() => {
         const ta = this.$refs.chatInput;
         if (ta) this.autoGrow(ta);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3363,7 +3363,8 @@
                type=password input，iOS 就会把它当成账户字段。display:contents
                让这个 form 不参与布局，只提供 DOM 语义。 -->
           <form autocomplete="off" onsubmit="return false" style="display:contents">
-          <textarea x-model="input" x-ref="chatInput"
+          <textarea x-ref="chatInput"
+                    x-effect="_syncChatInputDom(input, { target: $el })"
                     rows="1"
                     :disabled="!availableModels.length || workspaceSwitching"
                     class="chat-input-textarea"
@@ -3381,6 +3382,7 @@
                     @keydown.down="onChatArrowDown($event)"
                     @compositionstart="onImeCompositionStart($event)"
                     @compositionend="onImeCompositionEnd($event)"
+                    @beforeinput="onChatBeforeInput($event)"
                     @input="onChatInput($event); autoGrow($event.target)"
                     @paste="onImagePaste($event)"
                     @focus="onChatInputFocus($event)"

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -390,11 +390,14 @@ def test_native_ime_buffer_survives_reactive_composer_reconciliation(
         const ta = document.querySelector('.chat-input-textarea');
         return { value: ta.value, input: app.input,
           composing: !!ta._museImeComposing,
-          guarded: typeof ta._museImeOriginalForceModelUpdate === 'function' };
+          privateHookWrapped:
+            Object.prototype.hasOwnProperty.call(
+              ta, '_museImeOriginalForceModelUpdate') };
         """,
     )
     assert composing == {
-        "value": "ni", "input": "ni", "composing": True, "guarded": True,
+        "value": "ni", "input": "ni", "composing": True,
+        "privateHookWrapped": False,
     }
 
     # This is the rare real-world race: a tab/draft reconciliation writes the
@@ -430,11 +433,193 @@ def test_native_ime_buffer_survives_reactive_composer_reconciliation(
         const ta = document.querySelector('.chat-input-textarea');
         return { value: ta.value, input: app.input,
           composing: !!ta._museImeComposing,
-          guarded: !!ta._museImeOriginalForceModelUpdate };
+          privateHookWrapped:
+            Object.prototype.hasOwnProperty.call(
+              ta, '_museImeOriginalForceModelUpdate') };
         """,
     )
     assert committed == {
-        "value": "你", "input": "你", "composing": False, "guarded": False,
+        "value": "你", "input": "你", "composing": False,
+        "privateHookWrapped": False,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_native_ime_stays_attached_across_reconciliation_and_tab_switch(
+    page: Page, backend_url, auth_token,
+):
+    """Repeated background refreshes and owner changes keep one healthy IME."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    first_sid = "ime-owner-first"
+    second_sid = "ime-owner-second"
+    _bootstrap_session_for_real_load(page, first_sid, "IME owner first")
+    _app_eval(
+        page,
+        """
+        const first = app._ensureTabState(arg.first);
+        first._loaded = true;
+        first.draft.input = "";
+        const second = app._ensureTabState(arg.second);
+        second._loaded = true;
+        second.draft.input = "";
+        app.sessions.push({
+          id: arg.second, name: "IME owner second", updated_at: Date.now() / 1000,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        });
+        app.openTabIds.push(arg.second);
+        app._activateTabState(arg.first);
+        const ta = document.querySelector('.chat-input-textarea');
+        window.__imeStableNode = ta;
+        window.__imeStableModelHook = ta._x_forceModelUpdate;
+        return true;
+        """,
+        {"first": first_sid, "second": second_sid},
+    )
+    textarea = page.locator(".chat-input-textarea")
+    textarea.click()
+    page.wait_for_function(
+        "() => document.activeElement === document.querySelector('.chat-input-textarea')"
+    )
+    cdp = page.context.new_cdp_session(page)
+
+    for index, (phonetic, committed_text) in enumerate(
+        [("ni", "你"), ("hao", "好"), ("zhong", "中")]
+    ):
+        _app_eval(page, "app._setChatInput(''); return true;")
+        cdp.send("Input.imeSetComposition", {
+            "text": phonetic,
+            "selectionStart": len(phonetic),
+            "selectionEnd": len(phonetic),
+            "replacementStart": 0,
+            "replacementEnd": 0,
+        })
+        # A canonical/background reconciliation may mutate the root model, but
+        # must not write over Chromium's marked text while the control is focused.
+        protected = _app_eval(
+            page,
+            """
+            app.input = arg.model;
+            return new Promise(resolve => queueMicrotask(() => {
+              const ta = document.querySelector('.chat-input-textarea');
+              resolve({ value: ta.value, composing: !!ta._museImeComposing });
+            }));
+            """,
+            {"model": f"background-refresh-{index}"},
+        )
+        assert protected == {"value": phonetic, "composing": True}
+        cdp.send("Input.imeSetComposition", {
+            "text": committed_text,
+            "selectionStart": len(committed_text),
+            "selectionEnd": len(committed_text),
+            "replacementStart": 0,
+            "replacementEnd": len(phonetic),
+        })
+        cdp.send("Input.insertText", {"text": committed_text})
+        committed = _app_eval(
+            page,
+            """
+            const ta = document.querySelector('.chat-input-textarea');
+            return {
+              value: ta.value, input: app.input,
+              composing: !!ta._museImeComposing,
+              sameNode: ta === window.__imeStableNode,
+              sameModelHook: ta._x_forceModelUpdate === window.__imeStableModelHook,
+            };
+            """,
+        )
+        assert committed == {
+            "value": committed_text,
+            "input": committed_text,
+            "composing": False,
+            "sameNode": True,
+            "sameModelHook": True,
+        }
+
+    blur_commit = _app_eval(
+        page,
+        """
+        const ta = document.querySelector('.chat-input-textarea');
+        app.input = 'stale-background-model';
+        return new Promise(resolve => queueMicrotask(() => {
+          const visible = ta.value;
+          ta.blur();
+          resolve({
+            visible,
+            input: app.input,
+            draft: app._ensureTabState(arg).draft.input,
+          });
+        }));
+        """,
+        first_sid,
+    )
+    assert blur_commit == {"visible": "中", "input": "中", "draft": "中"}
+    textarea.click()
+
+    # Change session ownership while marked text is live. The phonetic buffer
+    # belongs to the old draft; the shared DOM then receives the new draft and
+    # must accept another native composition without rebuilding the whole app.
+    _app_eval(page, "app._setChatInput(''); return true;")
+    cdp.send("Input.imeSetComposition", {
+        "text": "wen",
+        "selectionStart": 3,
+        "selectionEnd": 3,
+        "replacementStart": 0,
+        "replacementEnd": 0,
+    })
+    switched = _app_eval(
+        page,
+        """
+        app._captureComposerState(arg.first);
+        app.currentId = arg.second;
+        app._activateTabState(arg.second);
+        const ta = document.querySelector('.chat-input-textarea');
+        return {
+          value: ta.value,
+          firstDraft: app._ensureTabState(arg.first).draft.input,
+          secondDraft: app._ensureTabState(arg.second).draft.input,
+          composing: !!ta._museImeComposing,
+          sameNode: ta === window.__imeStableNode,
+        };
+        """,
+        {"first": first_sid, "second": second_sid},
+    )
+    assert switched == {
+        "value": "",
+        "firstDraft": "wen",
+        "secondDraft": "",
+        "composing": False,
+        "sameNode": True,
+    }
+
+    textarea.click()
+    cdp.send("Input.imeSetComposition", {
+        "text": "wen",
+        "selectionStart": 3,
+        "selectionEnd": 3,
+        "replacementStart": 0,
+        "replacementEnd": 0,
+    })
+    cdp.send("Input.imeSetComposition", {
+        "text": "文",
+        "selectionStart": 1,
+        "selectionEnd": 1,
+        "replacementStart": 0,
+        "replacementEnd": 3,
+    })
+    cdp.send("Input.insertText", {"text": "文"})
+    recovered = _app_eval(
+        page,
+        """
+        const ta = document.querySelector('.chat-input-textarea');
+        return { value: ta.value, input: app.input,
+          composing: !!ta._museImeComposing,
+          sameNode: ta === window.__imeStableNode };
+        """,
+    )
+    assert recovered == {
+        "value": "文", "input": "文", "composing": False, "sameNode": True,
     }
     _assert_no_browser_errors(page, errors)
 

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -392,7 +392,7 @@ def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
           app.lang = 'zh';
-          app.input = 'alphaomega';
+          app._setChatInput('alphaomega');
           await new Promise(resolve => app.$nextTick(resolve));
           app._captureComposerState(app.currentId);
           const ta = app.$refs.chatInput;
@@ -440,7 +440,9 @@ def test_preview_selection_quotes_as_attachment_and_asks_in_side_session(
     page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
-          app.input = 'KEEP EXISTING DRAFT';
+          // Programmatic composer changes use the native-editor bridge so the
+          // focused textarea and the reactive draft advance together.
+          app._setChatInput('KEEP EXISTING DRAFT');
           app.pendingImages = [{id: 'keep-image'}];
           app.pendingDocs = [{id: 'keep-doc'}];
           app.pendingQuotes.splice(0);

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -403,8 +403,11 @@ def test_enter_submission_waits_for_ime_composition():
     assert "target._museImeEndedAt" in ime
     assert "eventAt - endedAt <= 80" in ime
     assert helper.index("return false") < helper.index("ev.preventDefault()")
-    assert "_museImeOriginalForceModelUpdate" in app
-    assert "target._x_forceModelUpdate = value =>" in app
+    assert "_museImeOriginalForceModelUpdate" not in app
+    assert "target._x_forceModelUpdate = value =>" not in app
+    assert "_syncChatInputDom(value = this.input, options = {})" in app
+    assert "target._museImeComposing" in app
+    assert "ev.inputType === \"insertCompositionText\"" in app
     assert "this._finishImeComposition(target)" in app
     assert "if (this.input !== target.value) this.input = target.value" in app
 
@@ -414,7 +417,11 @@ def test_enter_submission_waits_for_ime_composition():
     assert '@keydown.enter="onEnter($event)"' in html
     assert '@compositionstart="onImeCompositionStart($event)"' in html
     assert '@compositionend="onImeCompositionEnd($event)"' in html
+    assert '@beforeinput="onChatBeforeInput($event)"' in html
     assert '@blur="onChatInputBlur($event)"' in html
+    assert 'x-effect="_syncChatInputDom(input, { target: $el })"' in html
+    assert 'x-model="input"' not in html
+    assert 'x-model.unintrusive="input"' not in html
     assert '@keydown.enter.prevent="commitRenameTab()"' not in html
     assert '@keydown.enter.prevent="pickerCommitInlineRename()"' not in html
     assert '@keydown.enter.prevent.stop="onEnter($event)"' not in html


### PR DESCRIPTION
## What this changes

让主聊天输入框由原生 DOM 持有聚焦与组合文本，移除对 Alpine `x-model` 私有更新钩子的劫持；程序性草稿更新统一通过 `_setChatInput` 显式同步，并补充 `beforeinput` 兜底、组合态会话归属与 `compositionend` / `blur` 幂等结算。

## Why

修复 Windows 拼音等中文输入法偶发只剩英文可输入、切换输入法无效且必须重启 MuseLab 才恢复的问题；同时避免组词中切换会话时旧拼音串写入新会话。

## Testing

- [x] `uv run pytest -q tests/test_frontend_lint.py`（104 passed）
- [x] 真实 Chromium CDP IME 回归（3 passed）：连续中文组词、响应式刷新、失焦、组词中切换会话及切换后继续输入
- [x] 本地完整 Playwright：91 passed（包含草稿隔离、队列、后台任务、引用与独立询问等联动场景）
- [x] `node --check frontend/app.js` 与 `git diff --check`
- [x] 当前 8770 服务加载新版静态资源，`/api/health` 返回正常
- [x] 远端 CI 8/8 通过：Linux/macOS pytest、Playwright E2E、lint、语法、安全扫描与 Docker

首轮远端 E2E 捕获到一个仍直接写 `app.input` 的旧测试夹具；夹具已改为走新的 `_setChatInput` 程序性输入契约，随后本地 91/91 与第二轮远端 E2E 全部通过。

## Checklist

- [x] No secrets committed
- [x] No runtime dependency added
- [x] Tests added for the regression
- [x] Docs not required for this bug fix
