### PR TITLE
feat(activity): 任务中心默认展示 15 条

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -26958,7 +26958,7 @@ function portal() {
       ];
     },
     ACTIVITY_GROUP_CAP: 5,
-    ACTIVITY_TIMELINE_CAP: 10,
+    ACTIVITY_TIMELINE_CAP: 15,
     activityMatchesGroup(item, key) {
       if (!item) return false;
       if (key === "timeline") return true;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3644,11 +3644,11 @@ pre.text {
   border-right: 0;
 }
 .files-head-workspace .workspace-picker-btn { width: 100%; max-width: none; border-radius: var(--r-sm); }
-.activity-modal { width:620px; max-width:calc(100vw - 32px); }
+.activity-modal { width:700px; max-width:calc(100vw - 32px); }
 /* The later generic desktop modal cap is 480px. Keep this ledger wide enough
    for conversation + task hierarchy, without overriding mobile fullscreen. */
 @media (min-width:721px) {
-  .modal.activity-modal { width:620px; max-width:calc(100vw - 32px); }
+  .modal.activity-modal { width:700px; max-width:calc(100vw - 32px); }
 }
 .activity-view-switch { display:inline-flex; margin-left:auto; padding:2px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); }
 .activity-view-switch button { padding:4px 9px; border:0; border-radius:calc(var(--r-md) - 2px); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); cursor:pointer; }
@@ -3680,12 +3680,12 @@ pre.text {
 .activity-chip.is-empty { opacity:0.42; }
 .activity-chip.is-empty:hover { opacity:0.85; }
 @media (prefers-reduced-motion:reduce) { .activity-chip .activity-chip-dot { animation:none; } }
-.activity-body { position:relative; max-height:min(70vh,680px); overflow:auto; padding:10px 14px 18px; }
+.activity-body { position:relative; max-height:min(82vh,820px); overflow:auto; scrollbar-gutter:stable; padding:10px 14px 18px; }
 /* Keep the desktop ledger geometry stable across cold load → rows.  The
    loading/refresh indicators are absolutely positioned, so neither their
    appearance nor disappearance can push a mounted row or resize the modal. */
 @media (min-width:721px) {
-  .activity-body { min-height:min(46vh,420px); }
+  .activity-body { min-height:min(56vh,520px); }
 }
 .activity-loading-overlay {
   position:absolute;

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -132,6 +132,107 @@ def test_cached_activity_refresh_does_not_shift_rows_or_modal(
         assert abs(after[key] - before[key]) < 1, (before, after)
 
 
+def test_desktop_timeline_defaults_to_fifteen_rows_in_larger_modal(
+    page: Page, backend_url, auth_token,
+):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
+          app.lang = 'zh';
+          app.activity.viewLoaded = true;
+          app.activity.view = 'timeline';
+          app.activity.expanded = {};
+          app.activity.loading = false;
+          app.activity.events = Array.from({length: 20}, (_, index) => ({
+            id: `timeline-cap-${index}`,
+            kind: 'turn',
+            session_id: `timeline-session-${index}`,
+            session_name: `Timeline session ${index + 1}`,
+            task_summary: `Timeline task ${index + 1}`,
+            workspace: '/tmp/e2e',
+            workspace_name: 'e2e',
+            state: 'completed',
+            read: true,
+            started_at: 100 + index,
+            finished_at: 200 + index,
+            updated_at: 300 + index,
+          }));
+          app.activity.summary = {
+            running: 0, unread: 0, attention: 0,
+            groups: {review: 0, running: 0, failed: 0, history: 20},
+            group_unread: {review: 0, running: 0, failed: 0, history: 0},
+            workspaces: [],
+          };
+          app.activity.show = true;
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+
+    modal = page.locator(".activity-modal")
+    expect(modal).to_be_visible()
+    expect(page.locator(".activity-row")).to_have_count(15)
+    expect(page.locator(".activity-group-more")).to_have_text("还有 5 条")
+    page.wait_for_timeout(250)
+
+    geometry = page.evaluate(
+        """() => {
+          const modal = document.querySelector('.activity-modal');
+          const body = document.querySelector('.activity-body');
+          const modalRect = modal.getBoundingClientRect();
+          const bodyRect = body.getBoundingClientRect();
+          return {
+            modalWidth: modalRect.width,
+            modalHeight: modalRect.height,
+            modalTop: modalRect.top,
+            modalBottom: modalRect.bottom,
+            bodyHeight: bodyRect.height,
+            bodyScrollHeight: body.scrollHeight,
+            viewportHeight: window.innerHeight,
+          };
+        }"""
+    )
+    assert geometry["modalWidth"] >= 690
+    assert geometry["modalHeight"] >= 560
+    assert geometry["bodyHeight"] >= 500
+    assert geometry["bodyScrollHeight"] >= geometry["bodyHeight"]
+    assert geometry["modalTop"] >= 0
+    assert geometry["modalBottom"] <= geometry["viewportHeight"]
+
+    page.locator(".activity-group-more").click()
+    expect(page.locator(".activity-row")).to_have_count(20)
+    expect(page.locator(".activity-group-more")).to_have_text("收起")
+
+    # The larger ledger is desktop-only. The existing phone contract remains
+    # a full-width modal with an internally scrolling body.
+    page.set_viewport_size({"width": 390, "height": 844})
+    mobile_geometry = page.evaluate(
+        """() => {
+          const modal = document.querySelector('.activity-modal');
+          const body = document.querySelector('.activity-body');
+          const rect = modal.getBoundingClientRect();
+          return {
+            left: rect.left,
+            right: rect.right,
+            width: rect.width,
+            bottom: rect.bottom,
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+            bodyMaxHeight: getComputedStyle(body).maxHeight,
+          };
+        }"""
+    )
+    assert mobile_geometry["left"] == 0
+    assert mobile_geometry["right"] <= mobile_geometry["viewportWidth"]
+    assert mobile_geometry["width"] == mobile_geometry["viewportWidth"]
+    assert mobile_geometry["bottom"] <= mobile_geometry["viewportHeight"]
+    assert mobile_geometry["bodyMaxHeight"] == "none"
+
+
 def test_session_rename_updates_loaded_activity_row_immediately(
     page: Page, backend_url, auth_token
 ):
@@ -140,6 +241,8 @@ def test_session_rename_updates_loaded_activity_row_immediately(
     result = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
           const sid = app.currentId;
           const before = app.sessions.find(row => row.id === sid)?.name || '';
           app.activity.events = [{
@@ -324,7 +427,7 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
               workspaces: [],
             },
           });
-          for (let index = 0; index < 9; index += 1) {
+          for (let index = 0; index < 14; index += 1) {
             app.activity.events.push({
               ...base,
               id: `extra-${index}`,
@@ -341,8 +444,8 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
 
     session_labels = page.locator(".activity-group .activity-session-name")
     task_labels = page.locator(".activity-group .activity-task-summary")
-    expect(session_labels).to_have_count(10)
-    expect(task_labels).to_have_count(10)
+    expect(session_labels).to_have_count(15)
+    expect(task_labels).to_have_count(15)
     assert session_labels.all_text_contents()[:3] == [
         "Activity test", "Activity test", "Activity test",
     ]
@@ -380,8 +483,8 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
     more = page.locator(".activity-group-more")
     expect(more).to_have_text("2 more")
     more.click()
-    expect(session_labels).to_have_count(12)
-    expect(task_labels).to_have_count(12)
+    expect(session_labels).to_have_count(17)
+    expect(task_labels).to_have_count(17)
 
 
 def test_terminal_event_wins_over_stale_tab_activity_snapshot(

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1295,7 +1295,7 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'item.state === "completed" && !!item.read' in app
     assert 'item.state === "cancelled"' in app
     assert "ACTIVITY_GROUP_CAP: 5" in app
-    assert "ACTIVITY_TIMELINE_CAP: 10" in app
+    assert "ACTIVITY_TIMELINE_CAP: 15" in app
     assert 'group?.key === "timeline"' in app
     assert "this.activityGroupCap(group)" in app
     assert "activityHiddenCount(group)" in app
@@ -1318,6 +1318,10 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert '@click.stop="toggleActivityPin(item)"' in html
     assert 'x-show="activity.view === \'timeline\'"' in html
     assert ".activity-pin.active" in css
+    assert ".activity-modal { width:700px" in css
+    assert "max-height:min(82vh,820px)" in css
+    assert "min-height:min(56vh,520px)" in css
+    assert "scrollbar-gutter:stable" in css
 
     # The left marker is unread/action state, not a permanent failure marker.
     assert "activityIsUnreadResult(item) ? ' is-unread'" in html


### PR DESCRIPTION
## 变更

- 将任务中心时间倒序视图的默认展示上限从 10 条提高到 15 条；状态分组仍保持每组 5 条。
- 将桌面端任务中心弹窗扩至 700px，并增加可视高度和稳定滚动条槽，减少首屏拥挤和滚动条出现时的横向抖动。
- 保持移动端全屏布局不变，补充默认条数、展开、桌面几何和移动端边界回归。
- 稳定会话重命名 E2E 的活动流夹具，避免实时刷新覆盖注入数据。

## 验证

- `git diff --check`
- `node --check frontend/app.js`
- `uv run ruff check tests/e2e/test_activity_center.py`
- `uv run pytest -q tests/test_frontend_lint.py`（104 passed）
- `RUN_E2E=1 uv run pytest -q tests/e2e/test_activity_center.py`（7 passed）
- 当前本地服务 `/api/health` 正常，已加载新的 15 条上限和弹窗样式。

## 安全与兼容性

- 未新增依赖、配置或敏感信息。
- 移动端布局与状态分组上限保持不变。