### PR TITLE
feat(activity): 支持自定义会话分组与全局记忆浮层

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -16,6 +16,11 @@ from .settings import ROOT, atomic_write_text
 from . import sessions
 
 _MAX_EVENTS = 500
+_MAX_CUSTOM_GROUPS = 40
+_MAX_GROUP_NAME = 48
+_GROUP_COLORS = frozenset({
+    "blue", "violet", "cyan", "green", "amber", "rose", "gray",
+})
 _TERMINAL = {"completed", "failed", "cancelled"}
 _ACTIVE = {"running", "waiting_approval", "paused"}
 
@@ -79,14 +84,17 @@ class ActivityService:
 
     def __init__(self, root: Path = ROOT):
         self.path = root / ".muselab" / "activity.json"
+        self.groups_path = root / ".muselab" / "activity-groups.json"
         self._lock = threading.RLock()
         self._generation = uuid.uuid4().hex
         self._revision = 0
         self._subscribers: dict[
             asyncio.Queue[dict[str, Any]], asyncio.AbstractEventLoop
         ] = {}
+        self._custom_groups, self._group_assignments = self._load_group_state()
         self._events = self._load()
         changed = self._collapse_sessions()
+        changed = self._reconcile_event_groups() or changed
         for item in self._events:
             if item.get("state") in _ACTIVE:
                 now = time.time()
@@ -96,6 +104,98 @@ class ActivityService:
                 changed = True
         if changed:
             self._save()
+
+    @staticmethod
+    def _group_name(value: Any) -> str:
+        name = " ".join(str(value or "").split())
+        if not name:
+            raise ValueError("group name is required")
+        if len(name) > _MAX_GROUP_NAME:
+            raise ValueError(f"group name exceeds {_MAX_GROUP_NAME} characters")
+        return name
+
+    @staticmethod
+    def _group_color(value: Any) -> str:
+        color = str(value or "blue").strip().lower()
+        if color not in _GROUP_COLORS:
+            raise ValueError("invalid group color")
+        return color
+
+    def _load_group_state(self) -> tuple[list[dict[str, str]], dict[str, str]]:
+        try:
+            raw = json.loads(self.groups_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return [], {}
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"cannot parse activity groups: {self.groups_path}"
+            ) from exc
+        if not isinstance(raw, dict):
+            raise RuntimeError("activity group state must be an object")
+
+        source_groups = raw.get("groups", [])
+        source_assignments = raw.get("assignments", {})
+        if (not isinstance(source_groups, list)
+                or not isinstance(source_assignments, dict)):
+            raise RuntimeError("invalid activity group state")
+
+        groups: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for row in source_groups[:_MAX_CUSTOM_GROUPS]:
+            if not isinstance(row, dict):
+                continue
+            group_id = str(row.get("id") or "").strip()
+            if not group_id or group_id in seen:
+                continue
+            try:
+                name = self._group_name(row.get("name"))
+                color = self._group_color(row.get("color"))
+            except ValueError:
+                continue
+            seen.add(group_id)
+            groups.append({"id": group_id, "name": name, "color": color})
+
+        assignments = {
+            str(sid): str(group_id)
+            for sid, group_id in source_assignments.items()
+            if str(sid) and str(group_id) in seen
+        }
+        return groups, assignments
+
+    def _save_group_state(self) -> None:
+        self.groups_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(self.groups_path, json.dumps({
+            "version": 1,
+            "groups": self._custom_groups,
+            "assignments": self._group_assignments,
+        }, ensure_ascii=False, indent=2))
+
+    def _group_payload_locked(self) -> list[dict[str, str]]:
+        return [dict(group) for group in self._custom_groups]
+
+    def _apply_assignment_locked(self, item: dict[str, Any]) -> bool:
+        sid = str(item.get("session_id") or item.get("thread_id") or "")
+        assigned = self._group_assignments.get(sid, "")
+        current = str(item.get("group_id") or "")
+        if assigned == current:
+            return False
+        if assigned:
+            item["group_id"] = assigned
+        else:
+            item.pop("group_id", None)
+        return True
+
+    def _reconcile_event_groups(self) -> bool:
+        valid = {group["id"] for group in self._custom_groups}
+        self._group_assignments = {
+            sid: group_id
+            for sid, group_id in self._group_assignments.items()
+            if group_id in valid
+        }
+        changed = False
+        for item in self._events:
+            changed = self._apply_assignment_locked(item) or changed
+        return changed
 
     def _load(self) -> list[dict[str, Any]]:
         try:
@@ -134,6 +234,7 @@ class ActivityService:
         *,
         item: dict[str, Any] | None = None,
         acked_ids: list[str] | None = None,
+        resync: bool = False,
     ) -> None:
         """Fan out a compact transition to SSE subscribers.
 
@@ -149,7 +250,10 @@ class ActivityService:
             "generation": self._generation,
             "revision": self._revision,
             "summary": summary,
+            "custom_groups": self._group_payload_locked(),
         }
+        if resync:
+            payload["resync"] = True
         if item is not None:
             payload["item"] = dict(item)
         if acked_ids:
@@ -242,6 +346,7 @@ class ActivityService:
                 updated_at=now, needs_attention=False, read=True,
                 turn_count=int(item.get("turn_count") or 0) + 1,
             )
+            self._apply_assignment_locked(item)
             if source_id:
                 item["source_id"] = source_id[:200]
             else:
@@ -316,6 +421,7 @@ class ActivityService:
         """Return rows and counters from the same locked ledger snapshot."""
         with self._lock:
             events = [dict(x) for x in self._events]
+            custom_groups = self._group_payload_locked()
             generation = self._generation
             revision = self._revision
         ordered = sorted(events, key=_activity_at, reverse=True)
@@ -325,7 +431,155 @@ class ActivityService:
         return {
             "events": ordered[:min(max(limit, 1), _MAX_EVENTS)],
             "summary": summary,
+            "custom_groups": custom_groups,
         }
+
+    def list_groups(self) -> list[dict[str, str]]:
+        with self._lock:
+            return self._group_payload_locked()
+
+    def create_group(self, name: str, color: str = "blue") -> dict[str, Any]:
+        clean_name = self._group_name(name)
+        clean_color = self._group_color(color)
+        with self._lock:
+            if len(self._custom_groups) >= _MAX_CUSTOM_GROUPS:
+                raise ValueError("too many custom groups")
+            if any(group["name"].casefold() == clean_name.casefold()
+                   for group in self._custom_groups):
+                raise ValueError("group name already exists")
+            group = {
+                "id": uuid.uuid4().hex,
+                "name": clean_name,
+                "color": clean_color,
+            }
+            self._custom_groups.append(group)
+            self._save_group_state()
+            self._publish_locked()
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "group": dict(group),
+                "custom_groups": self._group_payload_locked(),
+            }
+
+    def update_group(
+        self,
+        group_id: str,
+        *,
+        name: str | None = None,
+        color: str | None = None,
+    ) -> dict[str, Any] | None:
+        with self._lock:
+            group = next((row for row in self._custom_groups
+                          if row["id"] == group_id), None)
+            if group is None:
+                return None
+            clean_name = (
+                group["name"] if name is None else self._group_name(name)
+            )
+            clean_color = (
+                group["color"] if color is None else self._group_color(color)
+            )
+            if any(row["id"] != group_id
+                   and row["name"].casefold() == clean_name.casefold()
+                   for row in self._custom_groups):
+                raise ValueError("group name already exists")
+            changed = group["name"] != clean_name or group["color"] != clean_color
+            group.update(name=clean_name, color=clean_color)
+            if changed:
+                self._save_group_state()
+                self._publish_locked()
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "group": dict(group),
+                "custom_groups": self._group_payload_locked(),
+            }
+
+    def reorder_groups(self, group_ids: list[str]) -> dict[str, Any]:
+        with self._lock:
+            current = [group["id"] for group in self._custom_groups]
+            if len(group_ids) != len(current) or set(group_ids) != set(current):
+                raise ValueError("group order must contain every group exactly once")
+            lookup = {group["id"]: group for group in self._custom_groups}
+            if group_ids != current:
+                self._custom_groups = [lookup[group_id] for group_id in group_ids]
+                self._save_group_state()
+                self._publish_locked()
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "custom_groups": self._group_payload_locked(),
+            }
+
+    def delete_group(self, group_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            if not any(group["id"] == group_id for group in self._custom_groups):
+                return None
+            self._custom_groups = [
+                group for group in self._custom_groups if group["id"] != group_id
+            ]
+            cleared_sessions = {
+                sid for sid, assigned in self._group_assignments.items()
+                if assigned == group_id
+            }
+            self._group_assignments = {
+                sid: assigned
+                for sid, assigned in self._group_assignments.items()
+                if assigned != group_id
+            }
+            changed_events = 0
+            for item in self._events:
+                if str(item.get("group_id") or "") == group_id:
+                    item.pop("group_id", None)
+                    changed_events += 1
+            self._save_group_state()
+            if changed_events:
+                self._save()
+            self._publish_locked(resync=True)
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "cleared_sessions": len(cleared_sessions),
+                "custom_groups": self._group_payload_locked(),
+            }
+
+    def set_group(self, event_id: str, group_id: str) -> dict[str, Any] | None:
+        target = str(group_id or "").strip()
+        with self._lock:
+            if target and not any(group["id"] == target
+                                  for group in self._custom_groups):
+                raise ValueError("activity group not found")
+            item = next((row for row in self._events
+                         if row.get("id") == event_id), None)
+            if item is None:
+                return None
+            sid = str(item.get("session_id") or item.get("thread_id") or "")
+            current = str(item.get("group_id") or "")
+            if target == current:
+                return {
+                    "generation": self._generation,
+                    "revision": self._revision,
+                    "item": dict(item),
+                    "custom_groups": self._group_payload_locked(),
+                }
+            if target:
+                if sid:
+                    self._group_assignments[sid] = target
+                item["group_id"] = target
+            else:
+                if sid:
+                    self._group_assignments.pop(sid, None)
+                item.pop("group_id", None)
+            self._save_group_state()
+            self._save()
+            self._publish_locked(item=item)
+            return {
+                "generation": self._generation,
+                "revision": self._revision,
+                "item": dict(item),
+                "custom_groups": self._group_payload_locked(),
+            }
 
     def rename_session(self, sid: str, name: str) -> dict[str, Any] | None:
         """Update only the mutable display name for a conversation row.

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 from .activity import activity
@@ -18,6 +18,24 @@ _EVENT_TICKET_TTL_S = 45
 
 class ActivityPatchRequest(BaseModel):
     pinned: bool
+
+
+class ActivityGroupCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=48)
+    color: str = Field(default="blue", max_length=16)
+
+
+class ActivityGroupUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=48)
+    color: str | None = Field(default=None, max_length=16)
+
+
+class ActivityGroupOrderRequest(BaseModel):
+    ids: list[str] = Field(max_length=40)
+
+
+class ActivityGroupAssignmentRequest(BaseModel):
+    group_id: str = Field(default="", max_length=64)
 
 
 def _json(request: Request, response: Response, payload: dict):
@@ -101,6 +119,63 @@ async def activity_events() -> EventSourceResponse:
 @router.post("/ack-all", dependencies=[Depends(require_token)])
 def ack_all():
     return {"ok": True, "changed": activity.ack(), "summary": activity.summary()}
+
+
+@router.get("/groups", dependencies=[Depends(require_token)])
+def list_activity_groups():
+    return {"custom_groups": activity.list_groups()}
+
+
+@router.post("/groups", dependencies=[Depends(require_token)])
+def create_activity_group(req: ActivityGroupCreateRequest):
+    try:
+        update = activity.create_group(req.name, req.color)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"ok": True, **update}
+
+
+@router.put("/groups/order", dependencies=[Depends(require_token)])
+def reorder_activity_groups(req: ActivityGroupOrderRequest):
+    try:
+        update = activity.reorder_groups(req.ids)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"ok": True, **update}
+
+
+@router.patch("/groups/{group_id}", dependencies=[Depends(require_token)])
+def update_activity_group(group_id: str, req: ActivityGroupUpdateRequest):
+    try:
+        update = activity.update_group(
+            group_id,
+            name=req.name,
+            color=req.color,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if update is None:
+        raise HTTPException(status_code=404, detail="activity group not found")
+    return {"ok": True, **update}
+
+
+@router.delete("/groups/{group_id}", dependencies=[Depends(require_token)])
+def delete_activity_group(group_id: str):
+    update = activity.delete_group(group_id)
+    if update is None:
+        raise HTTPException(status_code=404, detail="activity group not found")
+    return {"ok": True, **update}
+
+
+@router.put("/{event_id}/group", dependencies=[Depends(require_token)])
+def assign_activity_group(event_id: str, req: ActivityGroupAssignmentRequest):
+    try:
+        update = activity.set_group(event_id, req.group_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if update is None:
+        raise HTTPException(status_code=404, detail="activity not found")
+    return {"ok": True, **update}
 
 
 @router.patch("/{event_id}", dependencies=[Depends(require_token)])

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -405,6 +405,16 @@ function portal() {
       // converts x/y to viewport-relative top/left coordinates until close.
       dragged: false, dragging: false,
     },
+    // Per-turn memory recall details are rendered in a root-level fixed
+    // popover. Keeping the card outside .chat-body is load-bearing: every pane
+    // intentionally clips overflow, so no descendant z-index can escape the
+    // transcript/composer/preview boundaries.
+    memoryRecallPopover: {
+      show: false, recall: null, style: "",
+    },
+    _memoryRecallAnchor: null,
+    _memoryRecallOwner: null,
+    _memoryRecallPositionFrame: 0,
     _previewSelectionBound: false,
     _previewSelectionTimer: null,
     _previewQuoteDrag: null,
@@ -547,9 +557,9 @@ function portal() {
     },
     activity: {
       show: false, loading: false, events: [],
-      // The global center opens on the cross-status timeline by default.
-      // An explicit user choice is still restored from localStorage.
-      view: "timeline",
+      // Custom groups are the primary organization surface. An explicit user
+      // choice is still restored from localStorage.
+      view: "groups",
       viewLoaded: false,
       summary: {
         running: 0, unread: 0, attention: 0,
@@ -561,6 +571,13 @@ function portal() {
       expanded: {},
       // Selected group keys. Empty array = no filter = show every group.
       filter: [],
+      customGroups: [],
+      groupEditor: {
+        open: false, id: "", name: "", color: "blue", saving: false,
+      },
+      moveMenu: { show: false, eventId: "", style: "" },
+      dragEventId: "",
+      dragOverGroupId: null,
     },
     _activityEtags: {},
     _activityFetchPromises: {},
@@ -573,6 +590,7 @@ function portal() {
     _activityLiveTimer: null,
     _activityLiveVisibilityBound: false,
     _activityPinPending: {},
+    _activityGroupPending: {},
     // Per-task "run-now" inflight flag — disables retry / send buttons until
     // activity SSE reports a terminal state. Keyed by task id.
     schedRunning: {},
@@ -1279,6 +1297,8 @@ function portal() {
         }
       }
       if (ev.key === "Escape") {
+        if (this.memoryRecallPopover.show) { this.closeMemoryRecallPopover(); return; }
+        if (this.activity.moveMenu.show) { this.closeActivityMoveMenu(); return; }
         if (this.cheatSheet.show) { this.cheatSheet.show = false; return; }
         if (this.mentionShow) { this._cancelMentionLookup(); return; }
         if (this.ctxMenu.show) { this.ctxMenu.show = false; return; }
@@ -1339,6 +1359,10 @@ function portal() {
       this._prewarmPreviewLibs();
       // 全局快捷键（绑在 document，避免每个 textarea 单独处理）
       document.addEventListener("keydown", e => this.onGlobalKeyDown(e));
+      window.addEventListener("resize", () => {
+        this._queueMemoryRecallPosition();
+        if (this.activity.moveMenu.show) this.closeActivityMoveMenu();
+      });
       // (Cross-tab queue sync via localStorage `storage` events was removed
       // when the queue moved server-side: there's one authoritative copy now,
       // and each tab refreshes its mirror via _syncQueueFromServer on load /
@@ -1385,6 +1409,8 @@ function portal() {
       // picker, slash /resume, etc. without requiring each entry point
       // to remember to call _scrollTabIntoView.
       this.$watch("currentId", (tid) => {
+        this.closeMemoryRecallPopover();
+        this.closeActivityMoveMenu();
         if (this.previewQuote.show && this.previewQuote.sessionId
             && this.previewQuote.sessionId !== tid) {
           this.dismissTransientPreviewQuote(true);
@@ -13768,6 +13794,94 @@ function portal() {
       }
     },
 
+    toggleMemoryRecallPopover(ev, message) {
+      if (this.memoryRecallPopover.show && this._memoryRecallOwner === message) {
+        this.closeMemoryRecallPopover();
+        return;
+      }
+      const recall = message?.memoryRecall;
+      const anchor = ev?.currentTarget;
+      if (!recall || !anchor) return;
+      if (this.previewQuote.show && this.previewQuote.mode !== "ask") {
+        this.dismissPreviewQuote(true);
+      }
+      this._memoryRecallOwner = message;
+      this._memoryRecallAnchor = anchor;
+      this.memoryRecallPopover = {
+        show: true,
+        recall,
+        style: "position:fixed;left:12px;top:12px;visibility:hidden;",
+      };
+      this.$nextTick(() => this._positionMemoryRecallPopover());
+    },
+
+    _queueMemoryRecallPosition() {
+      if (!this.memoryRecallPopover.show || this._memoryRecallPositionFrame) return;
+      this._memoryRecallPositionFrame = requestAnimationFrame(() => {
+        this._memoryRecallPositionFrame = 0;
+        this._positionMemoryRecallPopover();
+      });
+    },
+
+    _positionMemoryRecallPopover() {
+      if (!this.memoryRecallPopover.show) return;
+      const anchor = this._memoryRecallAnchor;
+      const popover = document.querySelector(".memory-recall-global");
+      if (!anchor?.isConnected || !popover) {
+        this.closeMemoryRecallPopover();
+        return;
+      }
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const pad = 12;
+      const gap = 8;
+      const anchorRect = anchor.getBoundingClientRect();
+      if (anchorRect.bottom < 0 || anchorRect.top > viewportHeight) {
+        this.closeMemoryRecallPopover();
+        return;
+      }
+      const width = Math.max(1, Math.min(420, viewportWidth - pad * 2));
+      const maxHeight = Math.max(1, Math.min(420, viewportHeight - pad * 2));
+      // Measure at the final width.  Measuring the unconstrained portal first
+      // makes long memory text look like one short line; after width is
+      // applied it wraps taller and can fall below the viewport even though
+      // the initial geometry appeared to fit.
+      popover.style.width = `${Math.round(width)}px`;
+      popover.style.maxHeight = `${Math.round(maxHeight)}px`;
+      popover.style.left = `${pad}px`;
+      popover.style.top = `${pad}px`;
+      const measuredHeight = Math.min(
+        maxHeight,
+        Math.max(1, popover.getBoundingClientRect().height || popover.scrollHeight),
+      );
+      const centered = anchorRect.left + anchorRect.width / 2 - width / 2;
+      const left = Math.max(pad, Math.min(centered, viewportWidth - width - pad));
+      const roomAbove = anchorRect.top - pad - gap;
+      const roomBelow = viewportHeight - anchorRect.bottom - pad - gap;
+      const openAbove = roomAbove >= measuredHeight || roomAbove > roomBelow;
+      const top = openAbove
+        ? Math.max(pad, anchorRect.top - gap - measuredHeight)
+        : Math.min(viewportHeight - pad - measuredHeight, anchorRect.bottom + gap);
+      this.memoryRecallPopover.style = [
+        "position:fixed",
+        `left:${Math.round(left)}px`,
+        `top:${Math.round(Math.max(pad, top))}px`,
+        `width:${Math.round(width)}px`,
+        `max-height:${Math.round(maxHeight)}px`,
+        "visibility:visible",
+      ].join(";");
+    },
+
+    closeMemoryRecallPopover() {
+      if (this._memoryRecallPositionFrame) {
+        cancelAnimationFrame(this._memoryRecallPositionFrame);
+        this._memoryRecallPositionFrame = 0;
+      }
+      this.memoryRecallPopover = { show: false, recall: null, style: "" };
+      this._memoryRecallAnchor = null;
+      this._memoryRecallOwner = null;
+    },
+
     // ===== settings modal =====
     async openSettings(activePage = "") {
       const r = await fetch("/api/settings", { headers: this.hdr() });
@@ -23884,6 +23998,7 @@ function portal() {
       }
     },
     onChatScroll() {
+      this._queueMemoryRecallPosition();
       const el = this.$refs.chatBody;
       if (!el) return;
       const st = this.currentId && this.tabState && this.tabState[this.currentId];
@@ -26914,6 +27029,9 @@ function portal() {
             this.activity.events = data.events;
             this._syncScheduledActivitySnapshot(data.events);
           }
+          if (!opts.summaryOnly && Array.isArray(data.custom_groups)) {
+            this.activity.customGroups = data.custom_groups;
+          }
           this._syncAppBadge();
           return true;
         } catch (_) { return false; }
@@ -26923,11 +27041,12 @@ function portal() {
       finally { if (this._activityFetchPromises[key] === promise) delete this._activityFetchPromises[key]; }
     },
     async openActivityCenter() {
+      this.closeMemoryRecallPopover();
       if (!this.activity.viewLoaded) {
         this.activity.viewLoaded = true;
         try {
           const saved = localStorage.getItem("muselab_activity_view");
-          if (saved === "status" || saved === "timeline") {
+          if (["status", "groups", "timeline"].includes(saved)) {
             this.activity.view = saved;
           } else if (saved === "finished") {
             // Migrate the short-lived terminal-only view to the corrected
@@ -26941,8 +27060,17 @@ function portal() {
       await this.fetchActivity();
       this.activity.loading = false;
     },
+    closeActivityCenter() {
+      this.activity.show = false;
+      this.closeActivityMoveMenu();
+      this.cancelActivityGroupEditor();
+      this.onActivityDragEnd();
+    },
     setActivityView(view) {
-      if (view !== "status" && view !== "timeline") return;
+      if (!["status", "groups", "timeline"].includes(view)) return;
+      this.closeActivityMoveMenu();
+      this.cancelActivityGroupEditor();
+      this.onActivityDragEnd();
       this.activity.view = view;
       try { localStorage.setItem("muselab_activity_view", view); } catch (_) {}
     },
@@ -26959,9 +27087,34 @@ function portal() {
     },
     ACTIVITY_GROUP_CAP: 5,
     ACTIVITY_TIMELINE_CAP: 15,
+    ACTIVITY_GROUP_COLORS: [
+      "blue", "violet", "cyan", "green", "amber", "rose", "gray",
+    ],
+    activityCustomGroupSections() {
+      const sections = (this.activity.customGroups || []).map(group => ({
+        key: `custom:${group.id}`,
+        label: group.name,
+        custom: true,
+        groupId: group.id,
+        color: group.color || "blue",
+      }));
+      sections.push({
+        key: "custom:__ungrouped__",
+        label: this.lang === "zh" ? "未分组" : "Ungrouped",
+        custom: true,
+        groupId: "",
+        color: "gray",
+        builtin: true,
+      });
+      return sections;
+    },
     activityMatchesGroup(item, key) {
       if (!item) return false;
       if (key === "timeline") return true;
+      if (key === "custom:__ungrouped__") return !String(item.group_id || "");
+      if (key.startsWith("custom:")) {
+        return String(item.group_id || "") === key.slice("custom:".length);
+      }
       if (key === "review") return item.state === "completed" && !item.read;
       if (key === "running") return ["running", "waiting_approval", "paused"].includes(item.state);
       if (key === "failed") return item.state === "failed";
@@ -26975,12 +27128,25 @@ function portal() {
     },
     activityAllEvents(group) {
       const activeRank = { waiting_approval: 0, paused: 1, running: 2 };
+      const attentionRank = item => {
+        if (this.activityRequiresAction(item)) return 0;
+        if (this.activityIsUnreadResult(item)) return 1;
+        if (["running", "waiting_approval", "paused"].includes(item.state)) return 2;
+        return 3;
+      };
       return (this.activity.events || [])
         .filter(item => this.activityMatchesGroup(item, group.key))
         .sort((a, b) => {
           if (group.key === "timeline") {
             const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
             if (pinRank) return pinRank;
+            return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+          }
+          if (group.custom) {
+            const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
+            if (pinRank) return pinRank;
+            const rank = attentionRank(a) - attentionRank(b);
+            if (rank) return rank;
             return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
           }
           if (group.key === "running") {
@@ -27007,6 +27173,7 @@ function portal() {
       this.activity.expanded[key] = !this.activity.expanded[key];
     },
     activityGroupCount(group) {
+      if (group?.custom) return this.activityAllEvents(group).length;
       const count = this.activity.summary?.groups?.[group.key];
       return Number.isFinite(Number(count))
         ? Number(count) : this.activityAllEvents(group).length;
@@ -27019,6 +27186,9 @@ function portal() {
             ? "全部任务（置顶优先 · 时间倒序）"
             : "All tasks (pinned, then newest)",
         }];
+      }
+      if (this.activity.view === "groups") {
+        return this.activityCustomGroupSections();
       }
       const groups = this.activityGroups();
       const on = this.activity.filter || [];
@@ -27045,6 +27215,11 @@ function portal() {
       return !!item && ["waiting_approval", "paused"].includes(item.state);
     },
     activityGroupUnread(group) {
+      if (group?.custom) {
+        return this.activityAllEvents(group)
+          .filter(item => this.activityIsUnreadResult(item)
+            || this.activityRequiresAction(item)).length;
+      }
       const count = this.activity.summary?.group_unread?.[group.key];
       if (Number.isFinite(Number(count))) return Number(count);
       return this.activityAllEvents(group)
@@ -27141,6 +27316,224 @@ function portal() {
         this._activityPinPending = pending;
       }
     },
+    openActivityGroupEditor(group = null) {
+      const palette = this.ACTIVITY_GROUP_COLORS;
+      const fallback = palette[(this.activity.customGroups || []).length % palette.length];
+      this.closeActivityMoveMenu();
+      this.activity.groupEditor = {
+        open: true,
+        id: group?.groupId || group?.id || "",
+        name: group?.label || group?.name || "",
+        color: group?.color || fallback,
+        saving: false,
+      };
+      this.$nextTick(() => {
+        const input = document.querySelector(".activity-group-editor input");
+        if (input) input.focus();
+      });
+    },
+    cancelActivityGroupEditor() {
+      this.activity.groupEditor = {
+        open: false, id: "", name: "", color: "blue", saving: false,
+      };
+    },
+    async saveActivityGroup() {
+      const draft = this.activity.groupEditor;
+      const name = String(draft.name || "").trim();
+      if (!name || draft.saving) return;
+      draft.saving = true;
+      const editing = !!draft.id;
+      try {
+        const { ok, data, error } = await this.api(
+          editing
+            ? `/api/activity/groups/${encodeURIComponent(draft.id)}`
+            : "/api/activity/groups",
+          {
+            method: editing ? "PATCH" : "POST",
+            json: { name, color: draft.color || "blue" },
+          },
+        );
+        if (!ok || !Array.isArray(data?.custom_groups)) {
+          throw new Error(error || "activity group save failed");
+        }
+        this.activity.customGroups = data.custom_groups;
+        this._activityRevision = Math.max(
+          this._activityRevision, Number(data.revision) || 0,
+        );
+        this.cancelActivityGroupEditor();
+      } catch (error) {
+        draft.saving = false;
+        this.toast(
+          this.lang === "zh"
+            ? `保存分组失败：${String(error?.message || error)}`
+            : `Could not save group: ${String(error?.message || error)}`,
+          "error",
+        );
+      }
+    },
+    async deleteActivityGroup(group) {
+      if (!group?.groupId) return;
+      const ok = await this.confirm({
+        title: this.lang === "zh" ? "删除分组？" : "Delete group?",
+        body: this.lang === "zh"
+          ? `“${group.label}”中的会话会移回“未分组”，会话本身不会删除。`
+          : `Sessions in “${group.label}” will move to Ungrouped. No session will be deleted.`,
+        okText: this.lang === "zh" ? "删除分组" : "Delete group",
+        danger: true,
+      });
+      if (!ok) return;
+      const groupId = group.groupId;
+      const { ok: deleted, data, error } = await this.api(
+        `/api/activity/groups/${encodeURIComponent(groupId)}`,
+        { method: "DELETE" },
+      );
+      if (!deleted) {
+        this.toast(
+          this.lang === "zh" ? "删除分组失败" : (error || "Could not delete group"),
+          "error",
+        );
+        return;
+      }
+      this.activity.customGroups = data?.custom_groups || [];
+      for (const item of this.activity.events) {
+        if (String(item.group_id || "") === groupId) delete item.group_id;
+      }
+      this.activity.events = [...this.activity.events];
+      this.activity.expanded = {};
+      this._activityRevision = Math.max(
+        this._activityRevision, Number(data?.revision) || 0,
+      );
+    },
+    async moveActivityGroup(group, delta) {
+      if (!group?.groupId || !delta) return;
+      const previous = [...(this.activity.customGroups || [])];
+      const at = previous.findIndex(row => row.id === group.groupId);
+      const target = at + delta;
+      if (at < 0 || target < 0 || target >= previous.length) return;
+      const next = [...previous];
+      const [moved] = next.splice(at, 1);
+      next.splice(target, 0, moved);
+      this.activity.customGroups = next;
+      const { ok, data } = await this.api("/api/activity/groups/order", {
+        method: "PUT",
+        json: { ids: next.map(row => row.id) },
+      });
+      if (!ok) {
+        this.activity.customGroups = previous;
+        this.toast(this.lang === "zh" ? "分组排序失败" : "Could not reorder groups", "error");
+        return;
+      }
+      if (Array.isArray(data?.custom_groups)) {
+        this.activity.customGroups = data.custom_groups;
+      }
+      this._activityRevision = Math.max(
+        this._activityRevision, Number(data?.revision) || 0,
+      );
+    },
+    activityGroupCanMove(group, delta) {
+      if (!group?.groupId) return false;
+      const at = (this.activity.customGroups || [])
+        .findIndex(row => row.id === group.groupId);
+      return at >= 0 && at + delta >= 0
+        && at + delta < (this.activity.customGroups || []).length;
+    },
+    openActivityMoveMenu(ev, item) {
+      if (!item?.id) return;
+      const rect = ev?.currentTarget?.getBoundingClientRect();
+      if (!rect) return;
+      const width = Math.min(230, window.innerWidth - 16);
+      const estimatedHeight = Math.min(
+        360, 48 + ((this.activity.customGroups || []).length + 1) * 34,
+      );
+      const left = Math.max(
+        8, Math.min(rect.right - width, window.innerWidth - width - 8),
+      );
+      const top = rect.bottom + 6 + estimatedHeight <= window.innerHeight - 8
+        ? rect.bottom + 6
+        : Math.max(8, rect.top - estimatedHeight - 6);
+      this.activity.moveMenu = {
+        show: true,
+        eventId: String(item.id),
+        style: `position:fixed;left:${Math.round(left)}px;top:${Math.round(top)}px;width:${Math.round(width)}px;`,
+      };
+    },
+    closeActivityMoveMenu() {
+      this.activity.moveMenu = { show: false, eventId: "", style: "" };
+    },
+    activityMoveMenuItem() {
+      const eventId = this.activity.moveMenu.eventId;
+      return this.activity.events.find(row => String(row.id) === eventId) || null;
+    },
+    async assignActivityGroup(item, groupId = "") {
+      if (!item?.id) return false;
+      const eventId = String(item.id);
+      if (this._activityGroupPending[eventId]) return false;
+      const target = String(groupId || "");
+      const previous = String(item.group_id || "");
+      this.closeActivityMoveMenu();
+      if (target === previous) return true;
+      this._activityGroupPending = {
+        ...this._activityGroupPending,
+        [eventId]: true,
+      };
+      if (target) item.group_id = target;
+      else delete item.group_id;
+      this.activity.events = [...this.activity.events];
+      this._activityAppliedSeq = ++this._activityRequestSeq;
+      try {
+        const { ok, data, error } = await this.api(
+          `/api/activity/${encodeURIComponent(eventId)}/group`,
+          { method: "PUT", json: { group_id: target } },
+        );
+        if (!ok || !data?.item) throw new Error(error || "group assignment failed");
+        const at = this.activity.events.findIndex(row => row.id === eventId);
+        if (at >= 0) this.activity.events.splice(at, 1, data.item);
+        this.activity.events = [...this.activity.events];
+        if (Array.isArray(data.custom_groups)) {
+          this.activity.customGroups = data.custom_groups;
+        }
+        this._activityRevision = Math.max(
+          this._activityRevision, Number(data.revision) || 0,
+        );
+        return true;
+      } catch (_) {
+        const latest = this.activity.events.find(row => row.id === eventId);
+        if (latest) {
+          if (previous) latest.group_id = previous;
+          else delete latest.group_id;
+        }
+        this.activity.events = [...this.activity.events];
+        this.toast(this.lang === "zh" ? "移动会话失败" : "Could not move session", "error");
+        return false;
+      } finally {
+        const pending = { ...this._activityGroupPending };
+        delete pending[eventId];
+        this._activityGroupPending = pending;
+      }
+    },
+    onActivityDragStart(ev, item) {
+      if (this.activity.view !== "groups" || !item?.id) return;
+      this.activity.dragEventId = String(item.id);
+      if (ev?.dataTransfer) {
+        ev.dataTransfer.effectAllowed = "move";
+        ev.dataTransfer.setData("text/plain", String(item.id));
+      }
+    },
+    onActivityDragEnd() {
+      this.activity.dragEventId = "";
+      this.activity.dragOverGroupId = null;
+    },
+    onActivityGroupDragOver(group) {
+      if (!this.activity.dragEventId) return;
+      this.activity.dragOverGroupId = group.groupId || "";
+    },
+    async onActivityGroupDrop(group) {
+      const eventId = this.activity.dragEventId;
+      this.onActivityDragEnd();
+      if (!eventId) return;
+      const item = this.activity.events.find(row => String(row.id) === eventId);
+      if (item) await this.assignActivityGroup(item, group.groupId || "");
+    },
     _stopActivityEvents() {
       ++this._activityLiveSeq;
       if (this._activityLiveSource) {
@@ -27194,6 +27587,9 @@ function portal() {
       if (generation && generation !== this._activityGeneration) {
         this._activityGeneration = generation;
         this._activityRevision = 0;
+      }
+      if (Array.isArray(payload?.custom_groups)) {
+        this.activity.customGroups = payload.custom_groups;
       }
       const revision = Number(payload?.revision) || 0;
       if (revision && revision <= this._activityRevision) return;
@@ -27331,7 +27727,7 @@ function portal() {
     },
     async openActivityEvent(item) {
       if (!item) return;
-      this.activity.show = false;
+      this.closeActivityCenter();
       const ack = this.ackActivityEvent(item);
       const sid = item.session_id || item.thread_id;
       const opened = sid

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2838,30 +2838,13 @@
                 <span x-show="turnFooterModel(m, pane, tid)" class="turn-model"
                       :title="turnFooterModel(m, pane, tid)"
                       x-text="'· ' + modelLabel(turnFooterModel(m, pane, tid))"></span>
-                <details class="memory-recall-trace"
-                         x-show="m.memoryRecall && m.memoryRecall.count">
-                  <summary x-text="lang==='zh'
-                    ? `· 使用了 ${m.memoryRecall?.count || 0} 条记忆`
-                    : `· Used ${m.memoryRecall?.count || 0} memories`"></summary>
-                  <div class="memory-recall-popover">
-                    <div class="memory-recall-meta"
-                         x-text="`${m.memoryRecall?.latency_ms || 0} ms · ${m.memoryRecall?.status || ''}`"></div>
-                    <template x-for="item in (m.memoryRecall?.items || [])" :key="item.id">
-                      <div class="memory-recall-item">
-                        <span x-text="item.kind"></span>
-                        <p x-text="item.content"></p>
-                        <div class="memory-recall-feedback">
-                          <button @click.stop="memoryFeedback(item, true, m.memoryRecall?.id)"
-                                  :class="{ active: item._feedback === 'up' }"
-                                  :title="lang==='zh' ? '这条记忆有用' : 'Helpful'">↑</button>
-                          <button @click.stop="memoryFeedback(item, false, m.memoryRecall?.id)"
-                                  :class="{ active: item._feedback === 'down' }"
-                                  :title="lang==='zh' ? '这条记忆无用' : 'Not helpful'">↓</button>
-                        </div>
-                      </div>
-                    </template>
-                  </div>
-                </details>
+                <button type="button" class="memory-recall-trace"
+                        x-show="m.memoryRecall && m.memoryRecall.count"
+                        :aria-expanded="memoryRecallPopover.show && _memoryRecallOwner === m"
+                        @click.stop="toggleMemoryRecallPopover($event, m)"
+                        x-text="lang==='zh'
+                          ? `· 使用了 ${m.memoryRecall?.count || 0} 条记忆`
+                          : `· Used ${m.memoryRecall?.count || 0} memories`"></button>
                 <button class="turn-fork-btn"
                         type="button"
                         x-show="turnForkMessageId(paneMsgs, i) && !(pane && pane.streaming)"
@@ -5730,12 +5713,53 @@
     </div>
   </div>
 
-  <div class="modal-backdrop" x-show="activity.show" @click.self="activity.show=false" x-cloak>
-    <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="activity.show=false">
+  <!-- Root-level portal for per-turn memory details.  This cannot live inside
+       .turn-footer: chat panes deliberately clip overflow, so a descendant
+       popover will be cut off regardless of z-index. -->
+  <div class="memory-recall-global"
+       x-show="memoryRecallPopover.show"
+       :style="memoryRecallPopover.style"
+       @click.stop
+       @click.outside="closeMemoryRecallPopover()"
+       role="dialog"
+       :aria-label="lang==='zh' ? '本轮使用的记忆' : 'Memories used in this turn'"
+       x-cloak>
+    <div class="memory-recall-head">
+      <strong x-text="lang==='zh'
+        ? `本轮使用了 ${memoryRecallPopover.recall?.count || 0} 条记忆`
+        : `Used ${memoryRecallPopover.recall?.count || 0} memories`"></strong>
+      <button type="button" @click="closeMemoryRecallPopover()"
+              :aria-label="lang==='zh' ? '关闭记忆详情' : 'Close memory details'">×</button>
+    </div>
+    <div class="memory-recall-meta"
+         x-text="`${memoryRecallPopover.recall?.latency_ms || 0} ms · ${memoryRecallPopover.recall?.status || ''}`"></div>
+    <template x-for="item in (memoryRecallPopover.recall?.items || [])" :key="item.id">
+      <div class="memory-recall-item">
+        <span x-text="item.kind"></span>
+        <p x-text="item.content"></p>
+        <div class="memory-recall-feedback">
+          <button type="button"
+                  @click="memoryFeedback(item, true, memoryRecallPopover.recall?.id)"
+                  :class="{ active: item._feedback === 'up' }"
+                  :title="lang==='zh' ? '这条记忆有用' : 'Helpful'">↑</button>
+          <button type="button"
+                  @click="memoryFeedback(item, false, memoryRecallPopover.recall?.id)"
+                  :class="{ active: item._feedback === 'down' }"
+                  :title="lang==='zh' ? '这条记忆无用' : 'Not helpful'">↓</button>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <div class="modal-backdrop" x-show="activity.show" @click.self="closeActivityCenter()" x-cloak>
+    <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="closeActivityCenter()">
       <div class="modal-head">
         <span class="modal-title"><svg class="modal-title-icon"><use href="#i-inbox"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
         <div class="activity-view-switch" role="group"
              :aria-label="lang==='zh' ? '任务视图' : 'Task view'">
+          <button type="button" @click="setActivityView('groups')"
+                  :class="{ active: activity.view === 'groups' }"
+                  x-text="lang==='zh' ? '按分组' : 'By group'"></button>
           <button type="button" @click="setActivityView('status')"
                   :class="{ active: activity.view === 'status' }"
                   x-text="lang==='zh' ? '按状态' : 'By status'"></button>
@@ -5750,7 +5774,7 @@
               :aria-hidden="!activity.loading">
           <span class="spinner-sm"></span>
         </span>
-        <button class="modal-close" @click="activity.show=false" aria-label="Close">×</button>
+        <button class="modal-close" @click="closeActivityCenter()" aria-label="Close">×</button>
       </div>
       <!-- One chip per attention group, in the same order as the sections below:
            completed results to review, live work, failures, then viewed history. -->
@@ -5779,6 +5803,47 @@
                 x-text="lang==='zh' ? '清除筛选' : 'Clear filter'"></button>
         <button class="btn-ghost sm" x-show="activity.summary.unread" @click="ackAllActivity()" x-text="lang==='zh' ? '全部标为已读' : 'Mark all read'"></button>
       </div>
+      <div class="activity-groups-toolbar" x-show="activity.view === 'groups'">
+        <div>
+          <strong x-text="lang==='zh' ? '自定义分组' : 'Custom groups'"></strong>
+          <small x-text="lang==='zh'
+            ? '拖动会话，或使用每行右侧的分组按钮移动'
+            : 'Drag a session, or use the group button on each row'"></small>
+        </div>
+        <button type="button" class="btn-ghost sm"
+                :disabled="activity.customGroups.length >= 40"
+                @click="openActivityGroupEditor()">
+          <svg><use href="#i-plus"/></svg>
+          <span x-text="lang==='zh' ? '新建分组' : 'New group'"></span>
+        </button>
+      </div>
+      <form class="activity-group-editor"
+            x-show="activity.view === 'groups' && activity.groupEditor.open"
+            @submit.prevent="saveActivityGroup()" x-cloak>
+        <input type="text" maxlength="48" autocomplete="off"
+               x-model="activity.groupEditor.name"
+               :placeholder="lang==='zh' ? '分组名称' : 'Group name'"
+               :aria-label="lang==='zh' ? '分组名称' : 'Group name'" />
+        <div class="activity-group-colors"
+             :aria-label="lang==='zh' ? '分组颜色' : 'Group color'">
+          <template x-for="color in ACTIVITY_GROUP_COLORS" :key="color">
+            <button type="button" class="activity-group-swatch"
+                    :class="['is-' + color, { active: activity.groupEditor.color === color }]"
+                    :aria-pressed="activity.groupEditor.color === color"
+                    :aria-label="(lang==='zh' ? '选择颜色：' : 'Choose color: ') + color"
+                    @click="activity.groupEditor.color = color"></button>
+          </template>
+        </div>
+        <div class="activity-group-editor-actions">
+          <button type="button" class="btn-ghost sm" @click="cancelActivityGroupEditor()"
+                  x-text="lang==='zh' ? '取消' : 'Cancel'"></button>
+          <button type="submit" class="btn-primary sm"
+                  :disabled="activity.groupEditor.saving || !activity.groupEditor.name.trim()"
+                  x-text="activity.groupEditor.saving
+                    ? (lang==='zh' ? '保存中…' : 'Saving…')
+                    : (lang==='zh' ? '保存' : 'Save')"></button>
+        </div>
+      </form>
       <div class="modal-body activity-body" :aria-busy="activity.loading">
         <!-- Loading is an overlay, not a list row.  A normal-flow hint used to
              disappear above the mounted rows when fetchActivity settled,
@@ -5789,14 +5854,58 @@
           <span x-text="lang==='zh' ? '正在加载任务…' : 'Loading tasks…'"></span>
         </div>
         <template x-for="group in activityVisibleGroups()" :key="group.key">
-          <section class="activity-group" x-show="activityEvents(group).length"
-                   :class="{ 'is-timeline': group.key === 'timeline' }">
+          <section class="activity-group"
+                   x-show="group.custom || activityEvents(group).length"
+                   :class="{
+                     'is-timeline': group.key === 'timeline',
+                     'is-custom': group.custom,
+                     'is-drag-over': group.custom
+                       && activity.dragOverGroupId === (group.groupId || '')
+                   }"
+                   @dragover.prevent="group.custom && onActivityGroupDragOver(group)"
+                   @drop.prevent="group.custom && onActivityGroupDrop(group)">
             <!-- The timeline toggle already communicates ordering. Repeating
                  "all tasks · pinned first · newest" here adds visual noise. -->
-            <h3 x-show="group.key !== 'timeline'" x-text="group.label"></h3>
+            <h3 x-show="!group.custom && group.key !== 'timeline'" x-text="group.label"></h3>
+            <div class="activity-custom-group-head" x-show="group.custom">
+              <span class="activity-custom-group-dot"
+                    :class="'is-' + (group.color || 'gray')"></span>
+              <strong x-text="group.label"></strong>
+              <span class="activity-custom-group-count"
+                    x-text="activityGroupCount(group)"></span>
+              <span class="activity-custom-group-attention"
+                    x-show="activityGroupUnread(group)"
+                    :title="lang==='zh' ? '需要关注' : 'Needs attention'"
+                    x-text="activityGroupUnread(group)"></span>
+              <div class="activity-custom-group-actions" x-show="!group.builtin">
+                <button type="button" :disabled="!activityGroupCanMove(group, -1)"
+                        @click="moveActivityGroup(group, -1)"
+                        :title="lang==='zh' ? '上移分组' : 'Move group up'">↑</button>
+                <button type="button" :disabled="!activityGroupCanMove(group, 1)"
+                        @click="moveActivityGroup(group, 1)"
+                        :title="lang==='zh' ? '下移分组' : 'Move group down'">↓</button>
+                <button type="button" @click="openActivityGroupEditor(group)"
+                        :title="lang==='zh' ? '编辑分组' : 'Edit group'">
+                  <svg><use href="#i-edit"/></svg>
+                </button>
+                <button type="button" class="danger" @click="deleteActivityGroup(group)"
+                        :title="lang==='zh' ? '删除分组' : 'Delete group'">
+                  <svg><use href="#i-trash"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="activity-custom-group-empty"
+                 x-show="group.custom && !activityAllEvents(group).length"
+                 x-text="lang==='zh' ? '拖动会话到这里' : 'Drag sessions here'"></div>
             <template x-for="item in activityEvents(group)" :key="item.id">
               <div class="activity-row-wrap"
-                   :class="{ pinned: activity.view === 'timeline' && item.pinned }">
+                   :class="{
+                     pinned: activity.view === 'timeline' && item.pinned,
+                     dragging: activity.dragEventId === String(item.id)
+                   }"
+                   :draggable="activity.view === 'groups'"
+                   @dragstart="onActivityDragStart($event, item)"
+                   @dragend="onActivityDragEnd()">
                 <button class="activity-row" type="button"
                         @click="openActivityEvent(item)"
                         :class="item.state
@@ -5841,6 +5950,15 @@
                     <path d="M9 12V5h6v7"/>
                   </svg>
                 </button>
+                <button class="activity-row-group" type="button"
+                        x-show="activity.view === 'groups'"
+                        :class="{ pending: _activityGroupPending[item.id] }"
+                        :disabled="!!_activityGroupPending[item.id]"
+                        @click.stop="openActivityMoveMenu($event, item)"
+                        :title="lang==='zh' ? '移动到分组' : 'Move to group'"
+                        :aria-label="lang==='zh' ? '移动到分组' : 'Move to group'">
+                  <svg><use href="#i-folder"/></svg>
+                </button>
               </div>
             </template>
             <button class="activity-group-more" type="button"
@@ -5863,6 +5981,31 @@
              x-text="lang==='zh' ? '该状态下暂无任务' : 'No tasks in this state'"></div>
       </div>
     </div>
+  </div>
+
+  <!-- Portalled above the activity modal so it never gets clipped by the
+       modal body's scroll container. -->
+  <div class="activity-move-menu"
+       x-show="activity.moveMenu.show"
+       :style="activity.moveMenu.style"
+       @click.stop
+       @click.outside="closeActivityMoveMenu()"
+       role="menu"
+       x-cloak>
+    <div class="activity-move-menu-title"
+         x-text="lang==='zh' ? '移动到分组' : 'Move to group'"></div>
+    <template x-for="group in activityCustomGroupSections()" :key="group.key">
+      <button type="button" role="menuitem"
+              :class="{ active: String(activityMoveMenuItem()?.group_id || '') === String(group.groupId || '') }"
+              @click="assignActivityGroup(activityMoveMenuItem(), group.groupId || '')">
+        <span class="activity-custom-group-dot"
+              :class="'is-' + (group.color || 'gray')"></span>
+        <span x-text="group.label"></span>
+        <svg x-show="String(activityMoveMenuItem()?.group_id || '') === String(group.groupId || '')">
+          <use href="#i-check"/>
+        </svg>
+      </button>
+    </template>
   </div>
 
   <!-- Scheduled-tasks drawer — modal listing tasks + create form +

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3656,6 +3656,19 @@ pre.text {
 .activity-view-switch button.active { background:var(--c-bg-1); color:var(--c-fg-0); box-shadow:var(--shadow-sm); }
 .activity-summary { display:flex; align-items:center; flex-wrap:wrap; gap:6px; padding:10px 14px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
 .activity-summary .btn-ghost { margin-left:auto; }
+.activity-groups-toolbar { display:flex; align-items:center; justify-content:space-between; gap:12px; min-height:56px; padding:9px 14px; border-bottom:1px solid var(--c-border); }
+.activity-groups-toolbar > div { min-width:0; display:flex; flex-direction:column; gap:2px; }
+.activity-groups-toolbar strong { color:var(--c-fg-1); font-size:var(--fs-sm); font-weight:var(--fw-medium); }
+.activity-groups-toolbar small { overflow:hidden; color:var(--c-fg-3); font-size:var(--fs-xs); text-overflow:ellipsis; white-space:nowrap; }
+.activity-groups-toolbar .btn-ghost { flex:0 0 auto; display:inline-flex; align-items:center; gap:5px; }
+.activity-groups-toolbar .btn-ghost svg { width:13px; height:13px; }
+.activity-group-editor { display:grid; grid-template-columns:minmax(160px,1fr) auto auto; align-items:center; gap:10px; padding:10px 14px; border-bottom:1px solid var(--c-border); background:var(--c-bg-2); }
+.activity-group-editor > input { min-width:0; height:32px; padding:0 9px; border:1px solid var(--c-border-strong); border-radius:var(--r-sm); outline:0; background:var(--c-bg-1); color:var(--c-fg-0); font:inherit; font-size:var(--fs-sm); }
+.activity-group-editor > input:focus { border-color:var(--c-accent); box-shadow:0 0 0 2px var(--c-accent-soft); }
+.activity-group-colors { display:flex; align-items:center; gap:6px; }
+.activity-group-swatch { width:18px; height:18px; padding:0; border:2px solid transparent; border-radius:50%; background:var(--activity-group-color,var(--c-fg-3)); cursor:pointer; box-shadow:0 0 0 1px color-mix(in srgb,var(--activity-group-color,var(--c-fg-3)) 45%,transparent); }
+.activity-group-swatch.active { border-color:var(--c-bg-1); box-shadow:0 0 0 2px var(--activity-group-color,var(--c-accent)); }
+.activity-group-editor-actions { display:flex; align-items:center; gap:5px; }
 /* Status chips follow the same attention order as the body. Counts come from
    the full backend ledger, while colour only signals unread/actionable work. */
 .activity-chip { display:inline-flex; align-items:center; gap:6px; padding:5px 10px; border:1px solid var(--c-border); border-radius:var(--r-full); background:transparent; color:var(--c-fg-2); font:inherit; font-size:var(--fs-xs); line-height:1.2; cursor:pointer; transition:background var(--t-fast), border-color var(--t-fast), color var(--t-fast), opacity var(--t-fast); }
@@ -3716,10 +3729,35 @@ pre.text {
 .activity-refreshing .spinner-sm,
 .activity-loading-overlay .spinner-sm { flex:0 0 auto; }
 .activity-group h3 { margin:10px 4px 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
+.activity-group.is-custom { margin:8px 0; padding:4px; border:1px solid var(--c-border); border-radius:var(--r-md); background:color-mix(in srgb,var(--c-bg-2) 46%,transparent); transition:border-color var(--t-fast),background var(--t-fast),box-shadow var(--t-fast); }
+.activity-group.is-custom.is-drag-over { border-color:var(--c-accent); background:var(--c-accent-soft); box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--c-accent) 35%,transparent); }
+.activity-custom-group-head { min-height:34px; display:flex; align-items:center; gap:7px; padding:3px 6px 5px; }
+.activity-custom-group-head > strong { min-width:0; overflow:hidden; color:var(--c-fg-1); font-size:var(--fs-sm); font-weight:var(--fw-medium); text-overflow:ellipsis; white-space:nowrap; }
+.activity-custom-group-dot { --activity-group-color:var(--c-fg-3); width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--activity-group-color); }
+.activity-custom-group-dot.is-blue,.activity-group-swatch.is-blue { --activity-group-color:#6093ff; }
+.activity-custom-group-dot.is-violet,.activity-group-swatch.is-violet { --activity-group-color:#9b7cff; }
+.activity-custom-group-dot.is-cyan,.activity-group-swatch.is-cyan { --activity-group-color:#38bcd8; }
+.activity-custom-group-dot.is-green,.activity-group-swatch.is-green { --activity-group-color:#42b883; }
+.activity-custom-group-dot.is-amber,.activity-group-swatch.is-amber { --activity-group-color:#d9a441; }
+.activity-custom-group-dot.is-rose,.activity-group-swatch.is-rose { --activity-group-color:#dc6d88; }
+.activity-custom-group-dot.is-gray,.activity-group-swatch.is-gray { --activity-group-color:var(--c-fg-3); }
+.activity-custom-group-count { min-width:18px; color:var(--c-fg-3); font:10px var(--font-mono); text-align:center; }
+.activity-custom-group-attention { min-width:18px; padding:1px 5px; border-radius:var(--r-full); background:var(--c-accent-soft); color:var(--c-accent); font:10px var(--font-mono); text-align:center; }
+.activity-custom-group-actions { margin-left:auto; display:flex; align-items:center; gap:2px; opacity:0; transition:opacity var(--t-fast); }
+.activity-group.is-custom:hover .activity-custom-group-actions,.activity-custom-group-actions:focus-within { opacity:1; }
+.activity-custom-group-actions button { width:26px; height:26px; display:flex; align-items:center; justify-content:center; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:12px var(--font-mono); cursor:pointer; }
+.activity-custom-group-actions button:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.activity-custom-group-actions button.danger:hover { color:var(--c-danger); }
+.activity-custom-group-actions button:disabled { opacity:.25; cursor:default; }
+.activity-custom-group-actions svg { width:12px; height:12px; }
+.activity-custom-group-empty { margin:0 4px 4px; padding:12px; border:1px dashed var(--c-border); border-radius:var(--r-sm); color:var(--c-fg-4); font-size:var(--fs-xs); text-align:center; }
 .activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
 .activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
 .activity-row-wrap { display:flex; align-items:center; border-radius:var(--r-sm); }
 .activity-row-wrap.pinned { box-shadow:inset 2px 0 0 color-mix(in srgb, var(--c-accent) 65%, transparent); }
+.activity-row-wrap[draggable="true"] { cursor:grab; }
+.activity-row-wrap[draggable="true"]:active { cursor:grabbing; }
+.activity-row-wrap.dragging { opacity:.38; }
 .activity-row { width:100%; display:flex; align-items:center; gap:10px; padding:10px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); text-align:left; cursor:pointer; }
 .activity-row-wrap .activity-row { width:auto; min-width:0; flex:1; }
 .activity-row:hover { background:var(--c-bg-2); }
@@ -3729,6 +3767,11 @@ pre.text {
 .activity-pin:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
 .activity-pin.active { color:var(--c-accent); opacity:1; }
 .activity-pin:disabled { opacity:0.35; cursor:wait; }
+.activity-row-group { width:30px; height:30px; flex:0 0 30px; margin-right:4px; padding:0; display:flex; align-items:center; justify-content:center; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-4); opacity:0; cursor:pointer; transition:opacity var(--t-fast),color var(--t-fast),background var(--t-fast); }
+.activity-row-wrap:hover .activity-row-group,.activity-row-group:focus-visible { opacity:1; }
+.activity-row-group:hover { background:var(--c-bg-3); color:var(--c-accent); }
+.activity-row-group:disabled { opacity:.35; cursor:wait; }
+.activity-row-group svg { width:14px; height:14px; }
 .activity-state-dot { width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--c-fg-3); visibility:hidden; }
 .activity-row.running .activity-state-dot { visibility:visible; background:var(--c-running); animation:muse-breath 1.8s ease-in-out infinite; }
 .activity-row.waiting_approval .activity-state-dot,.activity-row.paused .activity-state-dot { visibility:visible; background:var(--c-warn); }
@@ -3746,7 +3789,24 @@ pre.text {
 .activity-row-side small { color:var(--c-fg-3); font-size:var(--fs-xs); }
 .activity-row-side { flex:0 0 auto; display:flex; flex-direction:column; align-items:flex-end; gap:3px; color:var(--c-fg-2); font-size:var(--fs-xs); }
 @media (hover:none), (pointer:coarse) {
-  .activity-pin { opacity:0.72; }
+  .activity-pin,.activity-row-group,.activity-custom-group-actions { opacity:0.72; }
+}
+.activity-move-menu { position:fixed; z-index:1100; max-height:min(360px,calc(100vh - 16px)); overflow:auto; padding:5px; border:1px solid var(--c-border-strong); border-radius:var(--r-md); background:var(--c-bg-1); box-shadow:var(--shadow-pop); }
+.activity-move-menu-title { padding:6px 8px 5px; color:var(--c-fg-3); font-size:10px; font-weight:var(--fw-medium); }
+.activity-move-menu > button { width:100%; min-height:32px; display:flex; align-items:center; gap:8px; padding:5px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); font:inherit; font-size:var(--fs-sm); text-align:left; cursor:pointer; }
+.activity-move-menu > button:hover { background:var(--c-bg-2); }
+.activity-move-menu > button.active { color:var(--c-accent); }
+.activity-move-menu > button > span:nth-child(2) { min-width:0; flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.activity-move-menu > button svg { width:13px; height:13px; flex:0 0 13px; }
+@media (max-width:720px) {
+  .activity-modal .modal-head { flex-wrap:wrap; }
+  .activity-modal .modal-title { flex:1 1 auto; }
+  .activity-view-switch { order:3; width:100%; margin-left:0; }
+  .activity-view-switch button { flex:1; }
+  .activity-groups-toolbar small { white-space:normal; }
+  .activity-group-editor { grid-template-columns:1fr; }
+  .activity-group-colors { padding:2px; }
+  .activity-group-editor-actions { justify-content:flex-end; }
 }
 @media (max-width:600px) {
   .files-head-workspace { flex:1 1 auto; max-width:none; margin-left:2px; }
@@ -11113,21 +11173,42 @@ html[data-theme="eyecare"] .tool-error-hint {
   line-height: 1.5;
   resize: vertical;
 }
-.memory-recall-trace { position: relative; color: var(--c-fg-3); }
-.memory-recall-trace summary { cursor: pointer; font-size: 10px; }
-.memory-recall-popover {
-  position: absolute;
-  z-index: 30;
-  left: 0;
-  bottom: 20px;
-  width: min(360px, calc(100vw - 36px));
-  max-height: 300px;
+.memory-recall-trace {
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--c-fg-3);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+.memory-recall-trace:hover,
+.memory-recall-trace[aria-expanded="true"] { color: var(--c-accent); }
+.memory-recall-global {
+  position: fixed;
+  z-index: 880;
   overflow: auto;
-  padding: 10px;
+  padding: 12px;
   border: 1px solid var(--c-border);
-  border-radius: 10px;
+  border-radius: var(--r-md);
   background: var(--c-bg-1);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-pop);
+  box-sizing: border-box;
+  overscroll-behavior: contain;
+}
+.memory-recall-head { display:flex; align-items:center; gap:10px; margin-bottom:3px; }
+.memory-recall-head strong { min-width:0; flex:1; color:var(--c-fg-0); font-size:var(--fs-sm); font-weight:var(--fw-medium); }
+.memory-recall-head button { width:24px; height:24px; flex:0 0 24px; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:18px; line-height:1; cursor:pointer; }
+.memory-recall-head button:hover { background:var(--c-bg-2); color:var(--c-fg-0); }
+.memory-recall-global:focus-visible { outline:2px solid var(--c-accent); outline-offset:2px; }
+.memory-recall-global .memory-recall-item:last-child { padding-bottom:0; }
+.memory-recall-global .memory-recall-item > span { display:inline-block; max-width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.memory-recall-global .memory-recall-item p {
+  max-height:8.5em;
+  overflow:auto;
+  white-space:pre-wrap;
+  overflow-wrap:anywhere;
 }
 .memory-recall-meta { margin-bottom: 6px; font: 10px var(--font-mono); }
 .memory-recall-item {
@@ -11148,4 +11229,5 @@ html[data-theme="eyecare"] .tool-error-hint {
   .memory-status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .memory-filters { align-items: stretch; flex-direction: column; }
   .memory-filters select { width: 100%; }
+  .memory-recall-global { border-radius:var(--r-sm); }
 }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -233,6 +233,116 @@ def test_desktop_timeline_defaults_to_fifteen_rows_in_larger_modal(
     assert mobile_geometry["bodyMaxHeight"] == "none"
 
 
+def test_custom_groups_show_empty_sections_and_move_sessions(
+    page: Page, backend_url, auth_token,
+):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
+          app.lang = 'zh';
+          app.activity.viewLoaded = true;
+          app.activity.view = 'groups';
+          app.activity.loading = false;
+          app.activity.expanded = {};
+          app.activity.customGroups = [
+            {id: 'research', name: 'Research', color: 'violet'},
+            {id: 'delivery', name: 'Delivery', color: 'green'},
+          ];
+          app.activity.events = [{
+            id: 'grouped-row', session_id: 'grouped-session',
+            session_name: 'Research session', task_summary: 'Grouped task',
+            workspace: '/tmp/e2e', workspace_name: 'e2e',
+            state: 'completed', read: false, group_id: 'research',
+            started_at: 10, finished_at: 20, updated_at: 20,
+          }, {
+            id: 'ungrouped-row', session_id: 'ungrouped-session',
+            session_name: 'Ungrouped session', task_summary: 'Move this task',
+            workspace: '/tmp/e2e', workspace_name: 'e2e',
+            state: 'running', read: true,
+            started_at: 30, finished_at: 0, updated_at: 30,
+          }];
+          app.activity.summary = {
+            running: 1, unread: 1, attention: 0,
+            groups: {review: 1, running: 1, failed: 0, history: 0},
+            group_unread: {review: 1, running: 0, failed: 0, history: 0},
+            workspaces: [],
+          };
+          window.__activityGroupCalls = [];
+          app.api = async (path, options = {}) => {
+            window.__activityGroupCalls.push({path, options});
+            if (path === '/api/activity/groups' && options.method === 'POST') {
+              const group = {
+                id: 'writing', name: options.json.name,
+                color: options.json.color,
+              };
+              return {ok: true, data: {
+                revision: app._activityRevision + 1,
+                custom_groups: [...app.activity.customGroups, group],
+              }};
+            }
+            if (path.endsWith('/group') && options.method === 'PUT') {
+              const id = decodeURIComponent(path.split('/').at(-2));
+              const item = app.activity.events.find(row => row.id === id);
+              const updated = {...item};
+              if (options.json.group_id) updated.group_id = options.json.group_id;
+              else delete updated.group_id;
+              return {ok: true, data: {
+                revision: app._activityRevision + 1,
+                item: updated,
+                custom_groups: [...app.activity.customGroups],
+              }};
+            }
+            return {ok: false, data: null, error: 'unexpected test request'};
+          };
+          app.activity.show = true;
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+
+    groups = page.locator(".activity-group.is-custom")
+    expect(groups).to_have_count(3)
+    assert page.locator(
+        ".activity-custom-group-head > strong"
+    ).all_text_contents() == ["Research", "Delivery", "未分组"]
+    delivery = groups.filter(has_text="Delivery")
+    expect(delivery.locator(".activity-custom-group-empty")).to_be_visible()
+
+    ungrouped_row = page.locator(".activity-row-wrap").filter(
+        has_text="Ungrouped session"
+    )
+    ungrouped_row.hover()
+    ungrouped_row.locator(".activity-row-group").click()
+    menu = page.locator(".activity-move-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator("button")).to_have_count(3)
+    menu.locator("button").filter(has_text="Research").click()
+
+    research = groups.filter(has_text="Research")
+    expect(research.locator(".activity-row-wrap")).to_have_count(2)
+    expect(groups.filter(has_text="未分组").locator(
+        ".activity-custom-group-empty"
+    )).to_be_visible()
+
+    page.locator(".activity-groups-toolbar .btn-ghost").click()
+    editor = page.locator(".activity-group-editor")
+    expect(editor).to_be_visible()
+    editor.locator("input").fill("Writing")
+    editor.locator(".activity-group-swatch.is-rose").click()
+    editor.locator('button[type="submit"]').click()
+    expect(page.locator(".activity-custom-group-head > strong")).to_contain_text(
+        ["Research", "Delivery", "Writing", "未分组"]
+    )
+
+    calls = page.evaluate("() => window.__activityGroupCalls")
+    assert any(call["path"].endswith("/ungrouped-row/group") for call in calls)
+    assert any(call["path"] == "/api/activity/groups" for call in calls)
+
+
 def test_session_rename_updates_loaded_activity_row_immediately(
     page: Page, backend_url, auth_token
 ):
@@ -292,7 +402,11 @@ def test_live_updates_and_all_status_time_view(page: Page, backend_url, auth_tok
 
     page.locator(".activity-center-btn").click()
     expect(page.locator(".activity-modal")).to_be_visible()
-    expect(page.locator(".activity-view-switch button").nth(1)).to_have_class(
+    expect(page.locator(".activity-view-switch button").nth(0)).to_have_class(
+        "active"
+    )
+    page.locator(".activity-view-switch button").nth(2).click()
+    expect(page.locator(".activity-view-switch button").nth(2)).to_have_class(
         "active"
     )
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -2848,7 +2848,10 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
               model: 'e2e-model',
               memory_recall: {
                 id: 'tool-tail-memory-trace', count: 1,
-                latency_ms: 8, status: 'ok', items: [],
+                latency_ms: 8, status: 'ok', items: [{
+                  id: 'tool-tail-memory-item', kind: 'preference',
+                  content: 'A deliberately long memory detail '.repeat(36),
+                }],
               },
               session_usage: {
                 context_used_pct: 5,
@@ -2912,8 +2915,38 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     expect(footer.locator(".msg-elapsed")).to_have_text("· 2m05s")
     expect(footer.locator(".turn-model")).to_have_text("· E2E model")
     expect(footer.locator(".turn-status")).to_have_text(expected_status)
-    expect(footer.locator(".memory-recall-trace")).to_be_visible()
+    recall_trigger = footer.locator(".memory-recall-trace")
+    expect(recall_trigger).to_be_visible()
     expect(footer.locator(".turn-fork-btn")).to_be_visible()
+
+    recall_trigger.click()
+    recall = page.locator(".memory-recall-global")
+    expect(recall).to_be_visible()
+    recall_geometry = recall.evaluate(
+        """node => {
+          const rect = node.getBoundingClientRect();
+          return {
+            position: getComputedStyle(node).position,
+            zIndex: Number(getComputedStyle(node).zIndex),
+            insideChatScroller: !!node.closest('.chat-body'),
+            left: rect.left,
+            top: rect.top,
+            right: rect.right,
+            bottom: rect.bottom,
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+          };
+        }"""
+    )
+    assert recall_geometry["position"] == "fixed"
+    assert recall_geometry["zIndex"] >= 800
+    assert recall_geometry["insideChatScroller"] is False
+    assert recall_geometry["left"] >= 0
+    assert recall_geometry["top"] >= 0
+    assert recall_geometry["right"] <= recall_geometry["viewportWidth"]
+    assert recall_geometry["bottom"] <= recall_geometry["viewportHeight"]
+    page.keyboard.press("Escape")
+    expect(recall).to_be_hidden()
 
     state = _app_eval(
         page,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -170,6 +170,74 @@ def test_pin_persists_without_rewriting_activity_time(tmp_path, monkeypatch):
     assert restarted.set_pin("missing", True) is None
 
 
+def test_custom_groups_persist_reorder_and_assignment_without_rewriting_task(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    ticks = iter([1, 2, 3, 4])
+    monkeypatch.setattr("backend.activity.time.time", lambda: next(ticks))
+    first = service.start("s1", summary="older task")
+    service.finish("s1", "completed")
+    service.start("s2", summary="newer task")
+    service.finish("s2", "completed")
+    before = dict(next(row for row in service.list()
+                       if row["session_id"] == "s1"))
+
+    research = service.create_group("Research", "violet")["group"]
+    delivery = service.create_group("Delivery", "green")["group"]
+    assigned = service.set_group(first["id"], research["id"])
+    assert assigned is not None
+    assert assigned["item"]["group_id"] == research["id"]
+    after = next(row for row in service.list() if row["session_id"] == "s1")
+    for field in (
+        "updated_at", "started_at", "finished_at", "state", "read",
+        "task_summary", "turn_count",
+    ):
+        assert after[field] == before[field]
+    assert [row["session_id"] for row in service.list()] == ["s2", "s1"]
+
+    ordered = service.reorder_groups([delivery["id"], research["id"]])
+    assert [row["id"] for row in ordered["custom_groups"]] == [
+        delivery["id"], research["id"],
+    ]
+    restarted = ActivityService(tmp_path)
+    assert [row["id"] for row in restarted.list_groups()] == [
+        delivery["id"], research["id"],
+    ]
+    restored = next(row for row in restarted.list()
+                    if row["session_id"] == "s1")
+    assert restored["group_id"] == research["id"]
+
+    cleared = restarted.delete_group(research["id"])
+    assert cleared is not None
+    assert cleared["cleared_sessions"] == 1
+    assert "group_id" not in next(
+        row for row in restarted.list() if row["session_id"] == "s1"
+    )
+    state = json.loads(restarted.groups_path.read_text(encoding="utf-8"))
+    assert state["assignments"] == {}
+
+
+@pytest.mark.asyncio
+async def test_group_delete_pushes_resync_for_all_affected_rows(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    item = service.start("s1", summary="grouped task")
+    group = service.create_group("Temporary", "amber")["group"]
+    service.set_group(item["id"], group["id"])
+
+    async with service.subscribe() as queue:
+        deleted = await asyncio.to_thread(service.delete_group, group["id"])
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert deleted is not None
+    assert payload["resync"] is True
+    assert payload["custom_groups"] == []
+
+
 @pytest.mark.asyncio
 async def test_rename_persists_and_pushes_without_reordering_task(
     tmp_path,
@@ -302,3 +370,66 @@ def test_activity_pin_endpoint_is_authenticated_and_returns_live_envelope(
     assert payload["item"]["pinned"] is True
     assert payload["revision"] == service.revision
     assert payload["generation"] == service.generation
+
+
+def test_activity_group_endpoints_manage_and_assign_custom_groups(
+    client,
+    auth,
+    tmp_path,
+    monkeypatch,
+):
+    from backend import activity_api
+
+    service = _service(tmp_path, monkeypatch)
+    started = service.start("s1", summary="group from task center")
+    service.finish("s1", "completed")
+    monkeypatch.setattr(activity_api, "activity", service)
+
+    denied = client.post(
+        "/api/activity/groups",
+        json={"name": "Research", "color": "violet"},
+    )
+    assert denied.status_code == 401
+
+    created = client.post(
+        "/api/activity/groups",
+        headers=auth,
+        json={"name": "Research", "color": "violet"},
+    )
+    assert created.status_code == 200
+    group = created.json()["group"]
+    assert group["name"] == "Research"
+
+    duplicate = client.post(
+        "/api/activity/groups",
+        headers=auth,
+        json={"name": "research", "color": "blue"},
+    )
+    assert duplicate.status_code == 400
+
+    assigned = client.put(
+        f"/api/activity/{started['id']}/group",
+        headers=auth,
+        json={"group_id": group["id"]},
+    )
+    assert assigned.status_code == 200
+    assert assigned.json()["item"]["group_id"] == group["id"]
+
+    renamed = client.patch(
+        f"/api/activity/groups/{group['id']}",
+        headers=auth,
+        json={"name": "Deep research", "color": "cyan"},
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["group"]["color"] == "cyan"
+
+    listed = client.get("/api/activity/groups", headers=auth)
+    assert listed.status_code == 200
+    assert listed.json()["custom_groups"][0]["name"] == "Deep research"
+
+    deleted = client.delete(
+        f"/api/activity/groups/{group['id']}",
+        headers=auth,
+    )
+    assert deleted.status_code == 200
+    assert "group_id" not in service.list()[0]

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1281,7 +1281,12 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
 
     activity_state = app[app.index("activity: {"):app.index("_activityEtags:")]
-    assert 'view: "timeline"' in activity_state
+    assert 'view: "groups"' in activity_state
+
+    group_button = html.index("setActivityView('groups')")
+    status_button = html.index("setActivityView('status')")
+    timeline_button = html.index("setActivityView('timeline')")
+    assert group_button < status_button < timeline_button
 
     review = app.index('{ key: "review"')
     running = app.index('{ key: "running"', review)
@@ -1312,6 +1317,19 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'this.activity.view === "timeline"' in app
     assert 'key === "timeline") return true' in app
     assert "setActivityView('timeline')" in html
+    assert "setActivityView('groups')" in html
+    assert 'activity.view === "groups"' in app
+    assert "activityCustomGroupSections()" in app
+    assert 'key: "custom:__ungrouped__"' in app
+    assert '"/api/activity/groups"' in app
+    assert '"/api/activity/groups/order"' in app
+    assert '}/group`' in app
+    assert 'class="activity-groups-toolbar"' in html
+    assert 'class="activity-group-editor"' in html
+    assert 'class="activity-row-group"' in html
+    assert '@dragstart="onActivityDragStart($event, item)"' in html
+    assert ".activity-group.is-custom.is-drag-over" in css
+    assert ".activity-move-menu" in css
     assert "const pinRank = Number(!!b.pinned) - Number(!!a.pinned)" in app
     assert "async toggleActivityPin(item)" in app
     assert 'method: "PATCH", json: { pinned: target }' in app
@@ -1327,6 +1345,26 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert "activityIsUnreadResult(item) ? ' is-unread'" in html
     assert ".activity-row.failed.is-unread .activity-state-dot" in css
     assert ".activity-row.failed .activity-state-dot,.activity-row.waiting_approval" not in css
+
+
+def test_memory_recall_details_use_a_root_fixed_portal():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    trigger = html.index('class="memory-recall-trace"')
+    portal = html.index('class="memory-recall-global"')
+    activity = html.index('class="modal activity-modal"')
+    assert trigger < portal < activity
+    assert 'class="memory-recall-popover"' not in html
+    assert "document.querySelector(\".memory-recall-global\")" in app
+    assert '"position:fixed"' in app
+    assert "_queueMemoryRecallPosition()" in app
+    assert ".memory-recall-global {" in css
+    portal_css = css[css.index(".memory-recall-global {"):]
+    portal_css = portal_css[:portal_css.index("}")]
+    assert "position: fixed" in portal_css
+    assert "z-index: 880" in portal_css
 
 
 def test_activity_center_uses_two_compact_numberless_status_dots():


### PR DESCRIPTION
## 变更类型
- [x] 新功能 (feature)
- [x] 修复 (bugfix)
- [ ] 重构 (refactor)
- [ ] 文档 (docs)
- [ ] 其他 (other)

## 变更说明
- 为全局任务中心新增可持久化的自定义会话分组，支持创建、改名、选色、排序、删除、拖放和菜单移动
- 将“按分组”调整为首个默认视图，同时保留用户已保存的显式视图偏好
- 提供内置“未分组”区域；删除分组只清除归属，不删除会话或改写任务时间与已读状态
- 将记忆召回详情迁移为页面根级固定浮层，避免被会话、预览或滚动容器裁剪
- 分组元数据仅保存在本地 `.muselab/activity-groups.json`，通过鉴权接口访问，不进入模型上下文

## 测试情况
- `git diff --check`
- `node --check frontend/app.js`
- `ruff check backend/activity.py backend/activity_api.py tests/test_activity.py`
- `pytest tests/test_activity.py tests/test_frontend_lint.py`：123 passed
- Playwright：任务中心完整回归及记忆浮层回归共 9 passed
- 当前本地服务健康检查与真实浏览器验收通过

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 未包含凭据、私有路径或真实用户内容

## 截图
- 本次未附截图；交互与视口几何由 Playwright 覆盖。