### PR TITLE
feat(workspace): improve task and file workflows

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -13011,10 +13011,11 @@ async def _maybe_drain_queue(session_id: str) -> None:
     async with _queue_drain_lock_for(session_id):
         if session_id in _active_turns and not _active_turns[session_id].done:
             return
-        watcher = _task_watchers.get(session_id)
-        if (_sessions_with_inflight_tasks.get(session_id)
-                or (watcher is not None and not watcher.done())):
-            return
+        # Background task watchers no longer block user turns. _SessionStream is
+        # the single SDK reader and safely routes messages between an active turn
+        # and the watcher, so queued turns must follow the same concurrency
+        # contract as direct sends. Only an actually active user turn blocks the
+        # next FIFO item.
         item = sess.dequeue_message(session_id)
         if item is None:
             return

--- a/backend/files.py
+++ b/backend/files.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import heapq
 import os
 import json
 import re
@@ -464,7 +465,6 @@ def list_dir(
     if not target.is_dir():
         raise HTTPException(status_code=400, detail="not a directory")
     entries: list[dict] = []
-    truncated = False
     # Keep the caller's logical path when `path` traverses a directory
     # symlink. `target` is the resolved real directory (required for the
     # containment check), but DirEntry.path therefore points at that real
@@ -484,27 +484,41 @@ def list_dir(
     # syscall-heavy.
     try:
         with os.scandir(target) as scan:
-            candidates = []
-            for child in scan:
-                if is_root_listing and child.name in {
-                    TRASH_DIR_NAME,
-                    INTERNAL_DIR_NAME,
-                }:
-                    continue
-                if not show_hidden and child.name.startswith("."):
-                    continue
-                try:
-                    is_dir = child.is_dir()
-                except OSError:
-                    continue
-                candidates.append((child.name.lower(), child, is_dir))
+            # Keep only the first UI page while scanning. The previous code
+            # accumulated and sorted every DirEntry before slicing to 500, so a
+            # dump directory with tens of thousands of files caused a large
+            # allocation and O(N log N) sort even though the browser could never
+            # receive more than MAX_LIST_ENTRIES rows. nsmallest still preserves
+            # deterministic directory-first ordering while bounding memory and
+            # sorting work to O(MAX_LIST_ENTRIES).
+            def candidates():
+                for child in scan:
+                    if is_root_listing and child.name in {
+                        TRASH_DIR_NAME,
+                        INTERNAL_DIR_NAME,
+                    }:
+                        continue
+                    if not show_hidden and child.name.startswith("."):
+                        continue
+                    try:
+                        is_dir = child.is_dir()
+                    except OSError:
+                        continue
+                    yield (
+                        (not is_dir, child.name.lower(), child.name),
+                        child,
+                        is_dir,
+                    )
+
+            selected = heapq.nsmallest(
+                MAX_LIST_ENTRIES + 1,
+                candidates(),
+                key=lambda item: item[0],
+            )
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"failed to list: {e}")
-    candidates.sort(key=lambda item: (not item[2], item[0]))
-    for _, child, is_dir in candidates:
-        if len(entries) >= MAX_LIST_ENTRIES:
-            truncated = True
-            break
+    truncated = len(selected) > MAX_LIST_ENTRIES
+    for _, child, is_dir in selected[:MAX_LIST_ENTRIES]:
         try:
             stat = child.stat()
         except OSError:

--- a/backend/workspace_store.py
+++ b/backend/workspace_store.py
@@ -41,6 +41,10 @@ _EVENT_LIMIT = 20_000
 # (for example when a formerly indexed cache tree becomes opaque). Replaying
 # that many rows is slower than one clean snapshot and would be pruned anyway.
 _RECONCILE_REPLAY_LIMIT = 500
+# Compact bootstrap restores root plus previously expanded directories. Cap each
+# sibling set independently so one generated/dump directory cannot turn a cold
+# page load into a multi-megabyte JSON response and browser main-thread stall.
+_BOOTSTRAP_CHILDREN_PER_PARENT = 500
 
 
 class WorkspaceScanIncomplete(RuntimeError):
@@ -221,6 +225,19 @@ class WorkspaceStore:
                     """
                     CREATE INDEX IF NOT EXISTS files_workspace_parent_path
                     ON files(workspace_id, parent, path)
+                    """
+                )
+                db.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS files_workspace_parent_kind_name
+                    ON files(
+                        workspace_id,
+                        parent,
+                        is_dir DESC,
+                        name COLLATE NOCASE,
+                        name,
+                        path
+                    )
                     """
                 )
             self._secure_database_files()
@@ -794,20 +811,20 @@ class WorkspaceStore:
                 ).fetchone()
                 if workspace is None:
                     raise KeyError(f"unknown workspace: {workspace_id}")
-                rows = (
-                    self._file_rows(
+                truncated_parents: list[str] = []
+                if normalized_parents is None:
+                    rows = self._file_rows(
                         db,
                         workspace_id,
                         show_hidden=show_hidden,
                     )
-                    if normalized_parents is None
-                    else self._file_rows_for_parents(
+                else:
+                    rows, truncated_parents = self._file_rows_for_parents(
                         db,
                         workspace_id,
                         normalized_parents,
                         show_hidden=show_hidden,
                     )
-                )
                 entries = [
                     {
                         key: value
@@ -831,6 +848,8 @@ class WorkspaceStore:
                 {
                     "partial": True,
                     "parents": normalized_parents,
+                    "truncated_parents": truncated_parents,
+                    "children_per_parent_limit": _BOOTSTRAP_CHILDREN_PER_PARENT,
                 }
                 if normalized_parents is not None
                 else {}
@@ -1026,28 +1045,43 @@ class WorkspaceStore:
         parents: Iterable[str],
         *,
         show_hidden: bool = True,
-    ) -> list[dict[str, Any]]:
-        """Read root and expanded-directory children through a bounded index."""
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Read bounded children for root and each expanded directory.
+
+        The parent-count bound alone is insufficient: a single generated
+        directory can contain tens of thousands of direct children. Query each
+        selected parent through the directory-order index with a hard sibling
+        cap so compact bootstrap stays bounded per expanded directory.
+        """
         selected_parents = ["", *dict.fromkeys(parents)]
-        placeholders = ", ".join("?" for _ in selected_parents)
-        parameters: list[Any] = [workspace_id, *selected_parents]
         hidden_clause = ""
         if not show_hidden:
             hidden_clause = (
                 " AND path NOT GLOB '.*'"
                 " AND path NOT GLOB '*/.*'"
             )
-        rows = db.execute(
-            f"""
-            SELECT path, name, is_dir, size, mtime, mtime_ns, ctime_ns, inode
-            FROM files INDEXED BY files_workspace_parent_path
-            WHERE workspace_id = ?
-              AND parent IN ({placeholders}){hidden_clause}
-            ORDER BY path
-            """,
-            parameters,
-        ).fetchall()
-        return [
+        rows: list[sqlite3.Row] = []
+        truncated_parents: list[str] = []
+        for parent in selected_parents:
+            parent_rows = db.execute(
+                f"""
+                SELECT path, name, is_dir, size, mtime, mtime_ns,
+                       ctime_ns, inode
+                FROM files INDEXED BY files_workspace_parent_kind_name
+                WHERE workspace_id = ? AND parent = ?{hidden_clause}
+                ORDER BY is_dir DESC, name COLLATE NOCASE, name, path
+                LIMIT ?
+                """,
+                (
+                    workspace_id,
+                    parent,
+                    _BOOTSTRAP_CHILDREN_PER_PARENT + 1,
+                ),
+            ).fetchall()
+            if len(parent_rows) > _BOOTSTRAP_CHILDREN_PER_PARENT:
+                truncated_parents.append(parent)
+            rows.extend(parent_rows[:_BOOTSTRAP_CHILDREN_PER_PARENT])
+        entries = [
             {
                 "path": row["path"],
                 "name": row["name"],
@@ -1060,6 +1094,7 @@ class WorkspaceStore:
             }
             for row in rows
         ]
+        return entries, truncated_parents
 
     @staticmethod
     def _subtree_pattern(path: str) -> str:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -586,6 +586,12 @@ function portal() {
         session_mode: "fresh",
       },
     },
+    // User-owned scratch TODO clipboard for the active conversation. It is
+    // deliberately independent from Muse/Claude Task tools and stored only in
+    // this browser, per session.
+    sessionTodoOpen: false,
+    sessionTodoDraft: "",
+    sessionTodoDragId: "",
     activity: {
       show: false, loading: false, events: [],
       // Custom groups are the primary organization surface. An explicit user
@@ -602,6 +608,9 @@ function portal() {
       expanded: {},
       // Selected group keys. Empty array = no filter = show every group.
       filter: [],
+      // Local search over the loaded activity snapshot. Keep this derived from
+      // events so SSE updates and session renames appear without another query.
+      query: "",
       customGroups: [],
       groupEditor: {
         open: false, id: "", name: "", color: "blue", saving: false,
@@ -4067,6 +4076,24 @@ function portal() {
       return p;
     },
 
+    // Convert a local file: URL emitted by the model into its decoded absolute
+    // pathname so the normal workspace-root safety check can handle it. Browsers
+    // block http(s) pages from navigating to file://, so these links must be
+    // intercepted by Muse. Remote file hosts stay rejected instead of being
+    // mistaken for local workspace paths. Returns null for non-file schemes and
+    // "" for malformed or non-local file URLs.
+    _localFileUrlPath(href) {
+      if (!/^file:/i.test(String(href || ""))) return null;
+      try {
+        const url = new URL(href);
+        if (url.protocol !== "file:") return "";
+        if (url.hostname && url.hostname !== "localhost") return "";
+        return decodeURIComponent(url.pathname || "");
+      } catch (_) {
+        return "";
+      }
+    },
+
     // Rewrite author-relative <img src> in rendered-markdown HTML to the backend
     // raw endpoint. A README's `![](promo/media/x.png)` is relative to the file,
     // but once injected into the preview pane the browser resolves it against the
@@ -4376,6 +4403,11 @@ function portal() {
         FORBID_TAGS: ["style", "iframe", "form", "object", "embed"],
         FORBID_ATTR: ["style", "formaction"],
         ADD_ATTR: ["aria-hidden"],                            // KaTeX uses these
+        // DOMPurify drops file: hrefs by default before _linkifyFilePaths can
+        // convert them into workspace-safe links. Keep the upstream allowlist
+        // plus file:, then intercept every file URL below; local paths are
+        // normalized under MUSELAB_ROOT and remote/malformed hosts are disabled.
+        ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|file|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
       });
       // Restore protected math (HTML-escaped) now that markdown can no longer
       // mangle it. Done before the length-loss heuristic so short placeholders
@@ -4534,14 +4566,21 @@ function portal() {
         code.classList.add("has-file-link");
       }
       // 2) markdown links — [label](path/to/file.md) — marked renders as <a>.
-      // Convert to .file-link if href is relative (no protocol) and matches the
-      // path regex; otherwise leave the anchor alone (real URLs stay clickable).
+      // Convert relative, workspace-absolute, and local file:/// links to
+      // .file-link; otherwise leave real external URLs clickable.
       const anchors = rootEl.querySelectorAll("a[href]");
       for (const a of anchors) {
         if (a.classList.contains("file-link")) continue;
         let href = a.getAttribute("href") || "";
         if (!href || href.startsWith("#")) continue;
-        if (/^[a-z]+:/i.test(href)) {                  // http: / https: / mailto: / etc.
+        const localFilePath = this._localFileUrlPath(href);
+        if (localFilePath !== null) {
+          href = localFilePath;
+          if (!href) {
+            a.removeAttribute("href");
+            continue;
+          }
+        } else if (/^[a-z]+:/i.test(href)) {            // http: / https: / mailto: / etc.
           // External web links open in a NEW tab so a click never unloads the
           // chat SPA (the default same-tab navigation threw the user out of
           // the conversation). rel guards against tab-nabbing + referrer leak.
@@ -4551,11 +4590,13 @@ function portal() {
             a.setAttribute("rel", "noopener noreferrer");
           }
           continue;
+        } else {
+          // marked / the model may URL-encode the href (e.g. Chinese filenames
+          // come through as %E8%B5%84...). Decode so the regex + backend list
+          // lookup operate on the raw UTF-8 form. file: paths were decoded by
+          // _localFileUrlPath already.
+          try { href = decodeURIComponent(href); } catch (_) { /* malformed → leave as-is */ }
         }
-        // marked / the model may URL-encode the href (e.g. Chinese filenames
-        // come through as %E8%B5%84...). Decode so the regex + backend list
-        // lookup operate on the raw UTF-8 form.
-        try { href = decodeURIComponent(href); } catch (_) { /* malformed → leave as-is */ }
         const m = href.match(RE);
         if (!m) continue;
         const path = toRel(m[1]);
@@ -4593,9 +4634,16 @@ function portal() {
         window.open(href, "_blank", "noopener,noreferrer");
         return;
       }
-      if (/^[a-z]+:/i.test(href)) return;             // mailto:/tel:/… → let browser handle
-      try { href = decodeURIComponent(href); } catch (_) { /* malformed → leave as-is */ }
-      ev.preventDefault();
+      const localFilePath = this._localFileUrlPath(href);
+      if (localFilePath !== null) {
+        ev.preventDefault();
+        if (!localFilePath) return;
+        href = localFilePath;
+      } else {
+        if (/^[a-z]+:/i.test(href)) return;           // mailto:/tel:/… → let browser handle
+        try { href = decodeURIComponent(href); } catch (_) { /* malformed → leave as-is */ }
+        ev.preventDefault();
+      }
       // Try ROOT-relative normalization first (absolute under ROOT, or ROOT
       // basename duplicated as prefix). If that returns "" (e.g. /etc/passwd),
       // fall back to the raw href minus leading slash so the user at least
@@ -6814,6 +6862,9 @@ function portal() {
         // different tab — drives a green dot on the tab strip so the user
         // notices "this one's ready". Cleared when the user activates the tab.
         unread: false,
+        // User-maintained scratch TODOs for this conversation. Loaded from
+        // localStorage when the tab state is first created.
+        userTodos: [],
         // Per-session message queue. Populated when the user sends while
         // this tab's turn is still streaming OR while a compact is in
         // flight. Drained automatically on the next `done` event /
@@ -6887,6 +6938,7 @@ function portal() {
         this.tabState[id] = this._blankTabState();
         this.tabState[id]._sid = id;
         this.tabState[id].draft.input = this._consumePersistedChatDraft(id);
+        this.tabState[id].userTodos = this._loadSessionUserTodos(id);
         // The queue now lives server-side (sessions/{sid}.queue.json). We do
         // NOT pull it here — _ensureTabState is called synchronously all over
         // the place and shouldn't fire a fetch each time. The queue mirror is
@@ -10860,6 +10912,103 @@ function portal() {
       if (dirty) this._storeTaskSubjects(map);
       this._cachedTaskSubjectMap = { key: cacheKey, map };
       return map;
+    },
+    _sessionUserTodoStorageKey(sid = this.currentId) {
+      return "muselab.userTodos." + (sid || "_default");
+    },
+    _loadSessionUserTodos(sid) {
+      try {
+        const parsed = JSON.parse(localStorage.getItem(
+          this._sessionUserTodoStorageKey(sid)) || "[]");
+        return Array.isArray(parsed)
+          ? parsed.filter(item => item && item.text).slice(0, 100).map(item => ({
+              ...item,
+              priority: ["high", "medium", "low"].includes(item.priority)
+                ? item.priority : "medium",
+            })) : [];
+      } catch (_) { return []; }
+    },
+    _persistSessionUserTodos() {
+      if (!this.currentId) return;
+      try {
+        localStorage.setItem(
+          this._sessionUserTodoStorageKey(),
+          JSON.stringify(this.sessionTodoItems()),
+        );
+      } catch (_) { /* private mode / quota: keep the in-memory clipboard */ }
+    },
+    sessionTodoItems() {
+      if (!this.currentId) return [];
+      const state = this._ensureTabState(this.currentId);
+      return Array.isArray(state.userTodos) ? state.userTodos : [];
+    },
+    sessionTodoCount(completed = null) {
+      const items = this.sessionTodoItems();
+      return completed == null
+        ? items.length : items.filter(item => !!item.completed === completed).length;
+    },
+    addSessionUserTodo() {
+      const text = String(this.sessionTodoDraft || "").trim();
+      if (!text || !this.currentId) return;
+      const state = this._ensureTabState(this.currentId);
+      state.userTodos = [
+        ...(state.userTodos || []),
+        { id: `u-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          text, completed: false, priority: "medium" },
+      ].slice(-100);
+      this.sessionTodoDraft = "";
+      this._persistSessionUserTodos();
+    },
+    toggleSessionUserTodo(id) {
+      const state = this._ensureTabState(this.currentId);
+      state.userTodos = (state.userTodos || []).map(item =>
+        item.id === id ? { ...item, completed: !item.completed } : item);
+      this._persistSessionUserTodos();
+    },
+    deleteSessionUserTodo(id) {
+      const state = this._ensureTabState(this.currentId);
+      state.userTodos = (state.userTodos || []).filter(item => item.id !== id);
+      this._persistSessionUserTodos();
+    },
+    clearCompletedSessionUserTodos() {
+      const state = this._ensureTabState(this.currentId);
+      state.userTodos = (state.userTodos || []).filter(item => !item.completed);
+      this._persistSessionUserTodos();
+    },
+    sessionTodosForPriority(priority) {
+      return this.sessionTodoItems().filter(item => item.priority === priority);
+    },
+    onSessionTodoDragStart(ev, item) {
+      this.sessionTodoDragId = item.id;
+      if (ev?.dataTransfer) {
+        ev.dataTransfer.effectAllowed = "move";
+        ev.dataTransfer.setData("text/plain", item.id);
+      }
+    },
+    onSessionTodoDragEnd() {
+      this.sessionTodoDragId = "";
+    },
+    onSessionTodoDrop(ev, priority, beforeId = "") {
+      ev?.preventDefault?.();
+      const id = this.sessionTodoDragId
+        || ev?.dataTransfer?.getData("text/plain") || "";
+      if (!id || !["high", "medium", "low"].includes(priority)) return;
+      const state = this._ensureTabState(this.currentId);
+      const current = (state.userTodos || []).slice();
+      const source = current.findIndex(item => item.id === id);
+      if (source < 0) return;
+      const [moved] = current.splice(source, 1);
+      moved.priority = priority;
+      const target = beforeId ? current.findIndex(item => item.id === beforeId) : -1;
+      if (target >= 0) current.splice(target, 0, moved);
+      else current.push(moved);
+      state.userTodos = current;
+      this.sessionTodoDragId = "";
+      this._persistSessionUserTodos();
+    },
+    toggleSessionTodoBoard() {
+      this.sessionTodoOpen = !this.sessionTodoOpen;
+      if (!this.sessionTodoOpen) this.sessionTodoDraft = "";
     },
     taskLogLine(m) {
       if (!m || !m.name) return null;
@@ -16102,17 +16251,12 @@ function portal() {
             }),
           });
           if ([404, 405, 501].includes(response.status)) {
-            if (treeSeq !== this._treeLoadSeq
-                || !this._workspaceIsCurrent(ownerWorkspace)
-                || !this._workspaceGenerationIsCurrent(
-                  ownerWorkspace, workspaceGeneration,
-                )) return false;
-            // Rolling deploy compatibility with a backend that only knows the
-            // original full-snapshot GET contract.
-            response = await fetch(
-              `/api/files/bootstrap${query ? `?${query}` : ""}`,
-              { headers: ownerHeaders },
-            );
+            // Never fall back to the legacy full-snapshot GET here: one expanded
+            // dump directory can make that response unbounded and freeze the
+            // browser before virtual scrolling gets a chance to help. Returning
+            // false lets _loadRootNow use the already-capped /api/files/list
+            // compatibility path instead.
+            return false;
           }
         }
       } catch (_) { return false; }
@@ -16136,6 +16280,7 @@ function portal() {
           && responseWorkspaceId !== expectedWorkspaceId) return false;
       const nextCursor = payload.cursor ?? payload.next_cursor ?? payload.nextCursor;
       let applied = false;
+      let snapshotHasTruncatedParents = false;
       if (!hasCursor && Array.isArray(payload.entries)) {
         const tree = this._materializeFileSnapshot(
           payload.entries, Array.from(this.expanded || []),
@@ -16145,6 +16290,19 @@ function portal() {
         this.expanded = tree.expanded;
         this._pendingExpanded = Array.from(this.expanded);
         this._scheduleFileTreeViewportSync(true);
+        const truncatedParents = Array.isArray(payload.truncated_parents)
+          ? payload.truncated_parents : [];
+        snapshotHasTruncatedParents = truncatedParents.length > 0;
+        if (snapshotHasTruncatedParents) {
+          const sample = truncatedParents[0] || "/";
+          const limit = Number(payload.children_per_parent_limit) || 500;
+          this.toast(
+            this.t("toast.dir_truncated", { path: sample, n: limit })
+              + (truncatedParents.length > 1
+                ? ` (+${truncatedParents.length - 1})` : ""),
+            "warn", 4500,
+          );
+        }
         applied = true;
       } else if (payload.resync === true) {
         this._workspaceTreeCursors.delete(ownerWorkspace);
@@ -16156,7 +16314,14 @@ function portal() {
           ? this._applyFileTreeDelta(payload.changes) : true;
       }
       if (!applied) return false;
-      if (nextCursor != null) {
+      if (snapshotHasTruncatedParents) {
+        // A capped sibling list is not a complete delta base. Keeping its
+        // workspace cursor would let later add/delete events grow it beyond the
+        // cap or leave it under-filled because the hidden 501st row emits no
+        // compensating event. Force the next sync through another bounded
+        // compact snapshot instead of applying deltas to incomplete parents.
+        this._workspaceTreeCursors.delete(ownerWorkspace);
+      } else if (nextCursor != null) {
         const currentCursor = Number(this._workspaceTreeCursors.get(ownerWorkspace) || 0);
         const numericCursor = Number(nextCursor);
         if (Number.isFinite(numericCursor)) {
@@ -19722,6 +19887,15 @@ function portal() {
 
     async openFile(n, opts = {}) {
       if (!n || !n.path) return false;
+      // A file open is an explicit request to see the preview. Restore the
+      // desktop preview rail even when it was hidden (or chat/files fullscreen
+      // collapsed it). Mobile already switches to the preview tab below.
+      if (opts.reveal !== false && !this._isMobileLayout()
+          && (!this.previewOpen || this.desktopFullPane)) {
+        this.desktopFullPane = "";
+        this.previewOpen = true;
+        this.savePrefs();
+      }
       this.dismissTransientPreviewQuote(true);
       if (this.previewSurface === "terminal") this._teardownTerminalView();
       this.previewSurface = "file";
@@ -27475,6 +27649,35 @@ function portal() {
       }
       return false;
     },
+    activitySearchQuery() {
+      return String(this.activity.query || "").trim().toLocaleLowerCase();
+    },
+    activityMatchesSearch(item) {
+      const query = this.activitySearchQuery();
+      if (!query) return true;
+      const fields = [
+        item?.session_name,
+        item?.task_summary,
+        item?.session_id,
+        item?.thread_id,
+        item?.workspace,
+        item?.workspace_name,
+        item?.state,
+        this.activityStateLabel(item?.state),
+        item?.status_detail,
+        item?.kind,
+        item?.source_id,
+        item?.id,
+      ];
+      return fields.some(value => String(value || "").toLocaleLowerCase().includes(query));
+    },
+    activitySearchResultCount() {
+      if (!this.activitySearchQuery()) return (this.activity.events || []).length;
+      return (this.activity.events || []).filter(item => this.activityMatchesSearch(item)).length;
+    },
+    clearActivitySearch() {
+      this.activity.query = "";
+    },
     activityEventTimestamp(item) {
       return Number(item?.updated_at || item?.finished_at || item?.started_at || 0);
     },
@@ -27488,10 +27691,18 @@ function portal() {
       };
       return (this.activity.events || [])
         .filter(item => this.activityMatchesGroup(item, group.key))
+        // Search before applying the per-group row cap so a matching older
+        // session remains discoverable even when it was outside the first page.
+        .filter(item => this.activityMatchesSearch(item))
         .sort((a, b) => {
           if (group.key === "timeline") {
             const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
             if (pinRank) return pinRank;
+            return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+          }
+          if (group.key === "custom:__ungrouped__") {
+            // Ungrouped is an inbox of recent sessions, not an attention queue.
+            // Keep its order predictable: newest activity always comes first.
             return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
           }
           if (group.custom) {
@@ -27525,7 +27736,11 @@ function portal() {
       this.activity.expanded[key] = !this.activity.expanded[key];
     },
     activityGroupCount(group) {
-      if (group?.custom) return this.activityAllEvents(group).length;
+      // While searching, counts must describe the visible result set rather
+      // than the unfiltered backend summary.
+      if (group?.custom || this.activitySearchQuery()) {
+        return this.activityAllEvents(group).length;
+      }
       const count = this.activity.summary?.groups?.[group.key];
       return Number.isFinite(Number(count))
         ? Number(count) : this.activityAllEvents(group).length;
@@ -27567,7 +27782,7 @@ function portal() {
       return !!item && ["waiting_approval", "paused"].includes(item.state);
     },
     activityGroupUnread(group) {
-      if (group?.custom) {
+      if (group?.custom || this.activitySearchQuery()) {
         return this.activityAllEvents(group)
           .filter(item => this.activityIsUnreadResult(item)
             || this.activityRequiresAction(item)).length;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1320,6 +1320,15 @@
           <span x-text="t('pane.chat')"></span>
         </span>
         <span class="spacer"></span>
+        <button class="session-todo-btn icon-btn" type="button"
+                @click="toggleSessionTodoBoard()"
+                :class="{ active: sessionTodoOpen, 'has-active': sessionTodoCount(false) }"
+                :aria-expanded="sessionTodoOpen"
+                :title="lang==='zh' ? '待办事项' : 'Current session TODOs'">
+          <svg><use href="#i-check-circle"/></svg>
+          <span class="session-todo-badge" x-show="sessionTodoCount()"
+                x-text="sessionTodoCount(true) + '/' + sessionTodoCount()"></span>
+        </button>
         <!-- Global task center — moved here from the files header to sit
              immediately left of the Skills entry (2026-07-21). -->
         <button class="activity-center-btn" type="button" @click="openActivityCenter()"
@@ -5751,6 +5760,81 @@
     </template>
   </div>
 
+  <div class="modal-backdrop" x-show="sessionTodoOpen"
+       @click.self="sessionTodoOpen=false" x-cloak>
+    <div class="modal session-todo-modal" role="dialog" aria-modal="true"
+         @keydown.escape.window="sessionTodoOpen=false">
+      <div class="modal-head">
+        <span class="modal-title">
+          <svg class="modal-title-icon"><use href="#i-check-circle"/></svg>
+          <span x-text="lang==='zh' ? '待办事项' : 'To-do board'"></span>
+        </span>
+        <span class="session-todo-modal-count"
+              x-text="sessionTodoCount(true) + '/' + sessionTodoCount()"></span>
+        <button class="btn-ghost sm" type="button" x-show="sessionTodoCount(true)"
+                @click="clearCompletedSessionUserTodos()"
+                x-text="lang==='zh' ? '清除已完成' : 'Clear completed'"></button>
+        <button class="modal-close" @click="sessionTodoOpen=false" aria-label="Close">×</button>
+      </div>
+      <form class="session-todo-compose" @submit.prevent="addSessionUserTodo()">
+        <input type="text" maxlength="240" autocomplete="off" autofocus
+               x-model="sessionTodoDraft"
+               :placeholder="lang==='zh' ? '添加一条待办…' : 'Add a TODO…'"
+               :aria-label="lang==='zh' ? '待办内容' : 'TODO text'" />
+        <button type="submit" :disabled="!sessionTodoDraft.trim()"
+                x-text="lang==='zh' ? '添加' : 'Add'"></button>
+      </form>
+      <div class="modal-body session-todo-modal-body">
+        <div class="session-todo-empty" x-show="!sessionTodoCount()"
+             x-text="lang==='zh' ? '暂无待办。' : 'No TODOs yet.'"></div>
+        <div class="session-todo-board" x-show="sessionTodoCount()">
+          <template x-for="priority in ['high','medium','low']" :key="priority">
+            <section class="session-todo-lane" :class="'is-' + priority"
+                     @dragover.prevent
+                     @drop="onSessionTodoDrop($event, priority)">
+              <header>
+                <span class="session-todo-priority-dot"></span>
+                <strong x-text="priority==='high'
+                  ? (lang==='zh' ? '高优先级' : 'High')
+                  : priority==='medium'
+                    ? (lang==='zh' ? '中优先级' : 'Medium')
+                    : (lang==='zh' ? '低优先级' : 'Low')"></strong>
+                <small x-text="sessionTodosForPriority(priority).length"></small>
+              </header>
+              <div class="session-todo-lane-empty"
+                   x-show="!sessionTodosForPriority(priority).length"
+                   x-text="lang==='zh' ? '拖动到这里' : 'Drop here'"></div>
+              <template x-for="item in sessionTodosForPriority(priority)" :key="item.id">
+                <div class="session-todo-item"
+                     :class="{ 'is-completed': item.completed,
+                               'is-dragging': sessionTodoDragId === item.id }"
+                     draggable="true"
+                     @dragstart="onSessionTodoDragStart($event, item)"
+                     @dragend="onSessionTodoDragEnd()"
+                     @dragover.prevent
+                     @drop.stop="onSessionTodoDrop($event, priority, item.id)">
+                  <span class="session-todo-grip" aria-hidden="true">⋮⋮</span>
+                  <button class="session-todo-check" type="button"
+                          @click="toggleSessionUserTodo(item.id)"
+                          :aria-label="item.completed
+                            ? (lang==='zh' ? '标为未完成' : 'Mark incomplete')
+                            : (lang==='zh' ? '标为完成' : 'Mark complete')">
+                    <svg x-show="item.completed"><use href="#i-check"/></svg>
+                    <span x-show="!item.completed" class="todo-dot"></span>
+                  </button>
+                  <span class="session-todo-copy"><strong x-text="item.text"></strong></span>
+                  <button class="session-todo-delete" type="button"
+                          @click="deleteSessionUserTodo(item.id)"
+                          :aria-label="lang==='zh' ? '删除待办' : 'Delete TODO'">×</button>
+                </div>
+              </template>
+            </section>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="modal-backdrop" x-show="activity.show" @click.self="closeActivityCenter()" x-cloak>
     <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="closeActivityCenter()">
       <div class="modal-head">
@@ -5775,6 +5859,22 @@
           <span class="spinner-sm"></span>
         </span>
         <button class="modal-close" @click="closeActivityCenter()" aria-label="Close">×</button>
+      </div>
+      <div class="activity-searchbar" role="search">
+        <svg aria-hidden="true"><use href="#i-search"/></svg>
+        <input type="search" autocomplete="off" autocorrect="off" spellcheck="false"
+               x-model="activity.query"
+               @keydown.escape.stop.prevent="clearActivitySearch()"
+               :placeholder="lang==='zh' ? '搜索会话、任务、工作区或状态…' : 'Search sessions, tasks, workspaces, or status…'"
+               :aria-label="lang==='zh' ? '搜索任务中心会话' : 'Search activity sessions'" />
+        <span class="activity-search-count" x-show="activitySearchQuery()"
+              x-text="lang==='zh'
+                ? activitySearchResultCount() + ' 条匹配'
+                : activitySearchResultCount() + ' matches'"></span>
+        <button type="button" class="activity-search-clear"
+                x-show="activitySearchQuery()" @click="clearActivitySearch()"
+                :aria-label="lang==='zh' ? '清除搜索' : 'Clear search'"
+                :title="lang==='zh' ? '清除搜索' : 'Clear search'">×</button>
       </div>
       <!-- One chip per attention group, in the same order as the sections below:
            completed results to review, live work, failures, then viewed history. -->
@@ -5855,7 +5955,8 @@
         </div>
         <template x-for="group in activityVisibleGroups()" :key="group.key">
           <section class="activity-group"
-                   x-show="group.custom || activityEvents(group).length"
+                   x-show="activityEvents(group).length
+                     || (group.custom && !activitySearchQuery())"
                    :class="{
                      'is-timeline': group.key === 'timeline',
                      'is-custom': group.custom,
@@ -5895,7 +5996,8 @@
               </div>
             </div>
             <div class="activity-custom-group-empty"
-                 x-show="group.custom && !activityAllEvents(group).length"
+                 x-show="group.custom && !activitySearchQuery()
+                   && !activityAllEvents(group).length"
                  x-text="lang==='zh' ? '拖动会话到这里' : 'Drag sessions here'"></div>
             <template x-for="item in activityEvents(group)" :key="item.id">
               <div class="activity-row-wrap"
@@ -5972,11 +6074,23 @@
           </section>
         </template>
         <div class="hint-row" x-show="!activity.loading && !activity.events.length" x-text="lang==='zh' ? '暂无任务记录' : 'No activity yet'"></div>
+        <div class="hint-row activity-search-empty"
+             x-show="!activity.loading && activity.events.length
+               && activitySearchQuery()
+               && !activityVisibleGroups().some(g => activityEvents(g).length)">
+          <strong x-text="lang==='zh' ? '没有匹配的会话' : 'No matching sessions'"></strong>
+          <small x-text="lang==='zh'
+            ? '试试会话名、任务摘要、工作区、状态或会话 ID'
+            : 'Try a session name, task summary, workspace, status, or session ID'"></small>
+          <button type="button" class="btn-ghost sm" @click="clearActivitySearch()"
+                  x-text="lang==='zh' ? '清除搜索' : 'Clear search'"></button>
+        </div>
         <!-- Filtering to an empty group must say so, or the body just goes
              blank and reads as a loading failure. -->
         <div class="hint-row"
              x-show="!activity.loading && activity.view === 'status'
-               && activity.events.length && activity.filter.length
+               && activity.events.length && !activitySearchQuery()
+               && activity.filter.length
                && !activityVisibleGroups().some(g => activityEvents(g).length)"
              x-text="lang==='zh' ? '该状态下暂无任务' : 'No tasks in this state'"></div>
       </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3625,6 +3625,72 @@ pre.text {
 .workspace-activity-mini .unread { color:var(--c-success); }
 /* Sized to match `.icon-btn` (28px box / 15px glyph). It used to be 34/16,
    which made it visibly the odd one out in a row of seven 28px siblings. */
+.session-todo-btn { position:relative; }
+.session-todo-btn.has-active { color:var(--c-accent); }
+.session-todo-modal { width:760px; max-width:calc(100vw - 32px); }
+.session-todo-modal .modal-head { gap:8px; }
+.session-todo-modal-count { margin-left:auto; color:var(--c-fg-3); font:var(--fs-xs) var(--font-mono); }
+.session-todo-modal .session-todo-compose { margin:0; padding:12px 14px; border-bottom:1px solid var(--c-border); }
+.session-todo-modal-body { max-height:min(60vh,520px); padding:12px 14px 16px; overflow:auto; }
+@media (max-width:600px) { .session-todo-modal { width:100vw; max-width:none; } }
+
+.session-todo-badge { position:absolute; right:-5px; top:-5px; min-width:18px; height:16px; padding:0 4px; display:flex; align-items:center; justify-content:center; border:2px solid var(--c-bg-1); border-radius:var(--r-full); background:var(--c-accent); color:var(--c-on-accent); font:9px/1 var(--font-mono); }
+.session-todo-panel { flex:0 0 auto; max-height:min(42vh,380px); overflow:auto; padding:10px 14px 12px; border-bottom:1px solid var(--c-border); background:var(--c-bg-1); box-shadow:0 5px 16px rgba(0,0,0,.08); }
+.session-todo-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:8px; }
+.session-todo-head > div { display:flex; flex-direction:column; gap:2px; }
+.session-todo-head strong { color:var(--c-fg-0); font-size:var(--fs-sm); }
+.session-todo-head small { color:var(--c-fg-3); font-size:var(--fs-xs); }
+.session-todo-head > button { width:26px; height:26px; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:18px/1 var(--font-sans); cursor:pointer; }
+.session-todo-head > button:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.session-todo-list { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; }
+.session-todo-group { min-width:0; padding:8px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); }
+.session-todo-group h4 { margin:0 0 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
+.session-todo-item { display:flex; align-items:flex-start; gap:8px; padding:6px 4px; border-radius:var(--r-sm); }
+.session-todo-item + .session-todo-item { border-top:1px solid var(--c-border); }
+.session-todo-state { width:16px; height:18px; flex:0 0 16px; display:flex; align-items:center; justify-content:center; }
+.session-todo-state svg { width:14px; height:14px; color:var(--c-success); }
+.session-todo-copy { min-width:0; display:flex; flex-direction:column; gap:2px; }
+.session-todo-copy strong { overflow:hidden; color:var(--c-fg-1); font-size:var(--fs-xs); font-weight:var(--fw-medium); line-height:1.35; text-overflow:ellipsis; }
+.session-todo-copy small { color:var(--c-fg-3); font-size:10px; line-height:1.35; }
+.session-todo-item.is-completed .session-todo-copy strong { color:var(--c-fg-3); text-decoration:line-through; }
+.session-todo-empty { padding:18px; color:var(--c-fg-3); font-size:var(--fs-sm); text-align:center; }
+.session-todo-head-actions { display:flex; align-items:center; gap:3px; }
+.session-todo-head-actions > button { width:26px; height:26px; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:16px/1 var(--font-sans); cursor:pointer; }
+.session-todo-head-actions > button:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.session-todo-compose { display:flex; gap:7px; margin-bottom:8px; }
+.session-todo-compose input { min-width:0; flex:1; height:34px; padding:0 10px; border:1px solid var(--c-border-strong); border-radius:var(--r-sm); outline:0; background:var(--c-bg-0); color:var(--c-fg-0); font:inherit; font-size:var(--fs-sm); }
+.session-todo-compose input:focus { border-color:var(--c-accent); box-shadow:0 0 0 2px var(--c-accent-soft); }
+.session-todo-compose button { padding:0 12px; border:0; border-radius:var(--r-sm); background:var(--c-accent); color:var(--c-on-accent); font:inherit; font-size:var(--fs-xs); cursor:pointer; }
+.session-todo-compose button:disabled { opacity:.4; cursor:default; }
+.session-todo-list { display:flex; flex-direction:column; gap:0; padding:2px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); }
+.session-todo-item { min-height:34px; align-items:center; }
+.session-todo-check,.session-todo-delete { width:26px; height:26px; flex:0 0 26px; display:flex; align-items:center; justify-content:center; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); cursor:pointer; }
+.session-todo-check:hover,.session-todo-delete:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.session-todo-check svg { width:14px; height:14px; color:var(--c-success); }
+.session-todo-delete { margin-left:auto; opacity:.5; font-size:17px; }
+.session-todo-item:hover .session-todo-delete,.session-todo-delete:focus-visible { opacity:1; }
+.session-todo-board { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; }
+.session-todo-lane { min-width:0; min-height:150px; padding:7px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); transition:border-color var(--t-fast),background var(--t-fast); }
+.session-todo-lane > header { display:flex; align-items:center; gap:7px; min-height:30px; padding:2px 4px 7px; }
+.session-todo-lane > header strong { color:var(--c-fg-1); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
+.session-todo-lane > header small { margin-left:auto; color:var(--c-fg-3); font:10px var(--font-mono); }
+.session-todo-priority-dot { width:8px; height:8px; border-radius:50%; background:var(--c-fg-3); }
+.session-todo-lane.is-high .session-todo-priority-dot { background:var(--c-danger); }
+.session-todo-lane.is-medium .session-todo-priority-dot { background:var(--c-warn); }
+.session-todo-lane.is-low .session-todo-priority-dot { background:var(--c-success); }
+.session-todo-lane-empty { padding:34px 8px; border:1px dashed var(--c-border); border-radius:var(--r-sm); color:var(--c-fg-4); font-size:var(--fs-xs); text-align:center; }
+.session-todo-lane .session-todo-item { margin:3px 0; border:1px solid var(--c-border); background:var(--c-bg-1); cursor:grab; }
+.session-todo-lane .session-todo-item:active { cursor:grabbing; }
+.session-todo-item.is-dragging { opacity:.35; }
+.session-todo-grip { flex:0 0 auto; color:var(--c-fg-4); font:12px/1 var(--font-mono); letter-spacing:-3px; }
+@media (max-width:720px) {
+  .session-todo-board { grid-template-columns:1fr; }
+  .session-todo-lane { min-height:90px; }
+
+  .session-todo-list { grid-template-columns:1fr; }
+  .session-todo-panel { max-height:48vh; padding-inline:10px; }
+  .session-todo-badge { right:-3px; }
+}
 .activity-center-btn { position:relative; width:28px; height:28px; flex:0 0 28px; display:inline-flex; align-items:center; justify-content:center; border:0; border-radius:var(--r-md); background:transparent; color:var(--c-fg-2); cursor:pointer; }
 .activity-center-btn:hover,.activity-center-btn.active { background:var(--c-bg-2); color:var(--c-accent); }
 .activity-center-btn.danger { color:var(--c-danger); }
@@ -3654,6 +3720,19 @@ pre.text {
 .activity-view-switch button { padding:4px 9px; border:0; border-radius:calc(var(--r-md) - 2px); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); cursor:pointer; }
 .activity-view-switch button:hover { color:var(--c-fg-1); }
 .activity-view-switch button.active { background:var(--c-bg-1); color:var(--c-fg-0); box-shadow:var(--shadow-sm); }
+.activity-searchbar { display:flex; align-items:center; gap:8px; padding:9px 14px; border-bottom:1px solid var(--c-border); background:color-mix(in srgb,var(--c-bg-2) 36%,transparent); }
+.activity-searchbar > svg { width:15px; height:15px; flex:0 0 15px; color:var(--c-fg-3); }
+.activity-searchbar > input { min-width:0; flex:1; height:32px; padding:0; border:0; outline:0; background:transparent; color:var(--c-fg-0); font:inherit; font-size:var(--fs-sm); }
+.activity-searchbar > input::placeholder { color:var(--c-fg-4); }
+.activity-searchbar > input::-webkit-search-cancel-button { display:none; }
+.activity-searchbar:focus-within { box-shadow:inset 0 -1px 0 var(--c-accent); }
+.activity-search-count { flex:0 0 auto; color:var(--c-fg-3); font-size:var(--fs-xs); font-variant-numeric:tabular-nums; white-space:nowrap; }
+.activity-search-clear { width:26px; height:26px; flex:0 0 26px; padding:0; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:18px/1 var(--font-sans); cursor:pointer; }
+.activity-search-clear:hover { background:var(--c-bg-3); color:var(--c-fg-1); }
+.activity-search-empty { display:flex; flex-direction:column; align-items:center; gap:6px; padding:28px 12px; text-align:center; }
+.activity-search-empty strong { color:var(--c-fg-1); font-size:var(--fs-sm); }
+.activity-search-empty small { max-width:430px; color:var(--c-fg-3); font-size:var(--fs-xs); }
+.activity-search-empty .btn-ghost { margin-top:2px; }
 .activity-summary { display:flex; align-items:center; flex-wrap:wrap; gap:6px; padding:10px 14px; border-bottom:1px solid var(--c-border); color:var(--c-fg-2); font-size:var(--fs-sm); }
 .activity-summary .btn-ghost { margin-left:auto; }
 .activity-groups-toolbar { display:flex; align-items:center; justify-content:space-between; gap:12px; min-height:56px; padding:9px 14px; border-bottom:1px solid var(--c-border); }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -233,6 +233,90 @@ def test_desktop_timeline_defaults_to_fifteen_rows_in_larger_modal(
     assert mobile_geometry["bodyMaxHeight"] == "none"
 
 
+def test_activity_search_finds_capped_sessions_and_combines_with_status_filter(
+    page: Page, backend_url, auth_token,
+):
+    page.set_viewport_size({"width": 1200, "height": 820})
+    _login(page, backend_url, auth_token)
+
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
+          app.lang = 'zh';
+          app.activity.viewLoaded = true;
+          app.activity.view = 'timeline';
+          app.activity.filter = [];
+          app.activity.query = '';
+          app.activity.expanded = {};
+          app.activity.loading = false;
+          app.activity.customGroups = [];
+          app.activity.events = Array.from({length: 20}, (_, index) => ({
+            id: `search-row-${index}`,
+            kind: 'turn',
+            session_id: index === 0 ? 'needle-session-uuid' : `session-${index}`,
+            session_name: index === 0 ? 'Needle Alpha' : `Generic session ${index}`,
+            task_summary: index === 0 ? 'Quant platform audit' : `Generic task ${index}`,
+            workspace: index === 0 ? '/srv/quant-research' : '/tmp/e2e',
+            workspace_name: index === 0 ? 'quant-research' : 'e2e',
+            state: 'completed', read: true,
+            started_at: 100 + index,
+            finished_at: 200 + index,
+            updated_at: 300 + index,
+          }));
+          app.activity.events.push({
+            id: 'failed-search-row', kind: 'scheduled',
+            session_id: 'failed-session', session_name: 'Broken delivery',
+            task_summary: 'Publish report', status_detail: 'Renderer crashed',
+            workspace: '/srv/delivery', workspace_name: 'delivery',
+            state: 'failed', read: false,
+            started_at: 500, finished_at: 510, updated_at: 510,
+          });
+          app.activity.summary = {
+            running: 0, unread: 1, attention: 1,
+            groups: {review: 0, running: 0, failed: 1, history: 20},
+            group_unread: {review: 0, running: 0, failed: 1, history: 0},
+            workspaces: ['/tmp/e2e', '/srv/quant-research', '/srv/delivery'],
+          };
+          app.activity.show = true;
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+
+    search = page.locator(".activity-searchbar input")
+    expect(search).to_be_visible()
+    expect(page.locator(".activity-row")).to_have_count(15)
+
+    # The target is older than the timeline cap, so filtering must happen before
+    # the 15-row slice rather than against the already-visible rows.
+    search.fill("Needle")
+    expect(page.locator(".activity-row")).to_have_count(1)
+    expect(page.locator(".activity-row")).to_contain_text("Needle Alpha")
+    expect(page.locator(".activity-search-count")).to_have_text("1 条匹配")
+
+    search.fill("quant-research")
+    expect(page.locator(".activity-row")).to_have_count(1)
+    search.fill("needle-session-uuid")
+    expect(page.locator(".activity-row")).to_have_count(1)
+
+    page.get_by_role("button", name="按状态").click()
+    page.locator(".activity-chip.failed").click()
+    expect(page.locator(".activity-search-empty")).to_be_visible()
+
+    # Localized state labels and status details are searchable, and the text
+    # query intersects with the selected failed-status group.
+    search.fill("失败")
+    expect(page.locator(".activity-row")).to_have_count(1)
+    expect(page.locator(".activity-row")).to_contain_text("Broken delivery")
+    search.fill("Renderer crashed")
+    expect(page.locator(".activity-row")).to_have_count(1)
+
+    page.locator(".activity-search-clear").click()
+    expect(search).to_have_value("")
+    expect(page.locator(".activity-row")).to_have_count(1)
+
+
 def test_custom_groups_show_empty_sections_and_move_sessions(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -2444,7 +2444,7 @@ def test_workspace_switch_only_waits_for_cold_tree_not_auxiliary_refreshes(
     assert result["runtime"]["terminalId"] == "terminal-slow"
 
 
-def test_workspace_compact_bootstrap_posts_expanded_parents_and_falls_back(
+def test_workspace_compact_bootstrap_never_falls_back_to_unbounded_get(
         page: Page, backend_url, auth_token):
     _login(page, backend_url, auth_token)
     result = page.evaluate(
@@ -2508,7 +2508,7 @@ def test_workspace_compact_bootstrap_posts_expanded_parents_and_falls_back(
           }
         }"""
     )
-    assert result["ok"] is True
+    assert result["ok"] is False
     assert {call["workspace"] for call in result["calls"]} == {result["owner"]}
     calls = [
         {key: value for key, value in call.items() if key != "workspace"}
@@ -2523,10 +2523,9 @@ def test_workspace_compact_bootstrap_posts_expanded_parents_and_falls_back(
                 "parents": ["src", "src/deep"],
             },
         },
-        {"method": "GET", "query": "?show_hidden=true", "body": None},
     ]
-    assert result["visible"] == ["src", "src/deep", "src/deep/file.txt", ".hidden"]
-    assert result["cursor"] == 9
+    assert result["visible"] == []
+    assert result["cursor"] is None
 
 
 def test_terminal_foreground_still_persists_cursor_matched_tree_snapshot(

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -12,6 +12,9 @@ fake, keeping queue permission and rollback semantics hermetic.
 """
 from __future__ import annotations
 
+import asyncio
+import contextlib
+
 import pytest
 
 
@@ -521,11 +524,11 @@ async def test_drain_replays_snapshot_without_reverting_session_permission(
 
 
 @pytest.mark.asyncio
-async def test_drain_waits_until_background_reader_releases_session(
+async def test_drain_starts_queued_turn_while_background_task_pending(
     app_module, monkeypatch,
 ):
-    """Queued follow-ups stay queued while the previous turn's task watcher
-    owns the SDK stream."""
+    """Queued sends follow the same background-task concurrency contract as
+    direct sends: a watcher is not an active user turn and must not block FIFO."""
     from backend import chat
 
     sess = _sess(app_module)
@@ -538,12 +541,17 @@ async def test_drain_waits_until_background_reader_releases_session(
 
     monkeypatch.setattr(chat, "_start_turn", fake_start_turn)
     chat._sessions_with_inflight_tasks[sid] = {"task-1"}
+    watcher = asyncio.create_task(asyncio.sleep(60))
+    chat._task_watchers[sid] = watcher
     try:
         await chat._maybe_drain_queue(sid)
     finally:
         chat._sessions_with_inflight_tasks.pop(sid, None)
+        chat._task_watchers.pop(sid, None)
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
 
-    assert starts == []
-    assert [item["text"] for item in sess.get_queue(sid)["items"]] == [
-        "follow-up"
-    ]
+    assert len(starts) == 1
+    assert starts[0][0][:2] == (sid, "follow-up")
+    assert sess.get_queue(sid)["items"] == []

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -49,6 +49,8 @@ def test_selected_bootstrap_post_is_bounded_and_validates_parents(
     payload = response.json()
     assert payload["partial"] is True
     assert payload["parents"] == ["notes", "notes/deep"]
+    assert payload["truncated_parents"] == []
+    assert payload["children_per_parent_limit"] == 500
     assert {row["path"] for row in payload["entries"]} == {
         "README.md",
         "notes",

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,5 +1,6 @@
 """File CRUD + search + hidden-toggle endpoints."""
 import io
+from pathlib import Path
 
 
 # ---- list / read ----
@@ -520,6 +521,22 @@ def test_list_truncated_flag(client, auth, temp_root):
     d = r.json()
     assert d["truncated"] is True
     assert len(d["entries"]) == 500   # MAX_LIST_ENTRIES
+    assert [row["name"] for row in d["entries"]] == [
+        f"f{i:04d}.txt" for i in range(500)
+    ]
+
+
+def test_large_list_uses_bounded_top_page_selection():
+    """The implementation must not collect and sort every DirEntry in memory."""
+    source = Path(__file__).parents[1].joinpath("backend/files.py").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("def list_dir(")
+    end = source.index("\n\n# xlsx preview caps", start)
+    listing = source[start:end]
+    assert "heapq.nsmallest(" in listing
+    assert "MAX_LIST_ENTRIES + 1" in listing
+    assert "candidates.sort(" not in listing
 
 
 def test_no_extension_text_file(client, auth, temp_root):

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -203,6 +203,9 @@ def test_preview_tabs_persist_reading_positions_and_html_frames():
     open_file = app[start:end]
 
     assert "this._capturePreviewViewState(this.selected)" in open_file
+    assert "opts.reveal !== false && !this._isMobileLayout()" in open_file
+    assert 'this.desktopFullPane = ""' in open_file
+    assert "this.previewOpen = true" in open_file
     assert "this._schedulePreviewViewRestore(cachedPath, loadSeq)" in open_file
     assert "this.csvLoadPage(targetView.csvOffset)" in open_file
     assert 'x-ref="previewBody"' in html
@@ -1300,6 +1303,36 @@ def test_chat_file_link_fallback_prefers_suffix_then_unique_basename():
     assert "await this.chooseOne({" in open_path
 
 
+def test_chat_file_urls_are_routed_through_workspace_preview():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    helper_start = app.index("_localFileUrlPath(href)")
+    helper_end = app.index("\n    // Rewrite author-relative", helper_start)
+    helper = app[helper_start:helper_end]
+    linkify_start = app.index("_linkifyFilePaths(rootEl)")
+    linkify_end = app.index("\n    // Delegated click handler", linkify_start)
+    linkify = app[linkify_start:linkify_end]
+    click_start = app.index("onChatClick(ev)")
+    click_end = app.index("\n    // Fallback resolver", click_start)
+    click = app[click_start:click_end]
+
+    sanitize_start = app.index("window.DOMPurify.sanitize(raw")
+    sanitize_end = app.index("\n      // Restore protected math", sanitize_start)
+    sanitize = app[sanitize_start:sanitize_end]
+
+    assert 'if (!/^file:/i.test(String(href || ""))) return null' in helper
+    assert 'url.hostname !== "localhost"' in helper
+    assert "decodeURIComponent(url.pathname" in helper
+    assert "ALLOWED_URI_REGEXP" in sanitize
+    assert "file|mailto|tel" in sanitize
+    assert "const localFilePath = this._localFileUrlPath(href)" in linkify
+    assert 'a.removeAttribute("href")' in linkify
+    assert 'a.classList.add("file-link")' in linkify
+    assert 'a.setAttribute("href", "#")' in linkify
+    assert "const localFilePath = this._localFileUrlPath(href)" in click
+    assert "href = localFilePath" in click
+    assert "this.openByPathToasted(p)" in click
+
+
 def test_activity_center_groups_by_attention_order_and_read_state():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
@@ -1336,6 +1369,14 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert "!opts.summaryOnly && this._activityFetchPromises.summary" in app
     assert "const rank = (activeRank[a.state] ?? 9)" in app
     assert "return this.activityEventTimestamp(b)" in app
+    ungrouped_sort = app.index('group.key === "custom:__ungrouped__"')
+    custom_sort = app.index("if (group.custom) {", ungrouped_sort)
+    assert ungrouped_sort < custom_sort
+    assert "this.activityEventTimestamp(b) - this.activityEventTimestamp(a)" in app[
+        ungrouped_sort:custom_sort
+    ]
+    assert "attentionRank" not in app[ungrouped_sort:custom_sort]
+    assert "pinRank" not in app[ungrouped_sort:custom_sort]
     assert "this._activityAppliedSeq = ++this._activityRequestSeq" in app
     assert '"/api/activity/events-ticket"' in app
     assert "new EventSource(" in app
@@ -1372,6 +1413,44 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert ".activity-row.failed .activity-state-dot,.activity-row.waiting_approval" not in css
 
 
+def test_activity_center_searches_loaded_sessions_before_group_caps():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    activity_state = app[app.index("activity: {"):app.index("_activityEtags:")]
+    match_start = app.index("activityMatchesSearch(item)")
+    match_end = app.index("\n    activitySearchResultCount", match_start)
+    matcher = app[match_start:match_end]
+    all_start = app.index("activityAllEvents(group)")
+    all_end = app.index("\n    activityEvents(group)", all_start)
+    all_events = app[all_start:all_end]
+    count_start = app.index("activityGroupCount(group)")
+    count_end = app.index("\n    activityVisibleGroups()", count_start)
+    counts = app[count_start:count_end]
+
+    assert 'query: ""' in activity_state
+    for field in (
+        "session_name", "task_summary", "session_id", "thread_id",
+        "workspace", "workspace_name", "state", "status_detail",
+    ):
+        assert f"item?.{field}" in matcher
+    assert "this.activityStateLabel(item?.state)" in matcher
+    assert ".filter(item => this.activityMatchesSearch(item))" in all_events
+    assert all_events.index("activityMatchesSearch") < all_events.index(".sort(")
+    assert "this.activitySearchQuery()" in counts
+    assert 'role="search"' in html
+    assert 'x-model="activity.query"' in html
+    assert "activitySearchResultCount() + ' 条匹配'" in html
+    assert '@keydown.escape.stop.prevent="clearActivitySearch()"' in html
+    assert 'class="activity-search-clear"' in html
+    assert 'class="hint-row activity-search-empty"' in html
+    assert "没有匹配的会话" in html
+    assert "group.custom && !activitySearchQuery()" in html
+    assert ".activity-searchbar" in css
+    assert ".activity-search-empty" in css
+
+
 def test_memory_recall_details_use_a_root_fixed_portal():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
@@ -1390,6 +1469,48 @@ def test_memory_recall_details_use_a_root_fixed_portal():
     portal_css = portal_css[:portal_css.index("}")]
     assert "position: fixed" in portal_css
     assert "z-index: 880" in portal_css
+
+
+def test_chat_header_exposes_authenticated_session_todo_board():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+    assert "sessionTodoOpen: false" in app
+    assert 'sessionTodoDraft: ""' in app
+    assert "userTodos: []" in app
+    assert 'return "muselab.userTodos."' in app
+    assert "addSessionUserTodo()" in app
+    assert "toggleSessionUserTodo(id)" in app
+    assert "deleteSessionUserTodo(id)" in app
+    assert "sessionTodosForPriority(priority)" in app
+    assert "onSessionTodoDragStart(ev, item)" in app
+    assert "onSessionTodoDrop(ev, priority" in app
+    assert 'priority: "medium"' in app
+    todo_impl = app[app.index("_sessionUserTodoStorageKey"):app.index("taskLogLine(m)")]
+    assert "TodoWrite" not in todo_impl
+    assert "TaskCreate" not in todo_impl
+    assert "TaskUpdate" not in todo_impl
+    button = html.index('class="session-todo-btn icon-btn"')
+    activity = html.index('class="activity-center-btn"', button)
+    assert button < activity
+    assert '@click="toggleSessionTodoBoard()"' in html
+    assert 'class="modal session-todo-modal"' in html
+    assert "'待办事项'" in html
+    assert 'x-show="sessionTodoOpen"' in html
+    assert '@click.self="sessionTodoOpen=false"' in html
+    assert '@submit.prevent="addSessionUserTodo()"' in html
+    assert "['high','medium','low']" in html
+    assert '@dragstart="onSessionTodoDragStart($event, item)"' in html
+    assert '@drop="onSessionTodoDrop($event, priority)"' in html
+    assert '@drop.stop="onSessionTodoDrop($event, priority, item.id)"' in html
+    assert '@click="toggleSessionUserTodo(item.id)"' in html
+    assert '@click="deleteSessionUserTodo(item.id)"' in html
+    assert ".session-todo-modal" in css
+    assert ".session-todo-board" in css
+    assert ".session-todo-lane.is-high" in css
+    assert ".session-todo-compose" in css
+    assert "@media (max-width:720px)" in css
 
 
 def test_activity_center_uses_two_compact_numberless_status_dots():
@@ -2539,11 +2660,16 @@ def test_workspace_cache_uses_delta_without_blocking_or_copying_hidden_bursts():
     assert "[404, 405, 501].includes(response.status)" in sync
     assert 'ownerHeaders["X-Muselab-Workspace"]' in sync
     fallback = sync[sync.index("if ([404, 405, 501].includes(response.status))"):]
-    assert fallback.index("treeSeq !== this._treeLoadSeq") < fallback.index(
-        '`/api/files/bootstrap${query ? `?${query}` : ""}`')
-    assert "{ headers: ownerHeaders }" in fallback
-    assert "this.fileHdr()" not in fallback
-    assert '`/api/files/bootstrap${query ? `?${query}` : ""}`' in sync
+    assert "return false" in fallback
+    assert '`/api/files/bootstrap${query ? `?${query}` : ""}`' not in sync
+    assert "legacy full-snapshot GET" in sync
+    assert "Array.isArray(payload.truncated_parents)" in sync
+    assert "payload.children_per_parent_limit" in sync
+    assert "snapshotHasTruncatedParents" in sync
+    assert "this._workspaceTreeCursors.delete(ownerWorkspace)" in sync
+    truncated_cursor = sync.index("if (snapshotHasTruncatedParents)")
+    delta_cursor = sync.index("} else if (nextCursor != null)", truncated_cursor)
+    assert truncated_cursor < delta_cursor
     assert 'params.set("show_hidden", "true")' in sync
     assert "const hasCursor = hydrated && cursor != null" in sync
     assert "void task.then(release, release)" in app

--- a/tests/test_workspace_store_concurrency.py
+++ b/tests/test_workspace_store_concurrency.py
@@ -114,6 +114,51 @@ def test_compact_bootstrap_reads_only_root_and_expanded_children(
     }
 
 
+def test_compact_bootstrap_caps_each_expanded_directory(
+    app_module,
+    temp_root: Path,
+):
+    from backend.workspace_store import WorkspaceStore
+    from backend.workspaces import registry
+
+    huge = temp_root / "huge"
+    huge.mkdir()
+    for index in range(550):
+        (huge / f"item-{index:04d}.txt").write_text("x", encoding="utf-8")
+
+    workspace_id = registry.id_for(temp_root)
+    store = WorkspaceStore(temp_root)
+    store.reconcile(workspace_id, temp_root, "root", primary=True)
+    snapshot = store.bootstrap(workspace_id, parents=["huge"])
+
+    huge_rows = [
+        row for row in snapshot["entries"]
+        if row["path"].startswith("huge/")
+    ]
+    assert len(huge_rows) == 500
+    assert huge_rows[0]["path"] == "huge/item-0000.txt"
+    assert huge_rows[-1]["path"] == "huge/item-0499.txt"
+    assert snapshot["truncated_parents"] == ["huge"]
+    assert snapshot["children_per_parent_limit"] == 500
+
+    with store._connect() as db:
+        plan = db.execute(
+            """
+            EXPLAIN QUERY PLAN
+            SELECT path, name
+            FROM files INDEXED BY files_workspace_parent_kind_name
+            WHERE workspace_id = ? AND parent = ?
+            ORDER BY is_dir DESC, name COLLATE NOCASE, name, path
+            LIMIT ?
+            """,
+            (workspace_id, "huge", 501),
+        ).fetchall()
+    assert any(
+        "files_workspace_parent_kind_name" in str(row["detail"])
+        for row in plan
+    ), plan
+
+
 def test_bootstrap_cursor_and_rows_share_one_read_snapshot(
     app_module,
     temp_root: Path,


### PR DESCRIPTION
## 变更摘要

- 支持聊天消息中的本地 `file:///` 链接，并限制为工作区内的安全路径
- 为任务管理中心增加会话搜索，未分组会话严格按更新时间倒序
- 限制大目录列表与 compact bootstrap 的单目录条目数，避免文件树卡死
- 修复截断文件树快照与增量 cursor 不一致的问题
- 修复后台任务 watcher 阻塞排队消息自动执行的问题
- 增加用户手动维护的“待办事项”弹窗，支持高、中、低优先级及任意拖动
- 点击文件时自动展开已隐藏的预览区

## 验证

- 修改区域的后端、前端静态检查和回归测试：235 passed
- Activity Center Playwright E2E：9 passed
- 大文件树 Playwright E2E：2 passed
- `git diff --check` 通过
- 已部署到本地 `muselab-main.service` 完成人工测试

## 风险与兼容性

- 大目录每个父目录最多返回 500 个直接子项；截断快照不会作为增量同步基线
- 待办事项仅保存在浏览器 `localStorage`，不进入模型上下文，也不与服务端同步
- `file:` 链接仅接受本地路径，并继续经过工作区边界校验
- 未运行完整全仓测试套件；一次全量 pytest 超过 10 分钟后停止，已改为覆盖所有修改区域的定向测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)