### PR TITLE
feat(ui): improve global todo and preview behavior

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -586,12 +586,15 @@ function portal() {
         session_mode: "fresh",
       },
     },
-    // User-owned scratch TODO clipboard for the active conversation. It is
-    // deliberately independent from Muse/Claude Task tools and stored only in
-    // this browser, per session.
+    // User-owned global scratch TODO clipboard. It is deliberately independent
+    // from Muse/Claude Task tools and shared across every conversation and
+    // workspace in this browser.
     sessionTodoOpen: false,
     sessionTodoDraft: "",
     sessionTodoDragId: "",
+    sessionTodoEditId: "",
+    sessionTodoEditDraft: "",
+    userTodos: [],
     activity: {
       show: false, loading: false, events: [],
       // Custom groups are the primary organization surface. An explicit user
@@ -1420,6 +1423,18 @@ function portal() {
         }
         localStorage.removeItem(oldK);
       }
+      this.userTodos = this._loadGlobalUserTodos();
+      window.addEventListener("storage", ev => {
+        const key = this._globalUserTodoStorageKey();
+        if (ev.key === key) {
+          // Read the authoritative current value instead of the event snapshot:
+          // rapid writes from multiple tabs can deliver an older event after a
+          // newer write has already landed in localStorage.
+          this.userTodos = this._normalizeUserTodos(
+            localStorage.getItem(key) || "[]",
+          );
+        }
+      });
       // `pagehide` is bfcache-friendly (unlike an unconditional
       // beforeunload handler) and still fires for browser refresh/PWA close.
       // Flush the current composer synchronously so even a refresh immediately
@@ -2063,7 +2078,7 @@ function portal() {
         // selection must not silently pin a tab that was left in preview.
         const _restored = this.tabs.find(t => t.path === path);
         this.openFile({ path, name: path.split("/").pop() },
-                      { preview: !!(_restored && _restored.preview) })
+                      { preview: !!(_restored && _restored.preview), reveal: false })
             .catch(() => { /* file gone — silent */ });
       }
       // Restore mobile tab choice AFTER openFile (which would otherwise
@@ -4851,7 +4866,7 @@ function portal() {
           // Preserve the restored tab's preview/pinned state (see _bootApp).
           const _restored = this.tabs.find(t => t.path === path);
           this.openFile({ path, name: path.split("/").pop() },
-                        { preview: !!(_restored && _restored.preview) })
+                        { preview: !!(_restored && _restored.preview), reveal: false })
               .catch(() => { /* file went away — nothing to do */ });
         }
         // login() is the first-sign-in counterpart of _bootApp(). Keep the
@@ -6862,9 +6877,6 @@ function portal() {
         // different tab — drives a green dot on the tab strip so the user
         // notices "this one's ready". Cleared when the user activates the tab.
         unread: false,
-        // User-maintained scratch TODOs for this conversation. Loaded from
-        // localStorage when the tab state is first created.
-        userTodos: [],
         // Per-session message queue. Populated when the user sends while
         // this tab's turn is still streaming OR while a compact is in
         // flight. Drained automatically on the next `done` event /
@@ -6938,7 +6950,6 @@ function portal() {
         this.tabState[id] = this._blankTabState();
         this.tabState[id]._sid = id;
         this.tabState[id].draft.input = this._consumePersistedChatDraft(id);
-        this.tabState[id].userTodos = this._loadSessionUserTodos(id);
         // The queue now lives server-side (sessions/{sid}.queue.json). We do
         // NOT pull it here — _ensureTabState is called synchronously all over
         // the place and shouldn't fire a fetch each time. The queue mirror is
@@ -10913,67 +10924,129 @@ function portal() {
       this._cachedTaskSubjectMap = { key: cacheKey, map };
       return map;
     },
-    _sessionUserTodoStorageKey(sid = this.currentId) {
-      return "muselab.userTodos." + (sid || "_default");
+    _globalUserTodoStorageKey() {
+      return "muselab.userTodos.global";
     },
-    _loadSessionUserTodos(sid) {
+    _normalizeUserTodos(value) {
       try {
-        const parsed = JSON.parse(localStorage.getItem(
-          this._sessionUserTodoStorageKey(sid)) || "[]");
+        const parsed = typeof value === "string" ? JSON.parse(value) : value;
         return Array.isArray(parsed)
-          ? parsed.filter(item => item && item.text).slice(0, 100).map(item => ({
+          ? parsed.filter(item => item && item.text).slice(-100).map((item, index) => ({
               ...item,
+              id: String(item.id || `u-migrated-${index}`),
+              text: String(item.text).slice(0, 240),
+              completed: !!item.completed,
               priority: ["high", "medium", "low"].includes(item.priority)
                 ? item.priority : "medium",
             })) : [];
       } catch (_) { return []; }
     },
-    _persistSessionUserTodos() {
-      if (!this.currentId) return;
+    _loadGlobalUserTodos() {
+      try {
+        const storageKey = this._globalUserTodoStorageKey();
+        const saved = localStorage.getItem(storageKey);
+        if (saved != null) return this._normalizeUserTodos(saved);
+
+        // One-time migration from the original per-session clipboard. Keep the
+        // old keys as a recovery backup; the presence of the global key prevents
+        // deleted global items from ever being re-imported on a later refresh.
+        const migrated = [];
+        for (let index = 0; index < localStorage.length; index++) {
+          const key = localStorage.key(index) || "";
+          if (!key.startsWith("muselab.userTodos.") || key === storageKey) continue;
+          migrated.push(...this._normalizeUserTodos(localStorage.getItem(key) || "[]"));
+        }
+        const seen = new Set();
+        const result = migrated.filter(item => {
+          if (seen.has(item.id)) return false;
+          seen.add(item.id);
+          return true;
+        }).slice(-100);
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(result));
+        } catch (_) {
+          // Quota/private-mode failure must not hide successfully recovered
+          // per-session items from the current in-memory board.
+        }
+        return result;
+      } catch (_) { return []; }
+    },
+    _persistGlobalUserTodos() {
       try {
         localStorage.setItem(
-          this._sessionUserTodoStorageKey(),
+          this._globalUserTodoStorageKey(),
           JSON.stringify(this.sessionTodoItems()),
         );
       } catch (_) { /* private mode / quota: keep the in-memory clipboard */ }
     },
     sessionTodoItems() {
-      if (!this.currentId) return [];
-      const state = this._ensureTabState(this.currentId);
-      return Array.isArray(state.userTodos) ? state.userTodos : [];
+      return Array.isArray(this.userTodos) ? this.userTodos : [];
     },
     sessionTodoCount(completed = null) {
       const items = this.sessionTodoItems();
       return completed == null
         ? items.length : items.filter(item => !!item.completed === completed).length;
     },
+    sessionTodoIndicatorPriority() {
+      const active = this.sessionTodoItems().filter(item => !item.completed);
+      if (active.some(item => item.priority === "high")) return "high";
+      if (active.some(item => item.priority === "medium")) return "medium";
+      return "";
+    },
     addSessionUserTodo() {
       const text = String(this.sessionTodoDraft || "").trim();
-      if (!text || !this.currentId) return;
-      const state = this._ensureTabState(this.currentId);
-      state.userTodos = [
-        ...(state.userTodos || []),
+      if (!text) return;
+      this.userTodos = [
+        ...this.sessionTodoItems(),
         { id: `u-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
           text, completed: false, priority: "medium" },
       ].slice(-100);
       this.sessionTodoDraft = "";
-      this._persistSessionUserTodos();
+      this._persistGlobalUserTodos();
     },
     toggleSessionUserTodo(id) {
-      const state = this._ensureTabState(this.currentId);
-      state.userTodos = (state.userTodos || []).map(item =>
+      this.userTodos = this.sessionTodoItems().map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item);
-      this._persistSessionUserTodos();
+      this._persistGlobalUserTodos();
     },
     deleteSessionUserTodo(id) {
-      const state = this._ensureTabState(this.currentId);
-      state.userTodos = (state.userTodos || []).filter(item => item.id !== id);
-      this._persistSessionUserTodos();
+      this.userTodos = this.sessionTodoItems().filter(item => item.id !== id);
+      if (this.sessionTodoEditId === id) this.cancelSessionTodoEdit();
+      this._persistGlobalUserTodos();
+    },
+    startSessionTodoEdit(item, ev) {
+      if (!item || !item.id || ev?.target?.closest?.("button")) return;
+      const host = ev?.currentTarget;
+      this.sessionTodoEditId = item.id;
+      this.sessionTodoEditDraft = String(item.text || "");
+      this.$nextTick(() => {
+        // Run after the browser finishes the native dblclick sequence; focusing
+        // in the same event microtask is immediately undone by Chromium's
+        // default double-click text-selection step.
+        setTimeout(() => {
+          const input = host?.querySelector?.(".session-todo-edit");
+          if (input) { input.focus(); input.select(); }
+        }, 0);
+      });
+    },
+    saveSessionTodoEdit(id = this.sessionTodoEditId) {
+      if (!id || id !== this.sessionTodoEditId) return;
+      const text = String(this.sessionTodoEditDraft || "").trim();
+      if (text) {
+        this.userTodos = this.sessionTodoItems().map(item =>
+          item.id === id ? { ...item, text: text.slice(0, 240) } : item);
+        this._persistGlobalUserTodos();
+      }
+      this.sessionTodoEditId = "";
+      this.sessionTodoEditDraft = "";
+    },
+    cancelSessionTodoEdit() {
+      this.sessionTodoEditId = "";
+      this.sessionTodoEditDraft = "";
     },
     clearCompletedSessionUserTodos() {
-      const state = this._ensureTabState(this.currentId);
-      state.userTodos = (state.userTodos || []).filter(item => !item.completed);
-      this._persistSessionUserTodos();
+      this.userTodos = this.sessionTodoItems().filter(item => !item.completed);
+      this._persistGlobalUserTodos();
     },
     sessionTodosForPriority(priority) {
       return this.sessionTodoItems().filter(item => item.priority === priority);
@@ -10993,22 +11066,26 @@ function portal() {
       const id = this.sessionTodoDragId
         || ev?.dataTransfer?.getData("text/plain") || "";
       if (!id || !["high", "medium", "low"].includes(priority)) return;
-      const state = this._ensureTabState(this.currentId);
-      const current = (state.userTodos || []).slice();
+      const current = this.sessionTodoItems().slice();
       const source = current.findIndex(item => item.id === id);
       if (source < 0) return;
-      const [moved] = current.splice(source, 1);
-      moved.priority = priority;
+      const [sourceItem] = current.splice(source, 1);
+      const moved = { ...sourceItem, priority };
       const target = beforeId ? current.findIndex(item => item.id === beforeId) : -1;
       if (target >= 0) current.splice(target, 0, moved);
       else current.push(moved);
-      state.userTodos = current;
+      this.userTodos = current;
       this.sessionTodoDragId = "";
-      this._persistSessionUserTodos();
+      this._persistGlobalUserTodos();
     },
     toggleSessionTodoBoard() {
-      this.sessionTodoOpen = !this.sessionTodoOpen;
-      if (!this.sessionTodoOpen) this.sessionTodoDraft = "";
+      if (this.sessionTodoOpen) this.closeSessionTodoBoard();
+      else this.sessionTodoOpen = true;
+    },
+    closeSessionTodoBoard() {
+      this.sessionTodoOpen = false;
+      this.sessionTodoDraft = "";
+      this.cancelSessionTodoEdit();
     },
     taskLogLine(m) {
       if (!m || !m.name) return null;
@@ -24576,7 +24653,12 @@ function portal() {
     _userScrollIntent() {
       if (this.previewQuote.show && this.previewQuote.source === "chat"
           && this.previewQuote.mode !== "ask") {
-        this.dismissPreviewQuote(true);
+        // Hide the contextual actions while the transcript moves, but preserve
+        // the browser selection. Clearing it here made wheel-assisted text
+        // selection impossible: once the actions popover appeared, the next
+        // wheel tick called removeAllRanges() even while the mouse button was
+        // still held, so users could not extend a selection across viewports.
+        this.dismissPreviewQuote(false);
       }
       this._userScrollAt = Date.now();
       const st = this.currentId && this.tabState && this.tabState[this.currentId];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1320,17 +1320,7 @@
           <span x-text="t('pane.chat')"></span>
         </span>
         <span class="spacer"></span>
-        <button class="session-todo-btn icon-btn" type="button"
-                @click="toggleSessionTodoBoard()"
-                :class="{ active: sessionTodoOpen, 'has-active': sessionTodoCount(false) }"
-                :aria-expanded="sessionTodoOpen"
-                :title="lang==='zh' ? '待办事项' : 'Current session TODOs'">
-          <svg><use href="#i-check-circle"/></svg>
-          <span class="session-todo-badge" x-show="sessionTodoCount()"
-                x-text="sessionTodoCount(true) + '/' + sessionTodoCount()"></span>
-        </button>
-        <!-- Global task center — moved here from the files header to sit
-             immediately left of the Skills entry (2026-07-21). -->
+        <!-- Global task center is the first action after the title spacer. -->
         <button class="activity-center-btn" type="button" @click="openActivityCenter()"
                 :class="{ active: activity.summary.running || activity.summary.unread, danger: activity.summary.attention }"
                 :title="lang==='zh' ? '全局任务中心' : 'Global activity center'">
@@ -1340,6 +1330,16 @@
           <svg><use href="#i-inbox"/></svg>
           <span class="activity-running" x-show="activity.summary.running" aria-hidden="true"></span>
           <span class="activity-unread" x-show="activity.summary.unread" aria-hidden="true"></span>
+        </button>
+        <button class="session-todo-btn icon-btn" type="button"
+                @click="toggleSessionTodoBoard()"
+                :class="{ active: sessionTodoOpen, 'has-active': sessionTodoCount(false) }"
+                :aria-expanded="sessionTodoOpen"
+                :title="lang==='zh' ? '待办事项' : 'Global TODOs'">
+          <svg><use href="#i-check-circle"/></svg>
+          <span class="session-todo-badge" aria-hidden="true"
+                x-show="sessionTodoIndicatorPriority()"
+                :class="'is-' + sessionTodoIndicatorPriority()"></span>
         </button>
         <button class="icon-btn" type="button" @click="openMemoryCenter()"
                 :title="lang==='zh' ? '记忆中心' : 'Memory Center'"
@@ -5761,9 +5761,9 @@
   </div>
 
   <div class="modal-backdrop" x-show="sessionTodoOpen"
-       @click.self="sessionTodoOpen=false" x-cloak>
+       @click.self="closeSessionTodoBoard()" x-cloak>
     <div class="modal session-todo-modal" role="dialog" aria-modal="true"
-         @keydown.escape.window="sessionTodoOpen=false">
+         @keydown.escape.window="closeSessionTodoBoard()">
       <div class="modal-head">
         <span class="modal-title">
           <svg class="modal-title-icon"><use href="#i-check-circle"/></svg>
@@ -5774,7 +5774,7 @@
         <button class="btn-ghost sm" type="button" x-show="sessionTodoCount(true)"
                 @click="clearCompletedSessionUserTodos()"
                 x-text="lang==='zh' ? '清除已完成' : 'Clear completed'"></button>
-        <button class="modal-close" @click="sessionTodoOpen=false" aria-label="Close">×</button>
+        <button class="modal-close" @click="closeSessionTodoBoard()" aria-label="Close">×</button>
       </div>
       <form class="session-todo-compose" @submit.prevent="addSessionUserTodo()">
         <input type="text" maxlength="240" autocomplete="off" autofocus
@@ -5807,8 +5807,10 @@
               <template x-for="item in sessionTodosForPriority(priority)" :key="item.id">
                 <div class="session-todo-item"
                      :class="{ 'is-completed': item.completed,
-                               'is-dragging': sessionTodoDragId === item.id }"
-                     draggable="true"
+                               'is-dragging': sessionTodoDragId === item.id,
+                               'is-editing': sessionTodoEditId === item.id }"
+                     :draggable="sessionTodoEditId !== item.id"
+                     @dblclick.prevent="startSessionTodoEdit(item, $event)"
                      @dragstart="onSessionTodoDragStart($event, item)"
                      @dragend="onSessionTodoDragEnd()"
                      @dragover.prevent
@@ -5822,7 +5824,18 @@
                     <svg x-show="item.completed"><use href="#i-check"/></svg>
                     <span x-show="!item.completed" class="todo-dot"></span>
                   </button>
-                  <span class="session-todo-copy"><strong x-text="item.text"></strong></span>
+                  <span class="session-todo-copy">
+                    <strong x-show="sessionTodoEditId !== item.id" x-text="item.text"></strong>
+                    <template x-if="sessionTodoEditId === item.id">
+                      <input class="session-todo-edit" type="text" maxlength="240" autofocus
+                             x-model="sessionTodoEditDraft"
+                             @click.stop @dblclick.stop
+                             @keydown.enter.prevent="saveSessionTodoEdit(item.id)"
+                             @keydown.escape.stop.prevent="cancelSessionTodoEdit()"
+                             @blur="saveSessionTodoEdit(item.id)"
+                             :aria-label="lang==='zh' ? '编辑待办内容' : 'Edit TODO text'" />
+                    </template>
+                  </span>
                   <button class="session-todo-delete" type="button"
                           @click="deleteSessionUserTodo(item.id)"
                           :aria-label="lang==='zh' ? '删除待办' : 'Delete TODO'">×</button>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3632,9 +3632,30 @@ pre.text {
 .session-todo-modal-count { margin-left:auto; color:var(--c-fg-3); font:var(--fs-xs) var(--font-mono); }
 .session-todo-modal .session-todo-compose { margin:0; padding:12px 14px; border-bottom:1px solid var(--c-border); }
 .session-todo-modal-body { max-height:min(60vh,520px); padding:12px 14px 16px; overflow:auto; }
-@media (max-width:600px) { .session-todo-modal { width:100vw; max-width:none; } }
+/* The generic desktop `.modal` rule later in this stylesheet caps dialogs at
+   480px. The two-class selector intentionally outranks that cap: a three-lane
+   board needs real horizontal and vertical working space for reading + drag. */
+@media (min-width:721px) {
+  .modal.session-todo-modal {
+    width:min(1040px,calc(100vw - 64px));
+    max-width:calc(100vw - 64px);
+    height:min(76vh,720px);
+    max-height:calc(100vh - 64px);
+    display:flex;
+    flex-direction:column;
+  }
+  .modal.session-todo-modal .session-todo-modal-body {
+    flex:1;
+    min-height:0;
+    max-height:none;
+  }
+  .modal.session-todo-modal .session-todo-board { min-height:100%; }
+}
+@media (max-width:600px) { .modal.session-todo-modal { width:100vw; max-width:none; } }
 
-.session-todo-badge { position:absolute; right:-5px; top:-5px; min-width:18px; height:16px; padding:0 4px; display:flex; align-items:center; justify-content:center; border:2px solid var(--c-bg-1); border-radius:var(--r-full); background:var(--c-accent); color:var(--c-on-accent); font:9px/1 var(--font-mono); }
+.session-todo-badge { position:absolute; right:-2px; top:-2px; width:10px; height:10px; border:2px solid var(--c-bg-1); border-radius:50%; box-sizing:border-box; pointer-events:none; }
+.session-todo-badge.is-high { background:var(--c-danger); box-shadow:0 0 0 2px color-mix(in srgb,var(--c-danger) 18%,transparent); }
+.session-todo-badge.is-medium { background:var(--c-warn); box-shadow:0 0 0 2px color-mix(in srgb,var(--c-warn) 18%,transparent); }
 .session-todo-panel { flex:0 0 auto; max-height:min(42vh,380px); overflow:auto; padding:10px 14px 12px; border-bottom:1px solid var(--c-border); background:var(--c-bg-1); box-shadow:0 5px 16px rgba(0,0,0,.08); }
 .session-todo-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:8px; }
 .session-todo-head > div { display:flex; flex-direction:column; gap:2px; }
@@ -3649,7 +3670,7 @@ pre.text {
 .session-todo-item + .session-todo-item { border-top:1px solid var(--c-border); }
 .session-todo-state { width:16px; height:18px; flex:0 0 16px; display:flex; align-items:center; justify-content:center; }
 .session-todo-state svg { width:14px; height:14px; color:var(--c-success); }
-.session-todo-copy { min-width:0; display:flex; flex-direction:column; gap:2px; }
+.session-todo-copy { min-width:0; flex:1; display:flex; flex-direction:column; gap:2px; }
 .session-todo-copy strong { overflow:hidden; color:var(--c-fg-1); font-size:var(--fs-xs); font-weight:var(--fw-medium); line-height:1.35; text-overflow:ellipsis; }
 .session-todo-copy small { color:var(--c-fg-3); font-size:10px; line-height:1.35; }
 .session-todo-item.is-completed .session-todo-copy strong { color:var(--c-fg-3); text-decoration:line-through; }
@@ -3682,6 +3703,8 @@ pre.text {
 .session-todo-lane .session-todo-item { margin:3px 0; border:1px solid var(--c-border); background:var(--c-bg-1); cursor:grab; }
 .session-todo-lane .session-todo-item:active { cursor:grabbing; }
 .session-todo-item.is-dragging { opacity:.35; }
+.session-todo-item.is-editing { cursor:text; border-color:var(--c-accent); }
+.session-todo-modal .session-todo-edit { width:100%; min-width:0; height:28px; margin:0; padding:0 7px; border:1px solid var(--c-accent); border-radius:var(--r-sm); outline:0; background:var(--c-bg-0); color:var(--c-fg-0); font:inherit; font-size:var(--fs-xs); box-shadow:0 0 0 2px var(--c-accent-soft); }
 .session-todo-grip { flex:0 0 auto; color:var(--c-fg-4); font:12px/1 var(--font-mono); letter-spacing:-3px; }
 @media (max-width:720px) {
   .session-todo-board { grid-template-columns:1fr; }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -34,9 +34,11 @@ def test_memory_shortcut_opens_memory_settings_page(
 ):
     _login(page, backend_url, auth_token)
 
-    shortcut = page.locator(".activity-center-btn + .icon-btn")
+    shortcut = page.locator(
+        ".pane.chat > .pane-head button.icon-btn",
+        has=page.locator('use[href="#i-brain"]'),
+    )
     expect(shortcut).to_have_count(1)
-    expect(shortcut.locator('use[href="#i-brain"]')).to_have_count(1)
     shortcut.click()
 
     expect(page.locator(".settings-modal")).to_be_visible()

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -807,6 +807,185 @@ def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
     _assert_no_browser_errors(page, errors)
 
 
+def test_chat_wheel_preserves_selection_across_messages(
+    page: Page, backend_url, auth_token,
+):
+    """Scrolling the transcript must not collapse a live browser selection."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    sid = "selection-wheel-source"
+    _bootstrap_session_for_real_load(page, sid, "Selection wheel source")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        st._loaded = true;
+        st.messages = [
+          {
+            role: "assistant", text: "FIRST_WHEEL_SELECTION_MARKER",
+            html: "<p>FIRST_WHEEL_SELECTION_MARKER</p>",
+            uuid: "selection-wheel-first", _k: "selection-wheel-first",
+            _noAnim: true,
+          },
+          {
+            role: "assistant", text: "SECOND_WHEEL_SELECTION_MARKER",
+            html: "<p>SECOND_WHEEL_SELECTION_MARKER</p>",
+            uuid: "selection-wheel-second", _k: "selection-wheel-second",
+            _noAnim: true,
+          },
+        ];
+        app._activateTabState(arg);
+        app.mobileTab = "chat";
+        return true;
+        """,
+        sid,
+    )
+    page.wait_for_function(
+        """sid => document.querySelectorAll(
+          `.msg-pane[data-tid="${CSS.escape(sid)}"] .msg.assistant p`).length === 2""",
+        arg=sid,
+    )
+
+    selected = page.evaluate(
+        """sid => {
+          const nodes = document.querySelectorAll(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"] .msg.assistant p`);
+          const range = document.createRange();
+          range.selectNodeContents(nodes[0]);
+          const selection = window.getSelection();
+          selection.removeAllRanges();
+          selection.addRange(range);
+          document.dispatchEvent(new Event('selectionchange'));
+          return selection.toString();
+        }""",
+        sid,
+    )
+    assert selected == "FIRST_WHEEL_SELECTION_MARKER"
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.previewQuote.show && app.previewQuote.source === 'chat';
+        }"""
+    )
+
+    after_wheel = page.evaluate(
+        """() => {
+          const body = document.querySelector('.chat-body');
+          body.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: 320, bubbles: true, cancelable: true,
+          }));
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            text: window.getSelection().toString(),
+            rangeCount: window.getSelection().rangeCount,
+            popover: app.previewQuote.show,
+          };
+        }"""
+    )
+    assert after_wheel == {
+        "text": "FIRST_WHEEL_SELECTION_MARKER",
+        "rangeCount": 1,
+        "popover": False,
+    }
+
+    extended = page.evaluate(
+        """sid => {
+          const nodes = document.querySelectorAll(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"] .msg.assistant p`);
+          const range = document.createRange();
+          range.setStart(nodes[0].firstChild, 0);
+          range.setEnd(nodes[1].firstChild, nodes[1].firstChild.length);
+          const selection = window.getSelection();
+          selection.removeAllRanges();
+          selection.addRange(range);
+          document.dispatchEvent(new Event('selectionchange'));
+          return selection.toString();
+        }""",
+        sid,
+    )
+    assert "FIRST_WHEEL_SELECTION_MARKER" in extended
+    assert "SECOND_WHEEL_SELECTION_MARKER" in extended
+    _assert_no_browser_errors(page, errors)
+
+
+def test_session_todo_modal_uses_large_desktop_board(
+    page: Page, backend_url, auth_token,
+):
+    """The three priority lanes should use the desktop viewport, not 480px."""
+    _login(page, backend_url, auth_token)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    todo_state = _app_eval(
+        page,
+        """
+        const originalId = app.currentId;
+        app.userTodos = [
+          {id: 'todo-high', text: 'High item', completed: false, priority: 'high'},
+          {id: 'todo-medium', text: 'Medium item', completed: false, priority: 'medium'},
+          {id: 'todo-low', text: 'Low item', completed: false, priority: 'low'},
+        ];
+        app._persistGlobalUserTodos();
+        const beforeSwitch = app.sessionTodoItems().map(item => item.id);
+        app.currentId = 'different-conversation';
+        const afterSwitch = app.sessionTodoItems().map(item => item.id);
+        app.currentId = originalId;
+        const highIndicator = app.sessionTodoIndicatorPriority();
+        app.userTodos = app.userTodos.map(item => item.id === 'todo-high'
+          ? {...item, completed: true} : item);
+        const mediumIndicator = app.sessionTodoIndicatorPriority();
+        app.userTodos = app.userTodos.map(item => item.id === 'todo-medium'
+          ? {...item, completed: true} : item);
+        const lowOnlyIndicator = app.sessionTodoIndicatorPriority();
+        app.userTodos = app.userTodos.map(item => ({...item, completed: false}));
+        app.sessionTodoOpen = true;
+        return {
+          beforeSwitch,
+          afterSwitch,
+          storageKey: app._globalUserTodoStorageKey(),
+          highIndicator,
+          mediumIndicator,
+          lowOnlyIndicator,
+        };
+        """,
+    )
+    assert todo_state == {
+        "beforeSwitch": ["todo-high", "todo-medium", "todo-low"],
+        "afterSwitch": ["todo-high", "todo-medium", "todo-low"],
+        "storageKey": "muselab.userTodos.global",
+        "highIndicator": "high",
+        "mediumIndicator": "medium",
+        "lowOnlyIndicator": "",
+    }
+    modal = page.locator(".session-todo-modal")
+    expect(modal).to_be_visible()
+    box = modal.bounding_box()
+    assert box is not None
+    assert box["width"] >= 900
+    assert box["height"] >= 600
+    expect(modal.locator(".session-todo-lane")).to_have_count(3)
+
+    high_item = modal.locator(".session-todo-item", has_text="High item")
+    high_item.dblclick()
+    edit = high_item.locator(".session-todo-edit")
+    expect(edit).to_be_visible()
+    expect(edit).to_be_focused()
+    edit.fill("Edited high item")
+    edit.press("Enter")
+    expect(high_item.locator("strong")).to_have_text("Edited high item")
+    saved = page.evaluate(
+        """() => JSON.parse(localStorage.getItem(
+          'muselab.userTodos.global') || '[]').find(item => item.id === 'todo-high')?.text"""
+    )
+    assert saved == "Edited high item"
+
+    medium_item = modal.locator(".session-todo-item", has_text="Medium item")
+    medium_item.dblclick()
+    medium_edit = medium_item.locator(".session-todo-edit")
+    medium_edit.fill("Must not save")
+    medium_edit.press("Escape")
+    expect(medium_item.locator("strong")).to_have_text("Medium item")
+    expect(modal).to_be_visible()
+
+
 def test_effort_fast_capabilities_and_session_restore(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -188,6 +188,84 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
     assert result["chatFullscreen"]["sameChatNode"] is True
 
 
+def test_refresh_restores_file_without_reopening_hidden_preview(
+        page: Page, backend_url, auth_token):
+    """Background file restoration preserves the user's hidden right rail."""
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    prepared = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const opened = await app.openFile({path: 'README.md', name: 'README.md'});
+          app.desktopFullPane = '';
+          app.previewOpen = false;
+          app.savePrefs();
+          return {
+            opened,
+            selected: app.selected,
+            previewOpen: app.previewOpen,
+            savedPreviewOpen: JSON.parse(
+              localStorage.getItem('muselab_prefs') || '{}').previewOpen,
+          };
+        }"""
+    )
+    assert prepared == {
+        "opened": True,
+        "selected": "README.md",
+        "previewOpen": False,
+        "savedPreviewOpen": False,
+    }
+
+    # A fresh boot should reload the selected file in the background without
+    # treating restoration as a user click that reveals the preview rail.
+    _login(page, backend_url, auth_token)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          return app && app.selected === 'README.md' && !app.previewOpen;
+        }"""
+    )
+    restored = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const preview = document.querySelector('.pane.preview');
+          return {
+            selected: app.selected,
+            previewOpen: app.previewOpen,
+            previewDisplay: getComputedStyle(preview).display,
+          };
+        }"""
+    )
+    assert restored == {
+        "selected": "README.md",
+        "previewOpen": False,
+        "previewDisplay": "none",
+    }
+
+    # The ordinary openFile path remains the explicit user action: clicking the
+    # already-selected file must reveal the rail without requiring a reload.
+    revealed = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          await app.openFile({path: 'README.md', name: 'README.md'});
+          await new Promise(resolve => app.$nextTick(resolve));
+          await new Promise(resolve => requestAnimationFrame(resolve));
+          return {
+            selected: app.selected,
+            previewOpen: app.previewOpen,
+            previewDisplay: getComputedStyle(
+              document.querySelector('.pane.preview')).display,
+          };
+        }"""
+    )
+    assert revealed == {
+        "selected": "README.md",
+        "previewOpen": True,
+        "previewDisplay": "flex",
+    }
+
+
 def test_os_file_drop_uses_whole_window_root_except_explicit_directory(
         page: Page, backend_url, auth_token):
     """Composer/tree blank/file rows are root; only a dir row is nested."""

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -207,6 +207,8 @@ def test_preview_tabs_persist_reading_positions_and_html_frames():
     assert 'this.desktopFullPane = ""' in open_file
     assert "this.previewOpen = true" in open_file
     assert "this._schedulePreviewViewRestore(cachedPath, loadSeq)" in open_file
+    restore_call = "{ preview: !!(_restored && _restored.preview), reveal: false }"
+    assert app.count(restore_call) == 2
     assert "this.csvLoadPage(targetView.csvOffset)" in open_file
     assert 'x-ref="previewBody"' in html
     assert '@scroll.passive="onPreviewViewportScroll()"' in html
@@ -276,6 +278,11 @@ def test_preview_selection_quote_attachment_and_side_question_are_safely_wired()
     assert "finishPreviewQuoteDrag(ev)" in app
     assert "window.visualViewport.addEventListener" in app
     assert "new ResizeObserver" in app
+    scroll_intent_start = app.index("\n    _userScrollIntent() {")
+    scroll_intent_end = app.index("\n    scrollToBottom(", scroll_intent_start)
+    scroll_intent = app[scroll_intent_start:scroll_intent_end]
+    assert "this.dismissPreviewQuote(false)" in scroll_intent
+    assert "this.dismissPreviewQuote(true)" not in scroll_intent
 
     quote_start = app.index("quotePreviewSelection()")
     quote_end = app.index("\n\n    removePendingQuote", quote_start)
@@ -1478,37 +1485,67 @@ def test_chat_header_exposes_authenticated_session_todo_board():
 
     assert "sessionTodoOpen: false" in app
     assert 'sessionTodoDraft: ""' in app
+    assert 'sessionTodoEditId: ""' in app
+    assert 'sessionTodoEditDraft: ""' in app
     assert "userTodos: []" in app
-    assert 'return "muselab.userTodos."' in app
+    assert "_globalUserTodoStorageKey()" in app
+    assert 'return "muselab.userTodos.global"' in app
     assert "addSessionUserTodo()" in app
     assert "toggleSessionUserTodo(id)" in app
     assert "deleteSessionUserTodo(id)" in app
+    assert "startSessionTodoEdit(item, ev)" in app
+    assert "saveSessionTodoEdit(id = this.sessionTodoEditId)" in app
+    assert "cancelSessionTodoEdit()" in app
     assert "sessionTodosForPriority(priority)" in app
+    assert "sessionTodoIndicatorPriority()" in app
+    assert 'item.priority === "high"' in app
+    assert 'item.priority === "medium"' in app
     assert "onSessionTodoDragStart(ev, item)" in app
     assert "onSessionTodoDrop(ev, priority" in app
     assert 'priority: "medium"' in app
-    todo_impl = app[app.index("_sessionUserTodoStorageKey"):app.index("taskLogLine(m)")]
+    todo_start = app.index("\n    _globalUserTodoStorageKey() {")
+    todo_impl = app[todo_start:app.index("taskLogLine(m)", todo_start)]
+    assert "this.currentId" not in todo_impl
+    assert "_ensureTabState" not in todo_impl
+    assert "tabState" not in todo_impl
+    assert 'startsWith("muselab.userTodos.")' in todo_impl
     assert "TodoWrite" not in todo_impl
     assert "TaskCreate" not in todo_impl
     assert "TaskUpdate" not in todo_impl
-    button = html.index('class="session-todo-btn icon-btn"')
-    activity = html.index('class="activity-center-btn"', button)
-    assert button < activity
+    activity = html.index('class="activity-center-btn"')
+    button = html.index('class="session-todo-btn icon-btn"', activity)
+    assert activity < button
     assert '@click="toggleSessionTodoBoard()"' in html
+    todo_button = html[button:html.index("</button>", button)]
+    assert 'x-show="sessionTodoIndicatorPriority()"' in todo_button
+    assert ':class="\'is-\' + sessionTodoIndicatorPriority()"' in todo_button
+    assert "sessionTodoCount(true) + '/' + sessionTodoCount()" not in todo_button
     assert 'class="modal session-todo-modal"' in html
     assert "'待办事项'" in html
     assert 'x-show="sessionTodoOpen"' in html
-    assert '@click.self="sessionTodoOpen=false"' in html
+    assert '@click.self="closeSessionTodoBoard()"' in html
     assert '@submit.prevent="addSessionUserTodo()"' in html
     assert "['high','medium','low']" in html
+    assert '@dblclick.prevent="startSessionTodoEdit(item, $event)"' in html
+    assert ':draggable="sessionTodoEditId !== item.id"' in html
+    assert 'class="session-todo-edit"' in html
+    assert '@keydown.enter.prevent="saveSessionTodoEdit(item.id)"' in html
+    assert '@keydown.escape.stop.prevent="cancelSessionTodoEdit()"' in html
+    assert '@blur="saveSessionTodoEdit(item.id)"' in html
     assert '@dragstart="onSessionTodoDragStart($event, item)"' in html
     assert '@drop="onSessionTodoDrop($event, priority)"' in html
     assert '@drop.stop="onSessionTodoDrop($event, priority, item.id)"' in html
     assert '@click="toggleSessionUserTodo(item.id)"' in html
     assert '@click="deleteSessionUserTodo(item.id)"' in html
     assert ".session-todo-modal" in css
+    assert ".modal.session-todo-modal" in css
+    assert "width:min(1040px,calc(100vw - 64px))" in css
+    assert "height:min(76vh,720px)" in css
     assert ".session-todo-board" in css
     assert ".session-todo-lane.is-high" in css
+    assert ".session-todo-badge.is-high" in css
+    assert ".session-todo-badge.is-medium" in css
+    assert ".session-todo-modal .session-todo-edit" in css
     assert ".session-todo-compose" in css
     assert "@media (max-width:720px)" in css
 


### PR DESCRIPTION
## 变更摘要

- 修复聊天区滚轮滚动时清空文本选区的问题，支持跨视口继续选择内容
- 恢复已打开文件时保持预览区隐藏；只有用户主动打开文件才展开预览区
- 将待办事项从会话级改为浏览器全局清单，并自动迁移已有会话待办
- 放大桌面端待办事项弹窗，保留移动端单列布局
- 调整顶栏顺序：全局任务中心在前，待办事项在后
- 使用红／黄优先级指示灯替代数字角标
- 支持双击待办条目内联编辑，Enter 或失焦保存，Escape 取消
- 支持多个浏览器标签页之间同步全局待办

## 验证

- `node --check frontend/app.js`
- `git diff --check`
- `tests/test_frontend_lint.py`：112 passed
- 聊天选区与待办事项 Playwright 回归：2 passed
- 预览区刷新恢复 Playwright 回归：1 passed
- 独立代码审查：未发现遗留问题

## 风险与兼容性

- 全局待办仍仅保存在浏览器 `localStorage`，不会进入模型上下文或服务端
- 首次加载会将旧的 `muselab.userTodos.<session>` 数据合并到 `muselab.userTodos.global`；旧键保留作为恢复备份
- 只有未完成的高／中优先级待办会显示红／黄提示灯，低优先级不显示角标
- 未运行完整全仓测试套件；已运行覆盖全部修改路径的静态与浏览器回归测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)