### PR TITLE
feat(ui): refine activity board and preview behavior

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4760,7 +4760,7 @@ function portal() {
             if (!resolved) return;   // cancelled
           }
           if (resolved) {
-            await this.openFile({ path: resolved, name });
+            await this.openFile({ path: resolved, name }, { reveal: true });
             if (!this._workspaceIsCurrent(ownerWorkspace)) return;
             this.revealInTree(resolved, { mode: "background" }).catch(() => {});
             return;
@@ -4772,7 +4772,7 @@ function portal() {
           this.toast(this.lang === "zh" ? `这是目录：${path}` : `Is a directory: ${path}`, "warn");
           return;
         }
-        await this.openFile({ path, name });
+        await this.openFile({ path, name }, { reveal: true });
         if (!this._workspaceIsCurrent(ownerWorkspace)) return;
         // Mirror the click into the file tree: expand parents + scroll the
         // row into view so the user sees where the file lives. Use background
@@ -4803,7 +4803,7 @@ function portal() {
         + encodeURIComponent(this.currentId)
         + "&path=" + encodeURIComponent(path);
       try {
-        await this.openFile({ path, name }, { readUrl: url });
+        await this.openFile({ path, name }, { readUrl: url, reveal: true });
       } catch (e) {
         this.toast(this.lang === "zh" ? `打开失败：${path}` : `Open failed: ${path}`, "warn");
       }
@@ -11819,7 +11819,7 @@ function portal() {
           // Switch first, mutate second. openFile owns the dirty-editor guard;
           // if the user cancels, keep the original tab array intact.
           if (this.selected !== path) {
-            await this.switchTab(path);
+            await this.switchTab(path, { reveal: true });
             if (this.selected !== path) return;
           }
           this.tabs = this.tabs.filter(t => t.path === path);
@@ -11829,7 +11829,7 @@ function portal() {
           const idx = this.tabs.findIndex(t => t.path === path);
           const selectedIdx = this.tabs.findIndex(t => t.path === this.selected);
           if (idx >= 0 && selectedIdx > idx) {
-            await this.switchTab(path);
+            await this.switchTab(path, { reveal: true });
             if (this.selected !== path) return;
           }
           if (idx >= 0) this.tabs = this.tabs.slice(0, idx + 1);
@@ -12237,7 +12237,7 @@ function portal() {
     },
     pickEditorTab(path) {
       this.editorTabPickerOpen = false;
-      this.switchTab(path);
+      this.switchTab(path, { reveal: true });
     },
     pickerRowMenu(ev, sid) {
       if (ev && ev.stopPropagation) ev.stopPropagation();
@@ -17470,7 +17470,9 @@ function portal() {
         // reliable double-click gesture to pin it, so recycling A when B is
         // tapped would also discard A's saved reading position. Mobile taps
         // therefore open normal, closable tabs.
-        await this.openFile(n, { preview: !this._isMobileLayout() });
+        await this.openFile(n, {
+          preview: !this._isMobileLayout(), reveal: true,
+        });
       }
     },
     // ===== multi-select helpers =====
@@ -17603,7 +17605,9 @@ function portal() {
     // promotes that slot to permanent (openFile's `existing && !asPreview`
     // branch clears the preview flag).
     async onNodeDblClick(n) {
-      if (n && !n.is_dir) await this.openFile(n, { preview: false });
+      if (n && !n.is_dir) {
+        await this.openFile(n, { preview: false, reveal: true });
+      }
     },
     // Pin a preview (italic) tab so it stays open: double-clicking the tab
     // itself, or starting to edit its file, promotes it to permanent.
@@ -17715,7 +17719,7 @@ function portal() {
       if (!n) return;
       switch (action) {
         case "open":
-          if (!n.is_dir) await this.openFile(n);
+          if (!n.is_dir) await this.openFile(n, { reveal: true });
           break;
         case "mention":
           this.insertFileMention(n.path, !!n.is_dir);
@@ -17787,7 +17791,7 @@ function portal() {
         if (!this._workspaceIsCurrent(ownerWorkspace)) return;
         this.toast(this.t("toast.created_name", { name }), "success");
         // 自动打开编辑
-        await this.openFile({ path, name });
+        await this.openFile({ path, name }, { reveal: true });
         if (!this._workspaceIsCurrent(ownerWorkspace)) return;
         if (this.selected === path) await this.toggleEdit();
       } else {
@@ -19964,35 +19968,42 @@ function portal() {
 
     async openFile(n, opts = {}) {
       if (!n || !n.path) return false;
-      // A file open is an explicit request to see the preview. Restore the
-      // desktop preview rail even when it was hidden (or chat/files fullscreen
-      // collapsed it). Mobile already switches to the preview tab below.
-      if (opts.reveal !== false && !this._isMobileLayout()
+      // Loading file content and revealing the preview rail are separate
+      // operations. Background refresh/restore/remap paths call openFile too;
+      // only a direct user gesture opts into layout changes with reveal:true.
+      const reveal = opts.reveal === true;
+      const keepCurrentEditor = this.editing
+        && n.path === this.selected && !opts.forceReload;
+      // Confirm before mutating layout or surface ownership. Cancelling a dirty
+      // file switch must leave a hidden rail/fullscreen pane and terminal intact.
+      if (!keepCurrentEditor && this.editing
+          && !opts.editsConfirmed && !this._confirmLoseEdits()) {
+        return false;
+      }
+      if (reveal && !this._isMobileLayout()
           && (!this.previewOpen || this.desktopFullPane)) {
         this.desktopFullPane = "";
         this.previewOpen = true;
         this.savePrefs();
       }
       this.dismissTransientPreviewQuote(true);
-      if (this.previewSurface === "terminal") this._teardownTerminalView();
-      this.previewSurface = "file";
+      // A hidden background reload must not evict a terminal that currently
+      // owns the preview surface. Direct user opens explicitly activate files.
+      if (this.previewSurface !== "terminal" || reveal) {
+        if (this.previewSurface === "terminal") this._teardownTerminalView();
+        this.previewSurface = "file";
+      }
       // Clicking / double-clicking the file that already owns the editor is a
       // focus or pin gesture, not a request to throw the buffer away and read
       // it again. The old path guard only prompted for a *different* file, but
       // then unconditionally set editing=false below — so one innocent repeat
       // click silently discarded dirty text. Explicit force-reload is the one
       // same-path operation that is allowed to replace the buffer.
-      if (this.editing && n.path === this.selected && !opts.forceReload) {
+      if (keepCurrentEditor) {
         if (!opts.preview) this.pinTab(n.path);
         this.treeFocusPath = n.path;
+        if (this._isMobileLayout() && reveal) this.setMobileTab("preview");
         return true;
-      }
-      // Unsaved-edits guard: switching to a DIFFERENT file while the editor
-      // is dirty, or explicitly force-reloading the current one, would replace
-      // the buffer. Confirm first; reloadPreview can pass the confirmation it
-      // already obtained so the user never sees the same dialog twice.
-      if (this.editing && !opts.editsConfirmed && !this._confirmLoseEdits()) {
-        return false;
       }
       this._capturePreviewViewState(this.selected);
       this._cancelPreviewViewRestore();
@@ -20061,7 +20072,7 @@ function portal() {
       this._scheduleSavePrefs();
       // Mobile: opening a file should jump to the preview pane (otherwise
       // the user is still on `files` tab and sees nothing change).
-      if (this._isMobileLayout() && opts.reveal !== false) {
+      if (this._isMobileLayout() && reveal) {
         this.setMobileTab("preview");
       }
       // When many files are open, the active row/tab can end up off-screen
@@ -20364,10 +20375,22 @@ function portal() {
       };
       return map[ext] || "plaintext";
     },
-    async openByPath(path) { await this.openFile({ path, name: path.split("/").pop() }); },
+    async openByPath(path, opts = {}) {
+      await this.openFile(
+        { path, name: path.split("/").pop() },
+        { reveal: opts.reveal === true },
+      );
+    },
 
-    async switchTab(path) {
-      if (!path || (path === this.selected && this.previewSurface === "file")) return true;
+    async switchTab(path, opts = {}) {
+      if (!path) return true;
+      const revealNeeded = opts.reveal === true && (
+        this._isMobileLayout()
+          ? this.mobileTab !== "preview"
+          : (!this.previewOpen || !!this.desktopFullPane)
+      );
+      if (path === this.selected && this.previewSurface === "file"
+          && !revealNeeded) return true;
       // A terminal overlays the last selected file without clearing
       // `selected`. Clicking that same (usually rightmost) file tab must still
       // route through openFile so the preview surface leaves terminal mode.
@@ -20379,7 +20402,7 @@ function portal() {
       const cur = this.tabs.find(t => t.path === path);
       const opened = await this.openFile(
         { path, name: path.split("/").pop() },
-        { preview: !!(cur && cur.preview) },
+        { preview: !!(cur && cur.preview), reveal: opts.reveal === true },
       );
       if (!opened) return false;
       // Pass mode:"background" so we expand/scroll the tree quietly —
@@ -22554,7 +22577,7 @@ function portal() {
     },
     async onSearchClick(n) {
       if (n.is_dir) { this.clearSearch(); await this.expandPath(n.path); }
-      else { await this.openFile(n); }
+      else { await this.openFile(n, { reveal: true }); }
     },
     async expandPath(path) {
       const parts = path.split("/");
@@ -24130,7 +24153,9 @@ function portal() {
       if (!r.ok) { this.toast(this.t("slash.failed"), "error"); return; }
       await this.loadRoot();
       if (!this._workspaceIsCurrent(ownerWorkspace)) return;
-      await this.openFile({ path: trimmed, name: trimmed });
+      await this.openFile(
+        { path: trimmed, name: trimmed }, { reveal: true },
+      );
       if (!this._workspaceIsCurrent(ownerWorkspace)) return;
       // Enter through the normal editor setup so CodeMirror receives the
       // newly-created body instead of reusing a previous file's buffer.
@@ -27526,7 +27551,7 @@ function portal() {
           type: "file",
           label: n.name,
           hint: n.path,
-          run: () => this.openFile(n),
+          run: () => this.openFile(n, { reveal: true }),
         });
       }
 
@@ -27694,6 +27719,7 @@ function portal() {
       ];
     },
     ACTIVITY_GROUP_CAP: 5,
+    ACTIVITY_CUSTOM_GROUP_CAP: 50,
     ACTIVITY_TIMELINE_CAP: 15,
     ACTIVITY_GROUP_COLORS: [
       "blue", "violet", "cyan", "green", "amber", "rose", "gray",
@@ -27807,8 +27833,9 @@ function portal() {
       return all.slice(0, this.activityGroupCap(group));
     },
     activityGroupCap(group) {
-      return group?.key === "timeline"
-        ? this.ACTIVITY_TIMELINE_CAP : this.ACTIVITY_GROUP_CAP;
+      if (group?.key === "timeline") return this.ACTIVITY_TIMELINE_CAP;
+      if (group?.custom) return this.ACTIVITY_CUSTOM_GROUP_CAP;
+      return this.ACTIVITY_GROUP_CAP;
     },
     activityHiddenCount(group) {
       return Math.max(

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -413,7 +413,7 @@
                 @dragleave="onPreviewTabDragLeave(t.path)"
                 @drop.prevent="onPreviewTabDrop($event, t.path)"
                 @dragend="onPreviewTabDragEnd()"
-                @click="switchTab(t.path)"
+                @click="switchTab(t.path, { reveal: true })"
                 @contextmenu.prevent="showPreviewTabMenu($event, t.path)"
                 :title="t.path">
               <span class="icon"><svg><use :href="iconRef({name: t.name, is_dir: false})"/></svg></span>
@@ -581,7 +581,7 @@
             <span class="count" x-text="'('+grepHits.length+(grepTruncated?'+':'')+')'"></span>
           </div>
           <template x-for="(h,i) in grepHits" :key="'grep-'+i">
-            <div :class="'srow ' + (selected===h.path?'sel':'')" @click="openByPath(h.path)">
+            <div :class="'srow ' + (selected===h.path?'sel':'')" @click="openByPath(h.path, { reveal: true })">
               <span class="icon"><svg><use :href="iconRef(h)"/></svg></span>
               <div class="body">
                 <div class="name" x-text="h.name + ':' + h.line"></div>
@@ -882,7 +882,7 @@
                @dragleave="onPreviewTabDragLeave(t.path)"
                @drop.prevent="onPreviewTabDrop($event, t.path)"
                @dragend="onPreviewTabDragEnd()"
-               @click="switchTab(t.path)"
+               @click="switchTab(t.path, { reveal: true })"
                @dblclick="pinTab(t.path)"
                @contextmenu.prevent="showPreviewTabMenu($event, t.path)"
                @auxclick.prevent="onPreviewTabAuxClick($event, t.path)"
@@ -3596,13 +3596,13 @@
         <span class="icon"><svg><use href="#i-folder"/></svg></span>
         <span x-text="t('pane.files')"></span>
       </button>
-      <button :class="{active: mobileTab==='preview'}" @click="setMobileTab('preview')">
-        <span class="icon"><svg><use href="#i-file-text"/></svg></span>
-        <span x-text="t('pane.preview')"></span>
-      </button>
       <button :class="{active: mobileTab==='chat'}" @click="setMobileTab('chat')">
         <span class="icon"><svg><use href="#i-brain"/></svg></span>
         <span x-text="t('pane.chat')"></span>
+      </button>
+      <button :class="{active: mobileTab==='preview'}" @click="setMobileTab('preview')">
+        <span class="icon"><svg><use href="#i-file-text"/></svg></span>
+        <span x-text="t('pane.preview')"></span>
       </button>
     </nav>
 
@@ -5849,7 +5849,9 @@
   </div>
 
   <div class="modal-backdrop" x-show="activity.show" @click.self="closeActivityCenter()" x-cloak>
-    <div class="modal activity-modal" role="dialog" aria-modal="true" @keydown.escape.window="closeActivityCenter()">
+    <div class="modal activity-modal" role="dialog" aria-modal="true"
+         :class="{ 'is-group-board': activity.view === 'groups' }"
+         @keydown.escape.window="closeActivityCenter()">
       <div class="modal-head">
         <span class="modal-title"><svg class="modal-title-icon"><use href="#i-inbox"/></svg><span x-text="lang==='zh' ? '全局任务中心' : 'Global activity center'"></span></span>
         <div class="activity-view-switch" role="group"
@@ -5957,7 +5959,9 @@
                     : (lang==='zh' ? '保存' : 'Save')"></button>
         </div>
       </form>
-      <div class="modal-body activity-body" :aria-busy="activity.loading">
+      <div class="modal-body activity-body"
+           :class="{ 'is-group-board': activity.view === 'groups' }"
+           :aria-busy="activity.loading">
         <!-- Loading is an overlay, not a list row.  A normal-flow hint used to
              disappear above the mounted rows when fetchActivity settled,
              shifting the entire ledger (and modal height) in one frame. -->

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3734,10 +3734,19 @@ pre.text {
 }
 .files-head-workspace .workspace-picker-btn { width: 100%; max-width: none; border-radius: var(--r-sm); }
 .activity-modal { width:700px; max-width:calc(100vw - 32px); }
-/* The later generic desktop modal cap is 480px. Keep this ledger wide enough
-   for conversation + task hierarchy, without overriding mobile fullscreen. */
+/* The later generic desktop modal cap is 480px. Status/time ledgers retain the
+   focused 700px reading width; the custom-group view becomes a real board with
+   the same generous working area as the global TODO lanes. */
 @media (min-width:721px) {
   .modal.activity-modal { width:700px; max-width:calc(100vw - 32px); }
+  .modal.activity-modal.is-group-board {
+    width:min(1120px,calc(100vw - 64px));
+    max-width:calc(100vw - 64px);
+    height:auto;
+    max-height:calc(100vh - 64px);
+    display:flex;
+    flex-direction:column;
+  }
 }
 .activity-view-switch { display:inline-flex; margin-left:auto; padding:2px; border:1px solid var(--c-border); border-radius:var(--r-md); background:var(--c-bg-2); }
 .activity-view-switch button { padding:4px 9px; border:0; border-radius:calc(var(--r-md) - 2px); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); cursor:pointer; }
@@ -3801,6 +3810,20 @@ pre.text {
    appearance nor disappearance can push a mounted row or resize the modal. */
 @media (min-width:721px) {
   .activity-body { min-height:min(56vh,520px); }
+  .activity-modal.is-group-board .activity-body.is-group-board {
+    flex:1 1 auto;
+    min-height:0;
+    max-height:none;
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
+    /* One lane starts at roughly a header + three session cards. Additional
+       sessions stay in the lane and are reached by its own scrollbar. */
+    grid-auto-rows:300px;
+    align-content:start;
+    align-items:stretch;
+    gap:12px;
+    padding:14px 16px 18px;
+  }
 }
 .activity-loading-overlay {
   position:absolute;
@@ -3853,6 +3876,71 @@ pre.text {
 .activity-custom-group-actions button:disabled { opacity:.25; cursor:default; }
 .activity-custom-group-actions svg { width:12px; height:12px; }
 .activity-custom-group-empty { margin:0 4px 4px; padding:12px; border:1px dashed var(--c-border); border-radius:var(--r-sm); color:var(--c-fg-4); font-size:var(--fs-xs); text-align:center; }
+/* Group view mirrors the clearer TODO-board hierarchy: each custom group is a
+   self-contained lane with a strong header, card-like sessions and a generous
+   empty drop target. The ledger/status views keep their compact row styling. */
+@media (min-width:721px) {
+  .activity-body.is-group-board > .activity-group.is-custom {
+    min-width:0;
+    min-height:300px;
+    height:100%;
+    max-height:100%;
+    margin:0;
+    padding:10px;
+    display:flex;
+    flex-direction:column;
+    overflow-x:hidden;
+    overflow-y:auto;
+    scrollbar-gutter:stable;
+    border-radius:var(--r-lg);
+    background:var(--c-bg-2);
+  }
+  .activity-body.is-group-board .activity-custom-group-head {
+    position:sticky;
+    top:-10px;
+    z-index:1;
+    min-height:38px;
+    padding:12px 3px 9px;
+    border-bottom:1px solid var(--c-border);
+    background:var(--c-bg-2);
+  }
+  .activity-body.is-group-board .activity-custom-group-head > strong {
+    font-size:var(--fs-md);
+  }
+  .activity-body.is-group-board .activity-custom-group-dot {
+    width:9px;
+    height:9px;
+    flex-basis:9px;
+  }
+  .activity-body.is-group-board .activity-custom-group-empty {
+    min-height:118px;
+    margin:8px 0 0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+  }
+  .activity-body.is-group-board .activity-row-wrap {
+    margin-top:8px;
+    border:1px solid var(--c-border);
+    background:var(--c-bg-1);
+  }
+  .activity-body.is-group-board .activity-row-wrap:hover {
+    border-color:var(--c-border-strong);
+  }
+  .activity-body.is-group-board .activity-row {
+    padding:10px 9px;
+  }
+  .activity-body.is-group-board .activity-row:hover {
+    background:var(--c-bg-3);
+  }
+  .activity-body.is-group-board .activity-group-more {
+    margin-top:8px;
+    padding:7px 8px;
+    border:1px dashed var(--c-border);
+    text-align:center;
+  }
+  .activity-body.is-group-board > .hint-row { grid-column:1 / -1; }
+}
 .activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
 .activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
 .activity-row-wrap { display:flex; align-items:center; border-radius:var(--r-sm); }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -395,6 +395,30 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     assert page.locator(
         ".activity-custom-group-head > strong"
     ).all_text_contents() == ["Research", "Delivery", "未分组"]
+    board_geometry = page.evaluate(
+        """() => {
+          const modal = document.querySelector('.activity-modal');
+          const body = document.querySelector('.activity-body');
+          const lanes = Array.from(body.querySelectorAll('.activity-group.is-custom'));
+          const rects = lanes.map(node => node.getBoundingClientRect());
+          return {
+            modalWidth: modal.getBoundingClientRect().width,
+            modalHeight: modal.getBoundingClientRect().height,
+            bodyDisplay: getComputedStyle(body).display,
+            columns: getComputedStyle(body).gridTemplateColumns.split(' ').length,
+            laneWidths: rects.map(rect => rect.width),
+            laneTops: rects.map(rect => Math.round(rect.top)),
+          };
+        }"""
+    )
+    assert board_geometry["modalWidth"] >= 1050
+    # One board row should size the modal to its content instead of stretching
+    # it to most of the viewport and leaving a large empty area underneath.
+    assert 450 <= board_geometry["modalHeight"] <= 650, board_geometry
+    assert board_geometry["bodyDisplay"] == "grid"
+    assert board_geometry["columns"] == 3
+    assert min(board_geometry["laneWidths"]) >= 300
+    assert len(set(board_geometry["laneTops"])) == 1
     delivery = groups.filter(has_text="Delivery")
     expect(delivery.locator(".activity-custom-group-empty")).to_be_visible()
 
@@ -422,6 +446,42 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     editor.locator('button[type="submit"]').click()
     expect(page.locator(".activity-custom-group-head > strong")).to_contain_text(
         ["Research", "Delivery", "Writing", "未分组"]
+    )
+
+    # A busy group is an independently scrollable lane. The old five-row cap
+    # plus a constrained grid lane clipped everything below roughly four rows,
+    # including the "more" control, so there was no way to reach older sessions.
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.activity.events = Array.from({length: 12}, (_, index) => ({
+            id: `busy-group-${index}`,
+            session_id: `busy-session-${index}`,
+            session_name: `Busy session ${index + 1}`,
+            task_summary: `Busy task ${index + 1}`,
+            workspace: '/tmp/e2e', workspace_name: 'e2e',
+            state: 'completed', read: true, group_id: 'research',
+            started_at: index, finished_at: index + 10, updated_at: index + 20,
+          }));
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+    research = page.locator(".activity-group.is-custom").filter(
+        has=page.locator(".activity-custom-group-head > strong", has_text="Research")
+    )
+    expect(research.locator(".activity-row-wrap")).to_have_count(12)
+    lane_scroll = research.evaluate(
+        """lane => {
+          const before = {clientHeight: lane.clientHeight, scrollHeight: lane.scrollHeight};
+          lane.scrollTop = lane.scrollHeight;
+          return {...before, scrollTop: lane.scrollTop};
+        }"""
+    )
+    assert 280 <= lane_scroll["clientHeight"] <= 320
+    assert lane_scroll["scrollHeight"] > lane_scroll["clientHeight"]
+    assert lane_scroll["scrollTop"] > 0
+    expect(research.locator(".activity-session-name").last).to_have_text(
+        "Busy session 1"
     )
 
     calls = page.evaluate("() => window.__activityGroupCalls")

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4464,7 +4464,7 @@ def test_mobile_pwa_tabs_preview_rotation_keep_chat_usable(page: Page, backend_u
           path: "reports/perf-preview.md",
           name: "perf-preview.md",
           is_dir: false,
-        }, { preview: false });
+        }, { preview: false, reveal: true });
         """,
     )
     page.wait_for_function(
@@ -4483,7 +4483,7 @@ def test_mobile_pwa_tabs_preview_rotation_keep_chat_usable(page: Page, backend_u
         """() => document.querySelector("#app")._x_dataStack[0].mobileTab === "files" """,
         timeout=5000,
     )
-    page.locator(SEL_MOBILE_TAB).nth(1).click()
+    page.locator(SEL_MOBILE_TAB).nth(2).click()
     page.wait_for_function(
         """() => document.querySelector("#app")._x_dataStack[0].mobileTab === "preview" """,
         timeout=5000,
@@ -4512,7 +4512,7 @@ def test_mobile_pwa_tabs_preview_rotation_keep_chat_usable(page: Page, backend_u
         }""",
         timeout=5000,
     )
-    page.locator(SEL_MOBILE_TAB).nth(2).click()
+    page.locator(SEL_MOBILE_TAB).nth(1).click()
     page.wait_for_function(
         """() => document.querySelector("#app")._x_dataStack[0].mobileTab === "chat" """,
         timeout=5000,

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -243,15 +243,38 @@ def test_refresh_restores_file_without_reopening_hidden_preview(
         "previewDisplay": "none",
     }
 
-    # The ordinary openFile path remains the explicit user action: clicking the
-    # already-selected file must reveal the rail without requiring a reload.
-    revealed = page.evaluate(
+    # A plain internal load is layout-neutral by default. Only an explicitly
+    # user-owned call with reveal:true may reopen the hidden rail.
+    reveal_contract = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
           await app.openFile({path: 'README.md', name: 'README.md'});
+          const afterBackground = {
+            previewOpen: app.previewOpen,
+            previewDisplay: getComputedStyle(
+              document.querySelector('.pane.preview')).display,
+          };
+          await app.reloadPreview();
+          const afterReload = {
+            previewOpen: app.previewOpen,
+            previewDisplay: getComputedStyle(
+              document.querySelector('.pane.preview')).display,
+          };
+          await app._maybeReloadPreview('README.md');
+          const afterToolReload = {
+            previewOpen: app.previewOpen,
+            previewDisplay: getComputedStyle(
+              document.querySelector('.pane.preview')).display,
+          };
+          await app.onNodeClick({}, {
+            path: 'README.md', name: 'README.md', is_dir: false,
+          });
           await new Promise(resolve => app.$nextTick(resolve));
           await new Promise(resolve => requestAnimationFrame(resolve));
           return {
+            afterBackground,
+            afterReload,
+            afterToolReload,
             selected: app.selected,
             previewOpen: app.previewOpen,
             previewDisplay: getComputedStyle(
@@ -259,7 +282,19 @@ def test_refresh_restores_file_without_reopening_hidden_preview(
           };
         }"""
     )
-    assert revealed == {
+    assert reveal_contract == {
+        "afterBackground": {
+            "previewOpen": False,
+            "previewDisplay": "none",
+        },
+        "afterReload": {
+            "previewOpen": False,
+            "previewDisplay": "none",
+        },
+        "afterToolReload": {
+            "previewOpen": False,
+            "previewDisplay": "none",
+        },
         "selected": "README.md",
         "previewOpen": True,
         "previewDisplay": "flex",
@@ -3272,6 +3307,81 @@ def test_reopening_current_file_does_not_discard_editor_buffer(page: Page,
         "editText": "unsaved draft",
         "dirty": True,
         "pinned": True,
+    }
+
+
+def test_cancelled_dirty_switch_preserves_hidden_layout_and_terminal(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.selected = 'draft.txt';
+          app.editing = true;
+          app.previewOpen = false;
+          app.desktopFullPane = 'chat';
+          app.previewSurface = 'terminal';
+          let teardowns = 0;
+          const realConfirm = app._confirmLoseEdits;
+          const realTeardown = app._teardownTerminalView;
+          app._confirmLoseEdits = () => false;
+          app._teardownTerminalView = () => { teardowns += 1; };
+          try {
+            const ok = await app.openFile(
+              {path: 'other.txt', name: 'other.txt'}, {reveal: true});
+            return {
+              ok, teardowns, selected: app.selected,
+              previewOpen: app.previewOpen,
+              desktopFullPane: app.desktopFullPane,
+              previewSurface: app.previewSurface,
+            };
+          } finally {
+            app._confirmLoseEdits = realConfirm;
+            app._teardownTerminalView = realTeardown;
+            app.editing = false;
+          }
+        }"""
+    )
+    assert result == {
+        "ok": False,
+        "teardowns": 0,
+        "selected": "draft.txt",
+        "previewOpen": False,
+        "desktopFullPane": "chat",
+        "previewSurface": "terminal",
+    }
+
+
+def test_mobile_reopening_current_editor_reveals_preview_without_discarding(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 390, "height": 844})
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app.tabs = [{path: 'draft.txt', name: 'draft.txt', preview: false}];
+          app.selected = 'draft.txt';
+          app.previewMode = 'text';
+          app.editText = 'unsaved mobile draft';
+          app.editing = true;
+          app.cmStatus = {...app.cmStatus, dirty: true};
+          app.mobileTab = 'files';
+          const ok = await app.openFile(
+            {path: 'draft.txt', name: 'draft.txt'}, {reveal: true});
+          const state = {
+            ok, mobileTab: app.mobileTab, editing: app.editing,
+            editText: app.editText, dirty: app.cmStatus.dirty,
+          };
+          app.editing = false;
+          return state;
+        }"""
+    )
+    assert result == {
+        "ok": True,
+        "mobileTab": "preview",
+        "editing": True,
+        "editText": "unsaved mobile draft",
+        "dirty": True,
     }
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -203,12 +203,22 @@ def test_preview_tabs_persist_reading_positions_and_html_frames():
     open_file = app[start:end]
 
     assert "this._capturePreviewViewState(this.selected)" in open_file
-    assert "opts.reveal !== false && !this._isMobileLayout()" in open_file
+    assert "const reveal = opts.reveal === true" in open_file
+    assert "const keepCurrentEditor = this.editing" in open_file
+    assert open_file.index("this._confirmLoseEdits()") < open_file.index(
+        "if (reveal && !this._isMobileLayout()")
+    assert "if (this._isMobileLayout() && reveal) this.setMobileTab(\"preview\")" in open_file
+    assert "if (reveal && !this._isMobileLayout()" in open_file
+    assert 'this.previewSurface !== "terminal" || reveal' in open_file
     assert 'this.desktopFullPane = ""' in open_file
     assert "this.previewOpen = true" in open_file
     assert "this._schedulePreviewViewRestore(cachedPath, loadSeq)" in open_file
     restore_call = "{ preview: !!(_restored && _restored.preview), reveal: false }"
     assert app.count(restore_call) == 2
+    assert html.count('@click="switchTab(t.path, { reveal: true })"') == 2
+    assert '@click="openByPath(h.path, { reveal: true })"' in html
+    assert "this.switchTab(path, { reveal: true })" in app
+    assert app.count("await this.switchTab(path, { reveal: true });") == 2
     assert "this.csvLoadPage(targetView.csvOffset)" in open_file
     assert 'x-ref="previewBody"' in html
     assert '@scroll.passive="onPreviewViewportScroll()"' in html
@@ -342,7 +352,8 @@ def test_side_question_stays_floating_and_is_hidden_from_activity_center():
         "async openFile(n, opts = {})",
     ):
         start = app.index(owner_change)
-        assert "dismissTransientPreviewQuote" in app[start:start + 700]
+        window = 1800 if owner_change.startswith("async openFile") else 700
+        assert "dismissTransientPreviewQuote" in app[start:start + window]
 
     create_start = app.index("async _createPreviewSelectionAskSession(")
     create_end = app.index("\n    previewSelectionAskMessages()", create_start)
@@ -594,10 +605,9 @@ def test_external_file_drop_is_global_root_by_default_and_directory_explicit():
 
     nav = html[html.index('<nav class="mobile-tab-bar"'):
                html.index("</nav>", html.index('<nav class="mobile-tab-bar"'))]
-    # This is a desktop-only layout change; preserve the established mobile
-    # navigation order and its muscle memory.
+    # Keep the primary conversation action in the centre of the mobile nav.
     assert nav.index("mobileTab==='files'") < nav.index(
-        "mobileTab==='preview'") < nav.index("mobileTab==='chat'")
+        "mobileTab==='chat'") < nav.index("mobileTab==='preview'")
 
 
 def test_multi_workspace_ui_and_folder_browser_are_wired_end_to_end():
@@ -1399,6 +1409,7 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert '}/group`' in app
     assert 'class="activity-groups-toolbar"' in html
     assert 'class="activity-group-editor"' in html
+    assert "'is-group-board': activity.view === 'groups'" in html
     assert 'class="activity-row-group"' in html
     assert '@dragstart="onActivityDragStart($event, item)"' in html
     assert ".activity-group.is-custom.is-drag-over" in css
@@ -1410,6 +1421,15 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'x-show="activity.view === \'timeline\'"' in html
     assert ".activity-pin.active" in css
     assert ".activity-modal { width:700px" in css
+    assert ".modal.activity-modal.is-group-board" in css
+    assert "width:min(1120px,calc(100vw - 64px))" in css
+    assert "height:auto" in css
+    assert "flex:1 1 auto" in css
+    assert "grid-template-columns:repeat(auto-fit,minmax(300px,1fr))" in css
+    assert "grid-auto-rows:300px" in css
+    assert ".activity-body.is-group-board > .activity-group.is-custom" in css
+    assert "ACTIVITY_CUSTOM_GROUP_CAP: 50" in app
+    assert "if (group?.custom) return this.ACTIVITY_CUSTOM_GROUP_CAP" in app
     assert "max-height:min(82vh,820px)" in css
     assert "min-height:min(56vh,520px)" in css
     assert "scrollbar-gutter:stable" in css


### PR DESCRIPTION
## 变更摘要

- 将全局任务中心的自定义分组视图改为响应式看板，每栏默认约三个会话高度并独立滚动
- 让分组看板弹窗按内容收缩，避免单行看板留下大面积空白
- 将文件加载与预览区展开解耦，仅由明确用户操作触发展开
- 保持后台恢复、刷新、重命名、移动和工具写入对布局无副作用
- 修复脏编辑取消切换、终端表面切换和移动端当前编辑文件重新显示等边界
- 将移动端导航顺序调整为“文件／对话／预览”
- 补充 Activity、文件预览和移动端交互回归测试

## 验证

- `tests/test_frontend_lint.py`：112 passed
- `tests/e2e/test_activity_center.py`：9 passed
- `tests/e2e/test_files_preview.py`：41 passed，1 个既有虚拟滚动时序测试首轮失败；单独连续重跑 2 次均通过
- 文件预览 reveal 定向 E2E：5 passed
- 移动端导航 E2E：1 passed
- `node --check frontend/app.js`：通过
- `git diff --check`：通过

## 风险与兼容性

- 变更集中在前端布局和文件预览交互，不修改后端 API 或持久化数据结构
- 自定义分组单栏最多渲染 50 个会话，更多内容仍保留数量提示
- 桌面端状态／时间视图保持原有紧凑布局

🤖 Generated with [Claude Code](https://claude.com/claude-code)