### PR TITLE
feat(activity): support free board dragging

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -197,16 +197,15 @@ class ActivityService:
             if str(sid) and str(group_id) in seen
         }
         order: list[str] = []
-        valid_order_ids = seen | {_UNGROUPED_GROUP_ID}
         for value in source_order:
             group_id = str(value or "").strip()
-            if group_id in valid_order_ids and group_id not in order:
+            if group_id in seen and group_id not in order:
                 order.append(group_id)
         for group in groups:
             if group["id"] not in order:
                 order.append(group["id"])
-        if _UNGROUPED_GROUP_ID not in order:
-            order.append(_UNGROUPED_GROUP_ID)
+        # Ungrouped is a system-managed inbox lane and always stays last.
+        order.append(_UNGROUPED_GROUP_ID)
         lookup = {group["id"]: group for group in groups}
         groups = [lookup[group_id] for group_id in order if group_id in lookup]
         return groups, assignments, order
@@ -670,16 +669,16 @@ class ActivityService:
             custom_ids = [group["id"] for group in self._custom_groups]
             full_ids = custom_ids + [_UNGROUPED_GROUP_ID]
             requested = [str(group_id or "").strip() for group_id in group_ids]
-            if len(requested) == len(custom_ids) and set(requested) == set(custom_ids):
-                iterator = iter(requested)
+            if len(requested) == len(full_ids) and set(requested) == set(full_ids):
                 requested = [
-                    group_id if group_id == _UNGROUPED_GROUP_ID else next(iterator)
-                    for group_id in self._group_order
+                    group_id for group_id in requested
+                    if group_id != _UNGROUPED_GROUP_ID
                 ]
-            elif len(requested) != len(full_ids) or set(requested) != set(full_ids):
+            elif len(requested) != len(custom_ids) or set(requested) != set(custom_ids):
                 raise ValueError("group order must contain every group exactly once")
             if len(requested) != len(set(requested)):
                 raise ValueError("group order must contain every group exactly once")
+            requested.append(_UNGROUPED_GROUP_ID)
 
             if requested != self._group_order:
                 self._group_order = requested

--- a/backend/activity.py
+++ b/backend/activity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import json
 import threading
 import time
@@ -18,6 +19,7 @@ from . import sessions
 _MAX_EVENTS = 500
 _MAX_CUSTOM_GROUPS = 40
 _MAX_GROUP_NAME = 48
+_UNGROUPED_GROUP_ID = "__ungrouped__"
 _GROUP_COLORS = frozenset({
     "blue", "violet", "cyan", "green", "amber", "rose", "gray",
 })
@@ -85,13 +87,17 @@ class ActivityService:
     def __init__(self, root: Path = ROOT):
         self.path = root / ".muselab" / "activity.json"
         self.groups_path = root / ".muselab" / "activity-groups.json"
+        self.transaction_path = root / ".muselab" / "activity-transaction.json"
+        self._group_event_transaction_active = False
         self._lock = threading.RLock()
         self._generation = uuid.uuid4().hex
         self._revision = 0
         self._subscribers: dict[
             asyncio.Queue[dict[str, Any]], asyncio.AbstractEventLoop
         ] = {}
-        self._custom_groups, self._group_assignments = self._load_group_state()
+        self._recover_group_event_transaction()
+        (self._custom_groups, self._group_assignments,
+         self._group_order) = self._load_group_state()
         self._events = self._load()
         changed = self._collapse_sessions()
         changed = self._reconcile_event_groups() or changed
@@ -121,11 +127,39 @@ class ActivityService:
             raise ValueError("invalid group color")
         return color
 
-    def _load_group_state(self) -> tuple[list[dict[str, str]], dict[str, str]]:
+    def _recover_group_event_transaction(self) -> None:
+        try:
+            payload = json.loads(self.transaction_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"cannot parse activity transaction: {self.transaction_path}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("activity transaction must be an object")
+        events = payload.get("events")
+        group_state = payload.get("group_state")
+        if not isinstance(events, list) or not isinstance(group_state, dict):
+            raise RuntimeError("invalid activity transaction")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(
+            self.groups_path,
+            json.dumps(group_state, ensure_ascii=False, indent=2),
+        )
+        atomic_write_text(
+            self.path,
+            json.dumps(events[-_MAX_EVENTS:], ensure_ascii=False, indent=2),
+        )
+        self.transaction_path.unlink(missing_ok=True)
+
+    def _load_group_state(
+        self,
+    ) -> tuple[list[dict[str, str]], dict[str, str], list[str]]:
         try:
             raw = json.loads(self.groups_path.read_text(encoding="utf-8"))
         except FileNotFoundError:
-            return [], {}
+            return [], {}, [_UNGROUPED_GROUP_ID]
         except (OSError, ValueError) as exc:
             raise RuntimeError(
                 f"cannot parse activity groups: {self.groups_path}"
@@ -135,8 +169,10 @@ class ActivityService:
 
         source_groups = raw.get("groups", [])
         source_assignments = raw.get("assignments", {})
+        source_order = raw.get("order", [])
         if (not isinstance(source_groups, list)
-                or not isinstance(source_assignments, dict)):
+                or not isinstance(source_assignments, dict)
+                or not isinstance(source_order, list)):
             raise RuntimeError("invalid activity group state")
 
         groups: list[dict[str, str]] = []
@@ -145,7 +181,7 @@ class ActivityService:
             if not isinstance(row, dict):
                 continue
             group_id = str(row.get("id") or "").strip()
-            if not group_id or group_id in seen:
+            if not group_id or group_id in seen or group_id == _UNGROUPED_GROUP_ID:
                 continue
             try:
                 name = self._group_name(row.get("name"))
@@ -160,18 +196,135 @@ class ActivityService:
             for sid, group_id in source_assignments.items()
             if str(sid) and str(group_id) in seen
         }
-        return groups, assignments
+        order: list[str] = []
+        valid_order_ids = seen | {_UNGROUPED_GROUP_ID}
+        for value in source_order:
+            group_id = str(value or "").strip()
+            if group_id in valid_order_ids and group_id not in order:
+                order.append(group_id)
+        for group in groups:
+            if group["id"] not in order:
+                order.append(group["id"])
+        if _UNGROUPED_GROUP_ID not in order:
+            order.append(_UNGROUPED_GROUP_ID)
+        lookup = {group["id"]: group for group in groups}
+        groups = [lookup[group_id] for group_id in order if group_id in lookup]
+        return groups, assignments, order
+
+    def _ensure_writes_available(self) -> None:
+        if (self.transaction_path.exists()
+                and not self._group_event_transaction_active):
+            raise RuntimeError(
+                "activity writes are blocked by an unrecovered transaction"
+            )
 
     def _save_group_state(self) -> None:
+        self._ensure_writes_available()
         self.groups_path.parent.mkdir(parents=True, exist_ok=True)
         atomic_write_text(self.groups_path, json.dumps({
-            "version": 1,
+            "version": 2,
             "groups": self._custom_groups,
             "assignments": self._group_assignments,
+            "order": self._group_order,
         }, ensure_ascii=False, indent=2))
 
     def _group_payload_locked(self) -> list[dict[str, str]]:
         return [dict(group) for group in self._custom_groups]
+
+    def _group_order_payload_locked(self) -> list[str]:
+        return list(self._group_order)
+
+    @staticmethod
+    def _event_group_id(item: dict[str, Any]) -> str:
+        return str(item.get("group_id") or "")
+
+    @staticmethod
+    def _manual_group_order(item: dict[str, Any]) -> float | None:
+        value = item.get("group_order")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
+    def _ordered_group_items_locked(
+        self,
+        group_id: str,
+        *,
+        exclude_id: str = "",
+    ) -> list[dict[str, Any]]:
+        items = [
+            item for item in self._events
+            if self._event_group_id(item) == group_id
+            and str(item.get("id") or "") != exclude_id
+        ]
+
+        def order_key(item: dict[str, Any]) -> tuple[float, float, str]:
+            manual = self._manual_group_order(item)
+            if manual is None:
+                return (0, -_activity_at(item), str(item.get("id") or ""))
+            return (1, manual, str(item.get("id") or ""))
+
+        return sorted(items, key=order_key)
+
+    @staticmethod
+    def _renumber_group_locked(items: list[dict[str, Any]]) -> None:
+        for index, item in enumerate(items):
+            item["group_order"] = index
+
+    def _group_event_snapshot_locked(self) -> tuple[
+        list[dict[str, Any]], list[dict[str, str]], dict[str, str], list[str]
+    ]:
+        return (
+            copy.deepcopy(self._events),
+            copy.deepcopy(self._custom_groups),
+            dict(self._group_assignments),
+            list(self._group_order),
+        )
+
+    def _save_group_event_state_locked(
+        self,
+        snapshot: tuple[
+            list[dict[str, Any]], list[dict[str, str]], dict[str, str], list[str]
+        ],
+    ) -> None:
+        old_events, old_groups, old_assignments, old_order = snapshot
+        self._ensure_writes_available()
+        transaction = {
+            "version": 1,
+            "events": old_events,
+            "group_state": {
+                "version": 2,
+                "groups": old_groups,
+                "assignments": old_assignments,
+                "order": old_order,
+            },
+        }
+        self._group_event_transaction_active = True
+        try:
+            try:
+                self.transaction_path.parent.mkdir(parents=True, exist_ok=True)
+                atomic_write_text(
+                    self.transaction_path,
+                    json.dumps(transaction, ensure_ascii=False, indent=2),
+                )
+                self._save_group_state()
+                self._save()
+                self.transaction_path.unlink(missing_ok=True)
+            except Exception:
+                (self._events, self._custom_groups,
+                 self._group_assignments, self._group_order) = snapshot
+                rollback_ok = True
+                try:
+                    self._save_group_state()
+                    self._save()
+                except Exception:
+                    rollback_ok = False
+                if rollback_ok:
+                    self.transaction_path.unlink(missing_ok=True)
+                # If rollback also fails, leave the journal in place. The next
+                # service start restores both files from the same pre-mutation state.
+                raise
+        finally:
+            self._group_event_transaction_active = False
 
     def _apply_assignment_locked(self, item: dict[str, Any]) -> bool:
         sid = str(item.get("session_id") or item.get("thread_id") or "")
@@ -183,6 +336,7 @@ class ActivityService:
             item["group_id"] = assigned
         else:
             item.pop("group_id", None)
+        item.pop("group_order", None)
         return True
 
     def _reconcile_event_groups(self) -> bool:
@@ -207,6 +361,7 @@ class ActivityService:
         return []
 
     def _save(self) -> None:
+        self._ensure_writes_available()
         self.path.parent.mkdir(parents=True, exist_ok=True)
         atomic_write_text(self.path, json.dumps(
             self._events[-_MAX_EVENTS:], ensure_ascii=False, indent=2))
@@ -251,6 +406,7 @@ class ActivityService:
             "revision": self._revision,
             "summary": summary,
             "custom_groups": self._group_payload_locked(),
+            "group_order": self._group_order_payload_locked(),
         }
         if resync:
             payload["resync"] = True
@@ -422,6 +578,7 @@ class ActivityService:
         with self._lock:
             events = [dict(x) for x in self._events]
             custom_groups = self._group_payload_locked()
+            group_order = self._group_order_payload_locked()
             generation = self._generation
             revision = self._revision
         ordered = sorted(events, key=_activity_at, reverse=True)
@@ -432,11 +589,19 @@ class ActivityService:
             "events": ordered[:min(max(limit, 1), _MAX_EVENTS)],
             "summary": summary,
             "custom_groups": custom_groups,
+            "group_order": group_order,
         }
 
     def list_groups(self) -> list[dict[str, str]]:
         with self._lock:
             return self._group_payload_locked()
+
+    def group_state(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
+            }
 
     def create_group(self, name: str, color: str = "blue") -> dict[str, Any]:
         clean_name = self._group_name(name)
@@ -453,6 +618,8 @@ class ActivityService:
                 "color": clean_color,
             }
             self._custom_groups.append(group)
+            ungrouped_at = self._group_order.index(_UNGROUPED_GROUP_ID)
+            self._group_order.insert(ungrouped_at, group["id"])
             self._save_group_state()
             self._publish_locked()
             return {
@@ -460,6 +627,7 @@ class ActivityService:
                 "revision": self._revision,
                 "group": dict(group),
                 "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
             }
 
     def update_group(
@@ -494,30 +662,50 @@ class ActivityService:
                 "revision": self._revision,
                 "group": dict(group),
                 "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
             }
 
     def reorder_groups(self, group_ids: list[str]) -> dict[str, Any]:
         with self._lock:
-            current = [group["id"] for group in self._custom_groups]
-            if len(group_ids) != len(current) or set(group_ids) != set(current):
+            custom_ids = [group["id"] for group in self._custom_groups]
+            full_ids = custom_ids + [_UNGROUPED_GROUP_ID]
+            requested = [str(group_id or "").strip() for group_id in group_ids]
+            if len(requested) == len(custom_ids) and set(requested) == set(custom_ids):
+                iterator = iter(requested)
+                requested = [
+                    group_id if group_id == _UNGROUPED_GROUP_ID else next(iterator)
+                    for group_id in self._group_order
+                ]
+            elif len(requested) != len(full_ids) or set(requested) != set(full_ids):
                 raise ValueError("group order must contain every group exactly once")
-            lookup = {group["id"]: group for group in self._custom_groups}
-            if group_ids != current:
-                self._custom_groups = [lookup[group_id] for group_id in group_ids]
+            if len(requested) != len(set(requested)):
+                raise ValueError("group order must contain every group exactly once")
+
+            if requested != self._group_order:
+                self._group_order = requested
+                lookup = {group["id"]: group for group in self._custom_groups}
+                self._custom_groups = [
+                    lookup[group_id] for group_id in requested if group_id in lookup
+                ]
                 self._save_group_state()
                 self._publish_locked()
             return {
                 "generation": self._generation,
                 "revision": self._revision,
                 "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
             }
 
     def delete_group(self, group_id: str) -> dict[str, Any] | None:
         with self._lock:
             if not any(group["id"] == group_id for group in self._custom_groups):
                 return None
+            snapshot = self._group_event_snapshot_locked()
             self._custom_groups = [
                 group for group in self._custom_groups if group["id"] != group_id
+            ]
+            self._group_order = [
+                value for value in self._group_order if value != group_id
             ]
             cleared_sessions = {
                 sid for sid, assigned in self._group_assignments.items()
@@ -528,24 +716,32 @@ class ActivityService:
                 for sid, assigned in self._group_assignments.items()
                 if assigned != group_id
             }
-            changed_events = 0
-            for item in self._events:
-                if str(item.get("group_id") or "") == group_id:
-                    item.pop("group_id", None)
-                    changed_events += 1
-            self._save_group_state()
-            if changed_events:
-                self._save()
+            ungrouped = self._ordered_group_items_locked("")
+            moved = self._ordered_group_items_locked(group_id)
+            for item in moved:
+                item.pop("group_id", None)
+            ordered_ungrouped = ungrouped + moved
+            self._renumber_group_locked(ordered_ungrouped)
+            self._save_group_event_state_locked(snapshot)
             self._publish_locked(resync=True)
             return {
                 "generation": self._generation,
                 "revision": self._revision,
                 "cleared_sessions": len(cleared_sessions),
+                "items": [dict(row) for row in ordered_ungrouped],
                 "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
             }
 
-    def set_group(self, event_id: str, group_id: str) -> dict[str, Any] | None:
+    def set_group(
+        self,
+        event_id: str,
+        group_id: str,
+        *,
+        before_event_id: str | None = None,
+    ) -> dict[str, Any] | None:
         target = str(group_id or "").strip()
+        before = None if before_event_id is None else str(before_event_id or "").strip()
         with self._lock:
             if target and not any(group["id"] == target
                                   for group in self._custom_groups):
@@ -554,15 +750,67 @@ class ActivityService:
                          if row.get("id") == event_id), None)
             if item is None:
                 return None
+            snapshot = self._group_event_snapshot_locked()
             sid = str(item.get("session_id") or item.get("thread_id") or "")
-            current = str(item.get("group_id") or "")
-            if target == current:
+            current = self._event_group_id(item)
+
+            # Old clients only assign a lane. Preserve that API while making a
+            # freshly moved row float above an existing manual order.
+            if before is None:
+                if target == current:
+                    return {
+                        "generation": self._generation,
+                        "revision": self._revision,
+                        "item": dict(item),
+                        "custom_groups": self._group_payload_locked(),
+                        "group_order": self._group_order_payload_locked(),
+                    }
+                if target:
+                    if sid:
+                        self._group_assignments[sid] = target
+                    item["group_id"] = target
+                else:
+                    if sid:
+                        self._group_assignments.pop(sid, None)
+                    item.pop("group_id", None)
+                item.pop("group_order", None)
+                self._save_group_event_state_locked(snapshot)
+                self._publish_locked(item=item)
                 return {
                     "generation": self._generation,
                     "revision": self._revision,
                     "item": dict(item),
                     "custom_groups": self._group_payload_locked(),
+                    "group_order": self._group_order_payload_locked(),
                 }
+
+            if before == event_id and target == current:
+                return {
+                    "generation": self._generation,
+                    "revision": self._revision,
+                    "item": dict(item),
+                    "items": [dict(item)],
+                    "custom_groups": self._group_payload_locked(),
+                    "group_order": self._group_order_payload_locked(),
+                }
+
+            source_items = self._ordered_group_items_locked(
+                current, exclude_id=event_id,
+            )
+            target_items = (
+                source_items if target == current
+                else self._ordered_group_items_locked(target, exclude_id=event_id)
+            )
+            if before:
+                insert_at = next((
+                    index for index, row in enumerate(target_items)
+                    if str(row.get("id") or "") == before
+                ), -1)
+                if insert_at < 0:
+                    raise ValueError("activity placement anchor not found in target group")
+            else:
+                insert_at = len(target_items)
+
             if target:
                 if sid:
                     self._group_assignments[sid] = target
@@ -571,14 +819,25 @@ class ActivityService:
                 if sid:
                     self._group_assignments.pop(sid, None)
                 item.pop("group_id", None)
-            self._save_group_state()
-            self._save()
-            self._publish_locked(item=item)
+            target_items.insert(insert_at, item)
+            if target != current:
+                self._renumber_group_locked(source_items)
+            self._renumber_group_locked(target_items)
+            changed_items = source_items + (
+                target_items if target != current else []
+            )
+            if target == current:
+                changed_items = target_items
+
+            self._save_group_event_state_locked(snapshot)
+            self._publish_locked(resync=True)
             return {
                 "generation": self._generation,
                 "revision": self._revision,
                 "item": dict(item),
+                "items": [dict(row) for row in changed_items],
                 "custom_groups": self._group_payload_locked(),
+                "group_order": self._group_order_payload_locked(),
             }
 
     def rename_session(self, sid: str, name: str) -> dict[str, Any] | None:

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -31,11 +31,12 @@ class ActivityGroupUpdateRequest(BaseModel):
 
 
 class ActivityGroupOrderRequest(BaseModel):
-    ids: list[str] = Field(max_length=40)
+    ids: list[str] = Field(max_length=41)
 
 
 class ActivityGroupAssignmentRequest(BaseModel):
     group_id: str = Field(default="", max_length=64)
+    before_event_id: str | None = Field(default=None, max_length=128)
 
 
 def _json(request: Request, response: Response, payload: dict):
@@ -123,7 +124,7 @@ def ack_all():
 
 @router.get("/groups", dependencies=[Depends(require_token)])
 def list_activity_groups():
-    return {"custom_groups": activity.list_groups()}
+    return activity.group_state()
 
 
 @router.post("/groups", dependencies=[Depends(require_token)])
@@ -170,7 +171,11 @@ def delete_activity_group(group_id: str):
 @router.put("/{event_id}/group", dependencies=[Depends(require_token)])
 def assign_activity_group(event_id: str, req: ActivityGroupAssignmentRequest):
     try:
-        update = activity.set_group(event_id, req.group_id)
+        update = activity.set_group(
+            event_id,
+            req.group_id,
+            before_event_id=req.before_event_id,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if update is None:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -27742,7 +27742,7 @@ function portal() {
     normalizeActivityGroupOrder(order = this.activity.groupOrder) {
       const customIds = (this.activity.customGroups || [])
         .map(group => String(group.id || "")).filter(Boolean);
-      const valid = new Set([...customIds, "__ungrouped__"]);
+      const valid = new Set(customIds);
       const result = [];
       for (const value of Array.isArray(order) ? order : []) {
         const groupId = String(value || "");
@@ -27751,7 +27751,7 @@ function portal() {
       for (const groupId of customIds) {
         if (!result.includes(groupId)) result.push(groupId);
       }
-      if (!result.includes("__ungrouped__")) result.push("__ungrouped__");
+      result.push("__ungrouped__");
       return result;
     },
     applyActivityGroupPayload(data) {
@@ -28197,24 +28197,28 @@ function portal() {
       const orderId = String(group?.orderId || group?.groupId || "");
       if (!orderId || !delta) return;
       const previous = this.normalizeActivityGroupOrder();
-      const at = previous.indexOf(orderId);
+      const customOrder = previous.filter(groupId => groupId !== "__ungrouped__");
+      const at = customOrder.indexOf(orderId);
       const target = at + delta;
-      if (at < 0 || target < 0 || target >= previous.length) return;
-      const next = [...previous];
+      if (at < 0 || target < 0 || target >= customOrder.length) return;
+      const next = [...customOrder];
       const [moved] = next.splice(at, 1);
       next.splice(target, 0, moved);
+      next.push("__ungrouped__");
       await this.persistActivityGroupOrder(next, previous);
     },
     activityGroupCanMove(group, delta) {
-      if (this.activitySearchQuery()) return false;
+      if (this.activitySearchQuery() || group?.builtin) return false;
       const orderId = String(group?.orderId || group?.groupId || "");
       if (!orderId) return false;
-      const order = this.normalizeActivityGroupOrder();
+      const order = this.normalizeActivityGroupOrder()
+        .filter(groupId => groupId !== "__ungrouped__");
       const at = order.indexOf(orderId);
       return at >= 0 && at + delta >= 0 && at + delta < order.length;
     },
     onActivityGroupOrderDragStart(ev, group) {
-      if (this.activity.view !== "groups" || this.activitySearchQuery()) return;
+      if (this.activity.view !== "groups" || this.activitySearchQuery()
+          || group?.builtin) return;
       const orderId = String(group?.orderId || group?.groupId || "");
       if (!orderId) return;
       this.onActivityDragEnd();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -615,12 +615,18 @@ function portal() {
       // events so SSE updates and session renames appear without another query.
       query: "",
       customGroups: [],
+      groupOrder: ["__ungrouped__"],
       groupEditor: {
         open: false, id: "", name: "", color: "blue", saving: false,
       },
       moveMenu: { show: false, eventId: "", style: "" },
       dragEventId: "",
       dragOverGroupId: null,
+      dragOverEventId: "",
+      dragInsertAfter: false,
+      dragGroupId: "",
+      dragOverGroupOrderId: "",
+      dragGroupInsertAfter: false,
     },
     _activityEtags: {},
     _activityFetchPromises: {},
@@ -634,6 +640,8 @@ function portal() {
     _activityLiveVisibilityBound: false,
     _activityPinPending: {},
     _activityGroupPending: {},
+    _activityGroupOrderSeq: 0,
+    _activityGroupOrderQueue: null,
     // Per-task "run-now" inflight flag — disables retry / send buttons until
     // activity SSE reports a terminal state. Keyed by task id.
     schedRunning: {},
@@ -27644,8 +27652,15 @@ function portal() {
           if (etag) this._activityEtags[key] = etag;
           const data = await r.json();
           if (seq < this._activityAppliedSeq) return false;
-          this._activityAppliedSeq = seq;
           const summary = opts.summaryOnly ? data : data.summary;
+          const incomingGeneration = String(summary?.generation || "");
+          const incomingRevision = Number(summary?.revision) || 0;
+          const sameGeneration = !incomingGeneration
+            || !this._activityGeneration
+            || incomingGeneration === this._activityGeneration;
+          if (sameGeneration && incomingRevision
+              && incomingRevision < this._activityRevision) return false;
+          this._activityAppliedSeq = seq;
           if (summary) {
             this.activity.summary = summary;
             const generation = String(summary.generation || "");
@@ -27662,9 +27677,7 @@ function portal() {
             this.activity.events = data.events;
             this._syncScheduledActivitySnapshot(data.events);
           }
-          if (!opts.summaryOnly && Array.isArray(data.custom_groups)) {
-            this.activity.customGroups = data.custom_groups;
-          }
+          if (!opts.summaryOnly) this.applyActivityGroupPayload(data);
           this._syncAppBadge();
           return true;
         } catch (_) { return false; }
@@ -27698,12 +27711,14 @@ function portal() {
       this.closeActivityMoveMenu();
       this.cancelActivityGroupEditor();
       this.onActivityDragEnd();
+      this.onActivityGroupOrderDragEnd();
     },
     setActivityView(view) {
       if (!["status", "groups", "timeline"].includes(view)) return;
       this.closeActivityMoveMenu();
       this.cancelActivityGroupEditor();
       this.onActivityDragEnd();
+      this.onActivityGroupOrderDragEnd();
       this.activity.view = view;
       try { localStorage.setItem("muselab_activity_view", view); } catch (_) {}
     },
@@ -27724,23 +27739,53 @@ function portal() {
     ACTIVITY_GROUP_COLORS: [
       "blue", "violet", "cyan", "green", "amber", "rose", "gray",
     ],
+    normalizeActivityGroupOrder(order = this.activity.groupOrder) {
+      const customIds = (this.activity.customGroups || [])
+        .map(group => String(group.id || "")).filter(Boolean);
+      const valid = new Set([...customIds, "__ungrouped__"]);
+      const result = [];
+      for (const value of Array.isArray(order) ? order : []) {
+        const groupId = String(value || "");
+        if (valid.has(groupId) && !result.includes(groupId)) result.push(groupId);
+      }
+      for (const groupId of customIds) {
+        if (!result.includes(groupId)) result.push(groupId);
+      }
+      if (!result.includes("__ungrouped__")) result.push("__ungrouped__");
+      return result;
+    },
+    applyActivityGroupPayload(data) {
+      if (Array.isArray(data?.custom_groups)) {
+        this.activity.customGroups = data.custom_groups;
+      }
+      if (Array.isArray(data?.group_order)) {
+        this.activity.groupOrder = this.normalizeActivityGroupOrder(data.group_order);
+      } else {
+        this.activity.groupOrder = this.normalizeActivityGroupOrder();
+      }
+    },
     activityCustomGroupSections() {
-      const sections = (this.activity.customGroups || []).map(group => ({
-        key: `custom:${group.id}`,
-        label: group.name,
-        custom: true,
-        groupId: group.id,
-        color: group.color || "blue",
-      }));
-      sections.push({
+      const lookup = new Map((this.activity.customGroups || []).map(group => [
+        String(group.id || ""), {
+          key: `custom:${group.id}`,
+          label: group.name,
+          custom: true,
+          groupId: group.id,
+          orderId: String(group.id || ""),
+          color: group.color || "blue",
+        },
+      ]));
+      lookup.set("__ungrouped__", {
         key: "custom:__ungrouped__",
         label: this.lang === "zh" ? "未分组" : "Ungrouped",
         custom: true,
         groupId: "",
+        orderId: "__ungrouped__",
         color: "gray",
         builtin: true,
       });
-      return sections;
+      return this.normalizeActivityGroupOrder()
+        .map(groupId => lookup.get(groupId)).filter(Boolean);
     },
     activityMatchesGroup(item, key) {
       if (!item) return false;
@@ -27808,12 +27853,19 @@ function portal() {
             if (pinRank) return pinRank;
             return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
           }
-          if (group.key === "custom:__ungrouped__") {
-            // Ungrouped is an inbox of recent sessions, not an attention queue.
-            // Keep its order predictable: newest activity always comes first.
-            return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
-          }
           if (group.custom) {
+            const aManual = Number.isFinite(Number(a.group_order));
+            const bManual = Number.isFinite(Number(b.group_order));
+            // Newly arrived rows without a manual position remain visible at the
+            // top. Once the user drags a lane, numbered rows keep that exact order.
+            if (aManual !== bManual) return aManual ? 1 : -1;
+            if (aManual && bManual) {
+              const order = Number(a.group_order) - Number(b.group_order);
+              if (order) return order;
+            }
+            if (group.key === "custom:__ungrouped__") {
+              return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+            }
             const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
             if (pinRank) return pinRank;
             const rank = attentionRank(a) - attentionRank(b);
@@ -28032,10 +28084,13 @@ function portal() {
         if (!ok || !Array.isArray(data?.custom_groups)) {
           throw new Error(error || "activity group save failed");
         }
-        this.activity.customGroups = data.custom_groups;
-        this._activityRevision = Math.max(
-          this._activityRevision, Number(data.revision) || 0,
-        );
+        const responseRevision = Number(data.revision) || 0;
+        if (!responseRevision || responseRevision >= this._activityRevision) {
+          this.applyActivityGroupPayload(data);
+        } else {
+          this.fetchActivity().catch(() => {});
+        }
+        this._activityRevision = Math.max(this._activityRevision, responseRevision);
         this.cancelActivityGroupEditor();
       } catch (error) {
         draft.saving = false;
@@ -28070,48 +28125,136 @@ function portal() {
         );
         return;
       }
-      this.activity.customGroups = data?.custom_groups || [];
-      for (const item of this.activity.events) {
-        if (String(item.group_id || "") === groupId) delete item.group_id;
+      const responseRevision = Number(data?.revision) || 0;
+      if (!responseRevision || responseRevision >= this._activityRevision) {
+        this.applyActivityGroupPayload(data || {});
+        if (Array.isArray(data?.items)) {
+          const byId = new Map(data.items.map(row => [String(row.id), row]));
+          this.activity.events = this.activity.events.map(
+            row => byId.get(String(row.id)) || row,
+          );
+        } else {
+          for (const item of this.activity.events) {
+            if (String(item.group_id || "") === groupId) {
+              delete item.group_id;
+              delete item.group_order;
+            }
+          }
+          this.activity.events = [...this.activity.events];
+        }
+      } else {
+        this.fetchActivity().catch(() => {});
       }
-      this.activity.events = [...this.activity.events];
       this.activity.expanded = {};
-      this._activityRevision = Math.max(
-        this._activityRevision, Number(data?.revision) || 0,
-      );
+      this._activityRevision = Math.max(this._activityRevision, responseRevision);
+    },
+    async persistActivityGroupOrder(next, previous) {
+      const opSeq = ++this._activityGroupOrderSeq;
+      const baseRevision = this._activityRevision;
+      const requestedOrder = this.normalizeActivityGroupOrder(next);
+      this.activity.groupOrder = requestedOrder;
+      const lookup = new Map((this.activity.customGroups || [])
+        .map(group => [String(group.id || ""), group]));
+      this.activity.customGroups = requestedOrder
+        .map(groupId => lookup.get(groupId)).filter(Boolean);
+
+      const run = async () => {
+        const { ok, data } = await this.api("/api/activity/groups/order", {
+          method: "PUT",
+          json: { ids: requestedOrder },
+        });
+        if (opSeq !== this._activityGroupOrderSeq) return false;
+        const responseRevision = Number(data?.revision) || 0;
+        if (!ok) {
+          if (this._activityRevision <= baseRevision) {
+            this.activity.groupOrder = this.normalizeActivityGroupOrder(previous);
+            this.activity.customGroups = this.activity.groupOrder
+              .map(groupId => lookup.get(groupId)).filter(Boolean);
+          } else {
+            this.fetchActivity().catch(() => {});
+          }
+          this.toast(this.lang === "zh" ? "分组排序失败" : "Could not reorder groups", "error");
+          return false;
+        }
+        if (responseRevision && responseRevision < this._activityRevision) return true;
+        this.applyActivityGroupPayload(data || {});
+        this._activityRevision = Math.max(this._activityRevision, responseRevision);
+        return true;
+      };
+      const prior = this._activityGroupOrderQueue || Promise.resolve();
+      const task = prior.catch(() => {}).then(run);
+      this._activityGroupOrderQueue = task;
+      try {
+        return await task;
+      } finally {
+        if (this._activityGroupOrderQueue === task) {
+          this._activityGroupOrderQueue = null;
+        }
+      }
     },
     async moveActivityGroup(group, delta) {
-      if (!group?.groupId || !delta) return;
-      const previous = [...(this.activity.customGroups || [])];
-      const at = previous.findIndex(row => row.id === group.groupId);
+      if (this.activitySearchQuery()) return;
+      const orderId = String(group?.orderId || group?.groupId || "");
+      if (!orderId || !delta) return;
+      const previous = this.normalizeActivityGroupOrder();
+      const at = previous.indexOf(orderId);
       const target = at + delta;
       if (at < 0 || target < 0 || target >= previous.length) return;
       const next = [...previous];
       const [moved] = next.splice(at, 1);
       next.splice(target, 0, moved);
-      this.activity.customGroups = next;
-      const { ok, data } = await this.api("/api/activity/groups/order", {
-        method: "PUT",
-        json: { ids: next.map(row => row.id) },
-      });
-      if (!ok) {
-        this.activity.customGroups = previous;
-        this.toast(this.lang === "zh" ? "分组排序失败" : "Could not reorder groups", "error");
-        return;
-      }
-      if (Array.isArray(data?.custom_groups)) {
-        this.activity.customGroups = data.custom_groups;
-      }
-      this._activityRevision = Math.max(
-        this._activityRevision, Number(data?.revision) || 0,
-      );
+      await this.persistActivityGroupOrder(next, previous);
     },
     activityGroupCanMove(group, delta) {
-      if (!group?.groupId) return false;
-      const at = (this.activity.customGroups || [])
-        .findIndex(row => row.id === group.groupId);
-      return at >= 0 && at + delta >= 0
-        && at + delta < (this.activity.customGroups || []).length;
+      if (this.activitySearchQuery()) return false;
+      const orderId = String(group?.orderId || group?.groupId || "");
+      if (!orderId) return false;
+      const order = this.normalizeActivityGroupOrder();
+      const at = order.indexOf(orderId);
+      return at >= 0 && at + delta >= 0 && at + delta < order.length;
+    },
+    onActivityGroupOrderDragStart(ev, group) {
+      if (this.activity.view !== "groups" || this.activitySearchQuery()) return;
+      const orderId = String(group?.orderId || group?.groupId || "");
+      if (!orderId) return;
+      this.onActivityDragEnd();
+      this.activity.dragGroupId = orderId;
+      if (ev?.dataTransfer) {
+        ev.dataTransfer.effectAllowed = "move";
+        ev.dataTransfer.setData("application/x-muselab-activity-group", orderId);
+        ev.dataTransfer.setData("text/plain", orderId);
+      }
+    },
+    onActivityGroupOrderDragOver(ev, group) {
+      if (!this.activity.dragGroupId || this.activitySearchQuery()) return;
+      const orderId = String(group?.orderId || group?.groupId || "");
+      if (!orderId || orderId === this.activity.dragGroupId) return;
+      const rect = ev?.currentTarget?.getBoundingClientRect();
+      const vertical = rect && Math.abs((ev?.clientY || 0) - rect.top - rect.height / 2)
+        > Math.abs((ev?.clientX || 0) - rect.left - rect.width / 2);
+      this.activity.dragOverGroupOrderId = orderId;
+      this.activity.dragGroupInsertAfter = !!rect && (vertical
+        ? (ev.clientY > rect.top + rect.height / 2)
+        : (ev.clientX > rect.left + rect.width / 2));
+    },
+    async onActivityGroupOrderDrop(group) {
+      const sourceId = this.activity.dragGroupId;
+      const targetId = String(group?.orderId || group?.groupId || "");
+      const insertAfter = this.activity.dragGroupInsertAfter;
+      this.onActivityGroupOrderDragEnd();
+      if (!sourceId || !targetId || sourceId === targetId) return;
+      const previous = this.normalizeActivityGroupOrder();
+      const next = previous.filter(groupId => groupId !== sourceId);
+      let targetAt = next.indexOf(targetId);
+      if (targetAt < 0) return;
+      if (insertAfter) targetAt += 1;
+      next.splice(targetAt, 0, sourceId);
+      await this.persistActivityGroupOrder(next, previous);
+    },
+    onActivityGroupOrderDragEnd() {
+      this.activity.dragGroupId = "";
+      this.activity.dragOverGroupOrderId = "";
+      this.activity.dragGroupInsertAfter = false;
     },
     openActivityMoveMenu(ev, item) {
       if (!item?.id) return;
@@ -28140,43 +28283,136 @@ function portal() {
       const eventId = this.activity.moveMenu.eventId;
       return this.activity.events.find(row => String(row.id) === eventId) || null;
     },
-    async assignActivityGroup(item, groupId = "") {
+    activityGroupSectionForId(groupId = "") {
+      return this.activityCustomGroupSections().find(
+        group => String(group.groupId || "") === String(groupId || ""),
+      ) || null;
+    },
+    placeActivityEventLocally(item, groupId, beforeEventId) {
+      const eventId = String(item?.id || "");
+      if (!eventId) return;
+      const sourceId = String(item.group_id || "");
+      const targetId = String(groupId || "");
+      const sourceGroup = this.activityGroupSectionForId(sourceId);
+      const targetGroup = this.activityGroupSectionForId(targetId);
+      if (!targetGroup) return;
+      const sourceItems = sourceGroup
+        ? this.activityAllEvents(sourceGroup).filter(row => String(row.id) !== eventId)
+        : [];
+      const targetItems = sourceId === targetId
+        ? sourceItems
+        : this.activityAllEvents(targetGroup).filter(row => String(row.id) !== eventId);
+      let insertAt = targetItems.length;
+      const before = String(beforeEventId || "");
+      if (before) {
+        const found = targetItems.findIndex(row => String(row.id) === before);
+        if (found >= 0) insertAt = found;
+      }
+      if (targetId) item.group_id = targetId;
+      else delete item.group_id;
+      targetItems.splice(insertAt, 0, item);
+      if (sourceId !== targetId) {
+        sourceItems.forEach((row, index) => { row.group_order = index; });
+      }
+      targetItems.forEach((row, index) => { row.group_order = index; });
+      this.activity.events = [...this.activity.events];
+      return [...new Set([...sourceItems, ...targetItems]
+        .map(row => String(row.id || "")).filter(Boolean))];
+    },
+    async assignActivityGroup(item, groupId = "", beforeEventId = null) {
       if (!item?.id) return false;
       const eventId = String(item.id);
       if (this._activityGroupPending[eventId]) return false;
       const target = String(groupId || "");
       const previous = String(item.group_id || "");
+      const hasPlacement = beforeEventId !== null;
       this.closeActivityMoveMenu();
-      if (target === previous) return true;
+      if (!hasPlacement && target === previous) return true;
+      const previousPlacement = new Map(this.activity.events.map(row => [
+        String(row.id), {
+          hasGroup: Object.prototype.hasOwnProperty.call(row, "group_id"),
+          groupId: String(row.group_id || ""),
+          hasOrder: Object.prototype.hasOwnProperty.call(row, "group_order"),
+          order: row.group_order,
+        },
+      ]));
       this._activityGroupPending = {
         ...this._activityGroupPending,
         [eventId]: true,
       };
-      if (target) item.group_id = target;
-      else delete item.group_id;
-      this.activity.events = [...this.activity.events];
+      let affectedIds;
+      if (hasPlacement) {
+        affectedIds = this.placeActivityEventLocally(item, target, beforeEventId) || [eventId];
+      } else {
+        if (target) item.group_id = target;
+        else delete item.group_id;
+        delete item.group_order;
+        this.activity.events = [...this.activity.events];
+        affectedIds = [eventId];
+      }
+      const baseRevision = this._activityRevision;
+      const optimisticPlacement = new Map(affectedIds.map(id => {
+        const row = this.activity.events.find(itemRow => String(itemRow.id) === id);
+        return [id, {
+          groupId: String(row?.group_id || ""),
+          hasOrder: !!row && Object.prototype.hasOwnProperty.call(row, "group_order"),
+          order: row?.group_order,
+        }];
+      }));
       this._activityAppliedSeq = ++this._activityRequestSeq;
       try {
+        const json = { group_id: target };
+        if (hasPlacement) json.before_event_id = String(beforeEventId || "");
         const { ok, data, error } = await this.api(
           `/api/activity/${encodeURIComponent(eventId)}/group`,
-          { method: "PUT", json: { group_id: target } },
+          { method: "PUT", json },
         );
         if (!ok || !data?.item) throw new Error(error || "group assignment failed");
-        const at = this.activity.events.findIndex(row => row.id === eventId);
-        if (at >= 0) this.activity.events.splice(at, 1, data.item);
-        this.activity.events = [...this.activity.events];
-        if (Array.isArray(data.custom_groups)) {
-          this.activity.customGroups = data.custom_groups;
+        const responseRevision = Number(data.revision) || 0;
+        if (!responseRevision || responseRevision >= this._activityRevision) {
+          const updates = Array.isArray(data.items) ? data.items : [data.item];
+          const byId = new Map(updates.map(row => [String(row.id), row]));
+          this.activity.events = this.activity.events.map(row => {
+            const update = byId.get(String(row.id));
+            if (!update) return row;
+            if (update.group_id) row.group_id = update.group_id;
+            else delete row.group_id;
+            if (Object.prototype.hasOwnProperty.call(update, "group_order")) {
+              row.group_order = update.group_order;
+            } else {
+              delete row.group_order;
+            }
+            return row;
+          });
+          this.activity.events = [...this.activity.events];
+          this.applyActivityGroupPayload(data);
         }
-        this._activityRevision = Math.max(
-          this._activityRevision, Number(data.revision) || 0,
-        );
+        this._activityRevision = Math.max(this._activityRevision, responseRevision);
         return true;
       } catch (_) {
-        const latest = this.activity.events.find(row => row.id === eventId);
-        if (latest) {
-          if (previous) latest.group_id = previous;
-          else delete latest.group_id;
+        if (this._activityRevision > baseRevision) {
+          this.fetchActivity().catch(() => {});
+          this.toast(this.lang === "zh" ? "移动会话失败" : "Could not move session", "error");
+          return false;
+        }
+        const affected = new Set(affectedIds);
+        for (const row of this.activity.events) {
+          const id = String(row.id);
+          if (!affected.has(id)) continue;
+          const optimistic = optimisticPlacement.get(id);
+          const currentOrder = Object.prototype.hasOwnProperty.call(row, "group_order")
+            ? row.group_order : undefined;
+          if (!optimistic
+              || String(row.group_id || "") !== optimistic.groupId
+              || currentOrder !== (optimistic.hasOrder ? optimistic.order : undefined)) {
+            continue;
+          }
+          const prior = previousPlacement.get(id);
+          if (!prior) continue;
+          if (prior.hasGroup) row.group_id = prior.groupId;
+          else delete row.group_id;
+          if (prior.hasOrder) row.group_order = prior.order;
+          else delete row.group_order;
         }
         this.activity.events = [...this.activity.events];
         this.toast(this.lang === "zh" ? "移动会话失败" : "Could not move session", "error");
@@ -28188,27 +28424,76 @@ function portal() {
       }
     },
     onActivityDragStart(ev, item) {
-      if (this.activity.view !== "groups" || !item?.id) return;
+      if (this.activity.view !== "groups" || this.activitySearchQuery() || !item?.id) return;
+      this.onActivityGroupOrderDragEnd();
       this.activity.dragEventId = String(item.id);
       if (ev?.dataTransfer) {
         ev.dataTransfer.effectAllowed = "move";
+        ev.dataTransfer.setData("application/x-muselab-activity-event", String(item.id));
         ev.dataTransfer.setData("text/plain", String(item.id));
       }
     },
     onActivityDragEnd() {
       this.activity.dragEventId = "";
       this.activity.dragOverGroupId = null;
+      this.activity.dragOverEventId = "";
+      this.activity.dragInsertAfter = false;
     },
-    onActivityGroupDragOver(group) {
-      if (!this.activity.dragEventId) return;
+    onActivityLaneDragOver(ev, group) {
+      if (this.activity.dragGroupId) {
+        this.onActivityGroupOrderDragOver(ev, group);
+        return;
+      }
+      if (!this.activity.dragEventId || this.activitySearchQuery()) return;
       this.activity.dragOverGroupId = group.groupId || "";
+      this.activity.dragOverEventId = "";
+      this.activity.dragInsertAfter = false;
     },
-    async onActivityGroupDrop(group) {
+    onActivityRowDragOver(ev, group, item) {
+      if (this.activity.dragGroupId) {
+        this.onActivityGroupOrderDragOver(ev, group);
+        return;
+      }
+      if (!this.activity.dragEventId || this.activitySearchQuery()
+          || String(item?.id || "") === this.activity.dragEventId) return;
+      const rect = ev?.currentTarget?.getBoundingClientRect();
+      this.activity.dragOverGroupId = group.groupId || "";
+      this.activity.dragOverEventId = String(item.id);
+      this.activity.dragInsertAfter = !!rect && ev.clientY > rect.top + rect.height / 2;
+    },
+    activityDropBeforeId(group, targetItem, insertAfter) {
+      if (!targetItem?.id) return "";
+      if (!insertAfter) return String(targetItem.id);
+      const sourceId = this.activity.dragEventId;
+      const rows = this.activityAllEvents(group)
+        .filter(row => String(row.id) !== sourceId);
+      const at = rows.findIndex(row => String(row.id) === String(targetItem.id));
+      return at >= 0 && at + 1 < rows.length ? String(rows[at + 1].id) : "";
+    },
+    async onActivityRowDrop(group, targetItem) {
+      if (this.activity.dragGroupId) {
+        await this.onActivityGroupOrderDrop(group);
+        return;
+      }
+      const eventId = this.activity.dragEventId;
+      const beforeId = this.activityDropBeforeId(
+        group, targetItem, this.activity.dragInsertAfter,
+      );
+      this.onActivityDragEnd();
+      if (!eventId) return;
+      const item = this.activity.events.find(row => String(row.id) === eventId);
+      if (item) await this.assignActivityGroup(item, group.groupId || "", beforeId);
+    },
+    async onActivityLaneDrop(group) {
+      if (this.activity.dragGroupId) {
+        await this.onActivityGroupOrderDrop(group);
+        return;
+      }
       const eventId = this.activity.dragEventId;
       this.onActivityDragEnd();
       if (!eventId) return;
       const item = this.activity.events.find(row => String(row.id) === eventId);
-      if (item) await this.assignActivityGroup(item, group.groupId || "");
+      if (item) await this.assignActivityGroup(item, group.groupId || "", "");
     },
     _stopActivityEvents() {
       ++this._activityLiveSeq;
@@ -28264,11 +28549,11 @@ function portal() {
         this._activityGeneration = generation;
         this._activityRevision = 0;
       }
-      if (Array.isArray(payload?.custom_groups)) {
-        this.activity.customGroups = payload.custom_groups;
-      }
       const revision = Number(payload?.revision) || 0;
       if (revision && revision <= this._activityRevision) return;
+      if (Array.isArray(payload?.custom_groups) || Array.isArray(payload?.group_order)) {
+        this.applyActivityGroupPayload(payload);
+      }
       if (payload?.resync) {
         this._activityRevision = Math.max(this._activityRevision, revision);
         this._activityAppliedSeq = ++this._activityRequestSeq;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5977,15 +5977,31 @@
                    :class="{
                      'is-timeline': group.key === 'timeline',
                      'is-custom': group.custom,
-                     'is-drag-over': group.custom
-                       && activity.dragOverGroupId === (group.groupId || '')
+                     'is-drag-over': group.custom && activity.dragEventId
+                       && activity.dragOverGroupId === (group.groupId || ''),
+                     'is-group-dragging': group.custom
+                       && activity.dragGroupId === group.orderId,
+                     'is-group-drop-before': group.custom
+                       && activity.dragOverGroupOrderId === group.orderId
+                       && !activity.dragGroupInsertAfter,
+                     'is-group-drop-after': group.custom
+                       && activity.dragOverGroupOrderId === group.orderId
+                       && activity.dragGroupInsertAfter
                    }"
-                   @dragover.prevent="group.custom && onActivityGroupDragOver(group)"
-                   @drop.prevent="group.custom && onActivityGroupDrop(group)">
+                   @dragover.prevent="group.custom && onActivityLaneDragOver($event, group)"
+                   @drop.stop.prevent="group.custom && onActivityLaneDrop(group)">
             <!-- The timeline toggle already communicates ordering. Repeating
                  "all tasks · pinned first · newest" here adds visual noise. -->
             <h3 x-show="!group.custom && group.key !== 'timeline'" x-text="group.label"></h3>
             <div class="activity-custom-group-head" x-show="group.custom">
+              <span class="activity-group-drag-handle"
+                    :draggable="!activitySearchQuery()"
+                    @dragstart.stop="onActivityGroupOrderDragStart($event, group)"
+                    @dragend.stop="onActivityGroupOrderDragEnd()"
+                    :title="activitySearchQuery()
+                      ? (lang==='zh' ? '搜索时不能调整分组顺序' : 'Clear search to reorder groups')
+                      : (lang==='zh' ? '拖动调整分组顺序' : 'Drag to reorder group')"
+                    aria-hidden="true">⋮⋮</span>
               <span class="activity-custom-group-dot"
                     :class="'is-' + (group.color || 'gray')"></span>
               <strong x-text="group.label"></strong>
@@ -6020,10 +6036,16 @@
               <div class="activity-row-wrap"
                    :class="{
                      pinned: activity.view === 'timeline' && item.pinned,
-                     dragging: activity.dragEventId === String(item.id)
+                     dragging: activity.dragEventId === String(item.id),
+                     'drop-before': activity.dragOverEventId === String(item.id)
+                       && !activity.dragInsertAfter,
+                     'drop-after': activity.dragOverEventId === String(item.id)
+                       && activity.dragInsertAfter
                    }"
-                   :draggable="activity.view === 'groups'"
+                   :draggable="activity.view === 'groups' && !activitySearchQuery()"
                    @dragstart="onActivityDragStart($event, item)"
+                   @dragover.stop.prevent="onActivityRowDragOver($event, group, item)"
+                   @drop.stop.prevent="onActivityRowDrop(group, item)"
                    @dragend="onActivityDragEnd()">
                 <button class="activity-row" type="button"
                         @click="openActivityEvent(item)"
@@ -6128,7 +6150,7 @@
     <template x-for="group in activityCustomGroupSections()" :key="group.key">
       <button type="button" role="menuitem"
               :class="{ active: String(activityMoveMenuItem()?.group_id || '') === String(group.groupId || '') }"
-              @click="assignActivityGroup(activityMoveMenuItem(), group.groupId || '')">
+              @click="assignActivityGroup(activityMoveMenuItem(), group.groupId || '', '')">
         <span class="activity-custom-group-dot"
               :class="'is-' + (group.color || 'gray')"></span>
         <span x-text="group.label"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5995,7 +5995,8 @@
             <h3 x-show="!group.custom && group.key !== 'timeline'" x-text="group.label"></h3>
             <div class="activity-custom-group-head" x-show="group.custom">
               <span class="activity-group-drag-handle"
-                    :draggable="!activitySearchQuery()"
+                    x-show="!group.builtin"
+                    :draggable="!group.builtin && !activitySearchQuery()"
                     @dragstart.stop="onActivityGroupOrderDragStart($event, group)"
                     @dragend.stop="onActivityGroupOrderDragEnd()"
                     :title="activitySearchQuery()

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3856,7 +3856,13 @@ pre.text {
 .activity-group h3 { margin:10px 4px 6px; color:var(--c-fg-3); font-size:var(--fs-xs); font-weight:var(--fw-medium); }
 .activity-group.is-custom { margin:8px 0; padding:4px; border:1px solid var(--c-border); border-radius:var(--r-md); background:color-mix(in srgb,var(--c-bg-2) 46%,transparent); transition:border-color var(--t-fast),background var(--t-fast),box-shadow var(--t-fast); }
 .activity-group.is-custom.is-drag-over { border-color:var(--c-accent); background:var(--c-accent-soft); box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--c-accent) 35%,transparent); }
+.activity-group.is-custom.is-group-dragging { opacity:.42; }
+.activity-group.is-custom.is-group-drop-before { box-shadow:-4px 0 0 var(--c-accent),var(--shadow-sm); }
+.activity-group.is-custom.is-group-drop-after { box-shadow:4px 0 0 var(--c-accent),var(--shadow-sm); }
 .activity-custom-group-head { min-height:34px; display:flex; align-items:center; gap:7px; padding:3px 6px 5px; }
+.activity-group-drag-handle { width:15px; flex:0 0 15px; overflow:hidden; color:var(--c-fg-4); font:14px/1 var(--font-mono); letter-spacing:-4px; cursor:grab; user-select:none; }
+.activity-group-drag-handle[draggable="true"]:active { cursor:grabbing; }
+.activity-group-drag-handle[draggable="false"] { opacity:.35; cursor:not-allowed; }
 .activity-custom-group-head > strong { min-width:0; overflow:hidden; color:var(--c-fg-1); font-size:var(--fs-sm); font-weight:var(--fw-medium); text-overflow:ellipsis; white-space:nowrap; }
 .activity-custom-group-dot { --activity-group-color:var(--c-fg-3); width:8px; height:8px; flex:0 0 8px; border-radius:50%; background:var(--activity-group-color); }
 .activity-custom-group-dot.is-blue,.activity-group-swatch.is-blue { --activity-group-color:#6093ff; }
@@ -3943,11 +3949,14 @@ pre.text {
 }
 .activity-group-more { display:block; width:100%; margin:2px 0 0; padding:6px 8px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-3); font:inherit; font-size:var(--fs-xs); text-align:left; cursor:pointer; }
 .activity-group-more:hover { background:var(--c-bg-2); color:var(--c-fg-1); }
-.activity-row-wrap { display:flex; align-items:center; border-radius:var(--r-sm); }
+.activity-row-wrap { position:relative; display:flex; align-items:center; border-radius:var(--r-sm); }
 .activity-row-wrap.pinned { box-shadow:inset 2px 0 0 color-mix(in srgb, var(--c-accent) 65%, transparent); }
 .activity-row-wrap[draggable="true"] { cursor:grab; }
 .activity-row-wrap[draggable="true"]:active { cursor:grabbing; }
 .activity-row-wrap.dragging { opacity:.38; }
+.activity-row-wrap.drop-before::before,.activity-row-wrap.drop-after::after { content:""; position:absolute; z-index:2; left:4px; right:4px; height:2px; border-radius:2px; background:var(--c-accent); box-shadow:0 0 0 1px var(--c-accent-soft); pointer-events:none; }
+.activity-row-wrap.drop-before::before { top:-5px; }
+.activity-row-wrap.drop-after::after { bottom:-5px; }
 .activity-row { width:100%; display:flex; align-items:center; gap:10px; padding:10px; border:0; border-radius:var(--r-sm); background:transparent; color:var(--c-fg-1); text-align:left; cursor:pointer; }
 .activity-row-wrap .activity-row { width:auto; min-width:0; flex:1; }
 .activity-row:hover { background:var(--c-bg-2); }

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -485,9 +485,9 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
           app.activity.dragInsertAfter = false;
           await app.onActivityRowDrop(research, target);
 
-          const ungrouped = app.activityCustomGroupSections()
-            .find(group => group.orderId === '__ungrouped__');
-          app.activity.dragGroupId = ungrouped.orderId;
+          const writing = app.activityCustomGroupSections()
+            .find(group => group.orderId === 'writing');
+          app.activity.dragGroupId = writing.orderId;
           const fakeRect = {left: 0, top: 0, width: 300, height: 300};
           app.onActivityRowDragOver({
             clientX: 10, clientY: 10,
@@ -506,11 +506,14 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     assert drag_state["forwardedTarget"] == "research"
     assert drag_state["researchOrder"] == ["ungrouped-row", "grouped-row"]
     assert drag_state["groupOrder"] == [
-        "__ungrouped__", "research", "delivery", "writing",
+        "writing", "research", "delivery", "__ungrouped__",
     ]
     assert page.locator(
         ".activity-custom-group-head > strong"
-    ).all_text_contents() == ["未分组", "Research", "Delivery", "Writing"]
+    ).all_text_contents() == ["Writing", "Research", "Delivery", "未分组"]
+    expect(page.locator(".activity-group.is-custom").last.locator(
+        ".activity-group-drag-handle"
+    )).to_be_hidden()
 
     calls = page.evaluate("() => window.__activityGroupCalls")
     placement = next(
@@ -524,7 +527,7 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
         if call["path"] == "/api/activity/groups/order"
     )
     assert reorder["options"]["json"]["ids"] == [
-        "__ungrouped__", "research", "delivery", "writing",
+        "writing", "research", "delivery", "__ungrouped__",
     ]
 
     # A busy group is an independently scrollable lane. The old five-row cap

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -339,6 +339,7 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
             {id: 'research', name: 'Research', color: 'violet'},
             {id: 'delivery', name: 'Delivery', color: 'green'},
           ];
+          app.activity.groupOrder = ['research', 'delivery', '__ungrouped__'];
           app.activity.events = [{
             id: 'grouped-row', session_id: 'grouped-session',
             session_name: 'Research session', task_summary: 'Grouped task',
@@ -369,6 +370,15 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
               return {ok: true, data: {
                 revision: app._activityRevision + 1,
                 custom_groups: [...app.activity.customGroups, group],
+                group_order: [...app.activity.groupOrder.filter(id => id !== '__ungrouped__'), 'writing', '__ungrouped__'],
+              }};
+            }
+            if (path === '/api/activity/groups/order' && options.method === 'PUT') {
+              const lookup = new Map(app.activity.customGroups.map(group => [group.id, group]));
+              return {ok: true, data: {
+                revision: app._activityRevision + 1,
+                custom_groups: options.json.ids.map(id => lookup.get(id)).filter(Boolean),
+                group_order: [...options.json.ids],
               }};
             }
             if (path.endsWith('/group') && options.method === 'PUT') {
@@ -380,7 +390,9 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
               return {ok: true, data: {
                 revision: app._activityRevision + 1,
                 item: updated,
+                items: [{...updated}],
                 custom_groups: [...app.activity.customGroups],
+                group_order: [...app.activity.groupOrder],
               }};
             }
             return {ok: false, data: null, error: 'unexpected test request'};
@@ -431,6 +443,18 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     expect(menu).to_be_visible()
     expect(menu.locator("button")).to_have_count(3)
     menu.locator("button").filter(has_text="Research").click()
+    page.wait_for_function(
+        "() => window.__activityGroupCalls.some(call => call.path.endsWith('/ungrouped-row/group'))"
+    )
+    moved_state = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.activity.events.map(row => ({
+            id: row.id, group: row.group_id || '', order: row.group_order,
+          }));
+        }"""
+    )
+    assert next(row for row in moved_state if row["id"] == "ungrouped-row")["group"] == "research", moved_state
 
     research = groups.filter(has_text="Research")
     expect(research.locator(".activity-row-wrap")).to_have_count(2)
@@ -447,6 +471,61 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     expect(page.locator(".activity-custom-group-head > strong")).to_contain_text(
         ["Research", "Delivery", "Writing", "未分组"]
     )
+
+    # Rows can be inserted at an exact position, and every visible lane —
+    # including the built-in Ungrouped lane — participates in board ordering.
+    drag_state = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const research = app.activityCustomGroupSections()
+            .find(group => group.groupId === 'research');
+          const source = app.activity.events.find(row => row.id === 'ungrouped-row');
+          const target = app.activity.events.find(row => row.id === 'grouped-row');
+          app.activity.dragEventId = source.id;
+          app.activity.dragInsertAfter = false;
+          await app.onActivityRowDrop(research, target);
+
+          const ungrouped = app.activityCustomGroupSections()
+            .find(group => group.orderId === '__ungrouped__');
+          app.activity.dragGroupId = ungrouped.orderId;
+          const fakeRect = {left: 0, top: 0, width: 300, height: 300};
+          app.onActivityRowDragOver({
+            clientX: 10, clientY: 10,
+            currentTarget: {getBoundingClientRect: () => fakeRect},
+          }, research, target);
+          const forwardedTarget = app.activity.dragOverGroupOrderId;
+          await app.onActivityRowDrop(research, target);
+          await new Promise(resolve => app.$nextTick(resolve));
+          return {
+            forwardedTarget,
+            groupOrder: [...app.activity.groupOrder],
+            researchOrder: app.activityAllEvents(research).map(row => row.id),
+          };
+        }"""
+    )
+    assert drag_state["forwardedTarget"] == "research"
+    assert drag_state["researchOrder"] == ["ungrouped-row", "grouped-row"]
+    assert drag_state["groupOrder"] == [
+        "__ungrouped__", "research", "delivery", "writing",
+    ]
+    assert page.locator(
+        ".activity-custom-group-head > strong"
+    ).all_text_contents() == ["未分组", "Research", "Delivery", "Writing"]
+
+    calls = page.evaluate("() => window.__activityGroupCalls")
+    placement = next(
+        call for call in calls
+        if call["path"].endswith("/ungrouped-row/group")
+        and call["options"]["json"].get("before_event_id") == "grouped-row"
+    )
+    assert placement["options"]["json"]["group_id"] == "research"
+    reorder = next(
+        call for call in reversed(calls)
+        if call["path"] == "/api/activity/groups/order"
+    )
+    assert reorder["options"]["json"]["ids"] == [
+        "__ungrouped__", "research", "delivery", "writing",
+    ]
 
     # A busy group is an independently scrollable lane. The old five-row cap
     # plus a constrained grid lane clipped everything below roughly four rows,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -219,6 +219,162 @@ def test_custom_groups_persist_reorder_and_assignment_without_rewriting_task(
     assert state["assignments"] == {}
 
 
+def test_group_layout_order_includes_ungrouped_and_persists(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    research = service.create_group("Research", "violet")["group"]
+    delivery = service.create_group("Delivery", "green")["group"]
+
+    order = ["__ungrouped__", delivery["id"], research["id"]]
+    update = service.reorder_groups(order)
+    assert update["group_order"] == order
+    assert service.group_state()["group_order"] == order
+
+    restarted = ActivityService(tmp_path)
+    assert restarted.group_state()["group_order"] == order
+    assert [row["id"] for row in restarted.list_groups()] == [
+        delivery["id"], research["id"],
+    ]
+
+
+def test_activity_rows_reorder_within_and_across_groups_and_persist(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    items = [service.start(f"s{index}", summary=f"task {index}")
+             for index in range(1, 5)]
+    group_a = service.create_group("A", "blue")["group"]
+    group_b = service.create_group("B", "green")["group"]
+
+    service.set_group(items[0]["id"], group_a["id"], before_event_id="")
+    service.set_group(items[1]["id"], group_a["id"], before_event_id="")
+    service.set_group(
+        items[2]["id"], group_a["id"], before_event_id=items[1]["id"],
+    )
+    service.set_group(items[3]["id"], group_b["id"], before_event_id="")
+
+    def ordered(group_id):
+        return [
+            row["id"] for row in sorted(
+                (row for row in service.list(500)
+                 if str(row.get("group_id") or "") == group_id),
+                key=lambda row: row["group_order"],
+            )
+        ]
+
+    assert ordered(group_a["id"]) == [
+        items[0]["id"], items[2]["id"], items[1]["id"],
+    ]
+    service.set_group(
+        items[2]["id"], group_b["id"], before_event_id=items[3]["id"],
+    )
+    assert ordered(group_a["id"]) == [items[0]["id"], items[1]["id"]]
+    assert ordered(group_b["id"]) == [items[2]["id"], items[3]["id"]]
+
+    restarted = ActivityService(tmp_path)
+    restored = {
+        row["id"]: row for row in restarted.list(500)
+        if str(row.get("group_id") or "") == group_b["id"]
+    }
+    assert sorted(restored, key=lambda event_id: restored[event_id]["group_order"]) == [
+        items[2]["id"], items[3]["id"],
+    ]
+
+
+def test_group_placement_rolls_back_memory_and_files_when_second_save_fails(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    item = service.start("s1", summary="task")
+    group = service.create_group("Ordered", "blue")["group"]
+    real_save = service._save
+    calls = 0
+
+    def fail_once():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("simulated activity write failure")
+        real_save()
+
+    monkeypatch.setattr(service, "_save", fail_once)
+    with pytest.raises(OSError, match="simulated activity write failure"):
+        service.set_group(item["id"], group["id"], before_event_id="")
+
+    current = next(row for row in service.list() if row["id"] == item["id"])
+    assert "group_id" not in current
+    assert "group_order" not in current
+    assert service._group_assignments == {}
+
+    restarted = ActivityService(tmp_path)
+    restored = next(row for row in restarted.list() if row["id"] == item["id"])
+    assert "group_id" not in restored
+    assert "group_order" not in restored
+    assert restarted._group_assignments == {}
+
+
+def test_group_transaction_journal_recovers_when_disk_rollback_also_fails(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    item = service.start("s1", summary="task")
+    group = service.create_group("Ordered", "blue")["group"]
+
+    real_save = service._save
+
+    def always_fail():
+        raise OSError("simulated persistent activity write failure")
+
+    monkeypatch.setattr(service, "_save", always_fail)
+    with pytest.raises(OSError, match="simulated persistent activity write failure"):
+        service.set_group(item["id"], group["id"], before_event_id="")
+    assert service.transaction_path.exists()
+    monkeypatch.setattr(service, "_save", real_save)
+    with pytest.raises(RuntimeError, match="unrecovered transaction"):
+        service.set_group(item["id"], group["id"], before_event_id="")
+    with pytest.raises(RuntimeError, match="unrecovered transaction"):
+        service.start("s2", summary="must not be accepted")
+
+    restarted = ActivityService(tmp_path)
+    restored = next(row for row in restarted.list() if row["id"] == item["id"])
+    assert "group_id" not in restored
+    assert "group_order" not in restored
+    assert restarted._group_assignments == {}
+    assert not restarted.transaction_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_group_placement_pushes_resync_for_sibling_order_changes(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    first = service.start("s1", summary="first")
+    second = service.start("s2", summary="second")
+    group = service.create_group("Ordered", "amber")["group"]
+    service.set_group(first["id"], group["id"], before_event_id="")
+
+    async with service.subscribe() as queue:
+        update = await asyncio.to_thread(
+            service.set_group,
+            second["id"],
+            group["id"],
+            before_event_id=first["id"],
+        )
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert update is not None
+    assert [row["id"] for row in update["items"]] == [
+        second["id"], first["id"],
+    ]
+    assert payload["resync"] is True
+
+
 @pytest.mark.asyncio
 async def test_group_delete_pushes_resync_for_all_affected_rows(
     tmp_path,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -227,8 +227,9 @@ def test_group_layout_order_includes_ungrouped_and_persists(
     research = service.create_group("Research", "violet")["group"]
     delivery = service.create_group("Delivery", "green")["group"]
 
-    order = ["__ungrouped__", delivery["id"], research["id"]]
-    update = service.reorder_groups(order)
+    requested = ["__ungrouped__", delivery["id"], research["id"]]
+    order = [delivery["id"], research["id"], "__ungrouped__"]
+    update = service.reorder_groups(requested)
     assert update["group_order"] == order
     assert service.group_state()["group_order"] == order
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1414,11 +1414,14 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert '@drop.stop.prevent="group.custom && onActivityLaneDrop(group)"' in html
     assert "before_event_id" in app
     assert 'groupOrder: ["__ungrouped__"]' in app
+    assert 'result.push("__ungrouped__")' in app
+    assert 'x-show="!group.builtin"' in html
+    assert "|| group?.builtin) return" in app
     assert "async persistActivityGroupOrder(next, previous)" in app
     assert "const task = prior.catch(() => {}).then(run)" in app
     assert "json: { ids: requestedOrder }" in app
     assert "incomingRevision < this._activityRevision" in app
-    assert "if (this.activitySearchQuery()) return false" in app
+    assert "if (this.activitySearchQuery() || group?.builtin) return false" in app
     update_start = app.index("_applyActivityUpdate(payload)")
     update_end = app.index("\n    async _startActivityEvents()", update_start)
     update = app[update_start:update_end]

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1386,14 +1386,10 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert "!opts.summaryOnly && this._activityFetchPromises.summary" in app
     assert "const rank = (activeRank[a.state] ?? 9)" in app
     assert "return this.activityEventTimestamp(b)" in app
-    ungrouped_sort = app.index('group.key === "custom:__ungrouped__"')
-    custom_sort = app.index("if (group.custom) {", ungrouped_sort)
-    assert ungrouped_sort < custom_sort
-    assert "this.activityEventTimestamp(b) - this.activityEventTimestamp(a)" in app[
-        ungrouped_sort:custom_sort
-    ]
-    assert "attentionRank" not in app[ungrouped_sort:custom_sort]
-    assert "pinRank" not in app[ungrouped_sort:custom_sort]
+    custom_sort = app.index("const aManual = Number.isFinite")
+    assert "if (aManual !== bManual) return aManual ? 1 : -1" in app[custom_sort:]
+    assert "Number(a.group_order) - Number(b.group_order)" in app[custom_sort:]
+    assert 'group.key === "custom:__ungrouped__"' in app[custom_sort:]
     assert "this._activityAppliedSeq = ++this._activityRequestSeq" in app
     assert '"/api/activity/events-ticket"' in app
     assert "new EventSource(" in app
@@ -1412,7 +1408,25 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert "'is-group-board': activity.view === 'groups'" in html
     assert 'class="activity-row-group"' in html
     assert '@dragstart="onActivityDragStart($event, item)"' in html
+    assert '@dragover.stop.prevent="onActivityRowDragOver($event, group, item)"' in html
+    assert '@drop.stop.prevent="onActivityRowDrop(group, item)"' in html
+    assert '@dragstart.stop="onActivityGroupOrderDragStart($event, group)"' in html
+    assert '@drop.stop.prevent="group.custom && onActivityLaneDrop(group)"' in html
+    assert "before_event_id" in app
+    assert 'groupOrder: ["__ungrouped__"]' in app
+    assert "async persistActivityGroupOrder(next, previous)" in app
+    assert "const task = prior.catch(() => {}).then(run)" in app
+    assert "json: { ids: requestedOrder }" in app
+    assert "incomingRevision < this._activityRevision" in app
+    assert "if (this.activitySearchQuery()) return false" in app
+    update_start = app.index("_applyActivityUpdate(payload)")
+    update_end = app.index("\n    async _startActivityEvents()", update_start)
+    update = app[update_start:update_end]
+    assert update.index("revision && revision <= this._activityRevision") < update.index(
+        "this.applyActivityGroupPayload(payload)")
     assert ".activity-group.is-custom.is-drag-over" in css
+    assert ".activity-group.is-custom.is-group-drop-before" in css
+    assert ".activity-row-wrap.drop-before::before" in css
     assert ".activity-move-menu" in css
     assert "const pinRank = Number(!!b.pinned) - Number(!!a.pinned)" in app
     assert "async toggleActivityPin(item)" in app


### PR DESCRIPTION
## 变更摘要

- 支持任务中心会话在同一分组内拖到任意位置
- 支持会话跨分组插入指定位置，并允许拖到空分组或栏尾
- 支持自定义分组栏互相拖动排序
- “未分组”作为系统自动栏始终固定在最后，但其中会话仍可自由拖动和排序
- 保留上下移动按钮与移动菜单作为替代操作
- 搜索期间禁用排序，避免隐藏条目破坏完整顺序
- 持久化会话组内顺序与自定义分组布局，刷新和服务重启后保持
- 兼容旧版分组文件、旧客户端分组请求及原有自动排序数据

## 一致性与并发

- 跨文件写入使用事务日志；失败时回滚，回滚失败时阻止后续写入并在重启时恢复
- 排序请求串行提交，防止后端逆序落盘
- 丢弃旧 revision 的 HTTP 快照和 SSE 分组载荷
- API 失败只回滚本次拖动涉及的排序字段，不覆盖并发任务状态更新
- 多条顺序变化通过 SSE resync 让其他标签页收敛

## 验证

- `tests/test_activity.py` 与 `tests/test_frontend_lint.py`：135 passed
- `tests/e2e/test_activity_center.py`：9 passed
- `node --check frontend/app.js`：通过
- Ruff：通过
- `git diff --check`：通过

## 兼容性与风险

- `activity-groups.json` 升级为 version 2，并新增可选 `order`；旧文件会自动兼容加载
- 旧数据或请求即使把“未分组”放在中间，加载和保存时也会自动归到最后
- 活动记录新增可选 `group_order`；旧记录在首次人工拖动前继续使用原有动态排序
- 不修改会话内容、任务状态或现有后端认证机制

🤖 Generated with [Claude Code](https://claude.com/claude-code)