### PR TITLE
待办事项服务端持久化与跨设备同步 + 稳定性/体验修复

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -1051,6 +1051,37 @@ class ActivityService:
                 "item": dict(item),
             }
 
+    def migrate_group_to_successor(
+        self,
+        source_sid: str,
+        successor_sid: str,
+    ) -> bool:
+        """Carry a runtime rollover's activity-group lane onto its fork.
+
+        When a session with pending background work forks a same-named
+        successor (runtime rollover), the source is hidden and the fork keeps
+        running.  If the source had been assigned to a custom activity group,
+        the fork must inherit that lane so the rollover stays invisible to the
+        user instead of surfacing a new ungrouped row.
+        """
+        self.initialize_runtime_state()
+        source_sid = str(source_sid or "")
+        successor_sid = str(successor_sid or "")
+        if not source_sid or not successor_sid or source_sid == successor_sid:
+            return False
+        with self._lock:
+            assigned = self._group_assignments.get(source_sid, "")
+            if not assigned:
+                return False
+            self._group_assignments.pop(source_sid, None)
+            self._group_assignments[successor_sid] = assigned
+            events_changed = self._reconcile_event_groups()
+            if events_changed:
+                self._save()
+            self._save_group_state()
+            self._publish_locked(resync=True)
+            return True
+
     def set_pin(self, event_id: str, pinned: bool) -> dict[str, Any] | None:
         """Persist a pin and return the exact ledger revision it belongs to."""
         self.initialize_runtime_state()

--- a/backend/activity.py
+++ b/backend/activity.py
@@ -534,6 +534,31 @@ class ActivityService:
         return next((x for x in reversed(self._events)
                      if x.get("session_id") == sid), None)
 
+    def _live_session_ids(self) -> set[str]:
+        """Session ids the frontend can still open.
+
+        ``sessions.list_sessions()`` already excludes deleted sessions and rows
+        owned by a removed workspace — exactly the sessions a task-center click
+        would fail to open. Matching it here keeps the activity center from
+        showing (and erroring on) phantom rows.
+        """
+        return {
+            str(s.get("id"))
+            for s in sessions.list_sessions()
+            if s.get("id")
+        }
+
+    def _filter_live(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Drop ledger rows whose backing session no longer opens. Anonymous
+        rows (no session_id) are always kept."""
+        if not events:
+            return []
+        live = self._live_session_ids()
+        return [
+            x for x in events
+            if not x.get("session_id") or str(x.get("session_id")) in live
+        ]
+
     def start(
         self,
         sid: str,
@@ -708,16 +733,21 @@ class ActivityService:
     def list(self, limit: int = 100) -> list[dict[str, Any]]:
         self.initialize_runtime_state()
         with self._lock:
-            events = sorted(self._events, key=_activity_at, reverse=True)
-            return [dict(x) for x in events[:min(max(limit, 1), _MAX_EVENTS)]]
+            events = [dict(x) for x in self._events]
+        events = self._filter_live(events)
+        events.sort(key=_activity_at, reverse=True)
+        return events[:min(max(limit, 1), _MAX_EVENTS)]
 
     def summary(self) -> dict[str, Any]:
         self.initialize_runtime_state()
         with self._lock:
-            result = _summarize([dict(x) for x in self._events])
-            result["generation"] = self._generation
-            result["revision"] = self._revision
-            return result
+            events = [dict(x) for x in self._events]
+            generation = self._generation
+            revision = self._revision
+        result = _summarize(self._filter_live(events))
+        result["generation"] = generation
+        result["revision"] = revision
+        return result
 
     def snapshot(self, limit: int = 100) -> dict[str, Any]:
         """Return rows and counters from the same locked ledger snapshot."""
@@ -728,10 +758,11 @@ class ActivityService:
             group_order = self._group_order_payload_locked()
             generation = self._generation
             revision = self._revision
-        ordered = sorted(events, key=_activity_at, reverse=True)
+        events = self._filter_live(events)
         summary = _summarize(events)
         summary["generation"] = generation
         summary["revision"] = revision
+        ordered = sorted(events, key=_activity_at, reverse=True)
         return {
             "events": ordered[:min(max(limit, 1), _MAX_EVENTS)],
             "summary": summary,

--- a/backend/activity.py
+++ b/backend/activity.py
@@ -730,26 +730,29 @@ class ActivityService:
             self._publish_locked(item=item)
             return dict(item)
 
-    def list(self, limit: int = 100) -> list[dict[str, Any]]:
+    def list(self, limit: int = 100, *, filter_live: bool = False) -> list[dict[str, Any]]:
         self.initialize_runtime_state()
         with self._lock:
             events = [dict(x) for x in self._events]
-        events = self._filter_live(events)
+        if filter_live:
+            events = self._filter_live(events)
         events.sort(key=_activity_at, reverse=True)
         return events[:min(max(limit, 1), _MAX_EVENTS)]
 
-    def summary(self) -> dict[str, Any]:
+    def summary(self, *, filter_live: bool = False) -> dict[str, Any]:
         self.initialize_runtime_state()
         with self._lock:
             events = [dict(x) for x in self._events]
             generation = self._generation
             revision = self._revision
-        result = _summarize(self._filter_live(events))
+        if filter_live:
+            events = self._filter_live(events)
+        result = _summarize(events)
         result["generation"] = generation
         result["revision"] = revision
         return result
 
-    def snapshot(self, limit: int = 100) -> dict[str, Any]:
+    def snapshot(self, limit: int = 100, *, filter_live: bool = False) -> dict[str, Any]:
         """Return rows and counters from the same locked ledger snapshot."""
         self.initialize_runtime_state()
         with self._lock:
@@ -758,7 +761,8 @@ class ActivityService:
             group_order = self._group_order_payload_locked()
             generation = self._generation
             revision = self._revision
-        events = self._filter_live(events)
+        if filter_live:
+            events = self._filter_live(events)
         summary = _summarize(events)
         summary["generation"] = generation
         summary["revision"] = revision

--- a/backend/activity_api.py
+++ b/backend/activity_api.py
@@ -53,12 +53,12 @@ def _json(request: Request, response: Response, payload: dict):
 @router.get("", dependencies=[Depends(require_token)])
 def list_activity(request: Request, response: Response,
                   limit: int = Query(100, ge=1, le=500)):
-    return _json(request, response, activity.snapshot(limit))
+    return _json(request, response, activity.snapshot(limit, filter_live=True))
 
 
 @router.get("/summary", dependencies=[Depends(require_token)])
 def activity_summary(request: Request, response: Response):
-    return _json(request, response, activity.summary())
+    return _json(request, response, activity.summary(filter_live=True))
 
 
 @router.post("/events-ticket", dependencies=[Depends(require_token)])
@@ -119,7 +119,7 @@ async def activity_events() -> EventSourceResponse:
 
 @router.post("/ack-all", dependencies=[Depends(require_token)])
 def ack_all():
-    return {"ok": True, "changed": activity.ack(), "summary": activity.summary()}
+    return {"ok": True, "changed": activity.ack(), "summary": activity.summary(filter_live=True)}
 
 
 @router.get("/groups", dependencies=[Depends(require_token)])
@@ -193,9 +193,9 @@ def patch_activity(event_id: str, req: ActivityPatchRequest):
 
 @router.post("/{event_id}/ack", dependencies=[Depends(require_token)])
 def ack_event(event_id: str):
-    return {"ok": True, "changed": activity.ack(event_id), "summary": activity.summary()}
+    return {"ok": True, "changed": activity.ack(event_id), "summary": activity.summary(filter_live=True)}
 
 
 @router.post("/session/{sid}/ack", dependencies=[Depends(require_token)])
 def ack_session(sid: str):
-    return {"ok": True, "changed": activity.ack(sid=sid), "summary": activity.summary()}
+    return {"ok": True, "changed": activity.ack(sid=sid), "summary": activity.summary(filter_live=True)}

--- a/backend/api_memory.py
+++ b/backend/api_memory.py
@@ -14,7 +14,7 @@ from .memory_config import (
     public_config,
     save_config,
 )
-from .memory_engine import engine
+from .memory_engine import classify_memory_failure, engine
 
 router = APIRouter(
     prefix="/api/memory", tags=["memory"], dependencies=[Depends(require_token)])
@@ -25,6 +25,10 @@ _IMPORTABLE_STATUSES = ("active", "pending_review")
 # Authorities recall() knows how to weight (see memory_engine._rank); anything
 # else imports as "confirmed" rather than silently landing in the 0.8 bucket.
 _IMPORTABLE_AUTHORITIES = ("confirmed", "inferred", "legacy_import")
+
+
+def _failure_detail(exc: BaseException) -> dict[str, object]:
+    return classify_memory_failure(exc)[1]
 
 
 class MemoryCreate(BaseModel):
@@ -90,9 +94,7 @@ async def put_config(config: dict, probe: bool = Query(default=True)) -> dict:
         try:
             await engine.probe(merged)
         except Exception as exc:
-            raise HTTPException(
-                400, f"记忆环境健康检查失败，配置未保存：{type(exc).__name__}: {exc}"
-            ) from None
+            raise HTTPException(400, _failure_detail(exc)) from None
     save_config(merged)
     await engine.reconfigure()
     return {"config": public_config(merged), "status": engine.status()}
@@ -105,8 +107,7 @@ async def probe_memory(config: dict | None = None) -> dict:
     try:
         return await engine.probe(config)
     except Exception as exc:
-        raise HTTPException(
-            400, f"{type(exc).__name__}: {exc}") from None
+        raise HTTPException(400, _failure_detail(exc)) from None
 
 
 def _resolve_config_input(raw: dict, current: MemoryConfig) -> MemoryConfig:
@@ -132,7 +133,7 @@ def _resolve_config_input(raw: dict, current: MemoryConfig) -> MemoryConfig:
     try:
         return MemoryConfig.model_validate(data)
     except Exception as exc:
-        raise HTTPException(422, str(exc)) from None
+        raise HTTPException(422, _failure_detail(exc)) from None
 
 
 @router.get("/status")
@@ -171,7 +172,7 @@ async def create_item(body: MemoryCreate) -> dict:
         return await engine.add_confirmed_memory(
             body.kind, body.content, tags=body.tags, source=source)
     except ValueError as exc:
-        raise HTTPException(400, str(exc)) from None
+        raise HTTPException(400, _failure_detail(exc)) from None
 
 
 @router.get("/items/{memory_id}")
@@ -190,7 +191,7 @@ async def correct_item(memory_id: str, body: MemoryCorrection) -> dict:
     except KeyError:
         raise HTTPException(404, "memory not found") from None
     except ValueError as exc:
-        raise HTTPException(409, str(exc)) from None
+        raise HTTPException(409, _failure_detail(exc)) from None
 
 
 @router.post("/items/{memory_id}/approve")
@@ -272,7 +273,7 @@ def approve_skill(artifact_id: str, body: SkillApproval) -> dict:
     except KeyError:
         raise HTTPException(404, "pending skill candidate not found") from None
     except ValueError as exc:
-        raise HTTPException(400, str(exc)) from None
+        raise HTTPException(400, _failure_detail(exc)) from None
 
 
 @router.post("/skills/{artifact_id}/reject")
@@ -290,7 +291,7 @@ def disable_skill(artifact_id: str) -> dict:
     except KeyError:
         raise HTTPException(404, "skill candidate not found") from None
     except ValueError as exc:
-        raise HTTPException(400, str(exc)) from None
+        raise HTTPException(400, _failure_detail(exc)) from None
 
 
 @router.get("/jobs")
@@ -370,7 +371,7 @@ async def import_memory(body: MemoryImport) -> dict:
             counts = await asyncio.to_thread(
                 engine.store.import_snapshot, snapshot, cfg.owner_id)
         except (ValueError, TypeError) as exc:
-            raise HTTPException(422, str(exc)) from None
+            raise HTTPException(422, _failure_detail(exc)) from None
         queued = engine.reindex_all() if cfg.enabled and body.memories else 0
         return {
             "ok": True,
@@ -383,7 +384,7 @@ async def import_memory(body: MemoryImport) -> dict:
         legacy_memories = [MemoryImportItem.model_validate(row)
                            for row in body.memories]
     except (ValueError, TypeError) as exc:
-        raise HTTPException(422, f"invalid legacy memory import: {exc}") from None
+        raise HTTPException(422, _failure_detail(exc)) from None
     incoming = [*body.items, *legacy_memories]
     if not incoming:
         raise HTTPException(422, "memory import contains no items")
@@ -407,7 +408,7 @@ async def import_memory(body: MemoryImport) -> dict:
                 authority=authority,
                 confidence=1.0 if item.confidence is None else item.confidence)
         except ValueError as exc:
-            raise HTTPException(422, str(exc)) from None
+            raise HTTPException(422, _failure_detail(exc)) from None
         existing.add(key)
         created += 1
     return {"ok": True, "created": created}
@@ -419,7 +420,7 @@ async def import_legacy_mem0() -> dict:
     try:
         values = await memory_client.export_legacy_memories()
     except Exception as exc:
-        raise HTTPException(400, str(exc)) from None
+        raise HTTPException(400, _failure_detail(exc)) from None
     cfg = load_config()
     existing = {
         " ".join(item["content"].casefold().split())

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -11346,6 +11346,17 @@ async def _continue_detached_runtime_locked(source_sid: str) -> dict:
         # after the durable link observes those already-finished writes.
         await asyncio.to_thread(
             _sync_runtime_successor_postlude, source_sid)
+        # Best-effort: carry the source's activity-group lane onto the fork so
+        # a runtime rollover stays invisible instead of surfacing a new
+        # ungrouped row.  A failure here must not abort the fork.
+        try:
+            from .activity import activity as _activity
+            await asyncio.to_thread(
+                _activity.migrate_group_to_successor, source_sid, child_sid)
+        except Exception as _exc:
+            sys.stderr.write(
+                f"[activity] group migrate failed src={source_sid[:8]} "
+                f"dst={child_sid[:8]} exc={type(_exc).__name__}\n")
     except Exception as exc:
         if linked:
             await asyncio.to_thread(

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1,4 +1,5 @@
 import os
+import errno
 import threading
 import base64
 from collections import deque
@@ -282,6 +283,18 @@ def _perf_event(event: str, /, **fields: Any) -> None:
         obs.perf_event(event, **fields)
     except Exception:
         pass
+
+
+def _safe_secondary_diagnostic(
+    stage: str, session_id: str, exc: BaseException,
+) -> None:
+    """Emit one bounded, content-free diagnostic for contained cleanup faults."""
+    safe_stage = re.sub(r"[^a-z0-9_.-]", "_", stage.lower())[:48]
+    sys.stderr.write(
+        f"[chat-secondary] stage={safe_stage} "
+        f"sid={obs.short_id(session_id)} exc={type(exc).__name__}\n"
+    )
+    sys.stderr.flush()
 
 
 def _build_runtime_task_context_hook(session_id: str):
@@ -785,23 +798,77 @@ def _stream_text_payload(event: dict) -> tuple[str, str] | None:
     return kind, payload["text"]
 
 
+class _ReplayRecordCorruption(ValueError):
+    """A replay row is incomplete or violates the private spool schema."""
+
+
+def _decode_replay_record(line: bytes) -> dict:
+    """Decode and type-check one complete replay row for every reader path."""
+    if not line.endswith(b"\n"):
+        raise _ReplayRecordCorruption("incomplete replay record")
+    try:
+        event = json.loads(line)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise _ReplayRecordCorruption("invalid replay json") from exc
+    if not isinstance(event, dict):
+        raise _ReplayRecordCorruption("replay record is not an object")
+    if not isinstance(event.get("event"), str) or not event["event"]:
+        raise _ReplayRecordCorruption("replay event type is invalid")
+    if not isinstance(event.get("data"), str):
+        raise _ReplayRecordCorruption("replay event data is invalid")
+    if "_coalesced" in event and not isinstance(event["_coalesced"], bool):
+        raise _ReplayRecordCorruption("replay coalesced marker is invalid")
+    return event
+
+
+def _replay_runtime_dir() -> Path:
+    """Return private durable storage for transient replay records."""
+    configured = os.environ.get("MUSELAB_RUNTIME_DIR", "").strip()
+    root = (Path(configured).expanduser() if configured
+            else sess.SESS_DIR / "runtime")
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    root.chmod(0o700)
+    return root
+
+
 class _ReplaySpool:
     """Append-only replay storage outside the Python heap."""
 
     def __init__(self):
-        fd, name = tempfile.mkstemp(prefix="muselab-turn-", suffix=".jsonl")
+        fd, name = tempfile.mkstemp(
+            prefix="muselab-turn-", suffix=".jsonl",
+            dir=str(_replay_runtime_dir()),
+        )
+        os.fchmod(fd, 0o600)
         self.path = Path(name)
-        self._writer = os.fdopen(fd, "ab", buffering=0)
+        self._fd = fd
         self._count = 0
         self._bytes = 0
         self._closed = False
+        self._usable = True
 
     def append(self, event: dict) -> None:
         if self._closed:
             raise RuntimeError("replay spool is closed")
+        if not self._usable:
+            raise RuntimeError("replay spool is unusable")
         payload = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
         blob = payload.encode("utf-8") + b"\n"
-        self._writer.write(blob)
+        start = self._bytes
+        written = 0
+        try:
+            while written < len(blob):
+                count = os.write(self._fd, blob[written:])
+                if count <= 0:
+                    raise OSError(errno.EIO, "replay spool write made no progress")
+                written += count
+        except BaseException:
+            try:
+                os.ftruncate(self._fd, start)
+                os.lseek(self._fd, start, os.SEEK_SET)
+            except OSError:
+                self._usable = False
+            raise
         self._count += 1
         self._bytes += len(blob)
 
@@ -821,7 +888,7 @@ class _ReplaySpool:
     def __iter__(self):
         with self.open_reader() as reader:
             for line in reader:
-                yield json.loads(line)
+                yield _decode_replay_record(line)
 
     def __getitem__(self, index):
         if isinstance(index, slice):
@@ -837,7 +904,7 @@ class _ReplaySpool:
         if self._closed:
             return
         self._closed = True
-        self._writer.close()
+        os.close(self._fd)
         with suppress(OSError):
             self.path.unlink()
 
@@ -923,6 +990,8 @@ class _TurnSubscriber:
                 await self._wake.wait()
                 continue
             event = self._next_spool_event()
+            if self._resync_reason:
+                continue
             if event is _LIVE_MESSAGE_BARRIER:
                 self._draining_live_barrier = True
                 continue
@@ -943,6 +1012,8 @@ class _TurnSubscriber:
             # Close the clear/append race: publish() may have written between
             # the first EOF read and clear(). Recheck before sleeping.
             event = self._next_spool_event()
+            if self._resync_reason:
+                continue
             if event is _LIVE_MESSAGE_BARRIER:
                 self._draining_live_barrier = True
                 continue
@@ -968,9 +1039,10 @@ class _TurnSubscriber:
             if not line:
                 return None
             try:
-                event = json.loads(line)
-            except ValueError:
-                continue
+                event = _decode_replay_record(line)
+            except _ReplayRecordCorruption:
+                self.resync("replay_corrupt")
+                return None
             coalesced = event.pop("_coalesced", False)
             if coalesced and offset >= self._skip_from:
                 # Streamed to us live, token by token — emitting the coalesced
@@ -4174,6 +4246,17 @@ async def shutdown_runtime() -> None:
             await asyncio.gather(*done, return_exceptions=True)
         for task in pending:
             _retain_detached_cleanup(task)
+
+    broadcasts = {
+        id(broadcast): broadcast
+        for broadcast in (
+            *tuple(_active_turns.values()),
+            *tuple(_recent_turns.values()),
+        )
+    }.values()
+    for broadcast in broadcasts:
+        broadcast.close()
+    _recent_turns.clear()
 
     streams = list(_session_streams.values())
     _session_streams.clear()
@@ -16626,15 +16709,19 @@ async def _start_turn(
             # cannot collapse the live partial+error pair into bare JSONL.
             _failed_snapshot_ready = False
             if _is_error and not was_cancelled:
-                _failed_snapshot_ready = await asyncio.to_thread(
-                    _persist_failed_turn_snapshot,
-                    broadcast,
-                    _error_message,
-                    terminal_at_ms=_completed_at_ms,
-                    elapsed_s=_elapsed_s,
-                    memory_recall=_done_memory_receipt,
-                    canonical_terminal_published=True,
-                )
+                try:
+                    _failed_snapshot_ready = await asyncio.to_thread(
+                        _persist_failed_turn_snapshot,
+                        broadcast,
+                        _error_message,
+                        terminal_at_ms=_completed_at_ms,
+                        elapsed_s=_elapsed_s,
+                        memory_recall=_done_memory_receipt,
+                        canonical_terminal_published=True,
+                    )
+                except Exception as exc:
+                    _safe_secondary_diagnostic(
+                        "terminal_snapshot", session_id, exc)
             _done_background_tasks = len(
                 _merge_session_inflight(session_id, inflight_tasks)
             )
@@ -17229,15 +17316,20 @@ async def _start_turn(
                 0, terminal_at_ms - int(float(broadcast.started_at or 0) * 1000))
             recall = mem0.pop_recall_trace(session_id)
             receipt = _persistable_memory_recall(recall)
-            snapshot_ready = await asyncio.to_thread(
-                _persist_failed_turn_snapshot,
-                broadcast,
-                turn_error_text,
-                terminal_at_ms=terminal_at_ms,
-                elapsed_s=round(duration_ms / 1000, 1),
-                memory_recall=receipt,
-                canonical_terminal_published=False,
-            )
+            snapshot_ready = False
+            try:
+                snapshot_ready = await asyncio.to_thread(
+                    _persist_failed_turn_snapshot,
+                    broadcast,
+                    turn_error_text,
+                    terminal_at_ms=terminal_at_ms,
+                    elapsed_s=round(duration_ms / 1000, 1),
+                    memory_recall=receipt,
+                    canonical_terminal_published=False,
+                )
+            except Exception as exc:
+                _safe_secondary_diagnostic(
+                    "terminal_snapshot", session_id, exc)
             event = _error_event(turn_error_text)
             try:
                 data = json.loads(event.get("data") or "{}")
@@ -17384,16 +17476,23 @@ async def _start_turn(
                 f"[chat] turn exceeded MUSELAB_TURN_TIMEOUT_S={BG_TIMEOUT_S}s, "
                 f"aborting sid={session_id[:8]}\n")
             sys.stderr.flush()
-            broadcast.publish(await _durable_error_event(turn_error_text))
+            try:
+                broadcast.publish(await _durable_error_event(turn_error_text))
+            except Exception as exc:
+                _safe_secondary_diagnostic(
+                    "terminal_replay", session_id, exc)
         except Exception as e:
             if terminal_published:
                 sys.stderr.write(
                     f"[chat] post-turn bookkeeping failed "
                     f"sid={session_id[:8]} exc={type(e).__name__}\n")
                 return
+            primary_already_recorded = turn_errored and bool(turn_error_text)
             turn_errored = True
-            turn_error_text = f"{type(e).__name__}: {e}"
-            error_kind = _classify_stream_error(str(e)).get("kind", "unknown")
+            if not primary_already_recorded:
+                turn_error_text = f"{type(e).__name__}: {e}"
+            error_kind = _classify_stream_error(
+                turn_error_text).get("kind", "unknown")
             # The authenticated SSE frame below is the user-facing error
             # surface. Server logs keep only safe diagnostics: SDK/Gateway
             # exception strings and tracebacks can contain prompts, paths,
@@ -17402,7 +17501,16 @@ async def _start_turn(
                 f"[chat] background turn crashed sid={session_id[:8]} "
                 f"exc={type(e).__name__} kind={error_kind}\n")
             sys.stderr.flush()
-            broadcast.publish(await _durable_error_event(turn_error_text))
+            if primary_already_recorded:
+                _safe_secondary_diagnostic(
+                    "terminal_replay", session_id, e)
+            else:
+                try:
+                    broadcast.publish(
+                        await _durable_error_event(turn_error_text))
+                except Exception as exc:
+                    _safe_secondary_diagnostic(
+                        "terminal_replay", session_id, exc)
         finally:
             if broadcast.cancelled:
                 broadcast.perf_status = "cancelled"

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -5907,7 +5907,7 @@ def _summarize_tool_input(name: str | None, inp: dict) -> str:
     if name in ("Read", "Edit", "Write"):
         return inp.get("file_path", "")
     if name == "Bash":
-        return (inp.get("command") or "")[:200]
+        return (inp.get("command") or "")[:_MAX_INPUT_FIELD_LEN]
     if name in ("Glob", "Grep"):
         return (inp.get("pattern") or "") + (f"  in {inp.get('path','')}" if inp.get("path") else "")
     if name == "WebFetch":
@@ -12107,7 +12107,7 @@ def _render_tool_use(block: ToolUseBlock) -> dict:
     if name in ("Read", "Edit", "Write"):
         summary = inp.get("file_path", "")
     elif name == "Bash":
-        summary = (inp.get("command") or "")[:200]
+        summary = (inp.get("command") or "")[:_MAX_INPUT_FIELD_LEN]
     elif name in ("Glob", "Grep"):
         summary = (inp.get("pattern") or "") + (f"  in {inp.get('path','')}" if inp.get("path") else "")
     elif name == "WebFetch":

--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -24,7 +24,11 @@ from .auth import require_token
 from .capability_tickets import tickets
 from .files import INTERNAL_DIR_NAME, TRASH_DIR_NAME
 from .observability import elapsed_ms, is_slow, monotonic, perf_event, short_id
-from .workspace_store import WorkspaceStore, is_ignored_descendant
+from .workspace_store import (
+    WorkspaceScanCancelled,
+    WorkspaceStore,
+    is_ignored_descendant,
+)
 from .workspaces import registry, resolve_workspace_root
 
 
@@ -36,6 +40,8 @@ _WATCH_STEP_MS = 100
 _WATCH_RETRY_S = 1.5
 _WATCH_LINGER_S = 30.0
 _MAX_IDLE_WATCHERS = 3
+_RECONCILE_BACKOFF_START_S = 0.25
+_RECONCILE_BACKOFF_CAP_S = 5.0
 _EVENT_TICKET_TTL_S = 45
 _EXCLUDED_DIRS = frozenset({TRASH_DIR_NAME, INTERNAL_DIR_NAME})
 _POLLING_ENV = os.getenv("WATCHFILES_FORCE_POLLING")
@@ -77,6 +83,10 @@ class _WatchState:
     needs_closing_reconcile: bool = False
     reconcile_pending: bool = False
     reconcile_running: bool = False
+    reconcile_attempts: int = 0
+    reconcile_failures: int = 0
+    reconcile_retry_at: float = 0.0
+    reconcile_cancel: asyncio.Event = field(default_factory=asyncio.Event)
     scan_cancel: threading.Event = field(default_factory=threading.Event)
     stop_task: asyncio.Task[None] | None = None
     queue_overflow_active: bool = False
@@ -549,6 +559,7 @@ class FileWatchManager:
                     and not state.reconcile_task.done()
                 ):
                     reconcile_task = state.reconcile_task
+                    state.reconcile_cancel.set()
                     state.scan_cancel.set()
                 state.reconcile_pending = False
                 state.reconcile_task = None
@@ -797,16 +808,28 @@ class FileWatchManager:
             await state.ready.wait()
         if state.initialized:
             return
-        detail = "workspace index is temporarily unavailable"
-        if state.reconcile_error is not None:
-            detail = f"{detail}: {state.reconcile_error}"
-        raise HTTPException(status_code=503, detail=detail)
+        raise HTTPException(
+            status_code=503,
+            detail="workspace index is temporarily unavailable",
+        )
+
+    async def _wait_for_reconcile_backoff(self, state: _WatchState) -> bool:
+        delay = max(0.0, state.reconcile_retry_at - monotonic())
+        if delay <= 0:
+            return not state.reconcile_cancel.is_set()
+        try:
+            await asyncio.wait_for(state.reconcile_cancel.wait(), timeout=delay)
+        except TimeoutError:
+            return True
+        return False
 
     async def _reconcile_after_watch(self, state: _WatchState) -> None:
         """Reconcile downtime after the watcher gets a chance to register."""
         while True:
             state.reconcile_pending = False
             try:
+                if not await self._wait_for_reconcile_backoff(state):
+                    return
                 if state.task is not None:
                     # Never call a scan a closing reconciliation until the
                     # corresponding native watcher is genuinely armed. Waiting
@@ -818,8 +841,9 @@ class FileWatchManager:
                 await self._reconcile_and_broadcast(state)
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:
-                state.reconcile_error = exc
+            except WorkspaceScanCancelled:
+                return
+            except Exception:
                 self._broadcast(
                     state,
                     {"resync": True, "changes": []},
@@ -874,15 +898,34 @@ class FileWatchManager:
         }
         status = "error"
         error_type: str | None = None
+        phase = "initial" if not state.initialized else "closing"
+        state.reconcile_attempts += 1
+        attempt = state.reconcile_attempts
+        backoff_ms = 0
         try:
             await self._reconcile_and_broadcast_impl(state, metrics)
+            state.reconcile_failures = 0
+            state.reconcile_retry_at = 0.0
             status = "ok"
         except asyncio.CancelledError:
             status = "cancelled"
             error_type = "CancelledError"
             raise
+        except WorkspaceScanCancelled:
+            status = "cancelled"
+            error_type = "WorkspaceScanCancelled"
+            raise
         except Exception as exc:
             error_type = type(exc).__name__
+            state.reconcile_error = exc
+            state.reconcile_failures += 1
+            backoff = min(
+                _RECONCILE_BACKOFF_START_S
+                * (2 ** min(state.reconcile_failures - 1, 20)),
+                _RECONCILE_BACKOFF_CAP_S,
+            )
+            state.reconcile_retry_at = monotonic() + backoff
+            backoff_ms = round(backoff * 1000)
             raise
         finally:
             # Keep this true through replay, broadcast, and watcher-path
@@ -894,6 +937,10 @@ class FileWatchManager:
                 workspace=short_id(state.workspace_id),
                 status=status,
                 error_type=error_type,
+                phase=phase,
+                attempt=attempt,
+                failures=state.reconcile_failures,
+                backoff_ms=backoff_ms,
                 scan_slot_wait_ms=metrics["scan_slot_wait_ms"],
                 mutation_lock_wait_ms=metrics["mutation_lock_wait_ms"],
                 scan_ms=metrics["scan_ms"],
@@ -1233,6 +1280,7 @@ class FileWatchManager:
                 if task is not None
             ]
             for state in states:
+                state.reconcile_cancel.set()
                 state.scan_cancel.set()
                 if (state.reconcile_task is not None
                         and not state.reconcile_task.done()):
@@ -1329,66 +1377,76 @@ async def _event_stream(
     root: Path,
     cursor: int | None,
 ) -> AsyncIterator[ServerSentEvent]:
-    async with manager.subscribe(root) as queue:
-        # Do not call bootstrap here: on a home-directory workspace that used
-        # to materialize and JSON-encode tens of MB for every SSE connection.
-        ready_state = await manager.ready_state(root)
-        ready_cursor = ready_state["cursor"]
-        yield ServerSentEvent(
-            event="ready",
-            data=json.dumps(
-                {"ready": True, **ready_state},
-                separators=(",", ":"),
-            ),
-        )
-
-        delivered = ready_cursor if cursor is None else cursor
-        if cursor is not None:
-            while True:
-                replay = await manager.delta(root, delivered)
-                event = (
-                    "resync"
-                    if replay.get("resync")
-                    else "changes"
-                )
-                if replay.get("resync") or replay["changes"]:
-                    yield ServerSentEvent(
-                        event=event,
-                        data=json.dumps(
-                            replay,
-                            separators=(",", ":"),
-                        ),
-                    )
-                delivered = replay["cursor"]
-                if (
-                    replay.get("resync")
-                    or not replay.get("has_more")
-                ):
-                    break
-
-        while True:
-            payload = await queue.get()
-            if payload.get("close"):
-                return
-            if (
-                "cursor" in payload
-                and payload["cursor"] <= delivered
-            ):
-                continue
-            event = (
-                "resync"
-                if payload.get("resync")
-                else "changes"
-            )
+    ready_sent = False
+    try:
+        async with manager.subscribe(root) as queue:
+            # Do not call bootstrap here: on a home-directory workspace that used
+            # to materialize and JSON-encode tens of MB for every SSE connection.
+            ready_state = await manager.ready_state(root)
+            ready_cursor = ready_state["cursor"]
+            ready_sent = True
             yield ServerSentEvent(
-                event=event,
+                event="ready",
                 data=json.dumps(
-                    payload,
+                    {"ready": True, **ready_state},
                     separators=(",", ":"),
                 ),
             )
-            if "cursor" in payload:
-                delivered = payload["cursor"]
+
+            delivered = ready_cursor if cursor is None else cursor
+            if cursor is not None:
+                while True:
+                    replay = await manager.delta(root, delivered)
+                    event = (
+                        "resync"
+                        if replay.get("resync")
+                        else "changes"
+                    )
+                    if replay.get("resync") or replay["changes"]:
+                        yield ServerSentEvent(
+                            event=event,
+                            data=json.dumps(
+                                replay,
+                                separators=(",", ":"),
+                            ),
+                        )
+                    delivered = replay["cursor"]
+                    if (
+                        replay.get("resync")
+                        or not replay.get("has_more")
+                    ):
+                        break
+
+            while True:
+                payload = await queue.get()
+                if payload.get("close"):
+                    return
+                if (
+                    "cursor" in payload
+                    and payload["cursor"] <= delivered
+                ):
+                    continue
+                event = (
+                    "resync"
+                    if payload.get("resync")
+                    else "changes"
+                )
+                yield ServerSentEvent(
+                    event=event,
+                    data=json.dumps(
+                        payload,
+                        separators=(",", ":"),
+                    ),
+                )
+                if "cursor" in payload:
+                    delivered = payload["cursor"]
+    except HTTPException:
+        if not ready_sent:
+            yield ServerSentEvent(
+                event="unavailable",
+                data='{"available":false,"retryable":true}',
+            )
+        return
 
 
 @router.get(

--- a/backend/main.py
+++ b/backend/main.py
@@ -120,6 +120,86 @@ _BG_TASKS: set = set()
 GRACEFUL_SHUTDOWN_TIMEOUT = 3
 _LOOP_LAG_INTERVAL_S = 1.0
 _LOOP_LAG_THRESHOLD_MS = 250
+_LOOP_STALL_THRESHOLD_S = 5.0
+_LOOP_STALL_RATE_LIMIT_S = 60.0
+
+
+def _bounded_env_float(name: str, default: float,
+                       minimum: float, maximum: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    if not minimum <= value <= maximum:
+        value = default
+    return value
+
+
+class _EventLoopStallWatchdog:
+    """Attribute severe loop stalls from a daemon thread without user data.
+
+    The watchdog records only the blocked frame's module and function names.
+    It never formats locals, source lines, absolute paths, exception text, or
+    request/session identifiers.
+    """
+
+    def __init__(self, loop_thread_id: int, heartbeat_at: float, *,
+                 threshold_s: float, rate_limit_s: float, poll_s: float):
+        self._loop_thread_id = loop_thread_id
+        self._heartbeat_at = heartbeat_at
+        self._threshold_s = threshold_s
+        self._rate_limit_s = rate_limit_s
+        self._poll_s = poll_s
+        self._last_report_at: float | None = None
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="muselab-loop-watchdog",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def heartbeat(self, observed_at: float) -> None:
+        self._heartbeat_at = observed_at
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=min(1.0, self._poll_s * 2 + 0.05))
+
+    def _blocked_site(self) -> str:
+        frame = sys._current_frames().get(self._loop_thread_id)
+        if frame is None:
+            return "unknown"
+        module = str(frame.f_globals.get("__name__", "unknown"))
+        function = str(frame.f_code.co_name or "unknown")
+        safe_module = re.sub(r"[^A-Za-z0-9_.-]", "_", module)[:80]
+        safe_function = re.sub(r"[^A-Za-z0-9_.-]", "_", function)[:60]
+        return f"{safe_module}:{safe_function}"
+
+    def _check_once(self, observed_at: float) -> None:
+        lag_s = max(0.0, observed_at - self._heartbeat_at)
+        if lag_s < self._threshold_s:
+            return
+        if (self._last_report_at is not None
+                and observed_at - self._last_report_at < self._rate_limit_s):
+            return
+        self._last_report_at = observed_at
+        try:
+            perf_event(
+                "runtime.loop_stall",
+                lag_ms=round(lag_s * 1000),
+                site=self._blocked_site(),
+            )
+        except Exception:
+            # Diagnostics must never terminate the watchdog thread.
+            pass
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._poll_s):
+            self._check_once(_perf_monotonic())
 
 
 _ASSET_VERSION_CANDIDATES = tuple(sorted(
@@ -210,25 +290,54 @@ def _launch_background_tasks(coroutines) -> None:
 
 
 async def _monitor_event_loop_lag() -> None:
-    """Emit only actionable event-loop stalls; stay silent on healthy ticks."""
+    """Report loop lag and let a thread attribute severe stalls while blocked."""
     if not _perf_enabled():
         return
     import asyncio
 
-    expected = _perf_monotonic() + _LOOP_LAG_INTERVAL_S
-    while True:
-        await asyncio.sleep(_LOOP_LAG_INTERVAL_S)
-        observed = _perf_monotonic()
-        lag_ms = max(0, round((observed - expected) * 1000))
-        if lag_ms >= _LOOP_LAG_THRESHOLD_MS:
-            try:
-                perf_event("runtime.loop_lag", lag_ms=lag_ms)
-            except Exception:
-                # Diagnostics must never terminate their own long-lived monitor.
-                pass
-        # Reset after a stall so one pause creates one event rather than a
-        # permanent positive offset on every later healthy tick.
-        expected = observed + _LOOP_LAG_INTERVAL_S
+    interval_s = _bounded_env_float(
+        "MUSELAB_LOOP_HEARTBEAT_MS", _LOOP_LAG_INTERVAL_S * 1000, 50, 60_000
+    ) / 1000
+    warning_ms = _bounded_env_float(
+        "MUSELAB_LOOP_LAG_WARN_MS", _LOOP_LAG_THRESHOLD_MS, 25, 60_000
+    )
+    stall_s = max(
+        interval_s * 2,
+        _bounded_env_float(
+            "MUSELAB_LOOP_STALL_MS", _LOOP_STALL_THRESHOLD_S * 1000,
+            1000, 300_000,
+        ) / 1000,
+    )
+    rate_limit_s = _bounded_env_float(
+        "MUSELAB_LOOP_STALL_RATE_LIMIT_S", _LOOP_STALL_RATE_LIMIT_S, 1, 3600
+    )
+    observed = _perf_monotonic()
+    watchdog = _EventLoopStallWatchdog(
+        threading.get_ident(),
+        observed,
+        threshold_s=stall_s,
+        rate_limit_s=rate_limit_s,
+        poll_s=min(interval_s, max(0.05, stall_s / 4)),
+    )
+    watchdog.start()
+    expected = observed + interval_s
+    try:
+        while True:
+            await asyncio.sleep(interval_s)
+            observed = _perf_monotonic()
+            watchdog.heartbeat(observed)
+            lag_ms = max(0, round((observed - expected) * 1000))
+            if lag_ms >= warning_ms:
+                try:
+                    perf_event("runtime.loop_lag", lag_ms=lag_ms)
+                except Exception:
+                    # Diagnostics must never terminate their own long-lived monitor.
+                    pass
+            # Reset after a stall so one pause creates one event rather than a
+            # permanent positive offset on every later healthy tick.
+            expected = observed + interval_s
+    finally:
+        watchdog.stop()
 
 
 async def _recover_message_queues_at_startup(session_store) -> int:
@@ -462,33 +571,39 @@ async def _backfill_turn_counts() -> None:
     if _ROOT is None:
         return
     try:
-        ss = _sess.list_sessions()
+        ss = await _asyncio.to_thread(_sess.list_sessions)
     except Exception as e:
         sys.stderr.write(f"[muselab] backfill list_sessions failed: {e}\n")
         return
+
+    def _load_counts(sid: str) -> tuple[int, int]:
+        msgs = _gsm(sid, directory=str(_sess.session_workspace(sid)))
+        return len(msgs), sum(
+            1 for sm in msgs if _chat._is_real_user_prompt(sm)
+        )
+
     updated = 0
     for s in ss:
         sid = s.get("id")
         if not sid:
             continue
         try:
-            msgs = _gsm(sid, directory=str(_sess.session_workspace(sid)))
+            message_count, n_turns = await _asyncio.to_thread(_load_counts, sid)
         except Exception:
             continue
-        n_turns = sum(1 for sm in msgs if _chat._is_real_user_prompt(sm))
         cur = s.get("turn_count")
         if cur == n_turns:
             continue
         try:
-            _sess.bump_session(sid, message_count=len(msgs),
-                                turn_count=n_turns)
+            await _asyncio.to_thread(
+                _sess.bump_session,
+                sid,
+                message_count=message_count,
+                turn_count=n_turns,
+            )
             updated += 1
         except Exception:
             pass
-        # Yield to the event loop periodically so we don't starve the web
-        # server on a large archive (~200+ sessions).
-        if updated % 20 == 0:
-            await _asyncio.sleep(0)
     if updated:
         sys.stderr.write(
             f"[muselab] backfilled turn_count for {updated} sessions\n")

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from .workspaces import router as workspaces_router
 from .activity_api import router as activity_router
 from .terminal import router as terminal_router
 from .file_events import router as file_events_router
+from .todos_api import router as todos_router
 from .settings import ROOT, PORT, HOST
 from .version import project_version
 from .observability import (
@@ -388,6 +389,7 @@ async def _lifespan(app: FastAPI):
 
     from . import sessions as _sess
     from .activity import activity as _activity
+    from .todos import todos as _todos
     from . import scheduler as _sched
     from . import push as _push
     from . import memory_client as _mem0
@@ -397,6 +399,7 @@ async def _lifespan(app: FastAPI):
     await _asyncio.gather(
         _asyncio.to_thread(_sess.ensure_private_session_storage),
         _asyncio.to_thread(_activity.initialize_runtime_state),
+        _asyncio.to_thread(_todos.initialize_runtime_state),
     )
     # Older releases allowed a successor CLI's synthetic ``stopped`` record to
     # overwrite the predecessor's real terminal state. Repair each runtime
@@ -840,6 +843,7 @@ app.include_router(push_router)
 app.include_router(workspaces_router)
 app.include_router(activity_router)
 app.include_router(terminal_router)
+app.include_router(todos_router)
 
 
 @functools.lru_cache(maxsize=1)

--- a/backend/memory_client.py
+++ b/backend/memory_client.py
@@ -46,6 +46,28 @@ _MAX_EXPORT_BYTES = 10 * 1024 * 1024
 _MAX_QUERY_CHARS = 8_000
 _MAX_STORE_TEXT_CHARS = 50_000
 
+
+def _failure_metadata(exc: BaseException) -> dict[str, object]:
+    from .memory_engine import classify_memory_failure
+    return classify_memory_failure(exc)[1]
+
+
+def _failure_record(failure: dict[str, object]) -> str:
+    return json.dumps(failure, sort_keys=True, separators=(",", ":"))
+
+
+def _log_failure(level: int, event: str, exc: BaseException) -> None:
+    failure = _failure_metadata(exc)
+    log.log(
+        level,
+        "%s category=%s exception_class=%s status=%s",
+        event,
+        failure["category"],
+        failure["exception_class"],
+        failure.get("status"),
+    )
+
+
 _ZERO_WIDTH_RE = re.compile(r"[​-‏‪-‮⁠-⁯﻿]")
 _FENCE_RE = re.compile(r"-{2,}.*?memory.*?-{2,}", re.IGNORECASE)
 _ROLE_RE = re.compile(
@@ -79,7 +101,7 @@ def start() -> None:
         from .memory_engine import engine
         engine.start()
     except Exception as exc:
-        log.warning("native memory start skipped: %s", exc)
+        _log_failure(logging.WARNING, "native memory start skipped", exc)
 
 
 def base_url() -> str:
@@ -101,13 +123,7 @@ def base_url() -> str:
 
 
 def enabled() -> bool:
-    try:
-        from .memory_engine import engine
-        if engine.enabled():
-            return True
-    except Exception:
-        pass
-    return bool(base_url())
+    return native_enabled() or bool(base_url())
 
 
 def native_enabled() -> bool:
@@ -284,7 +300,8 @@ async def export_legacy_memories() -> list[str]:
                 return values
             errors.append(f"{path}: empty or unsupported response")
         except Exception as exc:
-            errors.append(f"{path}: {type(exc).__name__}")
+            failure = _failure_metadata(exc)
+            errors.append(_failure_record(failure))
     raise RuntimeError("legacy Mem0 export is unavailable (" + "; ".join(errors) + ")")
 
 
@@ -299,7 +316,7 @@ async def search_context(query: str, session_id: str) -> str:
                 if (clean := _sanitize(str(row.get("content", ""))))
             ], max_chars=engine.config().retrieval.max_context_chars)
         except Exception as exc:
-            log.debug("native memory search skipped: %s", exc)
+            _log_failure(logging.DEBUG, "native memory search skipped", exc)
             return ""
     url = base_url()
     query = _cap_text(query.strip(), _MAX_QUERY_CHARS)
@@ -325,7 +342,7 @@ async def search_context(query: str, session_id: str) -> str:
             latency_ms=round((time.perf_counter() - started) * 1000),
             status="error",
         )
-        log.debug("mem0 search skipped: %s", exc)
+        _log_failure(logging.DEBUG, "mem0 search skipped", exc)
         return ""
 
 
@@ -355,7 +372,7 @@ async def store_turn(session_id: str, model: str, user_text: str,
                 session_id, model, user_text, assistant_text, outcome="success",
                 turn_id=turn_id)
         except Exception as exc:
-            log.debug("native memory store skipped: %s", exc)
+            _log_failure(logging.DEBUG, "native memory store skipped", exc)
         return
     del session_id
     url = base_url()
@@ -373,7 +390,7 @@ async def store_turn(session_id: str, model: str, user_text: str,
         }
         await _post_no_result(f"{url}/add", payload, _STORE_TIMEOUT)
     except Exception as exc:
-        log.debug("mem0 store skipped: %s", exc)
+        _log_failure(logging.DEBUG, "mem0 store skipped", exc)
 
 
 def schedule_store(session_id: str, model: str, user_text: str,
@@ -455,4 +472,4 @@ async def aclose(timeout: float = _STORE_TIMEOUT + 1.0) -> None:
         from .memory_engine import engine
         await engine.stop(timeout=min(timeout, 5.0))
     except Exception as exc:
-        log.debug("native memory shutdown skipped: %s", exc)
+        _log_failure(logging.DEBUG, "native memory shutdown skipped", exc)

--- a/backend/memory_engine.py
+++ b/backend/memory_engine.py
@@ -13,7 +13,11 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+
+import httpx
+
 from .memory_config import MemoryConfig, database_path, load_config, memory_dir
+from .observability import elapsed_ms, perf_event
 from .memory_providers import (
     EmbeddingProvider,
     GenerationError,
@@ -70,6 +74,79 @@ _TOKEN_RE = re.compile(
 # retrieval quality is flat well below it — a query is a topic hint, not the
 # document being matched.
 _RECALL_QUERY_CHARS = 800
+_SAFE_TRANSIENT_STATUSES = {408, 409, 429, 529}
+_KNOWN_JOB_KINDS = {
+    "consolidate_episode",
+    "reconcile_transcript",
+    "cross_episode_dream",
+    "reindex_memory",
+    "reindex_memories",
+    "unindex_memory",
+}
+
+
+class UnknownMemoryJobError(ValueError):
+    pass
+
+
+class MemoryJobOwnerMismatchError(RuntimeError):
+    pass
+
+
+def _exception_status(exc: BaseException) -> int | None:
+    if isinstance(exc, GenerationError):
+        status = exc.api_error_status
+    else:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+        if status is None:
+            status = getattr(exc, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def classify_memory_failure(exc: BaseException) -> tuple[bool, dict[str, object]]:
+    """Classify a failure without retaining exception text or request details."""
+    status = _exception_status(exc)
+    if isinstance(exc, GenerationError):
+        retryable = bool(exc.retryable)
+        category = str(exc.category or "generation_failure")
+    elif isinstance(exc, TimeoutError):
+        retryable, category = True, "timeout"
+    elif isinstance(exc, httpx.TransportError):
+        retryable, category = True, "transport"
+    elif status is not None:
+        retryable = status in _SAFE_TRANSIENT_STATUSES or 500 <= status <= 599
+        if status in {401, 403}:
+            category = "authentication"
+        else:
+            category = "transient_http" if retryable else "http_error"
+    elif isinstance(exc, UnknownMemoryJobError):
+        retryable, category = False, "unknown_job"
+    elif isinstance(exc, MemoryJobOwnerMismatchError):
+        retryable, category = False, "owner_mismatch"
+    elif isinstance(exc, PermissionError):
+        retryable, category = False, "permission"
+    elif isinstance(exc, FileNotFoundError):
+        retryable, category = False, "file_not_found"
+    elif isinstance(exc, KeyError):
+        retryable, category = False, "missing_key"
+    elif isinstance(exc, TypeError):
+        retryable, category = False, "invalid_type"
+    elif isinstance(exc, ValueError):
+        retryable, category = False, "invalid_value"
+    else:
+        retryable, category = False, "unclassified"
+    detail: dict[str, object] = {
+        "category": category,
+        "exception_class": type(exc).__name__,
+    }
+    if status is not None:
+        detail["status"] = status
+    return retryable, detail
+
+
+def _failure_record(detail: dict[str, object]) -> str:
+    return json.dumps(detail, sort_keys=True, separators=(",", ":"))
 
 
 def _redact(text: str, limit: int = 40_000) -> str:
@@ -271,21 +348,18 @@ class MemoryEngine:
                 except TimeoutError:
                     pass
                 continue
+            started = time.perf_counter()
             error: str | None = None
-            retryable = True
-            # Owner fence. Jobs carry the owner that enqueued them; the
-            # handlers below resolve everything else from the LIVE config, so
-            # a job that outlives an owner change (config edit / profile
-            # switch) would attribute the old owner's episodes and memories to
-            # the new one. Drop instead of retrying — the payload references
-            # rows the current owner does not own, so no retry can fix it.
-            job_owner = str(job.get("owner_id") or "")
-            if job_owner and job_owner != self.config().owner_id:
-                await asyncio.to_thread(
-                    self.store.finish_job, job["id"],
-                    error=f"dropped: enqueued under owner {job_owner!r}")
-                continue
+            retryable = False
+            failure: dict[str, object] | None = None
+            attempts = int(job.get("attempts", 0)) + 1
+            safe_kind = job["kind"] if job.get("kind") in _KNOWN_JOB_KINDS else "unknown"
             try:
+                # Owner fence. Jobs carry the owner that enqueued them; the
+                # handlers below resolve everything else from the LIVE config.
+                job_owner = str(job.get("owner_id") or "")
+                if job_owner and job_owner != self.config().owner_id:
+                    raise MemoryJobOwnerMismatchError
                 if job["kind"] == "consolidate_episode":
                     await self._consolidate_episode(job["payload"]["episode_id"])
                 elif job["kind"] == "reconcile_transcript":
@@ -303,18 +377,33 @@ class MemoryEngine:
                 elif job["kind"] == "unindex_memory":
                     await self._unindex_memory(job["payload"]["memory_id"])
                 else:
-                    raise ValueError(f"unknown memory job: {job['kind']}")
+                    raise UnknownMemoryJobError
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                error = f"{type(exc).__name__}: {exc}"
-                retryable = not isinstance(exc, GenerationError) or exc.retryable
-                log.warning("memory job %s failed: %s", job["id"], error)
-            attempts = int(job.get("attempts", 0)) + 1
+                retryable, failure = classify_memory_failure(exc)
+                error = _failure_record(failure)
+                log.warning(
+                    "memory job failed category=%s exception_class=%s status=%s",
+                    failure["category"], failure["exception_class"],
+                    failure.get("status"),
+                )
             await asyncio.to_thread(
                 self.store.finish_job, job["id"], error=error,
                 retry_seconds=(min(300.0, 2 ** attempts)
                                if error and retryable and attempts < 3 else None))
+            perf_event(
+                "memory.job",
+                kind=safe_kind,
+                attempt=attempts,
+                duration_ms=elapsed_ms(started),
+                outcome=("retry" if error and retryable and attempts < 3
+                         else "failed" if error else "done"),
+                category=failure.get("category") if failure else None,
+                exception_class=(failure.get("exception_class")
+                                 if failure else None),
+                status=failure.get("status") if failure else None,
+            )
 
     async def _sweep_idle_episodes(self) -> None:
         cfg = self.config()
@@ -861,11 +950,17 @@ class MemoryEngine:
         dense_rows, lexical_rows = await asyncio.gather(
             _bounded(dense), _bounded(lexical), return_exceptions=True)
         if isinstance(dense_rows, Exception):
-            log.debug("dense recall skipped: %r", dense_rows)
+            _, failure = classify_memory_failure(dense_rows)
+            log.debug(
+                "dense recall skipped category=%s exception_class=%s status=%s",
+                failure["category"], failure["exception_class"], failure.get("status"))
             dense_rows, status = [], (
                 "timeout" if isinstance(dense_rows, TimeoutError) else "partial")
         if isinstance(lexical_rows, Exception):
-            log.debug("lexical recall skipped: %r", lexical_rows)
+            _, failure = classify_memory_failure(lexical_rows)
+            log.debug(
+                "lexical recall skipped category=%s exception_class=%s status=%s",
+                failure["category"], failure["exception_class"], failure.get("status"))
             lexical_rows, status = [], (
                 "timeout" if isinstance(lexical_rows, TimeoutError) else "partial")
 
@@ -912,7 +1007,11 @@ class MemoryEngine:
             except TimeoutError:
                 status = "timeout"
             except Exception as exc:
-                log.debug("rerank skipped: %s", exc)
+                _, failure = classify_memory_failure(exc)
+                log.debug(
+                    "rerank skipped category=%s exception_class=%s status=%s",
+                    failure["category"], failure["exception_class"],
+                    failure.get("status"))
                 status = "partial"
         result = hydrated[:cfg.retrieval.final_limit]
         latency = (time.perf_counter() - started) * 1000
@@ -986,8 +1085,11 @@ class MemoryEngine:
             try:
                 await vector_store(cfg.vector).delete(memory_id)
             except Exception as exc:
-                log.warning("old vector deletion queued for retry (%s): %s",
-                            memory_id, exc)
+                _, failure = classify_memory_failure(exc)
+                log.warning(
+                    "old vector deletion queued category=%s exception_class=%s status=%s",
+                    failure["category"], failure["exception_class"],
+                    failure.get("status"))
                 self.store.enqueue("unindex_memory", {"memory_id": memory_id},
                                    owner_id=cfg.owner_id)
             self.store.enqueue("reindex_memory", {"memory_id": memory["id"]},
@@ -1009,8 +1111,11 @@ class MemoryEngine:
             try:
                 await vector_store(cfg.vector).delete(memory_id)
             except Exception as exc:
-                log.warning("vector deletion queued for retry (%s): %s",
-                            memory_id, exc)
+                _, failure = classify_memory_failure(exc)
+                log.warning(
+                    "vector deletion queued category=%s exception_class=%s status=%s",
+                    failure["category"], failure["exception_class"],
+                    failure.get("status"))
                 self.store.enqueue("unindex_memory", {"memory_id": memory_id},
                                    owner_id=cfg.owner_id)
                 self._wake.set()

--- a/backend/todos.py
+++ b/backend/todos.py
@@ -1,0 +1,195 @@
+"""Server-authoritative user to-do board (cross-device sync)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from .settings import ROOT, atomic_write_text
+
+_MAX_ITEMS = 100
+_MAX_TEXT = 240
+_PRIORITIES = {"high", "medium", "low"}
+
+
+class TodosService:
+    """One global to-do list shared across devices and workspaces.
+
+    Mirrors the ``ActivityService`` shape: a single JSON file under
+    ``ROOT/.muselab`` guarded by an RLock, atomic writes, and an SSE
+    fan-out for live cross-device updates.
+    """
+
+    def __init__(
+        self,
+        root: Path = ROOT,
+        *,
+        initialize_runtime_state: bool = True,
+    ):
+        self.path = root / ".muselab" / "todos.json"
+        self._lock = threading.RLock()
+        self._revision = 0
+        self._items: list[dict[str, Any]] = []
+        self._subscribers: dict[
+            asyncio.Queue[dict[str, Any]], asyncio.AbstractEventLoop
+        ] = {}
+        self._initialized = False
+        if initialize_runtime_state:
+            self.initialize_runtime_state()
+
+    def initialize_runtime_state(self) -> None:
+        with self._lock:
+            if self._initialized:
+                return
+            self.ensure_private_storage()
+            self._load()
+            self._initialized = True
+
+    def ensure_private_storage(self) -> None:
+        storage_dir = self.path.parent
+        if storage_dir.is_symlink():
+            raise RuntimeError("todos storage directory must not be a symlink")
+        storage_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        storage_dir.chmod(0o700)
+        if self.path.is_symlink():
+            raise RuntimeError("todos state must not be a symlink")
+        if self.path.exists():
+            self.path.chmod(0o600)
+
+    @staticmethod
+    def _normalize_item(item: Any) -> dict[str, Any] | None:
+        if not isinstance(item, dict):
+            return None
+        text = str(item.get("text") or "").strip()
+        if not text:
+            return None
+        priority = item.get("priority")
+        if priority not in _PRIORITIES:
+            priority = "medium"
+        return {
+            "id": str(item.get("id") or ""),
+            "text": text[:_MAX_TEXT],
+            "completed": bool(item.get("completed")),
+            "priority": priority,
+        }
+
+    def _normalize_items(self, value: Any) -> list[dict[str, Any]]:
+        if not isinstance(value, list):
+            return []
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        for raw in value:
+            item = self._normalize_item(raw)
+            if item is None or not item["id"] or item["id"] in seen:
+                continue
+            seen.add(item["id"])
+            out.append(item)
+        return out[-_MAX_ITEMS:]
+
+    def _load(self) -> None:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            raw = {}
+        if not isinstance(raw, dict):
+            raw = {}
+        self._revision = int(raw.get("revision") or 0)
+        self._items = self._normalize_items(raw.get("items"))
+
+    def _save(self) -> None:
+        self.ensure_private_storage()
+        atomic_write_text(
+            self.path,
+            json.dumps({
+                "version": 1,
+                "revision": self._revision,
+                "items": self._items,
+            }, ensure_ascii=False, indent=2),
+            mode=0o600,
+        )
+
+    def get(self) -> dict[str, Any]:
+        self.initialize_runtime_state()
+        with self._lock:
+            return {
+                "revision": self._revision,
+                "items": [dict(x) for x in self._items],
+            }
+
+    def replace(
+        self,
+        items: list[dict[str, Any]],
+        base_revision: int | None = None,
+    ) -> dict[str, Any] | None:
+        """Replace the whole list, guarded by an optimistic revision check.
+
+        Returns ``None`` when ``base_revision`` is stale so the caller can
+        re-fetch and reconcile instead of silently clobbering a newer write.
+        """
+        self.initialize_runtime_state()
+        with self._lock:
+            if base_revision is not None and base_revision != self._revision:
+                return None
+            self._items = self._normalize_items(items)
+            self._revision += 1
+            self._save()
+            self._publish_locked()
+            return {
+                "revision": self._revision,
+                "items": [dict(x) for x in self._items],
+            }
+
+    def _publish_locked(self) -> None:
+        payload: dict[str, Any] = {
+            "revision": self._revision,
+            "items": [dict(x) for x in self._items],
+        }
+        stale: list[asyncio.Queue[dict[str, Any]]] = []
+        for queue, loop in tuple(self._subscribers.items()):
+            try:
+                loop.call_soon_threadsafe(self._enqueue_update, queue, payload)
+            except RuntimeError:
+                stale.append(queue)
+        for queue in stale:
+            self._subscribers.pop(queue, None)
+
+    @staticmethod
+    def _enqueue_update(
+        queue: asyncio.Queue[dict[str, Any]],
+        payload: dict[str, Any],
+    ) -> None:
+        if queue.full():
+            with contextlib.suppress(asyncio.QueueEmpty):
+                queue.get_nowait()
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(payload)
+
+    @contextlib.asynccontextmanager
+    async def subscribe(
+        self,
+    ) -> AsyncIterator[asyncio.Queue[dict[str, Any]]]:
+        self.initialize_runtime_state()
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1)
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            self._subscribers[queue] = loop
+        try:
+            yield queue
+        finally:
+            with self._lock:
+                self._subscribers.pop(queue, None)
+
+    @property
+    def revision(self) -> int:
+        self.initialize_runtime_state()
+        with self._lock:
+            return self._revision
+
+
+# Importing the API surface must stay read-only for hermetic test collection.
+todos = TodosService(initialize_runtime_state=False)

--- a/backend/todos_api.py
+++ b/backend/todos_api.py
@@ -1,0 +1,100 @@
+"""Authenticated to-do board API (cross-device sync)."""
+
+import json
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse, ServerSentEvent
+
+from .auth import require_token
+from .capability_tickets import tickets
+from .todos import todos
+
+router = APIRouter(prefix="/api/todos", tags=["todos"])
+_EVENT_TICKET_TTL_S = 45
+
+
+class TodoItem(BaseModel):
+    id: str = ""
+    text: str = ""
+    completed: bool = False
+    priority: str = "medium"
+
+
+class TodosReplaceRequest(BaseModel):
+    items: list[TodoItem]
+    base_revision: int | None = None
+
+
+@router.get("", dependencies=[Depends(require_token)])
+def list_todos():
+    return todos.get()
+
+
+@router.put("", dependencies=[Depends(require_token)])
+def replace_todos(req: TodosReplaceRequest):
+    result = todos.replace(
+        [item.model_dump() for item in req.items],
+        req.base_revision,
+    )
+    if result is None:
+        raise HTTPException(
+            status_code=409,
+            detail="todos changed elsewhere; re-fetch and retry",
+        )
+    return {"ok": True, **result}
+
+
+@router.post("/events-ticket", dependencies=[Depends(require_token)])
+def mint_todo_event_ticket() -> dict:
+    ticket = tickets.mint(
+        "todos",
+        (),
+        ttl=_EVENT_TICKET_TTL_S,
+        single_use=True,
+    )
+    return {"ticket": ticket, "expires_in": _EVENT_TICKET_TTL_S}
+
+
+def _require_todo_event_ticket(ticket: str = Query("")) -> None:
+    if not tickets.validate(ticket, "todos", ()):
+        raise HTTPException(
+            status_code=401,
+            detail="invalid or expired todo event ticket",
+        )
+
+
+@router.get("/events", dependencies=[Depends(_require_todo_event_ticket)])
+async def todo_events() -> EventSourceResponse:
+    """Push to-do board changes to every open device."""
+
+    async def events() -> AsyncIterator[ServerSentEvent]:
+        async with todos.subscribe() as queue:
+            yield ServerSentEvent(
+                event="ready",
+                data=json.dumps(
+                    todos.get(),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ),
+            )
+            while True:
+                payload = await queue.get()
+                yield ServerSentEvent(
+                    event="update",
+                    data=json.dumps(
+                        payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                )
+
+    return EventSourceResponse(
+        events(),
+        ping=20,
+        headers={
+            "Cache-Control": "no-cache, no-store",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/workspace_store.py
+++ b/backend/workspace_store.py
@@ -35,6 +35,8 @@ _IGNORED_SUBTREES = frozenset({
     ".pytest_cache",
     ".tox",
     ".hypothesis",
+    ".jumbo",
+    ".jumbo.bak",
 })
 _EVENT_LIMIT = 20_000
 # A reconciliation can discover tens of thousands of offline changes at once

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -80,6 +80,31 @@ bash scripts/doctor.sh                # re-verify install + probe service
 bash scripts/intake.sh                # optional: create or refresh workspace CLAUDE.md
 ```
 
+## Optional local `screen` deployment with bounded logs
+
+The standard systemd service above still writes to journald; its rotation and
+retention remain managed by journald. For a separate local `screen` deployment,
+use the tracked launcher to keep a bounded combined stdout/stderr archive:
+
+```bash
+REPO="$(pwd)"
+screen -dmS muselab-local \
+  python3 "$REPO/scripts/rotating_log_launcher.py" \
+    --log "$REPO/muselab.log" --max-bytes 52428800 --keep 5 -- \
+    uv run python -m backend.main
+```
+
+The launcher has no built-in repository, user, or command path. It rotates while
+the child is running and forwards `SIGTERM`, `SIGINT`, and `SIGHUP` to the
+child process group. Each retained generation is capped at `--max-bytes`;
+rotation may split an unusually long line across two generations.
+
+Severe event-loop attribution is privacy-bounded to Python module and function
+names (no locals, source lines, paths, prompts, or identifiers). The defaults
+can be adjusted with `MUSELAB_LOOP_HEARTBEAT_MS`, `MUSELAB_LOOP_LAG_WARN_MS`,
+`MUSELAB_LOOP_STALL_MS`, and `MUSELAB_LOOP_STALL_RATE_LIMIT_S`. Set
+`MUSELAB_PERF_LOG=0` to disable all performance events, including the watchdog.
+
 ## Optional workspace instructions
 
 To record durable project conventions for the primary workspace, run:

--- a/docs/install-linux_zh.md
+++ b/docs/install-linux_zh.md
@@ -72,6 +72,29 @@ bash scripts/doctor.sh                # 重新校验安装并探测服务
 bash scripts/intake.sh                # 可选：创建或刷新工作区 CLAUDE.md
 ```
 
+## 可选：本地 `screen` 部署与有界日志
+
+上面的标准 systemd 服务仍写入 journald，轮转与保留策略继续由 journald 管理。
+若另行使用本地 `screen` 部署，可通过仓库内的通用启动器保存有界的 stdout/stderr 合并日志：
+
+```bash
+REPO="$(pwd)"
+screen -dmS muselab-local \
+  python3 "$REPO/scripts/rotating_log_launcher.py" \
+    --log "$REPO/muselab.log" --max-bytes 52428800 --keep 5 -- \
+    uv run python -m backend.main
+```
+
+启动器不内置仓库、用户或命令路径；子进程运行期间也会按大小轮转，并把 `SIGTERM`、
+`SIGINT`、`SIGHUP` 转发给整个子进程组。每一代保留日志都不会超过 `--max-bytes`；
+若单行异常长，轮转可能把它拆到相邻两代日志中。
+
+严重事件循环卡顿的归因只记录 Python 模块名和函数名，不记录局部变量、源码行、路径、
+prompt 或任何标识符。可通过 `MUSELAB_LOOP_HEARTBEAT_MS`、
+`MUSELAB_LOOP_LAG_WARN_MS`、`MUSELAB_LOOP_STALL_MS`、
+`MUSELAB_LOOP_STALL_RATE_LIMIT_S` 调整默认值；设置 `MUSELAB_PERF_LOG=0`
+可关闭包括 watchdog 在内的全部性能事件。
+
 ## 可选：配置工作区说明
 
 如需为主工作区记录长期项目约定，可显式运行：

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -346,6 +346,7 @@ function portal() {
     _fileEventsSeq: 0,
     _fileEventsTimer: null,
     _fileEventsPending: null,
+    _fileEventsReconnectFailures: 0,
     _fileTreeDirty: false,
     _fileTreeRefreshBusy: false,
     _fileTreeRefreshGeneration: "",
@@ -17088,6 +17089,13 @@ function portal() {
       if (this._isMobileLayout()) return this.mobileTab === "files";
       return !!this.leftOpen && !this.desktopFullPane;
     },
+    _nextFileEventsReconnectDelay() {
+      this._fileEventsReconnectFailures += 1;
+      return Math.min(
+        500 * Math.pow(2, this._fileEventsReconnectFailures - 1),
+        8000,
+      );
+    },
     _stopFileEvents(markDirty = false) {
       const workspace = this._fileEventsWorkspace;
       ++this._fileEventsSeq;
@@ -17956,7 +17964,10 @@ function portal() {
             && this._workspaceGenerationIsCurrent(
               workspace, workspaceGeneration,
             )) {
-          this._fileEventsTimer = setTimeout(() => this._startFileEvents(), 1500);
+          this._fileEventsTimer = setTimeout(
+            () => this._startFileEvents(),
+            this._nextFileEventsReconnectDelay(),
+          );
         }
         return;
       }
@@ -17981,6 +17992,7 @@ function portal() {
         );
       es.addEventListener("ready", (ev) => {
         if (!owns()) return;
+        this._fileEventsReconnectFailures = 0;
         let payload = {};
         try { payload = JSON.parse(ev.data); } catch (_) {}
         const readyWorkspaceId = String(payload.workspace_id || "");
@@ -18034,7 +18046,10 @@ function portal() {
         this._fileEventsWorkspace = "";
         this._fileEventsGeneration = "";
         if (this._fileTreeIsVisible()) {
-          this._fileEventsTimer = setTimeout(() => this._startFileEvents(), 1500);
+          this._fileEventsTimer = setTimeout(
+            () => this._startFileEvents(),
+            this._nextFileEventsReconnectDelay(),
+          );
         }
       };
       if (!this._fileEventsVisibilityBound) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -637,6 +637,7 @@ function portal() {
     sessionTodoEditDraft: "",
     _sessionTodoEditOwner: null,
     userTodos: [],
+    todoRevision: 0,
     // Lightweight focus ownership shared by modal/popover surfaces. DOM nodes
     // live here only while their surface is open; the stack ensures a nested
     // managed dialog never restores focus behind the dialog above it.
@@ -685,6 +686,10 @@ function portal() {
     _activityLiveSeq: 0,
     _activityLiveTimer: null,
     _activityLiveVisibilityBound: false,
+    _todoLiveSource: null,
+    _todoLiveSeq: 0,
+    _todoLiveTimer: null,
+    _todoLiveVisibilityBound: false,
     _activityPinPending: {},
     _activityGroupPending: {},
     _activityGroupOrderSeq: 0,
@@ -1523,6 +1528,9 @@ function portal() {
         localStorage.removeItem(oldK);
       }
       this.userTodos = this._loadGlobalUserTodos();
+      // Pull the server-authoritative board once at boot (and one-time-migrate
+      // any existing localStorage todos up). Best-effort: offline keeps cache.
+      this._syncTodosFromServer();
       window.addEventListener("storage", ev => {
         const key = this._globalUserTodoStorageKey();
         if (ev.key === key) {
@@ -2221,6 +2229,7 @@ function portal() {
         () => this.ackCurrentActivity(),
       );
       this._startActivityEvents();
+      this._startTodoEvents();
       this._startMemoryMonitor();
     },
 
@@ -11969,6 +11978,57 @@ function portal() {
           JSON.stringify(this.sessionTodoItems()),
         );
       } catch (_) { /* private mode / quota: keep the in-memory clipboard */ }
+      this._pushTodosToServer();
+    },
+    _applyTodosPayload(payload) {
+      if (!payload || !Array.isArray(payload.items)) return;
+      const revision = Number(payload.revision) || 0;
+      if (revision === this.todoRevision) return;
+      this.userTodos = this._normalizeUserTodos(payload.items);
+      this.todoRevision = revision;
+      try {
+        localStorage.setItem(
+          this._globalUserTodoStorageKey(),
+          JSON.stringify(this.userTodos),
+        );
+      } catch (_) { /* offline cache is best-effort */ }
+    },
+    async _pushTodosToServer() {
+      if (!this.token) return;
+      const r = await this.api("/api/todos", {
+        method: "PUT",
+        json: {
+          items: this.sessionTodoItems(),
+          base_revision: this.todoRevision,
+        },
+      });
+      if (r.ok) {
+        this._applyTodosPayload(r.data || {});
+      } else if (r.status === 409) {
+        // A concurrent device won; reconcile to the server-authoritative list.
+        await this._syncTodosFromServer();
+      }
+    },
+    async _syncTodosFromServer() {
+      if (!this.token) return;
+      const r = await this.api("/api/todos");
+      if (!r.ok) return; // offline / unauthenticated: keep the local cache
+      let data = r.data || {};
+      const local = this.sessionTodoItems();
+      if ((!Array.isArray(data.items) || !data.items.length) && local.length) {
+        // One-time migration of pre-sync localStorage todos up to the server.
+        const pushed = await this.api("/api/todos", {
+          method: "PUT",
+          json: { items: local, base_revision: Number(data.revision) || 0 },
+        });
+        if (pushed.ok) {
+          data = pushed.data || data;
+        } else {
+          const refetch = await this.api("/api/todos");
+          if (refetch.ok) data = refetch.data || data;
+        }
+      }
+      this._applyTodosPayload(data);
     },
     sessionTodoItems() {
       return Array.isArray(this.userTodos) ? this.userTodos : [];
@@ -30375,6 +30435,73 @@ function portal() {
       return await this.fetchActivity({
         summaryOnly: !this.activity.show && this.activity.events.length > 0,
       });
+    },
+    async _startTodoEvents() {
+      if (!this.token || typeof EventSource === "undefined") return;
+      if (typeof document !== "undefined"
+          && document.visibilityState !== "visible") {
+        this._stopTodoEvents();
+        return;
+      }
+      if (this._todoLiveSource) return;
+      this._stopTodoEvents();
+      const seq = ++this._todoLiveSeq;
+      let ticket = "";
+      try {
+        const r = await fetch("/api/todos/events-ticket", {
+          method: "POST",
+          headers: this.hdr(),
+        });
+        if (!r.ok) throw new Error("todos ticket failed");
+        ticket = String((await r.json()).ticket || "");
+      } catch (_) {
+        if (seq === this._todoLiveSeq) {
+          this._todoLiveTimer = setTimeout(() => this._startTodoEvents(), 1500);
+        }
+        return;
+      }
+      if (seq !== this._todoLiveSeq || !ticket) return;
+      const es = new EventSource(
+        `/api/todos/events?ticket=${encodeURIComponent(ticket)}`,
+      );
+      this._todoLiveSource = es;
+      const owns = () => (
+        seq === this._todoLiveSeq && this._todoLiveSource === es
+      );
+      const apply = (ev) => {
+        if (!owns()) return;
+        let payload;
+        try { payload = JSON.parse(ev.data); } catch (_) { return; }
+        this._applyTodosPayload(payload);
+      };
+      es.addEventListener("ready", apply);
+      es.addEventListener("update", apply);
+      es.onerror = () => {
+        if (!owns()) return;
+        try { es.close(); } catch (_) {}
+        this._todoLiveSource = null;
+        this._todoLiveTimer = setTimeout(() => this._startTodoEvents(), 1500);
+      };
+      if (!this._todoLiveVisibilityBound) {
+        this._todoLiveVisibilityBound = true;
+        document.addEventListener("visibilitychange", () => {
+          if (document.visibilityState !== "visible") {
+            this._stopTodoEvents();
+          } else {
+            this._startTodoEvents();
+          }
+        });
+        window.addEventListener("pagehide", () => this._stopTodoEvents());
+      }
+    },
+    _stopTodoEvents() {
+      ++this._todoLiveSeq;
+      if (this._todoLiveSource) {
+        try { this._todoLiveSource.close(); } catch (_) {}
+      }
+      this._todoLiveSource = null;
+      if (this._todoLiveTimer) clearTimeout(this._todoLiveTimer);
+      this._todoLiveTimer = null;
     },
     _syncScheduledActivitySnapshot(events) {
       const scheduled = (events || []).filter(

--- a/scripts/rotating_log_launcher.py
+++ b/scripts/rotating_log_launcher.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run a command while rotating its combined stdout/stderr by size."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _rotate(log_path: Path, keep: int) -> None:
+    if keep <= 0:
+        log_path.unlink(missing_ok=True)
+        return
+    oldest = log_path.with_name(f"{log_path.name}.{keep}")
+    oldest.unlink(missing_ok=True)
+    for generation in range(keep - 1, 0, -1):
+        source = log_path.with_name(f"{log_path.name}.{generation}")
+        if source.exists():
+            source.replace(log_path.with_name(
+                f"{log_path.name}.{generation + 1}"))
+    if log_path.exists():
+        log_path.replace(log_path.with_name(f"{log_path.name}.1"))
+
+
+def run(command: list[str], *, log_path: Path, max_bytes: int, keep: int) -> int:
+    if max_bytes < 1:
+        raise ValueError("max_bytes must be positive")
+    if keep < 0:
+        raise ValueError("keep must be non-negative")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if log_path.is_symlink():
+        raise ValueError("log path must not be a symlink")
+    if log_path.exists() and not log_path.is_file():
+        raise ValueError("log path must be a regular file")
+    if log_path.exists() and log_path.stat().st_size >= max_bytes:
+        _rotate(log_path, keep)
+
+    child = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    def forward(signum, _frame) -> None:
+        try:
+            os.killpg(child.pid, signum)
+        except ProcessLookupError:
+            pass
+
+    forwarded = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+    previous = {signum: signal.signal(signum, forward) for signum in forwarded}
+    try:
+        size = log_path.stat().st_size if log_path.exists() else 0
+        output = child.stdout
+        assert output is not None
+        sink = log_path.open("ab", buffering=0)
+        try:
+            while True:
+                chunk = output.read1(64 * 1024)
+                if not chunk:
+                    break
+                remaining = memoryview(chunk)
+                while remaining:
+                    if size >= max_bytes:
+                        sink.close()
+                        _rotate(log_path, keep)
+                        sink = log_path.open("ab", buffering=0)
+                        size = 0
+                    part = remaining[:max_bytes - size]
+                    sink.write(part)
+                    size += len(part)
+                    remaining = remaining[len(part):]
+        finally:
+            sink.close()
+        return_code = child.wait()
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+        if child.poll() is None:
+            try:
+                os.killpg(child.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            child.wait()
+    return 128 - return_code if return_code < 0 else return_code
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, type=Path)
+    parser.add_argument("--max-bytes", type=_positive_int, default=50 * 1024 * 1024)
+    parser.add_argument("--keep", type=_nonnegative_int, default=5)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("a command is required after --")
+    try:
+        return run(command, log_path=args.log,
+                   max_bytes=args.max_bytes, keep=args.keep)
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -2208,6 +2208,56 @@ def test_workspace_remove_readd_rejects_old_path_generation(
     }
 
 
+def test_file_event_reconnect_backoff_resets_on_ready(
+        page: Page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const originals = {
+            EventSource: window.EventSource,
+            capabilities: app._fileCapabilities,
+            visible: app._fileTreeIsVisible,
+          };
+          class FakeEventSource extends EventTarget {
+            close() {}
+          }
+          try {
+            app._stopFileEvents(false);
+            app._fileEventsReconnectFailures = 0;
+            const delays = Array.from(
+              {length: 6}, () => app._nextFileEventsReconnectDelay(),
+            );
+            window.EventSource = FakeEventSource;
+            app._fileCapabilities = async () => ({
+              mintTicket: async () => 'fake-ticket',
+            });
+            app._fileTreeIsVisible = () => true;
+            await app._startFileEvents();
+            const stream = app._fileEvents;
+            stream.dispatchEvent(new MessageEvent('ready', {
+              data: JSON.stringify({ready: true, cursor: 0}),
+            }));
+            return {
+              delays,
+              failuresAfterReady: app._fileEventsReconnectFailures,
+              nextDelay: app._nextFileEventsReconnectDelay(),
+            };
+          } finally {
+            app._stopFileEvents(false);
+            window.EventSource = originals.EventSource;
+            app._fileCapabilities = originals.capabilities;
+            app._fileTreeIsVisible = originals.visible;
+          }
+        }"""
+    )
+    assert result == {
+        "delays": [500, 1000, 2000, 4000, 8000, 8000],
+        "failuresAfterReady": 0,
+        "nextDelay": 500,
+    }
+
+
 def test_sse_ready_workspace_id_mismatch_forces_cold_tree_recovery(
         page: Page, backend_url, auth_token):
     _login(page, backend_url, auth_token)

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -13,9 +13,7 @@ import base64
 import collections
 import inspect
 import json
-import sys
 import threading
-import time
 from types import SimpleNamespace
 
 import pytest

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -13,7 +13,9 @@ import base64
 import collections
 import inspect
 import json
+import sys
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -2940,6 +2942,108 @@ def test_subscribe_broadcast_marks_continuation_consumed(stream_env):
     assert plain.continuation_consumed is False
 
 
+def test_replay_spool_uses_private_configured_runtime_dir(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    runtime_dir = tmp_path / "durable-runtime"
+    monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(runtime_dir))
+
+    spool = chat_mod._ReplaySpool()
+    try:
+        assert spool.path.parent == runtime_dir
+        assert runtime_dir.stat().st_mode & 0o777 == 0o700
+        assert spool.path.stat().st_mode & 0o777 == 0o600
+    finally:
+        spool.close()
+
+
+def test_replay_spool_rolls_back_partial_enospc(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(tmp_path / "runtime"))
+    spool = chat_mod._ReplaySpool()
+    real_write = chat_mod.os.write
+    calls = 0
+
+    def partial_then_full(fd, blob):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return real_write(fd, blob[:max(1, len(blob) // 2)])
+        raise OSError(28, "disk full private detail")
+
+    try:
+        monkeypatch.setattr(chat_mod.os, "write", partial_then_full)
+        with pytest.raises(OSError) as failure:
+            spool.append({"event": "done", "data": "{}"})
+        assert failure.value.errno == 28
+        assert spool.size() == 0
+        assert len(spool) == 0
+        assert spool.path.read_bytes() == b""
+
+        monkeypatch.setattr(chat_mod.os, "write", real_write)
+        spool.append({"event": "done", "data": "{}"})
+        assert list(spool) == [{"event": "done", "data": "{}"}]
+    finally:
+        spool.close()
+
+
+def test_replay_spool_becomes_unusable_when_partial_rollback_fails(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(tmp_path / "runtime"))
+    spool = chat_mod._ReplaySpool()
+    real_write = chat_mod.os.write
+    calls = 0
+
+    def partial_then_enospc(fd, blob):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return real_write(fd, blob[:1])
+        raise OSError(28, "disk full")
+
+    monkeypatch.setattr(chat_mod.os, "write", partial_then_enospc)
+    monkeypatch.setattr(
+        chat_mod.os, "ftruncate",
+        lambda *_args: (_ for _ in ()).throw(OSError(5, "rollback failed")),
+    )
+    try:
+        with pytest.raises(OSError) as failure:
+            spool.append({"event": "done", "data": "{}"})
+        assert failure.value.errno == 28
+        with pytest.raises(RuntimeError, match="unusable"):
+            spool.append({"event": "done", "data": "{}"})
+    finally:
+        spool.close()
+
+
+def test_replay_corruption_is_typed_and_subscriber_resyncs_once(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(tmp_path / "runtime"))
+    spool = chat_mod._ReplaySpool()
+    spool.path.write_bytes(b'{"event":"done","data":7}\n')
+    try:
+        with pytest.raises(chat_mod._ReplayRecordCorruption):
+            list(spool)
+
+        async def consume():
+            subscriber = chat_mod._TurnSubscriber(spool.open_reader())
+            first = await subscriber.get()
+            second = await subscriber.get()
+            return first, second
+
+        first, second = asyncio.run(consume())
+        assert first["event"] == "resync"
+        assert json.loads(first["data"]) == {
+            "reason": "replay_corrupt", "retryable": True,
+        }
+        assert second is None
+    finally:
+        spool.close()
+
+
 def test_broadcast_replay_compacts_100k_deltas_into_bounded_chunks(stream_env):
     """Replay stays exact without retaining one envelope per token in memory."""
     import json
@@ -3423,6 +3527,25 @@ def test_stream_ticket_replays_complete_turn_for_mobile_and_desktop(
         bc.close()
 
 
+def test_shutdown_closes_active_and_recent_broadcast_spools(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(tmp_path / "runtime"))
+    active = chat_mod.TurnBroadcast("shutdown-active")
+    recent = chat_mod.TurnBroadcast("shutdown-recent")
+    active_path = active.events.path
+    recent_path = recent.events.path
+    chat_mod._active_turns[active.session_id] = active
+    chat_mod._recent_turns[recent.session_id] = recent
+
+    asyncio.run(chat_mod.shutdown_runtime())
+
+    assert not active_path.exists()
+    assert not recent_path.exists()
+    assert active.session_id not in chat_mod._active_turns
+    assert recent.session_id not in chat_mod._recent_turns
+
+
 def test_stream_error_path_classifies_auth_error(stream_env, client, monkeypatch):
     """If the SDK stream raises an auth-shaped error, the handler emits an
     `error` frame carrying the classification (kind=auth, non-retryable)."""
@@ -3453,6 +3576,99 @@ def test_stream_error_path_classifies_auth_error(stream_env, client, monkeypatch
     assert err["cta"] == "open_settings"
     assert err["retryable"] is False
     # Reservation released even on error so the user can retry.
+    assert sid not in chat_mod._active_turns
+
+
+def test_terminal_snapshot_failure_keeps_primary_error_frame(
+        stream_env, client, monkeypatch, capsys):
+    chat_mod = stream_env
+    sid = _make_session(client)
+    primary = "HTTP 401 primary-auth-failure"
+    secondary = "PRIVATE_SNAPSHOT_DETAIL"
+
+    class BoomClient:
+        async def query(self, _prompt):
+            return None
+
+        async def receive_response(self):
+            raise RuntimeError(primary)
+            yield  # pragma: no cover
+
+    async def fake_get_client(*_args, **_kwargs):
+        return BoomClient()
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        chat_mod,
+        "_persist_failed_turn_snapshot",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError(secondary)),
+    )
+
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=hi&model=claude-sonnet-4-6")
+    error = next(
+        json.loads(data)
+        for event, data in _parse_sse(response.text)
+        if event == "error"
+    )
+
+    assert primary in error["error"]
+    assert error["snapshot_ready"] is False
+    diagnostics = capsys.readouterr().err
+    assert "stage=terminal_snapshot" in diagnostics
+    assert secondary not in diagnostics
+    assert primary not in diagnostics
+
+
+def test_terminal_replay_failure_keeps_primary_failure_state(
+        stream_env, client, monkeypatch, capsys):
+    chat_mod = stream_env
+    sid = _make_session(client)
+    primary = "PRIMARY_STREAM_FAILURE"
+    secondary = "PRIVATE_REPLAY_FAILURE"
+    recorded = []
+
+    class BoomClient:
+        async def query(self, _prompt):
+            return None
+
+        async def receive_response(self):
+            raise RuntimeError(primary)
+            yield  # pragma: no cover
+
+    async def fake_get_client(*_args, **_kwargs):
+        return BoomClient()
+
+    real_append = chat_mod._ReplaySpool.append
+
+    def fail_error_record(spool, event):
+        if event.get("event") == "error":
+            raise OSError(28, secondary)
+        return real_append(spool, event)
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(chat_mod, "_persist_failed_turn_snapshot",
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(chat_mod._ReplaySpool, "append", fail_error_record)
+    monkeypatch.setattr(
+        chat_mod.mem0, "schedule_failed",
+        lambda *args, **_kwargs: recorded.append(args) or True,
+    )
+
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=hi&model=claude-sonnet-4-6")
+
+    assert response.status_code == 200
+    assert len(recorded) == 1
+    assert primary in recorded[0][4]
+    assert secondary not in recorded[0][4]
+    diagnostics = capsys.readouterr().err
+    assert "stage=terminal_replay" in diagnostics
+    assert secondary not in diagnostics
+    assert primary not in diagnostics
     assert sid not in chat_mod._active_turns
 
 

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -1,6 +1,7 @@
 """Shared filesystem watcher and SSE endpoint regressions."""
 
 import asyncio
+import contextlib
 import os
 import stat
 import threading
@@ -26,6 +27,44 @@ def test_file_event_ticket_is_workspace_bound_and_single_use(
     scope = (str(temp_root.resolve()),)
     assert tickets.validate(ticket, "files", scope) is True
     assert tickets.validate(ticket, "files", scope) is False
+
+
+def test_unavailable_sse_crosses_gzip_middleware_as_clean_event(
+    client,
+    auth,
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    class UnavailableManager:
+        @contextlib.asynccontextmanager
+        async def subscribe(self, _root):
+            yield asyncio.Queue()
+
+        async def ready_state(self, _root):
+            raise file_events.HTTPException(
+                status_code=503,
+                detail=f"private scan failure: {temp_root}/secret",
+            )
+
+    minted = client.post("/api/files/events-ticket", headers=auth)
+    ticket = minted.json()["ticket"]
+    monkeypatch.setattr(file_events, "manager", UnavailableManager())
+    response = client.get(
+        "/api/files/events",
+        params={"ticket": ticket},
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.headers.get("content-encoding") != "gzip"
+    assert response.text.count("event: unavailable") == 1
+    assert '{"available":false,"retryable":true}' in response.text
+    assert str(temp_root) not in response.text
+    assert "private scan failure" not in response.text
 
 
 def test_selected_bootstrap_post_is_bounded_and_validates_parents(
@@ -125,7 +164,10 @@ def test_watch_filter_checks_workspace_relative_paths(app_module, tmp_path):
         Change.modified,
         str(root / "node_modules" / "pkg" / "x.js"),
     ) is False
-    for opaque in (".cache", ".local", ".codex", ".claude", ".npm", "venv"):
+    for opaque in (
+        ".cache", ".local", ".codex", ".claude", ".npm", "venv",
+        ".jumbo", ".jumbo.bak",
+    ):
         assert include(Change.modified, str(root / opaque)) is True
         assert include(
             Change.modified,
@@ -1215,6 +1257,100 @@ async def test_failed_initial_reconcile_retries_on_next_ensure(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_failures_back_off_coalesce_and_reset(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    store = file_events.WorkspaceStore(temp_root)
+    real_reconcile = store.reconcile
+    calls = 0
+    events = []
+
+    def fail_twice(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            raise file_events.WorkspaceScanIncomplete(
+                f"private failure under {temp_root}/secret-{calls}"
+            )
+        return real_reconcile(*args, **kwargs)
+
+    monkeypatch.setattr(store, "reconcile", fail_twice)
+    monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_START_S", 0.02)
+    monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_CAP_S", 0.04)
+    monkeypatch.setattr(
+        file_events,
+        "perf_event",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    manager = file_events.FileWatchManager(store)
+
+    with pytest.raises(file_events.HTTPException) as first:
+        await manager.bootstrap(temp_root)
+    assert first.value.detail == "workspace index is temporarily unavailable"
+    assert str(temp_root) not in first.value.detail
+
+    started = file_events.monotonic()
+    failed_pair = await asyncio.gather(
+        manager.bootstrap(temp_root),
+        manager.bootstrap(temp_root),
+        return_exceptions=True,
+    )
+    assert all(isinstance(item, file_events.HTTPException) for item in failed_pair)
+    assert calls == 2
+    assert file_events.monotonic() - started >= 0.015
+
+    started = file_events.monotonic()
+    recovered = await asyncio.gather(
+        manager.bootstrap(temp_root),
+        manager.bootstrap(temp_root),
+    )
+    assert calls == 3
+    assert file_events.monotonic() - started >= 0.03
+    assert recovered[0] == recovered[1]
+
+    state = manager._states[temp_root.resolve()]
+    assert state.reconcile_attempts == 3
+    assert state.reconcile_failures == 0
+    assert state.reconcile_retry_at == 0.0
+    reconcile_events = [fields for event, fields in events
+                        if event == "files.reconcile"]
+    assert [fields["attempt"] for fields in reconcile_events] == [1, 2, 3]
+    assert [fields["failures"] for fields in reconcile_events] == [1, 2, 0]
+    assert [fields["backoff_ms"] for fields in reconcile_events] == [20, 40, 0]
+    assert {fields["phase"] for fields in reconcile_events} == {"initial"}
+    captured = repr(reconcile_events)
+    assert str(temp_root) not in captured
+    assert "private failure" not in captured
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_interrupts_reconcile_backoff(
+    app_module,
+    temp_root,
+):
+    import backend.file_events as file_events
+
+    manager = file_events.FileWatchManager(file_events.WorkspaceStore(temp_root))
+    state = file_events._WatchState(
+        root=temp_root.resolve(),
+        workspace_id="workspace-id",
+        reconcile_retry_at=file_events.monotonic() + 30,
+    )
+    manager._states[state.root] = state
+    async with manager._lock:
+        manager._queue_reconcile_locked(state)
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(manager.shutdown(), timeout=0.5)
+    assert state.reconcile_task is None
+
+
+@pytest.mark.asyncio
 async def test_sse_ready_uses_lightweight_cursor_not_bootstrap(
     app_module,
     temp_root,
@@ -1245,6 +1381,71 @@ async def test_sse_ready_uses_lightweight_cursor_not_bootstrap(
     assert f'"workspace_id":"{workspace_id}"' in ready.data
     await stream.aclose()
     await local_manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sse_initial_unavailable_is_private_and_closes_cleanly(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    exited = False
+
+    class UnavailableManager:
+        @contextlib.asynccontextmanager
+        async def subscribe(self, _root):
+            nonlocal exited
+            try:
+                yield asyncio.Queue()
+            finally:
+                exited = True
+
+        async def ready_state(self, _root):
+            raise file_events.HTTPException(
+                status_code=503,
+                detail=f"failed to scan {temp_root}/private: permission denied",
+            )
+
+    monkeypatch.setattr(file_events, "manager", UnavailableManager())
+    events = [event async for event in file_events._event_stream(temp_root, None)]
+
+    assert len(events) == 1
+    assert events[0].event == "unavailable"
+    assert events[0].data == '{"available":false,"retryable":true}'
+    assert str(temp_root) not in events[0].data
+    assert "permission denied" not in events[0].data
+    assert exited is True
+
+
+@pytest.mark.asyncio
+async def test_http_exception_after_sse_ready_becomes_clean_eof(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    class ClosingManager:
+        @contextlib.asynccontextmanager
+        async def subscribe(self, _root):
+            yield asyncio.Queue()
+
+        async def ready_state(self, _root):
+            return {"workspace_id": "safe-id", "cursor": 1}
+
+        async def delta(self, _root, _cursor):
+            raise file_events.HTTPException(
+                status_code=503,
+                detail=f"late failure at {temp_root}/private",
+            )
+
+    monkeypatch.setattr(file_events, "manager", ClosingManager())
+    events = [event async for event in file_events._event_stream(temp_root, 0)]
+
+    assert [event.event for event in events] == ["ready"]
+    assert str(temp_root) not in events[0].data
 
 
 @pytest.mark.asyncio

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2526,6 +2526,48 @@ def test_render_key_regression_boundaries_keep_state_and_owners_consistent():
     assert "this._releasePaneMessageRenderKeys(st" in truncate
 
 
+def test_render_key_owned_arrays_mutate_only_at_audited_boundaries():
+    """New pane-array mutations must explicitly join the render-key audit."""
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    method = "<top-level>"
+    mutation_methods = set()
+    method_re = re.compile(
+        r"^    (?:async )?([A-Za-z_$][\w$]*)\([^)]*\) \{$"
+    )
+    mutation_re = re.compile(
+        r"\b(?:st|sendState|ownerState|newSt|child)\."
+        r"(?:messages|_earlierMessages|_laterMessages)"
+        r"(?:\.(?:push|unshift|splice|pop|shift)\s*\(|\.length\s*=|\s*=)"
+    )
+    for line in app.splitlines():
+        declaration = method_re.match(line)
+        if declaration:
+            method = declaration.group(1)
+        if mutation_re.search(line):
+            mutation_methods.add(method)
+
+    assert mutation_methods == {
+        "_capHistoryCache",
+        "_capLiveMessages",
+        "_capMountedWindow",
+        "_ensureTabState",
+        "_fetchLaterWindow",
+        "_fetchOlderWindow",
+        "_loadAroundMessage",
+        "_reloadHistoryTailAfterConflict",
+        "_revealMessagesChunked",
+        "_scrollToUserMsg",
+        "_stateForDetachedSuccessor",
+        "loadEarlierMessages",
+        "loadLaterMessages",
+        "loadSession",
+        "newSession",
+        "onModelChange",
+        "returnToLatest",
+        "send",
+    }
+
+
 def test_render_key_telemetry_has_one_disposable_trailing_flush():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     report_start = app.index("_flushPaneRenderKeyTelemetry(tid, st)")
@@ -3224,6 +3266,15 @@ def test_file_tree_live_events_are_workspace_scoped_and_mobile_batched():
     assert "const delay = this._isMobileLayout() ? 650 : 250" in app
     assert "if (!this._fileTreeIsVisible())" in app
     assert "this._stopFileEvents(true)" in app
+    assert "_fileEventsReconnectFailures: 0" in app
+    assert "_nextFileEventsReconnectDelay()" in app
+    assert "500 * Math.pow(2, this._fileEventsReconnectFailures - 1)" in app
+    assert "this._fileEventsReconnectFailures = 0" in app
+    assert "this._nextFileEventsReconnectDelay()" in app
+    assert "1500" not in app[
+        app.index("async _startFileEvents()"):
+        app.index("\n    _queueFileChanges", app.index("async _startFileEvents()"))
+    ]
     assert 'if (t === "files") this._flushFileTreeDirty()' not in app
 
 

--- a/tests/test_main_observability.py
+++ b/tests/test_main_observability.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -174,13 +176,29 @@ async def test_unmatched_error_never_logs_concrete_path(
     assert "report.md" not in repr(events)
 
 
-@pytest.mark.asyncio
-async def test_event_loop_monitor_emits_only_threshold_crossing(
+def test_event_loop_monitor_emits_only_threshold_crossing(
     app_module, monkeypatch,
 ):
     events = []
     timestamps = iter((0.0, 1.3))
     sleeps = 0
+
+    class FakeWatchdog:
+        def __init__(self, *_args, **_kwargs):
+            self.started = False
+            self.stopped = False
+            self.heartbeats = []
+
+        def start(self):
+            self.started = True
+
+        def heartbeat(self, observed_at):
+            self.heartbeats.append(observed_at)
+
+        def stop(self):
+            self.stopped = True
+
+    watchdog = FakeWatchdog()
 
     async def fake_sleep(_delay):
         nonlocal sleeps
@@ -190,6 +208,8 @@ async def test_event_loop_monitor_emits_only_threshold_crossing(
 
     monkeypatch.setattr(app_module, "_perf_enabled", lambda: True)
     monkeypatch.setattr(app_module, "_perf_monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(app_module, "_EventLoopStallWatchdog",
+                        lambda *_args, **_kwargs: watchdog)
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
     monkeypatch.setattr(
         app_module, "perf_event",
@@ -197,6 +217,88 @@ async def test_event_loop_monitor_emits_only_threshold_crossing(
     )
 
     with pytest.raises(asyncio.CancelledError):
-        await app_module._monitor_event_loop_lag()
+        asyncio.run(app_module._monitor_event_loop_lag())
 
     assert events == [("runtime.loop_lag", {"lag_ms": 300})]
+    assert watchdog.started is True
+    assert watchdog.heartbeats == [1.3]
+    assert watchdog.stopped is True
+
+
+def test_backfill_loads_messages_and_updates_counts_off_loop(
+    app_module, monkeypatch,
+):
+    from backend import chat, sessions
+    import claude_agent_sdk
+
+    loop_thread_id = threading.get_ident()
+    worker_calls = []
+    updates = []
+
+    def assert_worker(name):
+        worker_calls.append((name, threading.get_ident()))
+        assert threading.get_ident() != loop_thread_id
+
+    def list_sessions():
+        assert_worker("list")
+        return [{"id": "session-1", "turn_count": 0}]
+
+    def load_messages(sid, *, directory):
+        assert_worker("load")
+        assert sid == "session-1"
+        assert directory
+        return [True, False, True]
+
+    def bump_session(sid, **counts):
+        assert_worker("update")
+        updates.append((sid, counts))
+
+    monkeypatch.setattr(sessions, "list_sessions", list_sessions)
+    monkeypatch.setattr(sessions, "session_workspace", lambda _sid: "/workspace")
+    monkeypatch.setattr(sessions, "bump_session", bump_session)
+    monkeypatch.setattr(claude_agent_sdk, "get_session_messages", load_messages)
+    monkeypatch.setattr(chat, "_is_real_user_prompt", bool)
+
+    asyncio.run(app_module._backfill_turn_counts())
+
+    assert [name for name, _thread_id in worker_calls] == ["list", "load", "update"]
+    assert updates == [("session-1", {"message_count": 3, "turn_count": 2})]
+    assert (sessions.SESS_DIR / ".backfill_done").exists()
+
+
+def test_severe_loop_watchdog_attributes_privacy_safe_site_and_rate_limits(
+    app_module, monkeypatch,
+):
+    events = []
+    monkeypatch.setattr(
+        app_module, "perf_event",
+        lambda event, **fields: events.append((event, fields)),
+    )
+
+    loop_thread_id = threading.get_ident()
+    blocked_frame = inspect.currentframe()
+    assert blocked_frame is not None
+    monkeypatch.setattr(
+        app_module.sys, "_current_frames", lambda: {loop_thread_id: blocked_frame}
+    )
+    watchdog = app_module._EventLoopStallWatchdog(
+        loop_thread_id,
+        10.0,
+        threshold_s=5.0,
+        rate_limit_s=60.0,
+        poll_s=1.0,
+    )
+    watchdog._check_once(14.9)
+    watchdog._check_once(15.0)
+    watchdog._check_once(40.0)
+    watchdog._check_once(75.0)
+
+    assert len(events) == 2
+    assert events[0][0] == "runtime.loop_stall"
+    assert events[0][1]["lag_ms"] == 5000
+    assert events[0][1]["site"].startswith(
+        "tests.test_main_observability:test_severe_loop_watchdog_"
+    )
+    assert "/home/" not in repr(events)
+    assert "prompt" not in repr(events)
+    assert events[1][1]["lag_ms"] == 65000

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -94,13 +94,20 @@ def test_enabled_config_must_pass_probe(client, auth, monkeypatch):
                    "collection": "memory"},
     }
 
+    secret = "https://user:password@example.test/private?token=secret"
+
     async def broken(_config=None):
-        raise RuntimeError("embedding unavailable")
+        raise RuntimeError(secret)
 
     monkeypatch.setattr(api_memory.engine, "probe", broken)
     response = client.put("/api/memory/config", headers=auth, json=body)
     assert response.status_code == 400
-    assert "配置未保存" in response.json()["detail"]
+    assert response.json()["detail"] == {
+        "category": "unclassified",
+        "exception_class": "RuntimeError",
+    }
+    assert secret not in response.text
+    assert "example.test" not in response.text
     assert client.get("/api/memory/config", headers=auth).json()["mode"] == "off"
 
 

--- a/tests/test_memory_client.py
+++ b/tests/test_memory_client.py
@@ -21,6 +21,7 @@ def _load(monkeypatch, url="http://127.0.0.1:8800"):
     importlib.reload(settings)
     import backend.memory_client as mc
     importlib.reload(mc)
+    monkeypatch.setattr(mc, "native_enabled", lambda: False)
     return mc
 
 
@@ -94,7 +95,7 @@ def test_disabled_when_no_or_invalid_url(monkeypatch):
     for url in ("", "ftp://127.0.0.1:8800", "http://host:8800?token=x",
                 "http://127.0.0.1:notaport", "http://127.0.0.1:70000"):
         mc = _load(monkeypatch, url=url)
-        assert mc.enabled() is False
+        assert mc.enabled() is False, url
         assert _run(mc.search_context("q", "sid")) == ""
 
 
@@ -157,6 +158,31 @@ def test_store_payload_has_no_run_id(monkeypatch, fake_httpx):
     assert url.endswith("/add")
     assert "run_id" not in payload
     assert payload["user_id"] == "muselab"
+
+
+def test_failsoft_logging_never_renders_exception_secrets(
+        monkeypatch, fake_httpx, caplog):
+    import httpx
+
+    mc = _load(monkeypatch)
+    secret = "sk-private-memory-client-secret"
+
+    async def fail(*_args, **_kwargs):
+        raise httpx.HTTPStatusError(
+            f"private body {secret}",
+            request=httpx.Request("POST", f"https://example.test/{secret}"),
+            response=httpx.Response(529),
+        )
+
+    monkeypatch.setattr(mc, "_post_json", fail)
+    caplog.set_level("DEBUG", logger="muselab.mem0")
+    assert _run(mc.search_context("private prompt", "s")) == ""
+    assert "category=transient_http" in caplog.text
+    assert "exception_class=HTTPStatusError" in caplog.text
+    assert "status=529" in caplog.text
+    assert secret not in caplog.text
+    assert "example.test" not in caplog.text
+    assert "private prompt" not in caplog.text
 
 
 def test_failsoft_wall_clock_timeout(monkeypatch, fake_httpx):

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -1,6 +1,7 @@
 """Episode consolidation, verification, hybrid recall and Skill approval."""
 import asyncio
 
+import httpx
 import pytest
 
 
@@ -366,6 +367,156 @@ def test_transcript_reconciliation_stops_at_next_real_user_turn(
         row["event_type"] for row in instance.store.episode(episode["id"])["evidence"]
     ]
     assert event_types == ["message", "tool_use", "tool_result"]
+
+
+def _run_worker_job(tmp_path, monkeypatch, failures, *, kind="reindex_memory"):
+    from backend import memory_engine as module, memory_store as store_module
+    from backend.memory_engine import MemoryEngine
+    from backend.memory_store import MemoryStore
+
+    instance = MemoryEngine(MemoryStore(tmp_path / "worker.sqlite3"))
+    cfg = _config()
+    monkeypatch.setattr(instance, "config", lambda: cfg)
+    clock = [1000.0]
+    monkeypatch.setattr(store_module, "_now", lambda: clock[0])
+    events = []
+    monkeypatch.setattr(
+        module, "perf_event",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    calls = 0
+
+    async def handle(_memory_id):
+        nonlocal calls
+        calls += 1
+        if failures:
+            raise failures.pop(0)
+
+    monkeypatch.setattr(instance, "_index_memory", handle)
+    job_id = instance.store.enqueue(
+        kind, {"memory_id": "memory-1"}, owner_id=cfg.owner_id)
+    finish_job = instance.store.finish_job
+
+    def finish_and_advance(job_id, *, error=None, retry_seconds=None):
+        finish_job(job_id, error=error, retry_seconds=retry_seconds)
+        if retry_seconds is not None:
+            clock[0] += retry_seconds
+        else:
+            instance._closing = True
+
+    monkeypatch.setattr(instance.store, "finish_job", finish_and_advance)
+    _run(instance._worker())
+    job = next(row for row in instance.store.list_jobs() if row["id"] == job_id)
+    return calls, job, events
+
+
+@pytest.mark.parametrize(("exc", "retryable", "category", "status"), [
+    (TimeoutError("secret prompt"), True, "timeout", None),
+    (httpx.ConnectError(
+        "secret transport", request=httpx.Request(
+            "GET", "https://token.example/private")), True, "transport", None),
+    (httpx.HTTPStatusError(
+        "secret response", request=httpx.Request(
+            "GET", "https://token.example/private"),
+        response=httpx.Response(409)), True, "transient_http", 409),
+    (httpx.HTTPStatusError(
+        "secret response", request=httpx.Request(
+            "GET", "https://token.example/private"),
+        response=httpx.Response(401)), False, "authentication", 401),
+    (ValueError("secret config"), False, "invalid_value", None),
+    (TypeError("secret body"), False, "invalid_type", None),
+    (KeyError("secret key"), False, "missing_key", None),
+    (FileNotFoundError("/private/path"), False, "file_not_found", None),
+    (PermissionError("/private/path"), False, "permission", None),
+    (RuntimeError("unknown secret"), False, "unclassified", None),
+])
+def test_failure_classifier_is_explicit_and_private(exc, retryable, category, status):
+    from backend.memory_engine import classify_memory_failure
+
+    actual_retryable, detail = classify_memory_failure(exc)
+    assert actual_retryable is retryable
+    assert detail == {
+        "category": category,
+        "exception_class": type(exc).__name__,
+        **({"status": status} if status is not None else {}),
+    }
+    assert "secret" not in repr(detail)
+    assert "/private" not in repr(detail)
+    assert "token.example" not in repr(detail)
+
+
+def test_worker_retries_safe_transient_three_times_without_secret_leakage(
+        tmp_path, monkeypatch, caplog):
+    import httpx
+
+    secret = "sk-super-secret-worker-token"
+    failures = [
+        httpx.HTTPStatusError(
+            f"provider body {secret}",
+            request=httpx.Request("POST", f"https://example.test/{secret}"),
+            response=httpx.Response(500),
+        )
+        for _ in range(3)
+    ]
+    calls, job, events = _run_worker_job(tmp_path, monkeypatch, failures)
+
+    assert calls == 3
+    assert job["attempts"] == 3
+    assert job["status"] == "failed"
+    assert job["last_error"] == (
+        '{"category":"transient_http","exception_class":'
+        '"HTTPStatusError","status":500}'
+    )
+    assert [fields["outcome"] for _, fields in events] == [
+        "retry", "retry", "failed"]
+    assert all(event == "memory.job" for event, _ in events)
+    assert secret not in job["last_error"]
+    assert secret not in caplog.text
+    assert "example.test" not in caplog.text
+
+
+def test_worker_does_not_retry_terminal_generation_error(tmp_path, monkeypatch):
+    from backend.memory_providers import GenerationError
+
+    calls, job, events = _run_worker_job(tmp_path, monkeypatch, [GenerationError(
+        retryable=False, category="invalid_configuration", api_error_status=400)])
+
+    assert calls == 1
+    assert job["attempts"] == 1
+    assert job["status"] == "failed"
+    assert job["last_error"] == (
+        '{"category":"invalid_configuration","exception_class":'
+        '"GenerationError","status":400}'
+    )
+    assert events[0][1]["outcome"] == "failed"
+
+
+def test_generation_error_retry_flag_is_authoritative():
+    from backend.memory_engine import classify_memory_failure
+    from backend.memory_providers import GenerationError
+
+    retryable, detail = classify_memory_failure(GenerationError(
+        retryable=True, category="provider_overloaded", api_error_status=400))
+    assert retryable is True
+    assert detail == {
+        "category": "provider_overloaded",
+        "exception_class": "GenerationError",
+        "status": 400,
+    }
+
+
+def test_worker_treats_unknown_job_kind_as_terminal(tmp_path, monkeypatch):
+    calls, job, events = _run_worker_job(
+        tmp_path, monkeypatch, [], kind="private-unknown-kind")
+
+    assert calls == 0
+    assert job["attempts"] == 1
+    assert job["status"] == "failed"
+    assert job["last_error"] == (
+        '{"category":"unknown_job","exception_class":"UnknownMemoryJobError"}'
+    )
+    assert events[0][1]["kind"] == "unknown"
+    assert events[0][1]["outcome"] == "failed"
 
 
 def test_reindex_all_queues_one_batch_job(tmp_path, monkeypatch):

--- a/tests/test_rotating_log_launcher.py
+++ b/tests/test_rotating_log_launcher.py
@@ -1,0 +1,77 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+LAUNCHER = Path(__file__).parents[1] / "scripts" / "rotating_log_launcher.py"
+
+
+def test_launcher_rotates_combined_output_by_size(tmp_path):
+    log = tmp_path / "muselab.log"
+    code = (
+        "import sys; "
+        "[(print(f'line-{i:02d}-' + 'x' * 20, flush=True), "
+        "  print(f'err-{i:02d}', file=sys.stderr, flush=True)) for i in range(12)]"
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(LAUNCHER), "--log", str(log),
+         "--max-bytes", "100", "--keep", "2", "--",
+         sys.executable, "-c", code],
+        check=False,
+        timeout=5,
+    )
+
+    assert result.returncode == 0
+    assert log.exists()
+    assert (tmp_path / "muselab.log.1").exists()
+    assert (tmp_path / "muselab.log.2").exists()
+    assert not (tmp_path / "muselab.log.3").exists()
+    retained = b"".join(path.read_bytes() for path in (
+        tmp_path / "muselab.log.2",
+        tmp_path / "muselab.log.1",
+        log,
+    ))
+    assert b"line-11-" in retained
+    assert b"err-11" in retained
+
+
+def test_launcher_forwards_sigterm_and_returns_child_status(tmp_path):
+    log = tmp_path / "muselab.log"
+    code = """
+import signal
+import sys
+import time
+
+def stop(_signum, _frame):
+    print("child-got-term", flush=True)
+    raise SystemExit(42)
+
+signal.signal(signal.SIGTERM, stop)
+print("child-ready", flush=True)
+while True:
+    time.sleep(0.05)
+"""
+    process = subprocess.Popen([
+        sys.executable, str(LAUNCHER), "--log", str(log), "--",
+        sys.executable, "-c", code,
+    ])
+    try:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if log.exists() and b"child-ready" in log.read_bytes():
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("child did not become ready")
+
+        os.kill(process.pid, signal.SIGTERM)
+        assert process.wait(timeout=2) == 42
+        assert b"child-got-term" in log.read_bytes()
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)


### PR DESCRIPTION
## 改动摘要

- **feat(todos)**: 待办事项改为服务端持久化（`/api/todos` + `todos.json`）+ 跨设备实时同步
- **fix(runtime)**: 强化运行时稳定性与聊天重放缓冲韧性
- **fix(memory)**: 统一 Memory 错误脱敏分类，剥离异常原文
- **fix(activity)**: 任务中心过滤已删除/不可见会话，避免点击报错
- **fix(activity)**: 运行时滚动时把活动分组迁移给 fork 出的后继会话
- **fix(chat)**: 完整显示 Bash 命令，去除 200 字符截断