### PR TITLE
fix(chat): 修复终止队列与会话加载

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -452,7 +452,12 @@ class ActivityService:
         loops and delivery crosses the boundary via ``call_soon_threadsafe``.
         """
         self._revision += 1
-        summary = _summarize([dict(x) for x in self._events])
+        # SSE and HTTP must summarize the same visible ledger. Keeping deleted
+        # sessions in the durable audit trail is fine, but letting their unread
+        # terminal rows leak only through SSE resurrects a green completion dot
+        # while every openable Activity row is still running.
+        visible_events = self._filter_live([dict(x) for x in self._events])
+        summary = _summarize(visible_events)
         summary["generation"] = self._generation
         summary["revision"] = self._revision
         payload: dict[str, Any] = {

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1375,6 +1375,10 @@ _session_runtime_locks: dict[str, asyncio.Lock] = {}
 # from popping adjacent FIFO items before either reserves _active_turns[sid].
 _queue_drain_locks: dict[str, asyncio.Lock] = {}
 _queue_drain_tasks: dict[str, asyncio.Task] = {}
+# Recoverable runtime-rollover conflicts (404/409 while a background watcher is
+# handing ownership to its successor) need a retained wake-up even when no new
+# enqueue or task notification arrives. One delayed retry per session is enough.
+_queue_drain_retry_tasks: dict[str, asyncio.Task] = {}
 # A queue POST can land while the coalesced drain is busy forking a detached
 # runtime. Remember that wakeup instead of dropping it; once the first drain
 # exits, one follow-up pass migrates any item accepted after its queue snapshot.
@@ -3587,6 +3591,7 @@ async def shutdown_runtime() -> None:
     _task_watchers.clear()
     _runtime_prewarm_tasks.clear()
     _queue_drain_tasks.clear()
+    _queue_drain_retry_tasks.clear()
     _queue_drain_rekicks.clear()
     _queue_drain_locks.clear()
 
@@ -5741,10 +5746,12 @@ def _clear_session_runtime_state(sid: str) -> list[asyncio.Task]:
     if runtime_lock is not None and not runtime_lock.locked():
         _session_runtime_locks.pop(sid, None)
     drain_task = _queue_drain_tasks.pop(sid, None)
+    retry_task = _queue_drain_retry_tasks.pop(sid, None)
     _queue_drain_rekicks.discard(sid)
-    if drain_task is not None and not drain_task.done():
-        drain_task.cancel()
-        cancelled_tasks.append(drain_task)
+    for task in (drain_task, retry_task):
+        if task is not None and not task.done():
+            task.cancel()
+            cancelled_tasks.append(task)
     prewarm_task = _runtime_prewarm_tasks.pop(sid, None)
     if prewarm_task is not None and not prewarm_task.done():
         prewarm_task.cancel()
@@ -8820,6 +8827,17 @@ async def _force_stop_after_grace(
         t = getattr(bc, "task", None)
         if t is not None and not t.done():
             t.cancel()
+            # Cancellation enters the pump's own ``finally``, which already
+            # settles Activity, queue ownership and the durable sidecar. Give
+            # that single owner a bounded chance to finish before taking over;
+            # otherwise both paths can release the same queue claim and publish
+            # the same Activity terminal transition.
+            try:
+                await asyncio.wait_for(asyncio.shield(t), timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            if bc.done or _active_turns.get(session_id) is not bc:
+                return
         async with _lock:
             if _active_turns.get(session_id) is bc:
                 _active_turns.pop(session_id, None)
@@ -8831,7 +8849,24 @@ async def _force_stop_after_grace(
                 "event": "cancelled",
                 "data": json.dumps({"snapshot_ready": snapshot_ready}),
             })
-            bc.finish()
+        # The pump normally owns all terminal bookkeeping. If it never unwinds,
+        # the watchdog must perform the same externally visible settlement rather
+        # than merely freeing `_active_turns`: otherwise Activity can stay green/
+        # running and a queued item can remain durably inflight forever.
+        mem0.pop_recall_trace(session_id)
+        await _finish_activity(session_id, bc, "cancelled")
+        if bc.queue_item_id:
+            sess.release_queue_claim(
+                session_id,
+                bc.queue_item_id,
+                turn_id=bc.turn_id,
+                pause=True,
+            )
+        sess.pause_queue_if_nonempty(session_id)
+        bc.perf_status = "cancelled"
+        bc.perf_error_kind = "cancelled"
+        bc.finish()
+        _remember_recent_turn(session_id, bc)
         if snapshot_ready or bc.queue_item_id:
             _delete_active_turn_sidecar(session_id)
         else:
@@ -13458,7 +13493,14 @@ async def _start_turn(
             # push fan-out, JSONL compatibility cleanup). The old ordering kept
             # the footer pulsing "Running" for seconds after the final answer
             # was already visible.
-            was_cancelled = session_id in _pending_interrupts
+            # ``interrupt()`` marks the exact live broadcast before awaiting the
+            # SDK control request. Treat that turn-owned bit as authoritative:
+            # ResultMessage can race the later session-level bookkeeping, and
+            # overwriting it with ``False`` used to turn a user Stop into a
+            # completed/failed result.
+            was_cancelled = bool(
+                broadcast.cancelled or session_id in _pending_interrupts
+            )
             _pending_interrupts.discard(session_id)
             broadcast.cancelled = was_cancelled
             _completed_at_ms = int(time.time() * 1000)
@@ -14576,6 +14618,44 @@ def _notify_queue_paused_on_error(session_id: str) -> None:
         pass  # no running loop (shouldn't happen in request context)
 
 
+def _schedule_queue_drain_retry(session_id: str, delay_s: float = 1.0) -> None:
+    """Retain one delayed retry for a recoverable runtime handoff conflict."""
+    existing = _queue_drain_retry_tasks.get(session_id)
+    if existing is not None and not existing.done():
+        return
+
+    async def _retry() -> None:
+        await asyncio.sleep(delay_s)
+        queue = sess.get_queue(session_id)
+        if queue.get("paused") or not (
+            queue.get("items") or queue.get("inflight")
+        ):
+            return
+        _schedule_queue_drain(session_id)
+
+    task = asyncio.create_task(_retry())
+    _queue_drain_retry_tasks[session_id] = task
+    _maintenance_tasks.add(task)
+
+    def _done(done: asyncio.Task) -> None:
+        _maintenance_tasks.discard(done)
+        if _queue_drain_retry_tasks.get(session_id) is done:
+            _queue_drain_retry_tasks.pop(session_id, None)
+        if done.cancelled():
+            return
+        try:
+            exc = done.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            sys.stderr.write(
+                f"[chat] delayed queue drain failed "
+                f"sid={session_id[:8]} exc={type(exc).__name__}\n"
+            )
+
+    task.add_done_callback(_done)
+
+
 async def _maybe_drain_queue(session_id: str) -> None:
     """Drain trigger: if no turn is running for this session and the queue
     has a non-paused head item, pop it and start the next turn headlessly.
@@ -14619,6 +14699,8 @@ async def _maybe_drain_queue(session_id: str) -> None:
                         f"[chat] queued runtime rollover deferred "
                         f"sid={session_id[:8]} status={exc.status_code}\n"
                     )
+                    if exc.status_code in {404, 409}:
+                        _schedule_queue_drain_retry(session_id)
             return
         # READY presentation events are part of the visible chronology. Commit
         # them before claiming the next FIFO item; if local I/O cannot do so,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9706,6 +9706,9 @@ function portal() {
           st._loaded = true;
           st._pendingExternalUpdate = false;
           this._syncQueueFromServer(sid);
+          this.$nextTick(() => this._drainPendingQueue(
+            sid, st.activeTurnId || "",
+          ));
         }
         return !!loaded;
       } catch (_) {
@@ -9756,6 +9759,9 @@ function portal() {
         st._loaded = true;
         st._pendingExternalUpdate = false;
         this._syncQueueFromServer(sid);
+        this.$nextTick(() => this._drainPendingQueue(
+          sid, st.activeTurnId || "",
+        ));
       }
       return !!loaded;
     },
@@ -10573,13 +10579,12 @@ function portal() {
             || this.workspaceOpenTabIds(path)
               .map(id => this.sessions.find(s => s.id === id)).find(Boolean)
             || workspaceRows[0];
-          if (target) await this._ensureSessionLoaded(target.id);
           return target || null;
         })().catch(() => null);
         const [surfaceOk, target] = await Promise.all([surfaceReady, targetReady]);
         if (switchSeq !== this._workspaceSwitchSeq
             || !surfaceOk || !this._workspaceIsCurrent(path)) return;
-        if (target) await this.openTab(target.id);
+        if (target) await this.openTab(target.id, true, { deferLoad: true });
         else this.newSession({ cwd: path });
         if (switchSeq !== this._workspaceSwitchSeq
             || !this._workspaceIsCurrent(path)) return;
@@ -11085,7 +11090,7 @@ function portal() {
     // ===== tabs =====
     // Switch to (and if needed open) a tab. Used by the picker dropdown to
     // promote a history session into a tab.
-    async openTab(id, makeCurrent = true) {
+    async openTab(id, makeCurrent = true, options = {}) {
       const session = this.sessions.find(s => s.id === id);
       const cwd = session && session.cwd;
       if (cwd && cwd !== this.currentWorkspacePath()
@@ -11104,7 +11109,16 @@ function portal() {
       if (makeCurrent && id !== this.currentId) {
         this._captureChatPosition(this.currentId);
         this.currentId = id;
-        await this.switchSession();
+        const switching = this.switchSession();
+        if (options.deferLoad) {
+          // Workspace switching owns only the shell transition. switchSession()
+          // synchronously commits the selected tab and then waits on the target
+          // transcript; let that wait continue behind the pane-local skeleton so
+          // unrelated controls regain input after the next shell paint.
+          void switching.catch(() => false);
+        } else {
+          await switching;
+        }
       }
       if (cwd) {
         this.workspaceLastSession = { ...this.workspaceLastSession, [cwd]: id };
@@ -14258,43 +14272,16 @@ function portal() {
       // finally so error / empty-result paths don't leave the skeleton stuck.
       let scheduledReveal = false;
       try {
-        // Backend windowing (perf): a long / un-compacted session can shape
-        // into thousands of bubbles and many MB of JSON. Shipping + parsing
-        // the whole thing on every entry was the dominant freeze ("卡死").
-        // So unless full mode is requested, ask the server for only the TAIL
-        // we'll actually paint up front. The tail must be wide enough that
-        // pickVisibleStart's "at least 2 user turns" guarantee still holds
-        // (it can rewind up to INITIAL_LOAD*5), so we request that much; we
-        // still render only ~INITIAL_LOAD and stash the rest. Older history
-        // pages in from the server via _fetchOlderWindow on "Load earlier".
-        const _coldEarly = !this.appReady;
-        // Mobile uses the same canonical history window as desktop. Viewport
-        // virtualization, rather than a device-specific message count, bounds
-        // mounted DOM work on smaller screens.
-        const _baseInitialLoad = _coldEarly ? 30 : 60;
-        // QUIET refresh must not shrink the pane. A quiet load is a merge into
-        // an ALREADY-PAINTED pane, and a long agentic turn can leave up to
-        // _historyWindowSize() canonical bubbles in its active request window —
-        // far more than the cold-open window above. Loading the narrow window in
-        // that state spliced several hundred bubbles down to ~60 and pushed the
-        // rest outside the visible range: a violent height collapse + mass DOM teardown,
-        // which is the post-turn half of the "会话区刷新闪烁" report
-        // (2026-08-04). Widen the request (and fetched tail) to preserve the
-        // current canonical window during the in-place morph.
-        // Cold opens and non-quiet loads keep the narrow, freeze-avoiding
-        // window — nothing is painted yet there, so there is nothing to
-        // preserve.
-        const _currentWindowSize = (quiet && Array.isArray(st.messages))
-          ? st.messages.length : 0;
-        const _quietFloor = Math.min(this._historyWindowSize(), _currentWindowSize);
-        const _initialLoadEarly = Math.max(_baseInitialLoad, _quietFloor);
-        // While the user reads history, request at least every canonical block
-        // already loaded so quiet reconciliation cannot drop the visible anchor.
-        const FETCH_TAIL = quiet
-          ? Math.max(_baseInitialLoad * 5, st.messages.length,
-            !st.atBottom ? this._historyReconcileWindowSize() : 0)
-          : Math.max(_baseInitialLoad * 5, _quietFloor);
-        const qs = full ? "?full=1" : ("?tail=" + FETCH_TAIL);
+        // Bound every normal session entry by canonical UI-block count. A cold
+        // open receives only the latest 20 blocks on mobile or 100 on desktop;
+        // older history remains server-authoritative and is fetched explicitly.
+        // Quiet reconciliation preserves only the resident blocks the reader has
+        // already chosen to load, rather than silently expanding toward full history.
+        const historyPage = this._historyWindowSize();
+        const requestedTail = quiet
+          ? Math.max(historyPage, st.messages.length)
+          : historyPage;
+        const qs = full ? "?full=1" : "?tail=" + requestedTail;
         const controller = new AbortController();
         const timeout = setTimeout(
           () => controller.abort(),
@@ -14618,7 +14605,7 @@ function portal() {
           // in a single multi-second task. The skeleton stays up until this
           // resolves, so the user sees a responsive page (tabs / sidebar stay
           // clickable) instead of a frozen one ("卡死").
-          await this._revealMessagesChunked(sid, st, visible);
+          await this._revealMessagesChunked(sid, st, visible, !quiet);
           if (this.tabState[sid] !== st || st.streaming || st.es) return true;
           this.$nextTick(async () => {
             try { await this.highlightCode(".chat-body"); st._highlighted = true; }
@@ -14720,22 +14707,72 @@ function portal() {
     },
     // Reveal the resident repository in small coordinate steps, yielding a frame
     // between updates so Alpine instantiates the directive-heavy bubble templates
-    // incrementally. The repository itself never moves; only messageRange's
-    // visible end advances.
-    async _revealMessagesChunked(sid, st, visible) {
-      const CH = this._isMobileLayout() ? 4 : 15;
-      const start = st.messageRange.visibleStart;
-      let i = 0;
-      while (i < visible.length) {
-        if (this.tabState[sid] !== st || st.streaming || st.es) return;
-        i = Math.min(visible.length, i + CH);
-        st.messageRange.visibleEnd = start + i;
-        if (sid !== this.currentId) {
-          st.messageRange.visibleEnd = start + visible.length;
-          return;
+    // incrementally. Start at the newest tail and prepend older rows: a manual tab
+    // switch can therefore show the latest answer after the first batch instead of
+    // hiding behind the skeleton until all 100 resident blocks have mounted.
+    async _revealMessagesChunked(sid, st, visible, tailFirst = true) {
+      // Alpine row creation is the remaining dominant long task: one row can
+      // contain many nested directives, tool cards and x-html bodies. Keep each
+      // commit deliberately small so transcript installation yields to shell
+      // buttons and the composer between batches instead of freezing the app.
+      const CH = this._isMobileLayout() ? 1 : 2;
+      if (!tailFirst) {
+        // Quiet canonical reconciliation preserves an existing viewport anchor.
+        // Keep its established chronological expansion; exposing only the tail
+        // first would temporarily remove the anchored row before the final restore.
+        const start = st.messageRange.visibleStart;
+        let i = 0;
+        while (i < visible.length) {
+          if (this.tabState[sid] !== st || st.streaming || st.es) return;
+          i = Math.min(visible.length, i + CH);
+          st.messageRange.visibleEnd = start + i;
+          await new Promise(resolve => this.$nextTick(resolve));
+          if (!this._paneElement(sid)) {
+            st.messageRange.visibleEnd = start + visible.length;
+            break;
+          }
+          if (i < visible.length) {
+            await new Promise(r => (typeof requestAnimationFrame === "function"
+              ? requestAnimationFrame(() => r()) : setTimeout(r, 16)));
+          }
         }
-        if (i < visible.length) {
-          await new Promise(r => (window.requestAnimationFrame
+        if (this.tabState[sid] === st) this._scheduleHistoryViewport(st, "older");
+        return;
+      }
+      const finalStart = st.messageRange.visibleStart;
+      const finalEnd = finalStart + visible.length;
+      let cursor = finalEnd;
+      st.messageRange.visibleStart = finalEnd;
+      st.messageRange.visibleEnd = finalEnd;
+      while (cursor > finalStart) {
+        if (this.tabState[sid] !== st || st.streaming || st.es) return;
+        const active = sid === this.currentId;
+        const scrollEl = active ? this._chatBodyElement() : null;
+        const anchor = scrollEl && st.atBottom === false
+          ? this._captureViewportMessageAnchor(scrollEl, sid) : null;
+        const nextStart = Math.max(finalStart, cursor - CH);
+        st.messageRange.visibleStart = nextStart;
+        st.messageRange.visibleEnd = finalEnd;
+        cursor = nextStart;
+        // Wait for Alpine to instantiate this keyed batch. As soon as the active
+        // pane owns its newest rows, remove only the transcript skeleton and pin
+        // the physical scroller; the remaining resident rows continue prepending
+        // between frames without blocking the composer or surrounding controls.
+        await new Promise(resolve => this.$nextTick(resolve));
+        if (active && sid === this.currentId && this.tabState[sid] === st) {
+          if (!st.messagesReady) st.messagesReady = true;
+          if (st.atBottom !== false) {
+            this._scrollChatTailNow(sid, st);
+          } else if (scrollEl) {
+            this._restoreMessageAnchor(scrollEl, anchor);
+          }
+        }
+        if (!this._paneElement(sid)) {
+          st.messageRange.visibleStart = finalStart;
+          break;
+        }
+        if (cursor > finalStart) {
+          await new Promise(r => (typeof requestAnimationFrame === "function"
             ? requestAnimationFrame(() => r()) : setTimeout(r, 16)));
         }
       }
@@ -15114,7 +15151,7 @@ function portal() {
     },
     // Server/history windows are independent of the rendered DOM row count.
     // Viewport virtualization alone decides which normalized messages mount.
-    _historyWindowSize() { return 300; },
+    _historyWindowSize() { return this._isMobileLayout() ? 20 : 100; },
     _historyReconcileWindowSize() { return 800; },
     _scheduleHistoryViewport(st, direction = "newer", anchorUuid = "") {
       if (!st) return;
@@ -28905,24 +28942,18 @@ function portal() {
         if (streamState.es === es) streamState.es = null;
 
         if (attempts > MAX_ATTEMPTS) {
-          // Given up. Surface manual retry UI.
+          // Transport exhaustion is not a server-authenticated terminal result.
+          // Keep the logical turn running and reconcile at low frequency; the
+          // detached backend pump may still complete, settle its queue claim and
+          // start the next queued turn while this browser is offline.
           this.toast(this.lang === "zh"
-                      ? "和 Muse 的连接断开了，重试一下"
-                      : "Lost connection to Muse — try again",
-                      "error");
-          if (!isContinuation) markUserFailed();
-          _markDone(); _stopTimer();
-          if (streamState.pendingQueue && streamState.pendingQueue.length > 0) {
-            // Optimistic — the server also pauses the queue in the turn's
-            // finally (Task 3) when an errored turn has items waiting. Show
-            // the banner now, reconcile with server truth a beat later.
-            streamState._queuePaused = true;
-            setTimeout(() => {
-              if (this.tabState[streamSid] === streamState) {
-                this._syncQueueFromServer(streamSid);
-              }
-            }, 800);
-          }
+                      ? "连接暂时中断，正在后台恢复会话状态"
+                      : "Connection interrupted; recovering session state",
+                      "warn", 4000);
+          streamState._serverActiveObserved = true;
+          this._scheduleCanonicalStreamReload(streamSid, streamState, {
+            minimumWaitMs: 1000,
+          });
           return;
         }
 
@@ -28961,7 +28992,13 @@ function portal() {
               _markDone(false, false, true); _stopTimer();
               this._ackViewedActivity(streamSid, streamState, 3);
               if (this.currentId === streamSid) {
-                this._reloadSessionCoalesced(streamSid, { quiet: true });
+                this._reloadSessionCoalesced(streamSid, { quiet: true }).then(loaded => {
+                  if (loaded && this.tabState[streamSid] === streamState) {
+                    this.$nextTick(() => this._drainPendingQueue(
+                      streamSid, streamState.activeTurnId || "",
+                    ));
+                  }
+                });
               }
               return;
             }
@@ -28992,12 +29029,14 @@ function portal() {
             // the running footer and temporarily unlock the composer even
             // though the server-side turn was still alive.
             if (attempts >= MAX_ATTEMPTS) {
-              _markDone(); _stopTimer();
               this.toast(this.lang === "zh"
-                          ? "和 Muse 的连接断开了，重试一下"
-                          : "Lost connection to Muse — try again",
-                          "error");
-              if (!isContinuation) markUserFailed();
+                          ? "连接暂时中断，正在后台恢复会话状态"
+                          : "Connection interrupted; recovering session state",
+                          "warn", 4000);
+              streamState._serverActiveObserved = true;
+              this._scheduleCanonicalStreamReload(streamSid, streamState, {
+                minimumWaitMs: 1000,
+              });
             } else {
               // Schedule next retry ourselves since the old EventSource is
               // closed and no new transport error will fire.
@@ -29104,6 +29143,19 @@ function portal() {
         st.streaming = false;
         st._stopping = false;
         st.streamingModel = "";
+        if (st.pendingQueue && st.pendingQueue.length > 0) {
+          // No backend turn exists yet, but the durable queue may already do.
+          // Persist the same Stop semantics instead of leaving only the local
+          // banner paused while the server remains free to drain it.
+          try {
+            await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/queue/pause`, {
+              method: "POST",
+              headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
+              body: JSON.stringify({ paused: true }),
+            });
+          } catch (_) { /* queue sync below/next activation reconciles */ }
+          this._syncQueueFromServer(sid);
+        }
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 1500);
         return;
       }

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -16,6 +16,16 @@ def _service(tmp_path, monkeypatch):
         "_metadata",
         lambda sid: (f"Session {sid}", workspace, "ws"),
     )
+    from backend import activity as activity_module
+    monkeypatch.setattr(
+        activity_module.sessions,
+        "list_sessions",
+        lambda: [
+            {"id": row.get("session_id")}
+            for row in service._events
+            if row.get("session_id")
+        ],
+    )
     return service
 
 
@@ -839,6 +849,34 @@ async def test_subscriber_receives_task_transition_without_polling(
     assert payload["summary"]["running"] == 1
     assert payload["summary"]["revision"] == 1
     assert payload["summary"]["generation"] == payload["generation"]
+
+
+@pytest.mark.asyncio
+async def test_sse_summary_excludes_unopenable_unread_rows(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    from backend import activity as activity_module
+
+    live_ids = {"deleted", "running"}
+    monkeypatch.setattr(
+        activity_module.sessions,
+        "list_sessions",
+        lambda: [{"id": sid} for sid in sorted(live_ids)],
+    )
+    service.start("deleted", summary="old completed task")
+    service.finish("deleted", "completed")
+    live_ids.remove("deleted")
+
+    async with service.subscribe() as queue:
+        await asyncio.to_thread(
+            service.start, "running", summary="current running task")
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert payload["summary"]["running"] == 1
+    assert payload["summary"]["unread"] == 0
+    assert payload["summary"] == service.summary(filter_live=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -1269,7 +1269,7 @@ async def test_sync_and_async_purge_from_leaf_clear_full_runtime_lineage(
 
 
 @pytest.mark.asyncio
-async def test_force_stop_tears_down_stuck_turn(chat_mod):
+async def test_force_stop_tears_down_stuck_turn(chat_mod, monkeypatch):
     """The SDK's client.interrupt() is best-effort; for an agentic turn the CLI
     may keep running, pinning the slot in _active_turns and bouncing every
     subsequent send with 'previous turn still running'. The force-stop watchdog
@@ -1277,6 +1277,32 @@ async def test_force_stop_tears_down_stuck_turn(chat_mod):
     sid = "sid-stuck"
     c = _seed(chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
     bc = chat_mod.TurnBroadcast(session_id=sid, model="claude-sonnet-4-6")
+    bc.queue_item_id = "q-stuck"
+    bc.activity_started = True
+    activity_finishes = []
+    queue_releases = []
+    queue_pauses = []
+    memory_clears = []
+    remembered = []
+
+    async def finish_activity(got_sid, got_bc, status):
+        activity_finishes.append((got_sid, got_bc.turn_id, status))
+        got_bc.activity_started = False
+
+    monkeypatch.setattr(chat_mod, "_finish_activity", finish_activity)
+    monkeypatch.setattr(
+        chat_mod.sess, "release_queue_claim",
+        lambda got_sid, item_id, **kwargs: queue_releases.append(
+            (got_sid, item_id, kwargs.get("turn_id"), kwargs.get("pause"))) or True,
+    )
+    monkeypatch.setattr(
+        chat_mod.sess, "pause_queue_if_nonempty", queue_pauses.append)
+    monkeypatch.setattr(
+        chat_mod.mem0, "pop_recall_trace", memory_clears.append)
+    monkeypatch.setattr(
+        chat_mod, "_remember_recent_turn",
+        lambda got_sid, got_bc: remembered.append((got_sid, got_bc.turn_id)),
+    )
     chat_mod._active_turns[sid] = bc
     try:
         # Tiny grace; the (absent) pump never frees the slot, so the watchdog
@@ -1286,7 +1312,51 @@ async def test_force_stop_tears_down_stuck_turn(chat_mod):
         assert sid not in chat_mod._active_turns  # slot freed → next send works
         assert bc.cancelled is True
         assert bc.done is True                    # subscribers get the sentinel
+        assert activity_finishes == [(sid, bc.turn_id, "cancelled")]
+        assert queue_releases == [(sid, "q-stuck", bc.turn_id, True)]
+        assert queue_pauses == [sid]
+        assert memory_clears == [sid]
+        assert remembered == [(sid, bc.turn_id)]
     finally:
+        chat_mod._active_turns.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_force_stop_lets_cancelled_pump_own_terminal_cleanup(
+    chat_mod, monkeypatch,
+):
+    """Cancelling the real pump must not race a second manual settlement."""
+    sid = "sid-pump-cleanup"
+    _seed(chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
+    bc = chat_mod.TurnBroadcast(session_id=sid, model="claude-sonnet-4-6")
+    manual_finishes = []
+    monkeypatch.setattr(
+        chat_mod,
+        "_finish_activity",
+        lambda *args, **kwargs: manual_finishes.append((args, kwargs)),
+    )
+
+    async def pump():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            bc.finish()
+            chat_mod._active_turns.pop(sid, None)
+
+    task = asyncio.create_task(pump())
+    bc.task = task
+    chat_mod._active_turns[sid] = bc
+    await asyncio.sleep(0)
+    try:
+        await chat_mod._force_stop_after_grace(sid, bc, grace=0.01)
+        assert task.done()
+        assert bc.done is True
+        assert sid not in chat_mod._active_turns
+        assert manual_finishes == []
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
         chat_mod._active_turns.pop(sid, None)
 
 

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -199,6 +199,36 @@ async def test_queue_drain_replays_one_wakeup_coalesced_during_rollover(
     assert sid not in chat_mod._queue_drain_rekicks
 
 
+@pytest.mark.asyncio
+async def test_queue_rollover_conflict_retains_delayed_retry(
+        app_module, monkeypatch):
+    """A transient background-owner 409 must not strand queued work forever."""
+    from fastapi import HTTPException
+    from backend import chat as chat_mod
+
+    sid = "queue-rollover-retry"
+    retried = []
+    chat_mod._sessions_with_inflight_tasks[sid] = {"task-1"}
+    monkeypatch.setattr(
+        chat_mod.sess, "get_queue",
+        lambda got_sid: {"items": [{"id": "q-1"}], "inflight": None}
+        if got_sid == sid else {"items": [], "inflight": None},
+    )
+
+    async def deferred(_sid):
+        raise HTTPException(status_code=409, detail="handoff in progress")
+
+    monkeypatch.setattr(chat_mod, "_continue_detached_runtime", deferred)
+    monkeypatch.setattr(
+        chat_mod, "_schedule_queue_drain_retry", retried.append)
+    try:
+        await chat_mod._maybe_drain_queue(sid)
+    finally:
+        chat_mod._sessions_with_inflight_tasks.pop(sid, None)
+
+    assert retried == [sid]
+
+
 def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypatch):
     """Happy path: assistant text → tool_use → tool_result → done. Assert
     every key frame flows through with the expected shape."""
@@ -390,6 +420,51 @@ def test_tool_only_turn_persists_completion_annotation(
     chat_mod._complete_turn_footer_metadata(
         shaped, "claude-sonnet-4-6", has_later=False)
     assert shaped[-1]["memoryRecall"] == persisted_recall
+
+
+def test_result_race_preserves_turn_owned_cancelled_state(
+        stream_env, client, monkeypatch):
+    """Stop marked on the exact broadcast wins before pending bookkeeping."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    tool_message = AssistantMessage(
+        content=[ToolUseBlock(
+            id="tu_cancel_race", name="Read",
+            input={"file_path": "/tmp/cancel-race.txt"},
+        )],
+        model="claude-sonnet-4-6", usage={},
+        uuid="assistant-cancel-race",
+    )
+    result = ResultMessage(
+        subtype="success", duration_ms=900, duration_api_ms=800,
+        is_error=False, num_turns=1, session_id=sid,
+        total_cost_usd=0.0, usage={},
+    )
+
+    class CancellingClient(_FakeStreamClient):
+        async def receive_response(self):
+            yield tool_message
+            chat_mod._active_turns[sid].cancelled = True
+            assert sid not in chat_mod._pending_interrupts
+            yield result
+
+    async def fake_get_client(*_args, **_kwargs):
+        return CancellingClient([])
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=inspect&model=claude-sonnet-4-6",
+    )
+    assert response.status_code == 200, response.text
+    done = next(
+        json.loads(data)
+        for event, data in _parse_sse(response.text)
+        if event == "done"
+    )
+
+    assert done["cancelled"] is True
+    assert done["is_error"] is False
 
 
 def test_forced_interrupt_persists_refreshable_footer_and_private_snapshot(

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -777,7 +777,7 @@ def test_workspace_switch_moves_files_preview_and_conversation_together():
     assert "const surfaceReady = Promise.resolve(" in switch
     assert "this._changeWorkspaceSurface(path)" in switch
     assert "await this._pullWorkspaceSessions(path)" in switch
-    assert "await this._ensureSessionLoaded(target.id)" in switch
+    assert "await this._ensureSessionLoaded(target.id)" not in switch
     assert "await Promise.all([surfaceReady, targetReady])" in switch
     assert "_pullAllSessions()" not in switch
     target_ready = switch[switch.index("const targetReady"):switch.index(
@@ -785,7 +785,13 @@ def test_workspace_switch_moves_files_preview_and_conversation_together():
     assert "this.currentId =" not in target_ready
     assert "this.openTab(" not in target_ready
     assert switch.index("await Promise.all([surfaceReady, targetReady])") < switch.index(
-        "await this.openTab(target.id)")
+        "await this.openTab(target.id, true, { deferLoad: true })")
+    open_start = app.index("async openTab(id, makeCurrent = true, options = {})")
+    open_end = app.index("// Open a session id arriving", open_start)
+    open_tab = app[open_start:open_end]
+    assert "const switching = this.switchSession()" in open_tab
+    assert "if (options.deferLoad)" in open_tab
+    assert "void switching.catch(() => false)" in open_tab
     assert "workspaceSurfaceTransition: false" in app
     assert "const switchSeq = ++this._workspaceSwitchSeq" in switch
     assert "this.workspaceSurfaceTransition = true" in switch
@@ -2624,9 +2630,15 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
 
     assert "if (st.streaming || st.es) return false" in load
     assert "this.tabState[sid] !== st || st.streaming || st.es" in load
-    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible)")
+    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true)")
     reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
     assert "this.tabState[sid] !== st || st.streaming || st.es" in reveal
+    assert "const CH = this._isMobileLayout() ? 1 : 2" in reveal
+    assert "let cursor = finalEnd" in reveal
+    assert "st.messageRange.visibleStart = nextStart" in reveal
+    assert "if (!st.messagesReady) st.messagesReady = true" in reveal
+    assert "this._scrollChatTailNow(sid, st)" in reveal
+    assert "requestAnimationFrame(() => r())" in reveal
     assert "const ownsCurBubble = () =>" in send
     assert "this._containsPaneMessage(streamState, curBubble)" in send
     contains_start = app.index("_containsPaneMessage(st, message)")
@@ -2661,8 +2673,14 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     transport_finished_start = send.index("if (!d.active)", no_active_end)
     transport_finished_end = send.index(
         "if (d.background && d.attachable === false)", transport_finished_start)
-    assert "this._reloadSessionCoalesced(streamSid, { quiet: true })" in send[
-        transport_finished_start:transport_finished_end]
+    transport_finished = send[transport_finished_start:transport_finished_end]
+    assert "this._reloadSessionCoalesced(streamSid, { quiet: true })" in transport_finished
+    assert "this._drainPendingQueue(" in transport_finished
+    assert "streamState.activeTurnId || \"\"" in transport_finished
+    health_start = app.index("async _runStreamHealthSync(sid, st, options = {})")
+    health_end = app.index("_scheduleCanonicalStreamReload(", health_start)
+    health = app[health_start:health_end]
+    assert "this._drainPendingQueue(" in health
 
 
 def test_fork_banner_and_message_template_are_null_and_key_safe():
@@ -2697,7 +2715,8 @@ def test_quiet_history_reload_restores_visible_block_anchor_not_absolute_scroll(
     assert "this._captureViewportMessageAnchor(quietScrollEl, sid)" in load
     assert "quietScrollEl && !st.atBottom" in load
     assert "st.messages.length" in load
-    assert "!st.atBottom ? this._historyReconcileWindowSize() : 0" in load
+    assert "Math.max(historyPage, st.messages.length)" in load
+    assert "_historyReconcileWindowSize()" not in load
     assert "this._restoreMessageAnchor(" in load
     assert "if (!restored) quietScrollEl.scrollTop = quietScrollTop" in load
     assert 'pane.querySelectorAll(".msg[data-message-key]")' in anchors
@@ -3307,14 +3326,15 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "_activated: false" in blank
     for removed in ("_earlierMessages", "_laterMessages", "_allPaneMessages"):
         assert removed not in app
-    assert "_historyWindowSize() { return 300; }" in app
+    assert "_historyWindowSize() { return this._isMobileLayout() ? 20 : 100; }" in app
     assert "_historyReconcileWindowSize() { return 800; }" in app
-    assert "_historyWindowSize() { return this._isMobileLayout()" not in app
     assert "_historyReconcileWindowSize() { return this._isMobileLayout()" not in app
     assert "_MAX_RESIDENT_PANES" not in app
     assert "residentPaneIds" not in app
     assert "_promoteResident" not in app
-    assert "const _baseInitialLoad = _coldEarly ? 30 : 60;" in app
+    assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in app
+    assert "Math.max(historyPage, st.messages.length)" in app
+    assert "const _baseInitialLoad" not in app
     assert "const _mobileEarly" not in app
     assert "_coldEarly ? 8 : 15" not in app
     assert "if (cst && cst.streaming) continue" not in app


### PR DESCRIPTION
## 变更类型
- [x] 修复 (bugfix)
- [x] 性能优化 (performance)

## 变更说明
- 保留精确 turn-owned 取消状态，避免 Stop 与 ResultMessage 竞态把已终止任务误记为完成或失败。
- 补齐强制终止 watchdog 的 Activity、队列 claim、memory trace 和 replay 清理，并避免与 pump 重复结算。
- 为后台 runtime 交接的可恢复 404/409 增加保留式队列重试；断线恢复后重新 attach 队列后继任务。
- 统一 Activity HTTP/SSE 的 live-session 摘要过滤，避免已删除会话遗留 unread 绿点。
- 将工作区外壳切换与 transcript 加载解耦，避免会话正文加载持续禁用输入框和周边控件。
- 历史窗口固定为桌面 100、移动端 20；Tab 切换优先挂载最新尾部，再逐帧向前补齐。

## 测试情况
- `tests/test_activity.py`: 36 passed
- `tests/test_chat_endpoints.py`: 71 passed
- `tests/test_chat_stream.py`: 137 passed
- `tests/test_frontend_lint.py`: 148 passed
- Python `py_compile` 通过
- `git diff --check` 通过

## 审查检查项
- [x] 仅包含本轮相关源代码与回归测试
- [x] 未提交主工作区其他未提交文件
- [x] 未包含凭据或调试产物
- [x] 未使用 force-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
