### PR TITLE
修复会话状态收敛与乐观交互

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -137,6 +137,12 @@ class ActivityService:
                         needs_attention=False,
                         read=False,
                     )
+                    # Activity owners are process-local lifecycle claims. Once a
+                    # restart terminalizes the row, retaining them lets the next
+                    # turn inherit dead owners and remain running after its real
+                    # owner finishes.
+                    item.pop("owner_id", None)
+                    item.pop("active_owner_ids", None)
                     changed = True
             if changed:
                 self._save()
@@ -452,7 +458,12 @@ class ActivityService:
         loops and delivery crosses the boundary via ``call_soon_threadsafe``.
         """
         self._revision += 1
-        summary = _summarize([dict(x) for x in self._events])
+        # SSE and HTTP must summarize the same visible ledger. Keeping deleted
+        # sessions in the durable audit trail is fine, but letting their unread
+        # terminal rows leak only through SSE resurrects a green completion dot
+        # while every openable Activity row is still running.
+        visible_events = self._filter_live([dict(x) for x in self._events])
+        summary = _summarize(visible_events)
         summary["generation"] = self._generation
         summary["revision"] = self._revision
         payload: dict[str, Any] = {
@@ -534,6 +545,25 @@ class ActivityService:
         return next((x for x in reversed(self._events)
                      if x.get("session_id") == sid), None)
 
+    @staticmethod
+    def _active_owner_ids(item: dict[str, Any]) -> list[str]:
+        values = item.get("active_owner_ids")
+        if not isinstance(values, list):
+            return []
+        return list(dict.fromkeys(
+            str(value)[:200] for value in values if str(value or "").strip()
+        ))
+
+    def _latest_by_owner(self, owner_id: str) -> dict[str, Any] | None:
+        owner = str(owner_id or "")[:200]
+        if not owner:
+            return None
+        return next((
+            item for item in reversed(self._events)
+            if item.get("owner_id") == owner
+            or owner in self._active_owner_ids(item)
+        ), None)
+
     def _live_session_ids(self) -> set[str]:
         """Session ids the frontend can still open.
 
@@ -578,6 +608,10 @@ class ActivityService:
                 item = {"id": uuid.uuid4().hex, "session_id": sid,
                         "turn_count": 0}
                 self._events.append(item)
+            inherited_owners = (
+                self._active_owner_ids(item)
+                if item.get("state") in _ACTIVE else []
+            )
             item.update(
                 kind=(kind or "turn")[:40],
                 # Chat turns use this delivery-class field to distinguish a
@@ -601,9 +635,17 @@ class ActivityService:
             else:
                 item.pop("source_id", None)
             if owner_id:
-                item["owner_id"] = owner_id[:200]
+                owner = owner_id[:200]
+                item["owner_id"] = owner
+                if inherited_owners:
+                    item["active_owner_ids"] = list(dict.fromkeys(
+                        [*inherited_owners, owner]
+                    ))
+                else:
+                    item.pop("active_owner_ids", None)
             else:
                 item.pop("owner_id", None)
+                item.pop("active_owner_ids", None)
             self._events = self._events[-_MAX_EVENTS:]
             self._save()
             self._publish_locked(item=item)
@@ -654,6 +696,12 @@ class ActivityService:
             "cancelled" if status in {"cancelled", "interrupted"} else "failed")
         with self._lock:
             item = self._latest(sid)
+            if item is None and owner_id:
+                # A successor moves the visible Activity row to its child SID,
+                # while the inherited watcher still settles through the source
+                # SID. Resolve that durable logical owner before treating the
+                # finish as an orphan.
+                item = self._latest_by_owner(owner_id)
             if item is None:
                 # A normal owner may only close the Activity incarnation it
                 # successfully started. If its start failed before persisting
@@ -673,10 +721,24 @@ class ActivityService:
                 item = self._latest(sid)
             assert item is not None
             # A detached watcher can finish after a newer foreground turn has
-            # reused this session row. Only the owner that started the current
-            # incarnation may close it; deletion intentionally omits owner_id
-            # to force a terminal state for whichever incarnation remains.
-            if owner_id and item.get("owner_id") != owner_id:
+            # reused this session row. Ordinary rows still have one replaceable
+            # owner. Successor inheritance promotes that owner into a small set,
+            # because the child may run a foreground turn while predecessor-owned
+            # background work remains active.
+            active_owners = self._active_owner_ids(item)
+            if owner_id and active_owners:
+                owner = owner_id[:200]
+                if owner not in active_owners:
+                    return dict(item)
+                remaining_owners = [value for value in active_owners if value != owner]
+                if remaining_owners:
+                    item["active_owner_ids"] = remaining_owners
+                    if item.get("owner_id") == owner:
+                        item["owner_id"] = remaining_owners[-1]
+                    self._save()
+                    return dict(item)
+                item.pop("active_owner_ids", None)
+            elif owner_id and item.get("owner_id") != owner_id:
                 return dict(item)
             owner_revoked = False
             if not owner_id:
@@ -684,6 +746,8 @@ class ActivityService:
                 # Revoke the current incarnation so its late ordinary owner can
                 # no longer overwrite this authoritative terminal state.
                 owner_revoked = item.pop("owner_id", None) is not None
+                owner_revoked = item.pop("active_owner_ids", None) is not None \
+                    or owner_revoked
             # Terminal delivery can be observed by more than one cleanup path
             # (for example the Result boundary and an outer pump fallback).
             # Repeating the same terminal state must be a true no-op: rewriting
@@ -711,12 +775,10 @@ class ActivityService:
             now = time.time()
             if activity_source:
                 item["activity_source"] = activity_source[:40]
-            # Background logical turns surface their result as a normal Agent
-            # bubble in chat.  Their Activity row remains useful history, but
-            # must become terminal+read in this same locked mutation: publishing
-            # an unread finish and ACKing it afterwards exposes a transient red
-            # badge to SSE clients.  Other callers retain the established unread
-            # completion/failure semantics by leaving ``mark_read`` unspecified.
+            # Callers may atomically finish as read when the result was already
+            # visible to the user. Otherwise completion/failure retains the normal
+            # unread-result semantics; the frontend ACKs a visibly mounted session
+            # after receiving the terminal Activity transition.
             terminal_read = (
                 bool(mark_read) if mark_read is not None
                 else state == "cancelled"
@@ -1069,6 +1131,16 @@ class ActivityService:
                 changed = True
             if successor:
                 if source_item is not None:
+                    # A running predecessor watcher keeps settling with its old
+                    # SID/owner after this row moves to the child. Preserve that
+                    # owner explicitly so a child foreground turn can coexist
+                    # without completing the shared logical task prematurely.
+                    inherited_owners = self._active_owner_ids(source_item)
+                    current_owner = str(source_item.get("owner_id") or "")[:200]
+                    if source_item.get("state") in _ACTIVE and current_owner:
+                        if current_owner not in inherited_owners:
+                            inherited_owners.append(current_owner)
+                        source_item["active_owner_ids"] = inherited_owners
                     source_item["session_id"] = child
                     source_item.pop("thread_id", None)
                     source_item["session_name"] = child_name

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -456,13 +456,15 @@ def _compact_tail_outcome(path: Path | None, offset: int) -> dict[str, bool]:
 
 
 @contextmanager
-def _session_config_dir(model: str = ""):
-    """Compatibility wrapper for the SDK's process-global config directory."""
+def _session_config_dir(model: str = "", *, sid: str = ""):
+    """Scope SDK session operations to the JSONL's actual config store."""
+    session_path = _find_session_jsonl(sid) if sid else None
     with chat_history.session_config_dir(
         model,
         lock=_vendor_msg_lock,
         is_third_party=endpoints.is_third_party,
         vendor_config_dir=endpoints._vendor_config_dir,
+        session_path=session_path,
     ):
         yield
 
@@ -1001,6 +1003,10 @@ class TurnBroadcast:
         # AssistantMessage UUID. Keep their display record separately so a
         # refresh cannot erase the visible error or relabel an older reply.
         self.failed_snapshot_persisted = False
+        # Some third-party runtimes return the final prose only on ResultMessage
+        # after their last tool call. Preserve that authoritative result in the
+        # same private presentation channel so live and refreshed views agree.
+        self.result_snapshot_persisted = False
         self.cancelled_snapshot_suppressed = False
         self.cancelled_snapshot_lock = threading.Lock()
         # True for a HEADLESS CONTINUATION turn: the cross-turn task watcher
@@ -1056,6 +1062,7 @@ class TurnBroadcast:
         self.perf_status = "unknown"
         self.perf_error_kind = "none"
         self.perf_background_count = 0
+        self.perf_final_mode = "normal"
         self._perf_emitted = False
 
     @property
@@ -1241,6 +1248,7 @@ class TurnBroadcast:
                     status=self.perf_status,
                     error_kind=self.perf_error_kind,
                     background_count=self.perf_background_count,
+                    final_mode=self.perf_final_mode,
                 )
             except Exception:
                 # Observability must never change turn lifecycle semantics.
@@ -1375,6 +1383,10 @@ _session_runtime_locks: dict[str, asyncio.Lock] = {}
 # from popping adjacent FIFO items before either reserves _active_turns[sid].
 _queue_drain_locks: dict[str, asyncio.Lock] = {}
 _queue_drain_tasks: dict[str, asyncio.Task] = {}
+# Recoverable runtime-rollover conflicts (404/409 while a background watcher is
+# handing ownership to its successor) need a retained wake-up even when no new
+# enqueue or task notification arrives. One delayed retry per session is enough.
+_queue_drain_retry_tasks: dict[str, asyncio.Task] = {}
 # A queue POST can land while the coalesced drain is busy forking a detached
 # runtime. Remember that wakeup instead of dropping it; once the first drain
 # exits, one follow-up pass migrates any item accepted after its queue snapshot.
@@ -1451,12 +1463,6 @@ _background_turn_started_at: dict[str, float] = {}
 # Originating user-turn identity retained across the watcher gap. Every
 # continuation gets its own turn_id and exposes this value as parent_turn_id.
 _background_origin_turn_id: dict[str, str] = {}
-# Activity Center completion deferred past the main ResultMessage while an SDK
-# background task still owns the logical turn. The value retains both the
-# terminal status and the Activity incarnation owner. A later foreground turn
-# may reuse the same session row while the old watcher is still alive; the
-# owner id prevents that stale watcher from closing the newer row.
-_background_activity_finishes: dict[str, tuple[str, str]] = {}
 # Monotonic per-session ownership token for detached continuation readers.
 # Cancelling a task is cooperative, so a replaced watcher can receive one more
 # message before CancelledError lands. Generation checks keep that stale reader
@@ -3583,10 +3589,10 @@ async def shutdown_runtime() -> None:
     _active_turns.clear()
     _sessions_with_inflight_tasks.clear()
     _bg_task_pinned_at.clear()
-    _background_activity_finishes.clear()
     _task_watchers.clear()
     _runtime_prewarm_tasks.clear()
     _queue_drain_tasks.clear()
+    _queue_drain_retry_tasks.clear()
     _queue_drain_rekicks.clear()
     _queue_drain_locks.clear()
 
@@ -5554,6 +5560,10 @@ def _persist_cancelled_footer_annotation_locked(bc: 'TurnBroadcast', now_ms: int
 def _persist_cancelled_turn_snapshot_locked(bc: 'TurnBroadcast') -> bool:
     return chat_overlays._persist_cancelled_turn_snapshot_locked(bc)
 
+def _persist_completed_result_snapshot(bc: 'TurnBroadcast', result_text: str, *, terminal_at_ms: int, elapsed_s: float | None=None, memory_recall: dict | None=None) -> bool:
+    return chat_overlays._persist_completed_result_snapshot(bc, result_text, terminal_at_ms=terminal_at_ms, elapsed_s=elapsed_s, memory_recall=memory_recall)
+
+
 def _persist_failed_turn_snapshot(bc: 'TurnBroadcast', error_text: str, *, terminal_at_ms: int | None=None, elapsed_s: float | None=None, memory_recall: dict | None=None, canonical_terminal_published: bool=False) -> bool:
     return chat_overlays._persist_failed_turn_snapshot(bc, error_text, terminal_at_ms=terminal_at_ms, elapsed_s=elapsed_s, memory_recall=memory_recall, canonical_terminal_published=canonical_terminal_published)
 
@@ -5623,6 +5633,61 @@ def _turn_uuids_from_boundary(
             f"exc={type(exc).__name__}\n")
         sys.stderr.flush()
         return None, None, False
+
+
+def _turn_prevented_error_from_boundary(
+    sid: str,
+    boundary: dict[str, Any],
+) -> dict | None:
+    """Recover a CLI hook rejection that the warm SDK stream did not emit.
+
+    Some UserPromptSubmit failures are persisted only as a canonical system row
+    followed by a nominally successful ResultMessage.  The missing user UUID is
+    then expected, not a generic commit race; preserve the actionable hook error.
+    """
+    if not bool((boundary or {}).get("capture_ok")):
+        return None
+    try:
+        indexed = _ensure_transcript_index(sid)
+        if indexed is None:
+            return None
+        transcript_path, index = indexed
+        source = index.get("source") or {}
+        expected_dev = int((boundary or {}).get("source_dev") or 0)
+        expected_inode = int((boundary or {}).get("source_inode") or 0)
+        if ((expected_dev and int(source.get("dev") or 0) != expected_dev)
+                or (expected_inode
+                    and int(source.get("inode") or 0) != expected_inode)):
+            return None
+        records = index.get("records") or []
+        start = max(0, int((boundary or {}).get("record_count") or 0))
+        system_ids = [
+            record_i
+            for record_i in range(start, len(records))
+            if records[record_i].get("type") == "system"
+        ]
+        for entry in transcript_idx.read_records(
+                transcript_path, index, system_ids):
+            data = entry.get("data") if isinstance(entry.get("data"), dict) else {}
+            if not (entry.get("preventContinuation") is True
+                    or data.get("preventContinuation") is True):
+                continue
+            text = str(
+                entry.get("content") or entry.get("error")
+                or data.get("content") or data.get("error") or ""
+            ).strip()
+            return {
+                "message": text or (
+                    "User prompt was rejected before it was committed."),
+                "source": "system_prevent_continuation",
+                "api_error_status": None,
+            }
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] turn hook rejection recovery skipped sid={sid[:8]} "
+            f"exc={type(exc).__name__}\n")
+        sys.stderr.flush()
+    return None
 
 
 async def _settle_turn_uuids(
@@ -5741,10 +5806,12 @@ def _clear_session_runtime_state(sid: str) -> list[asyncio.Task]:
     if runtime_lock is not None and not runtime_lock.locked():
         _session_runtime_locks.pop(sid, None)
     drain_task = _queue_drain_tasks.pop(sid, None)
+    retry_task = _queue_drain_retry_tasks.pop(sid, None)
     _queue_drain_rekicks.discard(sid)
-    if drain_task is not None and not drain_task.done():
-        drain_task.cancel()
-        cancelled_tasks.append(drain_task)
+    for task in (drain_task, retry_task):
+        if task is not None and not task.done():
+            task.cancel()
+            cancelled_tasks.append(task)
     prewarm_task = _runtime_prewarm_tasks.pop(sid, None)
     if prewarm_task is not None and not prewarm_task.done():
         prewarm_task.cancel()
@@ -5759,7 +5826,6 @@ def _clear_session_runtime_state(sid: str) -> list[asyncio.Task]:
         cancelled_tasks.append(watcher)
     _background_turn_started_at.pop(sid, None)
     _background_origin_turn_id.pop(sid, None)
-    _background_activity_finishes.pop(sid, None)
     task_ids = _sessions_with_inflight_tasks.pop(sid, set())
     for task_id in task_ids:
         _bg_task_descriptions.pop(task_id, None)
@@ -5998,13 +6064,6 @@ async def _purge_session_storage_async_inner(sid: str) -> bool:
     active = _active_turns.get(sid)
     had_active_activity = bool(
         active is not None and active.activity_started)
-    # A completed foreground Result may have transferred its Activity row to a
-    # still-running background watcher. `_clear_session_runtime_state` removes
-    # that ownership marker, so retain it long enough to close the ledger row.
-    had_background_activity = (
-        sid in _background_activity_finishes
-        or sid in _task_watchers
-    )
     pending = _clear_session_runtime_state(sid)
     # Cancellation alone does not reliably tear down a CLI blocked in
     # connect/receive. Pop and disconnect the pooled runtime before joining
@@ -6028,8 +6087,7 @@ async def _purge_session_storage_async_inner(sid: str) -> bool:
     # the global Activity ledger must never be left in `running` if that bound
     # is reached.  The normal owner cleanup clears this bit first; this is an
     # idempotent fallback for the timeout/future-cleanup race.
-    if (had_active_activity or had_background_activity
-            or had_scheduled_activity):
+    if had_active_activity or had_scheduled_activity:
         try:
             from .activity import activity as _activity
             await asyncio.to_thread(
@@ -6037,13 +6095,9 @@ async def _purge_session_storage_async_inner(sid: str) -> bool:
                 sid,
                 "cancelled",
                 activity_source=(
-                    "background"
-                    if had_background_activity
-                    else (
-                        active.activity_source
-                        if had_active_activity
-                        else "scheduled"
-                    )
+                    active.activity_source
+                    if had_active_activity
+                    else "scheduled"
                 ),
             )
         except Exception as exc:
@@ -6550,29 +6604,64 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
 
     ok = False
     if req.name is not None:
-        # Keep the local title and SDK customTitle as one serialized write.
-        # Runtime-rollover postlude propagation uses the same lock and rechecks
-        # the inherited title inside it, so a user's explicit rename always
-        # wins rather than being overwritten by a late automatic sync.
-        with _session_title_lock(sid):
-            renamed = sess.rename_session(sid, req.name)
-            # Also propagate to CLI's JSONL so list_sessions() / manual claude
-            # CLI runs see the new title. Silent no-op if JSONL doesn't exist.
-            try:
-                sdk_rename_session(
-                    sid, req.name,
-                    directory=str(sess.session_workspace(sid)))
-            except (FileNotFoundError, ValueError):
-                pass
-        ok = renamed or ok
-        if renamed:
-            # The task ledger stores one denormalized display name per
-            # conversation.  Keep it in lockstep with the session index and
-            # publish the targeted row over the existing Activity SSE.  This
-            # intentionally preserves task timestamps/read state, so a rename
-            # cannot reorder the task center or make a result unread again.
-            from .activity import activity as _activity
-            await asyncio.to_thread(_activity.rename_session, sid, req.name)
+        rename_started = time.monotonic()
+        lock_wait_ms = 0
+        local_index_ms = 0
+        sdk_rename_ms = 0
+        activity_ms = 0
+        rename_status = "error"
+        renamed = False
+        try:
+            # Keep the local title and SDK customTitle as one serialized write.
+            # Runtime-rollover postlude propagation uses the same lock and rechecks
+            # the inherited title inside it, so a user's explicit rename always
+            # wins rather than being overwritten by a late automatic sync.
+            lock_started = time.monotonic()
+            with _session_title_lock(sid):
+                lock_wait_ms = round((time.monotonic() - lock_started) * 1000)
+                local_started = time.monotonic()
+                renamed = sess.rename_session(sid, req.name)
+                local_index_ms = round(
+                    (time.monotonic() - local_started) * 1000)
+                # Also propagate to CLI's JSONL so list_sessions() / manual claude
+                # CLI runs see the new title. Silent no-op if JSONL doesn't exist.
+                sdk_started = time.monotonic()
+                try:
+                    sdk_rename_session(
+                        sid, req.name,
+                        directory=str(sess.session_workspace(sid)))
+                except (FileNotFoundError, ValueError):
+                    pass
+                finally:
+                    sdk_rename_ms = round(
+                        (time.monotonic() - sdk_started) * 1000)
+            ok = renamed or ok
+            if renamed:
+                # The task ledger stores one denormalized display name per
+                # conversation.  Keep it in lockstep with the session index and
+                # publish the targeted row over the existing Activity SSE.  This
+                # intentionally preserves task timestamps/read state, so a rename
+                # cannot reorder the task center or make a result unread again.
+                from .activity import activity as _activity
+                activity_started = time.monotonic()
+                try:
+                    await asyncio.to_thread(
+                        _activity.rename_session, sid, req.name)
+                finally:
+                    activity_ms = round(
+                        (time.monotonic() - activity_started) * 1000)
+            rename_status = "ok" if renamed else "not_found"
+        finally:
+            _perf_event(
+                "session.rename",
+                session=obs.short_id(sid) or "none",
+                status=rename_status,
+                lock_wait_ms=lock_wait_ms,
+                local_index_ms=local_index_ms,
+                sdk_rename_ms=sdk_rename_ms,
+                activity_ms=activity_ms,
+                total_ms=round((time.monotonic() - rename_started) * 1000),
+            )
     if req.tag is not None:
         # Empty string → clear tag. SDK accepts None or str.
         try:
@@ -7667,7 +7756,7 @@ def _create_context_recovery_session(
         if source_path is None:
             raise context_recovery.ContextRecoveryError(
                 "source transcript is unavailable")
-        with _session_config_dir(source_model):
+        with _session_config_dir(source_model, sid=source_sid):
             return context_recovery.create_recovery_fork(
                 source_sid,
                 source_path,
@@ -8820,6 +8909,17 @@ async def _force_stop_after_grace(
         t = getattr(bc, "task", None)
         if t is not None and not t.done():
             t.cancel()
+            # Cancellation enters the pump's own ``finally``, which already
+            # settles Activity, queue ownership and the durable sidecar. Give
+            # that single owner a bounded chance to finish before taking over;
+            # otherwise both paths can release the same queue claim and publish
+            # the same Activity terminal transition.
+            try:
+                await asyncio.wait_for(asyncio.shield(t), timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            if bc.done or _active_turns.get(session_id) is not bc:
+                return
         async with _lock:
             if _active_turns.get(session_id) is bc:
                 _active_turns.pop(session_id, None)
@@ -8831,7 +8931,24 @@ async def _force_stop_after_grace(
                 "event": "cancelled",
                 "data": json.dumps({"snapshot_ready": snapshot_ready}),
             })
-            bc.finish()
+        # The pump normally owns all terminal bookkeeping. If it never unwinds,
+        # the watchdog must perform the same externally visible settlement rather
+        # than merely freeing `_active_turns`: otherwise Activity can stay green/
+        # running and a queued item can remain durably inflight forever.
+        mem0.pop_recall_trace(session_id)
+        await _finish_activity(session_id, bc, "cancelled")
+        if bc.queue_item_id:
+            sess.release_queue_claim(
+                session_id,
+                bc.queue_item_id,
+                turn_id=bc.turn_id,
+                pause=True,
+            )
+        sess.pause_queue_if_nonempty(session_id)
+        bc.perf_status = "cancelled"
+        bc.perf_error_kind = "cancelled"
+        bc.finish()
+        _remember_recent_turn(session_id, bc)
         if snapshot_ready or bc.queue_item_id:
             _delete_active_turn_sidecar(session_id)
         else:
@@ -10537,7 +10654,7 @@ async def _watch_inflight_tasks(
     client: ClaudeSDKClient,
     pending: dict[str, str | None],
     generation: int | None = None,
-    activity_owner_id: str = "",
+    origin_turn_id: str = "",
 ) -> None:
     """Detached reader keeping an originating CLI client alive past its turn so
     SDK background tasks started in that turn can deliver their terminal
@@ -10571,11 +10688,8 @@ async def _watch_inflight_tasks(
     watch_error_kind = "none"
     cont: TurnBroadcast | None = None
     cont_state: dict | None = None
-    activity_failed = False
+    watcher_failed = False
     watcher_cancelled = False
-    if not activity_owner_id:
-        deferred = _background_activity_finishes.get(session_id)
-        activity_owner_id = deferred[1] if deferred else ""
     # The continuation is a real assistant turn for display/accounting even
     # though it has no user bubble.  Keep the session's public model id on its
     # broadcast so live and persisted footers do not reload with a blank model.
@@ -10781,7 +10895,7 @@ async def _watch_inflight_tasks(
         transcript rendering/conversation counts by the SDK's `isMeta`
         semantics.
         """
-        nonlocal activity_failed, watch_error_kind
+        nonlocal watcher_failed, watch_error_kind
         if (pending or cont is None or cont_state is None
                 or last_settle_status == "stopped"
                 or cont_state["explicit_resume_requested"]):
@@ -10813,7 +10927,7 @@ async def _watch_inflight_tasks(
             await client.query(_meta_prompt())
             return True
         except Exception as e:
-            activity_failed = True
+            watcher_failed = True
             watch_error_kind = "explicit_resume"
             cont_state["incomplete_error"] = (
                 "后台任务已经完成，但最终答复续接失败。请发送“继续”让 Muse "
@@ -10826,8 +10940,8 @@ async def _watch_inflight_tasks(
             return False
 
     def _mark_incomplete() -> None:
-        nonlocal activity_failed
-        activity_failed = True
+        nonlocal watcher_failed
+        watcher_failed = True
         if cont_state is not None and not cont_state.get("incomplete_error"):
             cont_state["incomplete_error"] = (
                 "后台任务已经完成，但没有生成最终答复。请发送“继续”让 Muse "
@@ -11093,9 +11207,7 @@ async def _watch_inflight_tasks(
                         # still be running.  Enter the same stop/disconnect
                         # fence as an absolute timeout; never infer process
                         # death from EOF alone.
-                        deferred = _background_activity_finishes.get(session_id)
-                        deferred_status = deferred[0] if deferred else None
-                        activity_failed = deferred_status != "cancelled"
+                        watcher_failed = True
                         await _terminate_expired_tasks(
                             "message stream ended before task settlement")
                         break
@@ -11269,11 +11381,11 @@ async def _watch_inflight_tasks(
         watch_error_kind = "cancelled"
         raise
     except asyncio.TimeoutError:
-        activity_failed = True
+        watcher_failed = True
         watch_error_kind = "timeout"
         await _terminate_expired_tasks("reached its absolute task deadline")
     except Exception as e:
-        activity_failed = True
+        watcher_failed = True
         watch_error_kind = str(
             _classify_stream_error(str(e)).get("kind") or "unknown")
         sys.stderr.write(
@@ -11293,7 +11405,7 @@ async def _watch_inflight_tasks(
             try:
                 await _close_continuation(cancelled=watcher_cancelled)
             except Exception as exc:
-                activity_failed = True
+                watcher_failed = True
                 if watch_error_kind == "none":
                     watch_error_kind = str(
                         _classify_stream_error(str(exc)).get("kind")
@@ -11307,7 +11419,7 @@ async def _watch_inflight_tasks(
         )
         _watch_status = (
             "cancelled" if watcher_cancelled else
-            "failed" if activity_failed else
+            "failed" if watcher_failed else
             "incomplete" if pending else
             "completed"
         )
@@ -11317,7 +11429,7 @@ async def _watch_inflight_tasks(
             "chat.background",
             sid8=obs.short_id(session_id),
             origin_turn8=obs.short_id(
-                activity_owner_id
+                origin_turn_id
                 or _background_origin_turn_id.get(session_id, "")),
             tasks_count=len(watched_task_ids),
             settled_count=len(watched_task_ids - set(pending)),
@@ -11327,16 +11439,6 @@ async def _watch_inflight_tasks(
             last_status=_safe_last_status,
             error_kind=watch_error_kind,
         )
-        # Close the logical turn before queue drain can start another turn and
-        # reuse this session's single Activity Center row.
-        if (not watcher_cancelled
-                and _owns_generation()
-                and not _sessions_with_inflight_tasks.get(session_id)):
-            await _finish_background_activity(
-                session_id,
-                failed=activity_failed,
-                owner_id=activity_owner_id,
-            )
         # Only clear the registry slot if it still points at us (a fresh
         # watcher may have replaced it).
         if _task_watchers.get(session_id) is asyncio.current_task():
@@ -11429,7 +11531,7 @@ def _spawn_task_watcher(
             client,
             pending,
             generation,
-            activity_owner_id=origin_turn_id,
+            origin_turn_id=origin_turn_id,
         ))
 
 
@@ -11770,72 +11872,6 @@ async def _fail_queued_attachment_startup(
     return queue_settled
 
 
-def _defer_activity_finish(
-    session_id: str,
-    broadcast: TurnBroadcast,
-    status: str,
-) -> bool:
-    """Transfer Activity Center ownership from a turn to its task watcher.
-
-    ``ResultMessage`` closes only the visible main response when SDK-native
-    background tasks remain.  Finishing the ledger row there made the task
-    center go quiet while the session tab correctly stayed yellow.  Clearing
-    ``broadcast.activity_started`` prevents the outer turn cleanup from closing
-    the row; the owning watcher generation consumes the deferred status later.
-    """
-    if not broadcast.activity_started:
-        return False
-    _background_activity_finishes[session_id] = (status, broadcast.turn_id)
-    broadcast.activity_started = False
-    return True
-
-
-async def _finish_background_activity(
-    session_id: str,
-    *,
-    failed: bool = False,
-    owner_id: str = "",
-) -> None:
-    """Close a deferred activity row after the detached logical turn ends."""
-    deferred = _background_activity_finishes.get(session_id)
-    if deferred is None:
-        return
-    status, current_owner_id = deferred
-    if owner_id and current_owner_id != owner_id:
-        return
-    if _background_activity_finishes.get(session_id) == deferred:
-        _background_activity_finishes.pop(session_id, None)
-    owner_id = current_owner_id
-    if failed:
-        status = "failed"
-    try:
-        from .activity import activity as _activity
-        finish_task = asyncio.create_task(
-            asyncio.to_thread(
-                _activity.finish,
-                session_id,
-                status,
-                activity_source="background",
-                owner_id=owner_id,
-                mark_read=True,
-            )
-        )
-        try:
-            await asyncio.shield(finish_task)
-        except asyncio.CancelledError:
-            while not finish_task.done():
-                try:
-                    await asyncio.shield(finish_task)
-                except asyncio.CancelledError:
-                    continue
-            finish_task.result()
-            raise
-    except Exception as e:
-        sys.stderr.write(
-            f"[activity] background finish failed sid={session_id[:8]} "
-            f"exc={type(e).__name__}\n")
-
-
 async def _start_turn(
     session_id: str,
     prompt: str,
@@ -11960,7 +11996,14 @@ async def _start_turn(
             raise _TurnStartError(
                 "previous interrupted turn could not be persisted for recovery")
         _interrupted_at_startup.pop(session_id, None)
-    if not _write_active_turn_sidecar(broadcast):
+    persisted_intent = await obs.to_thread_io(
+        "chat.active_turn_write",
+        session_id,
+        _write_active_turn_sidecar,
+        broadcast,
+        file_path=_active_turn_path(session_id),
+    )
+    if not persisted_intent:
         async with _lock:
             if _active_turns.get(session_id) is broadcast:
                 broadcast.finish()
@@ -13421,7 +13464,7 @@ async def _start_turn(
             """ResultMessage = turn complete. Update cumulative cost / stats,
             yield the consolidated 'done' SSE event the FE awaits, then finish
             slower per-message annotations and session metadata bookkeeping."""
-            nonlocal memory_outcome_scheduled
+            nonlocal memory_outcome_scheduled, assistant_acc, streamed_in_bubble
             if broadcast.perf_query_started:
                 broadcast.perf_result_ms = obs.elapsed_ms(
                     broadcast.perf_query_started)
@@ -13458,15 +13501,61 @@ async def _start_turn(
             # push fan-out, JSONL compatibility cleanup). The old ordering kept
             # the footer pulsing "Running" for seconds after the final answer
             # was already visible.
-            was_cancelled = session_id in _pending_interrupts
+            # ``interrupt()`` marks the exact live broadcast before awaiting the
+            # SDK control request.  Treat that turn-owned bit as authoritative:
+            # ResultMessage can race the later session-level bookkeeping, and
+            # overwriting it with ``False`` used to turn a user Stop into a
+            # completed/failed result (or recover Result-only prose after Stop).
+            was_cancelled = bool(
+                broadcast.cancelled or session_id in _pending_interrupts
+            )
             _pending_interrupts.discard(session_id)
             broadcast.cancelled = was_cancelled
             _completed_at_ms = int(time.time() * 1000)
+            _msg_duration_ms = getattr(msg, "duration_ms", None)
+            _elapsed_s = (round(_msg_duration_ms / 1000, 1)
+                          if _msg_duration_ms else None)
             _result_error = _sdk_result_error(msg)
             _turn_error = _merge_sdk_errors([
                 *turn_sdk_errors,
                 *([_result_error] if _result_error else []),
             ])
+            _result_recovered = False
+            _result_snapshot_ready = False
+            _result_text = str(getattr(msg, "result", None) or "").strip()
+            _ended_after_tool = (
+                bool(tool_use_names)
+                and not "".join(streamed_in_bubble).strip()
+                and not inflight_tasks
+                and not _sessions_with_inflight_tasks.get(session_id)
+                and bool(prompt.strip())
+                and not prompt.lstrip().startswith("/")
+            )
+            if (_turn_error is None and not was_cancelled
+                    and _ended_after_tool):
+                if _result_text:
+                    # Some third-party runtimes put the final answer only on the
+                    # terminal ResultMessage after their last tool call. Restore
+                    # it to the ordinary text stream before `done`; the private
+                    # snapshot below makes the same answer survive a refresh.
+                    assistant_acc.append(_result_text)
+                    streamed_in_bubble.append(_result_text)
+                    _result_recovered = True
+                    broadcast.perf_final_mode = "result_recovered"
+                    yield {
+                        "event": "text",
+                        "data": json.dumps({"text": _result_text}),
+                    }
+                else:
+                    broadcast.perf_final_mode = "missing"
+                    _turn_error = {
+                        "message": (
+                            "The turn ended after tool use without a final "
+                            "assistant response."
+                        ),
+                        "source": "missing_final_response",
+                        "api_error_status": None,
+                    }
 
             # A success-shaped ResultMessage proves only that the SDK operation
             # ended. Ordinary chat turns are committed only when this exact
@@ -13495,18 +13584,52 @@ async def _start_turn(
                 )
             if (_turn_error is None and not was_cancelled and _commit_required
                     and (not boundary_asst_uuid or not new_user_uuid)):
-                detail = (
-                    "Canonical conversation history could not be inspected."
-                    if not boundary_inspected else
-                    "The turn ended before the user message and assistant "
-                    "response were committed to conversation history."
+                _turn_error = await asyncio.to_thread(
+                    _turn_prevented_error_from_boundary,
+                    session_id,
+                    broadcast.transcript_boundary,
                 )
-                _turn_error = {
-                    "message": detail,
-                    "source": "canonical_commit",
-                    "api_error_status": None,
-                }
-            terminal_assistant_uuid = last_assistant_uuid or boundary_asst_uuid or ""
+                if _turn_error is None:
+                    detail = (
+                        "Canonical conversation history could not be inspected."
+                        if not boundary_inspected else
+                        "The turn ended before the user message and assistant "
+                        "response were committed to conversation history."
+                    )
+                    _turn_error = {
+                        "message": detail,
+                        "source": "canonical_commit",
+                        "api_error_status": None,
+                    }
+            _done_memory_recall = mem0.pop_recall_trace(session_id)
+            _done_memory_receipt = _persistable_memory_recall(
+                _done_memory_recall)
+            if _turn_error is None and _result_recovered:
+                try:
+                    _result_snapshot_ready = await asyncio.to_thread(
+                        _persist_completed_result_snapshot,
+                        broadcast,
+                        _result_text,
+                        terminal_at_ms=_completed_at_ms,
+                        elapsed_s=_elapsed_s,
+                        memory_recall=_done_memory_receipt,
+                    )
+                except Exception as exc:
+                    _safe_secondary_diagnostic(
+                        "result_snapshot", session_id, exc)
+                if not _result_snapshot_ready:
+                    _turn_error = {
+                        "message": (
+                            "The final response was received but could not be "
+                            "saved to conversation history."
+                        ),
+                        "source": "result_snapshot",
+                        "api_error_status": None,
+                    }
+            terminal_assistant_uuid = (
+                "" if _result_snapshot_ready
+                else last_assistant_uuid or boundary_asst_uuid or ""
+            )
 
             _is_error = _turn_error is not None
             _subtype = getattr(msg, "subtype", None)
@@ -13529,12 +13652,6 @@ async def _start_turn(
                 if _is_error else "none"
             )
             _done_session_usage = dict(sess_u)
-            _done_memory_recall = mem0.pop_recall_trace(session_id)
-            _done_memory_receipt = _persistable_memory_recall(
-                _done_memory_recall)
-            _msg_duration_ms = getattr(msg, "duration_ms", None)
-            _elapsed_s = (round(_msg_duration_ms / 1000, 1)
-                          if _msg_duration_ms else None)
             # A failed turn needs a durable copy of the terminal error bubble,
             # including when a legitimate partial AssistantMessage precedes
             # the Result error. Commit it before `done` so a quiet/hard reload
@@ -13566,27 +13683,23 @@ async def _start_turn(
                 _merge_session_inflight(session_id, inflight_tasks)
             )
             broadcast.perf_background_count = _done_background_tasks
-            _done_activity_source = (
-                "background"
-                if _done_background_tasks
-                else broadcast.activity_source
-            )
-            if _done_background_tasks:
-                _defer_activity_finish(
-                    session_id, broadcast, _activity_status)
-                if terminal_assistant_uuid:
-                    try:
-                        sess.set_runtime_background_boundary(
-                            session_id, terminal_assistant_uuid)
-                    except Exception as exc:
-                        sys.stderr.write(
-                            f"[chat] runtime boundary persist failed "
-                            f"sid={session_id[:8]} "
-                            f"exc={type(exc).__name__}\n"
-                        )
-            else:
-                await _finish_activity(
-                    session_id, broadcast, _activity_status)
+            # Activity Center tracks whether the human is still waiting for the
+            # main response, not whether detached process work remains. Settle it
+            # at the authoritative Result boundary; background task cards and
+            # runtime overlays continue independently inside the conversation.
+            _done_activity_source = broadcast.activity_source
+            await _finish_activity(
+                session_id, broadcast, _activity_status)
+            if _done_background_tasks and terminal_assistant_uuid:
+                try:
+                    sess.set_runtime_background_boundary(
+                        session_id, terminal_assistant_uuid)
+                except Exception as exc:
+                    sys.stderr.write(
+                        f"[chat] runtime boundary persist failed "
+                        f"sid={session_id[:8]} "
+                        f"exc={type(exc).__name__}\n"
+                    )
             # Capture once at the SDK's authoritative terminal boundary. The
             # exact assistant UUID is already known from AssistantMessage, so
             # persist the footer BEFORE yielding done.  A hard refresh or a new
@@ -13650,7 +13763,9 @@ async def _start_turn(
                     if _budget_usd() > 0 else 0
                 ),
                 "memory_recall": _done_memory_recall,
-                "snapshot_ready": _failed_snapshot_ready,
+                "snapshot_ready": (
+                    _failed_snapshot_ready or _result_snapshot_ready),
+                "result_recovered": _result_snapshot_ready,
                 "background_tasks_pending": _done_background_tasks,
                 "activity_source": _done_activity_source,
             })}
@@ -14576,6 +14691,44 @@ def _notify_queue_paused_on_error(session_id: str) -> None:
         pass  # no running loop (shouldn't happen in request context)
 
 
+def _schedule_queue_drain_retry(session_id: str, delay_s: float = 1.0) -> None:
+    """Retain one delayed retry for a recoverable runtime handoff conflict."""
+    existing = _queue_drain_retry_tasks.get(session_id)
+    if existing is not None and not existing.done():
+        return
+
+    async def _retry() -> None:
+        await asyncio.sleep(delay_s)
+        queue = sess.get_queue(session_id)
+        if queue.get("paused") or not (
+            queue.get("items") or queue.get("inflight")
+        ):
+            return
+        _schedule_queue_drain(session_id)
+
+    task = asyncio.create_task(_retry())
+    _queue_drain_retry_tasks[session_id] = task
+    _maintenance_tasks.add(task)
+
+    def _done(done: asyncio.Task) -> None:
+        _maintenance_tasks.discard(done)
+        if _queue_drain_retry_tasks.get(session_id) is done:
+            _queue_drain_retry_tasks.pop(session_id, None)
+        if done.cancelled():
+            return
+        try:
+            exc = done.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            sys.stderr.write(
+                f"[chat] delayed queue drain failed "
+                f"sid={session_id[:8]} exc={type(exc).__name__}\n"
+            )
+
+    task.add_done_callback(_done)
+
+
 async def _maybe_drain_queue(session_id: str) -> None:
     """Drain trigger: if no turn is running for this session and the queue
     has a non-paused head item, pop it and start the next turn headlessly.
@@ -14619,6 +14772,8 @@ async def _maybe_drain_queue(session_id: str) -> None:
                         f"[chat] queued runtime rollover deferred "
                         f"sid={session_id[:8]} status={exc.status_code}\n"
                     )
+                    if exc.status_code in {404, 409}:
+                        _schedule_queue_drain_retry(session_id)
             return
         # READY presentation events are part of the visible chronology. Commit
         # them before claiming the next FIFO item; if local I/O cannot do so,

--- a/backend/chat_history.py
+++ b/backend/chat_history.py
@@ -156,12 +156,33 @@ def session_config_dir(
     lock,
     is_third_party: Callable[[str], bool],
     vendor_config_dir: Callable[[], Path],
+    session_path: Path | None = None,
 ) -> Iterator[None]:
-    """Serialize and scope the SDK's process-global ``CLAUDE_CONFIG_DIR``."""
+    """Serialize and scope the SDK's process-global ``CLAUDE_CONFIG_DIR``.
+
+    Existing sessions are routed by their canonical transcript location rather
+    than their current model label.  A session can be switched to a third-party
+    model after its JSONL was created in the native store; model-only routing
+    would then make fork/rename report a false ``session not found``.  New
+    sessions without a transcript retain the historical model-based fallback.
+    """
     with lock:
         old = os.environ.get("CLAUDE_CONFIG_DIR")
         try:
-            if model and is_third_party(model):
+            routed = False
+            if session_path is not None:
+                try:
+                    projects_root = session_path.resolve().parent.parent
+                    vendor_dir = vendor_config_dir().resolve()
+                    if projects_root == vendor_dir / "projects":
+                        os.environ["CLAUDE_CONFIG_DIR"] = str(vendor_dir)
+                        routed = True
+                    elif projects_root == (Path.home() / ".claude" / "projects").resolve():
+                        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+                        routed = True
+                except OSError:
+                    pass
+            if not routed and model and is_third_party(model):
                 os.environ["CLAUDE_CONFIG_DIR"] = str(vendor_config_dir())
             yield
         finally:

--- a/backend/chat_overlays.py
+++ b/backend/chat_overlays.py
@@ -1008,10 +1008,10 @@ def _heal_cancelled_snapshot_from_canonical(
             f"[chat] late cancelled footer heal failed sid={sid[:8]} "
             f"exc={type(exc).__name__}\n")
         return False
-    if terminal_status == "failed":
+    if terminal_status == "failed" or snapshot.get("result_recovery") is True:
         # Keep replacing the whole canonical turn with the display snapshot.
-        # Otherwise a partial AssistantMessage causes the healer to delete the
-        # only durable copy of the terminal error row on the first quiet reload.
+        # Otherwise a partial AssistantMessage (including a final tool call with
+        # no prose) causes the healer to delete the only durable terminal row.
         return False
 
     # Exact path comes from the already-validated canonical sid/turn snapshot
@@ -1258,6 +1258,146 @@ def _persist_cancelled_turn_snapshot_locked(bc: "TurnBroadcast") -> bool:
             f"exc={type(exc).__name__}\n")
         sys.stderr.flush()
     return True
+
+
+def _persist_completed_result_snapshot(
+    bc: "TurnBroadcast",
+    result_text: str,
+    *,
+    terminal_at_ms: int,
+    elapsed_s: float | None = None,
+    memory_recall: dict | None = None,
+) -> bool:
+    """Persist final prose supplied only by a successful ResultMessage.
+
+    A few third-party runtimes can finish after a tool call without emitting a
+    final AssistantMessage, while still putting the user-facing answer in
+    ResultMessage.result. That value is authoritative for presentation but is
+    absent from canonical JSONL, so retain the complete live turn in the private
+    display snapshot channel. It is never fed back into model context.
+    """
+    _hooks = _require_hooks()
+    visible_result = str(result_text or "").strip()
+    if not visible_result:
+        return False
+    with bc.cancelled_snapshot_lock:
+        if bc.result_snapshot_persisted:
+            return True
+        if bc.cancelled_snapshot_suppressed or bc.cancelled:
+            return False
+        path = _cancelled_turn_snapshot_path(bc.session_id, bc.turn_id)
+        if path is None:
+            return False
+
+        messages = _hooks.broadcast_to_ui_messages(bc)
+        last_assistant = next(
+            (message for message in reversed(messages)
+             if message.get("role") == "assistant"),
+            None,
+        )
+        if (not last_assistant
+                or str(last_assistant.get("text") or "").strip()
+                != visible_result):
+            messages.append({
+                "role": "assistant",
+                "text": visible_result,
+                "model": bc.model,
+            })
+        if not messages:
+            return False
+
+        now_ms = int(terminal_at_ms)
+        duration = (
+            max(0.0, float(elapsed_s))
+            if elapsed_s is not None
+            else max(0.0, now_ms / 1000.0 - float(bc.started_at or 0))
+        )
+        duration = round(duration, 1)
+        for index, message in enumerate(messages):
+            block_id = f"snapshot:{bc.turn_id}:{index}:{message.get('role') or 'unknown'}"
+            message["block_id"] = block_id
+            message["_key"] = block_id
+            message["_terminalTurnId"] = bc.turn_id
+            message["presentation_only"] = True
+        for message in reversed(messages):
+            if message.get("role") == "user":
+                continue
+            message.setdefault("ts", now_ms)
+            if duration >= 1:
+                message.setdefault("elapsed", duration)
+            message.setdefault("model", bc.model)
+            message.setdefault("turn_status", "completed")
+            if memory_recall:
+                message.setdefault("memoryRecall", memory_recall)
+            break
+
+        boundary = dict(bc.transcript_boundary or {})
+        payload = {
+            "schema": _CANCELLED_TURN_SNAPSHOT_SCHEMA,
+            "sid": bc.session_id,
+            "turn_id": bc.turn_id,
+            "model": bc.model,
+            "terminal_status": "completed",
+            "result_recovery": True,
+            "started_at_ms": int(float(bc.started_at or 0) * 1000),
+            "terminal_at_ms": now_ms,
+            "interrupted_at_ms": now_ms,
+            "canonical_terminal_published": True,
+            "memory_recall": memory_recall,
+            "transcript_boundary": {
+                "record_count": int(boundary.get("record_count") or 0),
+                "source_dev": int(boundary.get("source_dev") or 0),
+                "source_inode": int(boundary.get("source_inode") or 0),
+            },
+            "anchors": {
+                "normal": {
+                    "uuid": boundary.get("normal_uuid") or "",
+                    "total": int(boundary.get("normal_total") or 0),
+                },
+                "full": {
+                    "uuid": boundary.get("full_uuid") or "",
+                    "total": int(boundary.get("full_total") or 0),
+                },
+            },
+            "hidden_uuids": [],
+            "messages": messages,
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with suppress(OSError):
+                path.parent.chmod(0o700)
+            atomic_write_text(
+                path,
+                json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+                mode=0o600,
+            )
+            with suppress(OSError):
+                path.chmod(0o600)
+        except Exception as exc:
+            sys.stderr.write(
+                f"[chat] result snapshot write failed sid={bc.session_id[:8]} "
+                f"exc={type(exc).__name__}\n")
+            sys.stderr.flush()
+            return False
+
+        bc.result_snapshot_persisted = True
+        try:
+            snapshots, _ = _hooks.load_cancelled_turn_snapshots(bc.session_id)
+            indexed = _hooks.ensure_transcript_index(bc.session_id)
+            index = indexed[1] if indexed is not None else None
+            total, turns = _interrupted_history_stats(index, snapshots, "normal")
+            sess.bump_session(
+                bc.session_id,
+                message_count=total,
+                turn_count=turns,
+                auto_rename_from=bc.user_text,
+            )
+        except Exception as exc:
+            sys.stderr.write(
+                f"[chat] result snapshot metadata sync failed "
+                f"sid={bc.session_id[:8]} exc={type(exc).__name__}\n")
+            sys.stderr.flush()
+        return True
 
 
 def _persist_failed_turn_snapshot(

--- a/backend/chat_successor.py
+++ b/backend/chat_successor.py
@@ -34,7 +34,7 @@ class SuccessorHooks:
     normalize_effort: Callable[[str | None], str]
     validate_permission: Callable[[str], str]
     normalize_plan_return_permission: Callable[[str, Any], str]
-    session_config_dir: Callable[[str], Any]
+    session_config_dir: Callable[..., Any]
     sdk_fork_session: Callable[..., Any]
     sdk_delete_session: Callable[..., Any]
     sdk_rename_session: Callable[..., Any]
@@ -276,7 +276,7 @@ def fork_session(
     )
 
     def _fork_explicit():
-        with hooks.session_config_dir(source_model):
+        with hooks.session_config_dir(source_model, sid=sid):
             return hooks.sdk_fork_session(
                 sid,
                 directory=str(sess.session_workspace(sid)),
@@ -402,7 +402,9 @@ def sync_runtime_successor_postlude(source_sid: str) -> dict[str, int]:
                             fresh_child.get("model") or hooks.model_default
                         ).strip()
                         try:
-                            with hooks.session_config_dir(child_model):
+                            with hooks.session_config_dir(
+                                child_model, sid=child_sid
+                            ):
                                 hooks.sdk_rename_session(
                                     child_sid,
                                     desired_name,
@@ -567,7 +569,7 @@ async def continue_detached_runtime_locked(source_sid: str) -> dict:
     def _fork_runtime():
         if sess.session_is_deleting(source_sid):
             raise ValueError("source session is being deleted")
-        with hooks.session_config_dir(source_model):
+        with hooks.session_config_dir(source_model, sid=source_sid):
             forked = hooks.sdk_fork_session(
                 source_sid,
                 directory=str(sess.session_workspace(source_sid)),

--- a/backend/main.py
+++ b/backend/main.py
@@ -1244,6 +1244,106 @@ def _safe_client_error_record(payload: object) -> dict[str, object] | None:
     return record
 
 
+@app.post("/api/log/client-perf", dependencies=[Depends(require_token)])
+async def client_performance_log(payload: dict = Body(...)) -> dict:
+    """Persist one strict, content-free browser history-load timing summary."""
+    allowed_status = {"ok", "cancelled", "error"}
+    allowed_mode = {"cold", "quiet", "prefetch"}
+    status = payload.get("status")
+    mode = payload.get("mode")
+    if status not in allowed_status or mode not in allowed_mode:
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+
+    def bounded_int(name: str) -> int:
+        value = payload.get(name)
+        if isinstance(value, bool) or not isinstance(value, int):
+            return 0
+        return min(100_000_000, max(0, value))
+
+    allowed_fields = {
+        "status", "mode", "foreground", "total_ms", "fetch_ms", "parse_ms",
+        "shape_ms", "markdown_ms", "install_ms", "response_bytes",
+        "block_count", "assistant_blocks", "long_task_count", "longest_task_ms",
+    }
+    if any(name not in allowed_fields for name in payload):
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+    try:
+        perf_event(
+            "client.history_load",
+            status=status,
+            mode=mode,
+            foreground=bool(payload.get("foreground")),
+            total_ms=bounded_int("total_ms"),
+            fetch_ms=bounded_int("fetch_ms"),
+            parse_ms=bounded_int("parse_ms"),
+            shape_ms=bounded_int("shape_ms"),
+            markdown_ms=bounded_int("markdown_ms"),
+            install_ms=bounded_int("install_ms"),
+            response_bytes=bounded_int("response_bytes"),
+            block_count=bounded_int("block_count"),
+            assistant_blocks=bounded_int("assistant_blocks"),
+            long_task_count=bounded_int("long_task_count"),
+            longest_task_ms=bounded_int("longest_task_ms"),
+        )
+    except Exception:
+        # Diagnostics must never turn a successful history load into an error.
+        pass
+    return {"ok": True}
+
+
+@app.post("/api/log/session-rename", dependencies=[Depends(require_token)])
+async def client_session_rename_log(payload: dict = Body(...)) -> dict:
+    """Persist one strict, title-free browser session-rename timing summary."""
+    allowed_fields = {
+        "surface", "status", "asset_version", "optimistic_apply_ms",
+        "optimistic_paint_ms", "request_ms", "total_ms",
+        "long_task_count", "longest_task_ms",
+    }
+    if any(name not in allowed_fields for name in payload):
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+    surface = payload.get("surface")
+    status = payload.get("status")
+    asset_version = payload.get("asset_version")
+    if surface not in {"tab", "picker", "modal"}:
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+    if status not in {"ok", "error", "rollback"}:
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+    if (not isinstance(asset_version, str)
+            or len(asset_version) > 32
+            or not re.fullmatch(r"[A-Za-z0-9._-]*", asset_version)):
+        return JSONResponse(
+            {"ok": False, "error": "invalid_payload"}, status_code=422)
+
+    def bounded_int(name: str) -> int:
+        value = payload.get(name)
+        if isinstance(value, bool) or not isinstance(value, int):
+            return 0
+        return min(100_000_000, max(0, value))
+
+    try:
+        perf_event(
+            "client.session_rename",
+            surface=surface,
+            status=status,
+            asset_version=asset_version,
+            optimistic_apply_ms=bounded_int("optimistic_apply_ms"),
+            optimistic_paint_ms=bounded_int("optimistic_paint_ms"),
+            request_ms=bounded_int("request_ms"),
+            total_ms=bounded_int("total_ms"),
+            long_task_count=bounded_int("long_task_count"),
+            longest_task_ms=bounded_int("longest_task_ms"),
+        )
+    except Exception:
+        # Diagnostics must never affect the rename interaction.
+        pass
+    return {"ok": True}
+
+
 @app.post("/api/log/client-error")
 async def client_error_log(request: Request) -> dict:
     """Capture browser-side JS errors that the user can't easily extract

--- a/backend/memory_client.py
+++ b/backend/memory_client.py
@@ -35,13 +35,15 @@ _legacy_recall_traces: dict[str, dict] = {}
 _LEGACY_TRACE_MAX = 256
 
 _USER_ID = "muselab"
-# Memory is optional context, never part of the message commit path.  Finish the
-# callback before the SDK's hook watchdog: an SDK-level hook timeout sets
-# preventContinuation=true and rejects the user's prompt.  The inner deadline
-# converts a slow recall into an empty additionalContext response instead.
+# Memory is optional context, never part of the message commit path. Finish the
+# callback before the SDK CLI's wall-clock hook watchdog: its timeout sets
+# preventContinuation=true and rejects the user's prompt. The inner deadline
+# converts a slow recall into empty additionalContext. The outer allowance must
+# also absorb event-loop stalls and the sibling runtime-handoff context hook;
+# a 0.5s margin proved insufficient under normal service load.
 _RECALL_DEADLINE = 3.0
 _SEARCH_TIMEOUT = _RECALL_DEADLINE
-RECALL_HOOK_TIMEOUT = _RECALL_DEADLINE + 0.5
+RECALL_HOOK_TIMEOUT = 10.0
 _STORE_TIMEOUT = 10.0
 _SEARCH_LIMIT = 5
 _MAX_MEM_CHARS = 400

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1447,14 +1447,36 @@ def get_message_annotations(sid: str) -> dict[str, dict]:
     return _load_sidecar(sid).get("messages", {})
 
 
-def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
-    """Return UI-only background task cards keyed by task id.
+_RUNTIME_TASK_OVERLAY_MARKER = b'"runtime_task_overlays"'
 
-    Runtime-rollover children never resume the predecessor's CLI process.  The
-    overlay lets their copied tool card reflect that process's lifecycle while
-    remaining completely absent from model context.
+
+def _sidecar_has_runtime_task_overlays(sid: str) -> bool:
+    """Check for the overlay section without parsing a potentially huge sidecar.
+
+    Message annotations can make sidecars tens of megabytes. Startup only needs
+    the small minority containing runtime task state, so parsing every indexed
+    sidecar made each cold start spend about two minutes in JSON decoding.
+    False positives are safe (the normal loader validates them); I/O failures
+    deliberately return true so the authoritative loader still fails closed.
     """
-    raw = _load_sidecar(sid).get("runtime_task_overlays") or {}
+    path = _sidecar_path(sid)
+    overlap = len(_RUNTIME_TASK_OVERLAY_MARKER) - 1
+    carry = b""
+    try:
+        with path.open("rb") as stream:
+            while chunk := stream.read(64 * 1024):
+                data = carry + chunk
+                if _RUNTIME_TASK_OVERLAY_MARKER in data:
+                    return True
+                carry = data[-overlap:]
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return False
+
+
+def _normalize_runtime_task_overlays(raw: Any) -> dict[str, dict]:
     if not isinstance(raw, dict):
         return {}
     return {
@@ -1462,6 +1484,43 @@ def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
         for task_id, value in raw.items()
         if task_id and isinstance(value, dict)
     }
+
+
+def _load_runtime_task_overlays_section(sid: str) -> dict[str, dict]:
+    """Decode only the overlay object, not the sidecar's large message map."""
+    path = _sidecar_path(sid)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(f"cannot parse session sidecar: {path}") from exc
+    marker_at = raw.find(_RUNTIME_TASK_OVERLAY_MARKER.decode("ascii"))
+    if marker_at < 0:
+        return {}
+    colon_at = raw.find(":", marker_at + len(_RUNTIME_TASK_OVERLAY_MARKER))
+    if colon_at < 0:
+        raise RuntimeError(f"cannot parse session sidecar: {path}")
+    value_at = colon_at + 1
+    while value_at < len(raw) and raw[value_at].isspace():
+        value_at += 1
+    try:
+        value, _ = json.JSONDecoder().raw_decode(raw, value_at)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise RuntimeError(f"cannot parse session sidecar: {path}") from exc
+    return _normalize_runtime_task_overlays(value)
+
+
+def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
+    """Return UI-only background task cards keyed by task id.
+
+    Runtime-rollover children never resume the predecessor's CLI process.  The
+    overlay lets their copied tool card reflect that process's lifecycle while
+    remaining completely absent from model context.
+    """
+    return _normalize_runtime_task_overlays(
+        _load_sidecar(sid).get("runtime_task_overlays") or {}
+    )
 
 
 _RUNTIME_TASK_TERMINAL_STATES = frozenset({
@@ -1664,29 +1723,34 @@ def get_authoritative_runtime_task_overlays(sid: str) -> dict[str, dict]:
     return authoritative
 
 
-def _replace_runtime_task_overlay_snapshot(
+def _replace_runtime_task_overlay_snapshots(
     sid: str,
-    task_id: str,
-    snapshot: dict,
-) -> bool:
-    """Repair helper that replaces one copied snapshot exactly."""
+    snapshots: dict[str, dict],
+) -> int:
+    """Replace copied snapshots in one read-modify-write transaction."""
+    if not snapshots:
+        return 0
     with session_lifecycle_lock(sid):
         with _QUEUE_LOCK:
             if sid in _DELETED_SESSION_IDS:
-                return False
+                return 0
         with _SIDECAR_LOCK:
             data = _load_sidecar(sid, use_cache=False)
             overlays = data.setdefault("runtime_task_overlays", {})
             if not isinstance(overlays, dict):
                 overlays = {}
                 data["runtime_task_overlays"] = overlays
-            replacement = dict(snapshot)
-            replacement["task_id"] = task_id
-            if overlays.get(task_id) == replacement:
-                return False
-            overlays[task_id] = replacement
-            _save_sidecar(sid, data)
-            return True
+            changed = 0
+            for task_id, snapshot in snapshots.items():
+                replacement = dict(snapshot)
+                replacement["task_id"] = task_id
+                if overlays.get(task_id) == replacement:
+                    continue
+                overlays[task_id] = replacement
+                changed += 1
+            if changed:
+                _save_sidecar(sid, data)
+            return changed
 
 
 def reconcile_runtime_task_overlay_chains() -> int:
@@ -1704,6 +1768,13 @@ def reconcile_runtime_task_overlay_chains() -> int:
         for row in rows
         if isinstance(row, dict) and row.get("id")
     ]
+    overlay_sids = {
+        sid for sid in indexed_ids
+        if _sidecar_has_runtime_task_overlays(sid)
+    }
+    if not overlay_sids:
+        return 0
+
     repaired = 0
     visited: set[str] = set()
     for indexed_sid in indexed_ids:
@@ -1713,8 +1784,13 @@ def reconcile_runtime_task_overlay_chains() -> int:
         if not lineage:
             continue
         visited.update(lineage)
+        if overlay_sids.isdisjoint(lineage):
+            continue
         overlays_by_sid = {
-            row_sid: get_runtime_task_overlays(row_sid)
+            row_sid: (
+                _load_runtime_task_overlays_section(row_sid)
+                if row_sid in overlay_sids else {}
+            )
             for row_sid in lineage
         }
         task_ids = {
@@ -1722,6 +1798,7 @@ def reconcile_runtime_task_overlay_chains() -> int:
             for overlay in overlays_by_sid.values()
             for task_id in overlay
         }
+        repairs_by_sid: dict[str, dict[str, dict]] = {}
         for task_id in task_ids:
             resolved = _authoritative_runtime_task_snapshot(
                 task_id, lineage, overlays_by_sid
@@ -1736,13 +1813,13 @@ def reconcile_runtime_task_overlay_chains() -> int:
             # Child-owned tasks do not exist in predecessor context.  Copy the
             # canonical owner record only forward from its launch runtime.
             for target_sid in lineage[owner_position:]:
-                if _replace_runtime_task_overlay_snapshot(
-                    target_sid, task_id, canonical
-                ):
-                    repaired += 1
-                    overlays_by_sid.setdefault(target_sid, {})[task_id] = dict(
-                        canonical
-                    )
+                if overlays_by_sid.get(target_sid, {}).get(task_id) == canonical:
+                    continue
+                repairs_by_sid.setdefault(target_sid, {})[task_id] = canonical
+        for target_sid, snapshots in repairs_by_sid.items():
+            repaired += _replace_runtime_task_overlay_snapshots(
+                target_sid, snapshots
+            )
     return repaired
 
 
@@ -1767,7 +1844,9 @@ def stop_stale_runtime_task_overlays() -> int:
     stopped = 0
     now_ms = int(time.time() * 1000)
     for sid in indexed_session_ids():
-        for task_id, overlay in get_runtime_task_overlays(sid).items():
+        if not _sidecar_has_runtime_task_overlays(sid):
+            continue
+        for task_id, overlay in _load_runtime_task_overlays_section(sid).items():
             if overlay.get("state") != "running":
                 continue
             changed = set_runtime_task_overlay(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -235,6 +235,7 @@ const _EMPTY_ACTIVE_SESSION_PANE = Object.freeze({
   backgroundActive: false,
   compacting: false,
   _draining: false,
+  _loadingEarlier: false,
   _historyHydrationError: false,
   atBottom: true,
 });
@@ -571,13 +572,20 @@ function portal() {
     // message repository remains the authority; these are disposable DOM views.
     _warmTranscriptTabs: [],
     _transcriptPaneLru: [],
-    WARM_TRANSCRIPT_LIMIT: 10,
+    WARM_TRANSCRIPT_LIMIT: 3,
     // Canonical history is normalized by stable block identity. Each tab keeps
     // one chronological repository and one explicit revealed/server range.
     _messagesById: new Map(),
     _sessionWindows: new Map(),
     _assistantBodyObserver: null,
     _assistantBodyTargets: new Map(),
+    // Rich history rendering is deliberately serialized. Alpine can mount many
+    // assistant rows in one tick; scheduling one marked/DOMPurify pass per row in
+    // the same animation frame turns those callbacks into one browser long task
+    // and freezes unrelated controls. Plain text remains complete and visible
+    // while this queue upgrades one mounted bubble per event-loop turn.
+    _historyRichRenderQueue: [],
+    _historyRichRenderScheduled: false,
     // Final assistant HTML is also retained by the same stable render key. This
     // survives window object eviction/reload without keying rich output by an
     // ever-growing text value, while the bounded LRU keeps memory predictable.
@@ -3927,7 +3935,7 @@ function portal() {
       if (activeState) activeState.atBottom = false;
       const tryScroll = () => {
         if (sid !== this.currentId) return false;
-        const body = this.$refs && this.$refs.chatBody;
+        const body = this._chatBodyElement();
         const el = body && body.querySelector(
           `.msg[data-uuid="${CSS.escape(uuid)}"]`);
         if (!el) return false;
@@ -4049,6 +4057,10 @@ function portal() {
         || (m && m._interrupted ? "cancelled" : "")
         || (m && m._failed ? "failed" : ""));
       if (stored) return stored;
+      // A continuation can pause after its main response while background work
+      // settles. Do not present that quiet handoff as a newly running turn; the
+      // live footer appears when the reaction stream actually starts.
+      if (pane && pane._continuationAwaitingReaction) return "";
       // Fresh live bubbles are created before the terminal done payload can
       // stamp turn_status.  A canonical historical footer already has ts, so
       // never relabel such a prior turn just because a newer stream is active.
@@ -4492,6 +4504,16 @@ function portal() {
       // breaks. This is both safe (no raw HTML enters the result) and visually
       // equivalent for ordinary prose.
       if (text.length >= 64 * 1024) {
+        // A single huge fenced dump is common in agent output and does not need
+        // marked + DOMPurify to discover its structure. Escaping it directly is
+        // equivalent, keeps the full code available, and avoids a multi-second
+        // uninterruptible parse on mobile. highlightCode still decorates ordinary
+        // sized blocks later and already leaves very large blocks as plain code.
+        const fenced = text.match(/^\s*(```|~~~)\s*([\w+#.\-]*)[^\n]*\n([\s\S]*?)\n\1\s*$/);
+        if (fenced) {
+          const lang = fenced[2] ? ` class="language-${fenced[2]}"` : "";
+          return `<pre><code${lang}>${this.escape(fenced[3])}</code></pre>`;
+        }
         const hasRichSyntax = /```|~~~|`|\[[^\]]+\]\(|<\/?[A-Za-z][^>]*>|\*\*|__|~~|\$\$|\\\(|\\\[|(^|\n)\s{0,3}(?:#{1,6}\s|>\s|[-+*]\s|\d+[.)]\s)/m.test(text);
         if (!hasRichSyntax) {
           const escaped = this.escape(text);
@@ -7203,6 +7225,10 @@ function portal() {
         es: null,
         // Deduplicate stop taps while the interrupt request is in flight.
         _stopping: false,
+        // The Stop button settles the visible turn immediately while the backend
+        // interrupt/watchdog confirms asynchronously. This marker suppresses a
+        // duplicate terminal toast and lets a failed /active probe restore truth.
+        _optimisticInterrupt: false,
         // Abort the POST /stream/start ticket request when Stop is clicked
         // before EventSource exists. Without this, the backend has no active
         // turn/client to interrupt yet and the reply starts after Stop.
@@ -7249,10 +7275,18 @@ function portal() {
         _permissionPatchTail: null,
         _thinkingPatchTail: null,
         _loaded: false,   // set true after first loadSession populates messages
+        // Canonical history installation watermark. Unlike messages.length this
+        // never advances for optimistic/live bubbles, so a non-empty pane can
+        // still detect that the server has committed a newer missing suffix.
+        _installedCanonicalCount: 0,
         _seenUpdated: undefined,
         _reconcileTargetUpdated: 0,
         _reconcileRetryN: 0,
         _pendingExternalUpdate: false,
+        // A Result boundary may race with the next stream taking ownership of
+        // the same pane. Retain the latest completion check until an owner-free
+        // moment instead of silently consuming the reconciliation request.
+        _pendingCompletedTurnSync: null,
         atBottom: true,
         scrollTop: 0,
         _userScrollAt: 0,
@@ -7293,15 +7327,10 @@ function portal() {
         _usageFetching: false,
         _hasMoreHistory: false,
         _truncatedFromTop: false,
-        // History paging is an internal transport concern. The active session
-        // fills its normalized repository in idle slices and promotes urgent
-        // reads when the user scrolls toward the loaded edge.
-        _historyHydrating: false,
-        _historyHydrationScheduled: false,
-        _historyHydrationUrgent: false,
-        _historyHydrationEpoch: 0,
+        _loadingEarlier: false,
+        // Set when an explicit "Load earlier" request fails; the button remains
+        // available so the reader can retry without losing the current window.
         _historyHydrationError: false,
-        _historyHydrationRetry: null,
         _lastVirtualScrollTop: 0,
         _lastVirtualScrollAt: 0,
         _virtualScrollVelocity: 0,
@@ -7374,6 +7403,15 @@ function portal() {
       }
       if (st._sessionActivityExpected === undefined) {
         st._sessionActivityExpected = null;
+      }
+      if (st._optimisticInterrupt === undefined) {
+        st._optimisticInterrupt = false;
+      }
+      if (!Number.isFinite(Number(st._installedCanonicalCount))) {
+        st._installedCanonicalCount = 0;
+      }
+      if (st._pendingCompletedTurnSync === undefined) {
+        st._pendingCompletedTurnSync = null;
       }
       if (!Number.isFinite(Number(st.inheritedBackgroundTaskCount))) {
         st.inheritedBackgroundTaskCount = 0;
@@ -7537,7 +7575,10 @@ function portal() {
       delete loadOptions.delayMs;
       delete loadOptions.loadOptions;
       const ok = await this.loadSession(sid, loadOptions);
-      if (ok && this.tabState[sid] === st) st._loaded = true;
+      if (ok && this.tabState[sid] === st) {
+        st._loaded = true;
+        st._pendingExternalUpdate = false;
+      }
       return !!ok;
     },
 
@@ -7995,6 +8036,7 @@ function portal() {
         this._cloneRolloverValue(row));
       child.messages = cloneMessages(sourceState.messages);
       child.messageRange = { ...sourceState.messageRange };
+      this._ensureNonEmptyMessageRange(child);
       child.messagesReady = sourceState.messagesReady !== false;
       child.messagesLoading = false;
       child.runtimeUiRevision = sourceState.runtimeUiRevision || "";
@@ -8006,7 +8048,12 @@ function portal() {
       child.serviceTier = sourceState.serviceTier || "";
       child.atBottom = sourceState.atBottom !== false;
       child.scrollTop = Number(sourceState.scrollTop) || 0;
-      child._loaded = true;
+      // A detached successor can be created while its off-screen predecessor has
+      // tab state but no resident canonical window. Marking that empty clone as
+      // loaded makes every later tab click skip loadSession until a full refresh.
+      child._loaded = !!sourceState._loaded && child.messages.length > 0;
+      child._installedCanonicalCount = Math.max(
+        0, Number(sourceState._installedCanonicalCount) || 0);
       child._seenUpdated = sourceState._seenUpdated;
       child.pendingQueue = this._cloneRolloverValue(sourceState.pendingQueue || []);
       child._queuePaused = !!sourceState._queuePaused;
@@ -8137,6 +8184,12 @@ function portal() {
               [childMeta.cwd]: childSid,
             };
           }
+        }
+        // Do not wait for the inherited-task poller to eventually notice an
+        // incomplete clone. Start canonical hydration as soon as the successor
+        // owns tab state; the coalescer keeps it serialized with later polling.
+        if (!childState._loaded) {
+          this._requestSessionSync(childSid, "history_load", { loadOptions: {} });
         }
         this._sessionsEtag = "";
         this.savePrefs();
@@ -8655,13 +8708,45 @@ function portal() {
       st.sessionSync.backgroundTicksLeft = 0;
       this._cancelSessionSyncReason(st, "background_continuation");
     },
+    _canonicalMetaBehind(st, meta) {
+      if (!st || !meta || !st._loaded) return false;
+      const canonicalCount = Math.max(0, Number(meta.message_count) || 0);
+      const installedCount = Math.max(0, Number(st._installedCanonicalCount) || 0);
+      if (canonicalCount > installedCount) return true;
+      const updated = Number(meta.updated_at) || 0;
+      const seen = Number(st._seenUpdated);
+      return st._seenUpdated !== undefined && Number.isFinite(seen) && updated > seen;
+    },
+    _resumePendingCanonicalSync(sid, st) {
+      if (!sid || !st || this.tabState[sid] !== st || st.streaming || st.es) return;
+      const pending = st._pendingCompletedTurnSync;
+      if (pending) {
+        this._requestSessionSync(sid, "completed_turn", {
+          ...pending, delayMs: 0,
+        });
+        return;
+      }
+      if (st._pendingExternalUpdate) {
+        this._requestSessionSync(sid, "history_revision", {
+          targetUpdated: Number(st._reconcileTargetUpdated) || 0,
+          delayMs: 0,
+        });
+      }
+    },
     _reconcileCompletedTurn(
       sid, ownerState, expectedText = "", attempt = 0, expectedAssistantUuid = "",
     ) {
       if (!sid || this.tabState[sid] !== ownerState) return Promise.resolve(false);
+      const options = {
+        expectedText: String(expectedText || ""),
+        expectedAssistantUuid: String(expectedAssistantUuid || ""),
+        attempt: Math.max(0, Number(attempt) || 0),
+      };
+      ownerState._pendingCompletedTurnSync = options;
       return this._requestSessionSync(sid, "completed_turn", {
-        expectedText, attempt, expectedAssistantUuid,
-        delayMs: attempt ? Math.min(2000, 250 + attempt * 100) : 80,
+        ...options,
+        delayMs: options.attempt
+          ? Math.min(2000, 250 + options.attempt * 100) : 80,
       });
     },
     async _runCompletedTurnSync(sid, ownerState, options = {}) {
@@ -8672,10 +8757,13 @@ function portal() {
         && !ownerState.streaming && !ownerState.es;
       if (!stillOwned()) return false;
       const retry = () => {
+        const next = {
+          expectedText, expectedAssistantUuid, attempt: attempt + 1,
+        };
+        ownerState._pendingCompletedTurnSync = next;
         if (attempt < 30 && stillOwned()) {
           this._requestSessionSync(sid, "completed_turn", {
-            expectedText, expectedAssistantUuid, attempt: attempt + 1,
-            delayMs: Math.min(2000, 350 + attempt * 100),
+            ...next, delayMs: Math.min(2000, 350 + attempt * 100),
           });
         }
       };
@@ -8727,7 +8815,10 @@ function portal() {
           quiet: true, probeActive: false,
         });
         if (!loaded) retry();
-        else ownerState._loaded = true;
+        else {
+          ownerState._loaded = true;
+          ownerState._pendingCompletedTurnSync = null;
+        }
         return !!loaded;
       } catch (_) {
         retry();
@@ -8968,9 +9059,10 @@ function portal() {
         return st && (st.streaming || st.es);
       });
       const streamingSet = new Set(streaming);
+      const warmLimit = this._isMobileLayout() ? 1 : this.WARM_TRANSCRIPT_LIMIT;
       const ordinary = lru
         .filter(tid => !streamingSet.has(tid))
-        .slice(0, this.WARM_TRANSCRIPT_LIMIT);
+        .slice(0, warmLimit);
       const desired = [...ordinary, ...streaming];
       const desiredSet = new Set(desired);
       // Preserve mount order for panes that remain warm. Reordering the x-for on
@@ -8990,8 +9082,19 @@ function portal() {
       }
       return warm;
     },
+    _chatBodyElement() {
+      // chatBody lives below a nested x-data scope (`activeSession` façade).
+      // Alpine does not expose descendant component refs through the root
+      // portal's `$refs`, so every root-owned scroll path previously received
+      // undefined and returned before touching scrollTop. Querying the single
+      // physical chat scroller is the stable cross-scope ownership boundary.
+      const fromRefs = this.$refs && this.$refs.chatBody;
+      if (fromRefs) return fromRefs;
+      return typeof document !== "undefined"
+        ? document.querySelector(".chat-body") : null;
+    },
     _paneElement(tid) {
-      const body = this.$refs && this.$refs.chatBody;
+      const body = this._chatBodyElement();
       if (!body || !tid) return null;
       return body.querySelector(`.msg-pane[data-tid="${CSS.escape(tid)}"]`);
     },
@@ -9017,10 +9120,30 @@ function portal() {
       if (!st || !Array.isArray(st.messages)) return [];
       const range = st.messageRange;
       if (!range) return st.messages;
+      // Enforce the visible-range invariant at the final pane boundary too.
+      // State handoff/clone paths can outlive the load generation that would
+      // normally repair an interrupted reveal; a non-empty repository must
+      // never derive an empty mounted pane.
+      this._ensureNonEmptyMessageRange(st);
       if (range.visibleStart === 0 && range.visibleEnd === st.messages.length) {
         return st.messages;
       }
       return st.messages.slice(range.visibleStart, range.visibleEnd);
+    },
+    _ensureNonEmptyMessageRange(st) {
+      if (!st || !Array.isArray(st.messages) || !st.messages.length) return false;
+      const range = st.messageRange;
+      if (!range) return true;
+      const length = st.messages.length;
+      range.visibleStart = Math.max(
+        0, Math.min(Number(range.visibleStart) || 0, length));
+      range.visibleEnd = Math.max(
+        range.visibleStart, Math.min(Number(range.visibleEnd) || 0, length));
+      if (range.visibleEnd <= range.visibleStart) {
+        range.visibleEnd = length;
+        range.visibleStart = Math.max(0, length - 1);
+      }
+      return true;
     },
     _containsPaneMessage(st, message) {
       // Streaming ownership must be checked against the authoritative resident
@@ -9108,38 +9231,14 @@ function portal() {
       const st = tid && this.tabState && this.tabState[tid];
       const messages = this._visiblePaneMessages(st);
       if (!st || !messages.length) return [];
-      // Read the revision so measured heights invalidate Alpine's derived rows.
-      void st._virtualRevision;
-      let start = Math.max(0, Math.min(st._virtualStart, messages.length));
-      let end = Math.max(start, Math.min(st._virtualEnd, messages.length));
-      if (st._virtualStart < 0 || end <= start) {
-        const initial = this._initialMessageVirtualRange(st);
-        start = initial.start;
-        end = initial.end;
-      }
-      const pane = this._paneElement(tid);
-      const gap = this._messageVirtualGap(pane);
-      const rows = [];
-      const spacer = (kind, from, to) => {
-        if (to <= from) return;
-        rows.push({
-          key: tid + ":virtual-spacer:" + kind,
-          index: -1,
-          message: { role: "virtual_spacer", _k: tid + ":virtual-spacer:" + kind },
-          spacer: true,
-          height: this._messageVirtualRangeHeight(st, messages, from, to, gap),
-        });
-      };
-      spacer("top", 0, start);
-      for (let i = start; i < end; i++) {
-        rows.push({ key: messages[i]._k, index: i, message: messages[i], spacer: false });
-      }
-      // Keep one virtual window only. Live messages remain authoritative in the
-      // normalized repository even when the reader is inspecting older rows;
-      // mounting a second three-row tail was unnecessary and made `streaming=false`
-      // remove those nodes exactly at completion, collapsing the scroll layout.
-      spacer("bottom", end, messages.length);
-      return rows;
+      // Render the resident window directly. The custom estimated-height spacers
+      // could not keep up with fast wheel/touch movement: readers outran the
+      // mounted range into blank space, then each measured-height correction
+      // resized the scrollbar and flashed the pane. Network paging still bounds
+      // the resident range; the browser now owns layout with exact row heights.
+      return messages.map((message, index) => ({
+        key: message._k, index, message, spacer: false,
+      }));
     },
     _measureMessageVirtualRows(tid, st) {
       const pane = this._paneElement(tid);
@@ -9157,80 +9256,12 @@ function portal() {
       return changed;
     },
     _syncMessageViewport(tid = this.currentId, forceTail = false) {
-      const st = tid && this.tabState && this.tabState[tid];
-      const body = this.$refs && this.$refs.chatBody;
-      const pane = this._paneElement(tid);
-      const messages = this._visiblePaneMessages(st);
-      if (!st || !body || !pane || !messages.length || tid !== this.currentId) return;
-      const followTail = forceTail || st.atBottom;
-      // Height realization changes spacer geometry even when the mounted index
-      // range itself stays unchanged. Capture the reader's stable message before
-      // measuring so that correction cannot move the content under their eyes.
-      const measurementAnchor = followTail
-        ? null : this._captureViewportMessageAnchor(body, tid);
-      const heightsChanged = this._measureMessageVirtualRows(tid, st);
-      const gap = this._messageVirtualGap(pane);
-      const overscan = Math.max(600, body.clientHeight * 1.5);
-      const speedScreens = Math.min(
-        8, (Number(st._virtualScrollVelocity) || 0) / Math.max(1, body.clientHeight));
-      const directionalExtra = body.clientHeight * speedScreens;
-      const topOverscan = overscan
-        + (st._virtualScrollDirection < 0 ? directionalExtra : 0);
-      const bottomOverscan = overscan
-        + (st._virtualScrollDirection > 0 ? directionalExtra : 0);
-      const paneRect = pane.getBoundingClientRect();
-      const bodyRect = body.getBoundingClientRect();
-      const wantedTop = Math.max(0, bodyRect.top - paneRect.top - topOverscan);
-      const wantedBottom = Math.max(wantedTop, bodyRect.bottom - paneRect.top + bottomOverscan);
-      let cursor = 0;
-      let start = 0;
-      while (start < messages.length) {
-        const next = cursor + this._messageVirtualHeight(st, messages[start]);
-        if (next >= wantedTop) break;
-        cursor = next + gap;
-        start++;
-      }
-      let end = start;
-      while (end < messages.length && cursor <= wantedBottom) {
-        cursor += this._messageVirtualHeight(st, messages[end]) + gap;
-        end++;
-      }
-      if (followTail) {
-        end = messages.length;
-        let tailHeight = 0;
-        start = end;
-        const target = body.clientHeight + overscan;
-        while (start > 0 && tailHeight < target) {
-          start--;
-          tailHeight += this._messageVirtualHeight(st, messages[start]) + gap;
-        }
-      }
-      if (start === st._virtualStart && end === st._virtualEnd) {
-        if (heightsChanged && measurementAnchor) {
-          this.$nextTick(() => {
-            if (this.tabState[tid] === st && tid === this.currentId && st.atBottom === false) {
-              this._restoreMessageAnchor(body, measurementAnchor);
-            }
-          });
-        }
-        return;
-      }
-      // Normal reader-controlled virtualization updates preserve the message
-      // currently under the reader's eyes. Tail-follow updates must not: every
-      // programmatic scroll event schedules another viewport sync with
-      // forceTail=false, but st.atBottom remains true. Restoring an anchor in
-      // that follow-up sync was undoing both Send's explicit jump and every
-      // streaming auto-follow step.
-      const anchor = followTail
-        ? null : (measurementAnchor || this._captureViewportMessageAnchor(body, tid));
-      st._virtualStart = start;
-      st._virtualEnd = end;
-      st._virtualRevision++;
-      this.$nextTick(() => {
-        if (this.tabState[tid] !== st || tid !== this.currentId) return;
-        this._measureMessageVirtualRows(tid, st);
-        if (!followTail) this._restoreMessageAnchor(body, anchor);
-      });
+      // Intentionally no-op: paneMessageRows renders the resident range with
+      // exact browser layout. Keeping the old velocity/estimated-height window
+      // updater active would continue rewriting indexes and restoring anchors
+      // on every scroll frame even though there are no virtual spacers left.
+      void tid;
+      void forceTail;
     },
     _scheduleMessageViewportSync(tid = this.currentId, forceTail = false) {
       const st = tid && this.tabState && this.tabState[tid];
@@ -9325,6 +9356,18 @@ function portal() {
       if (!st._loaded) {
         await this._ensureSessionLoaded(this.currentId);
       }
+      // Reproduce the already-active tab click once after cold restoration. The
+      // transcript load resolves before Alpine has necessarily mounted its pane;
+      // if the earlier tail scroll ran in that gap, only the virtual top spacer
+      // remains visible until the user clicks the selected tab manually.
+      const restoredId = this.currentId;
+      this.$nextTick(() => this._afterPaint(() => {
+        const restored = this.tabState && this.tabState[restoredId];
+        if (this.currentId !== restoredId || !restored
+            || !restored.messages.length || restored.atBottom === false) return;
+        restored.messagesReady = true;
+        this.scrollToBottom(true);
+      }));
       this._sessionsInitialized = true;
       this._scheduleSavePrefs();
       return true;
@@ -9706,6 +9749,9 @@ function portal() {
           st._loaded = true;
           st._pendingExternalUpdate = false;
           this._syncQueueFromServer(sid);
+          this.$nextTick(() => this._drainPendingQueue(
+            sid, st.activeTurnId || "",
+          ));
         }
         return !!loaded;
       } catch (_) {
@@ -9756,6 +9802,9 @@ function portal() {
         st._loaded = true;
         st._pendingExternalUpdate = false;
         this._syncQueueFromServer(sid);
+        this.$nextTick(() => this._drainPendingQueue(
+          sid, st.activeTurnId || "",
+        ));
       }
       return !!loaded;
     },
@@ -9850,6 +9899,21 @@ function portal() {
         const newer = hasBaseline && newU > baselineN;
         const priorTarget = Number(st._reconcileTargetUpdated) || 0;
         const backgroundOnly = !!cur.background_active && !cur.turn_active;
+        const canonicalCount = Math.max(0, Number(cur.message_count) || 0);
+        const installedCount = Math.max(
+          0, Number(st._installedCanonicalCount) || 0);
+        const canonicalSuffixMissing = st._loaded
+          && canonicalCount > installedCount;
+        const canonicalMissingLocally = canonicalCount > 0
+          && !st.messages.length && !st.streaming && !st.es;
+        if (canonicalMissingLocally) {
+          // Session-list polling is the final convergence owner. Even if a tab
+          // activation or runtime handoff was interrupted, a visible non-empty
+          // canonical session cannot remain an empty local pane indefinitely.
+          st._loaded = false;
+          this._requestSessionSync(sid, "history_load", { loadOptions: {} });
+          continue;
+        }
         const messageCountChanged = !!previous
           && Number(cur.message_count || 0) !== Number(previous.message_count || 0);
         const turnCountChanged = !!previous
@@ -9875,10 +9939,13 @@ function portal() {
           st._pendingExternalUpdate = true;
         }
         if (st.streaming || st.es) {
-          if (visibleNewer) st._pendingExternalUpdate = true;
+          if (visibleNewer || canonicalSuffixMissing) {
+            st._pendingExternalUpdate = true;
+          }
           continue;
         }
-        const needsRefresh = st._pendingExternalUpdate || visibleNewer;
+        const needsRefresh = st._pendingExternalUpdate
+          || visibleNewer || canonicalSuffixMissing;
         const hasTurnActivityFlag = Object.prototype.hasOwnProperty.call(
           cur, "turn_active",
         );
@@ -9887,7 +9954,10 @@ function portal() {
             : (!!cur.active && !cur.background_active)
         ) && !st.streaming && !st.es;
         if (!needsRefresh) {
-          if (!hasBaseline && st._loaded && newU) st._seenUpdated = newU;
+          // Do not consume the first post-done metadata snapshot as a baseline
+          // when its canonical count is ahead of the last installed history.
+          if (!hasBaseline && st._loaded && newU
+              && canonicalCount <= installedCount) st._seenUpdated = newU;
           if (wantsAttach && st._loaded) this._checkActiveTurn(sid);
           continue;
         }
@@ -9995,7 +10065,7 @@ function portal() {
       // reply yanked the user back to the very first message. Snapshot the
       // scroller here and re-pin it after the tickle. The `model` tickle
       // doesn't touch the panes, so it skips this.
-      const chatEl = field === "currentId" ? this.$refs.chatBody : null;
+      const chatEl = field === "currentId" ? this._chatBodyElement() : null;
       const savedTop = chatEl ? chatEl.scrollTop : 0;
       const wasAtBottom = this.activeSessionPane().atBottom !== false;
       await this.$nextTick();
@@ -10507,10 +10577,6 @@ function portal() {
       void Promise.resolve(
         this.fetchTerminals({ restore: true }),
       ).catch(() => false);
-      let coldTreeOk = null;
-      if (!runtime) {
-        coldTreeOk = await treeReady;
-      }
       if (this.previewSurface === "file"
           && selected && this.tabs.some(t => t.path === selected)) {
         const tab = this.tabs.find(t => t.path === selected);
@@ -10531,14 +10597,12 @@ function portal() {
         if (treeOk !== true) this._scheduleWorkspaceSyncRetry(path);
         this._startFileEvents();
       };
-      if (runtime) {
-        // The restored runtime tree paints synchronously. Revalidate it in the
-        // background and only then open the cursor replay stream; switching the
-        // workspace must not wait for a bootstrap/delta round trip.
-        void treeReady.then(startFileEvents);
-      } else {
-        startFileEvents(coldTreeOk);
-      }
+      // The workspace identity and cached surface are already committed above.
+      // File-tree bootstrap is pane-local work: a cold or wedged tree request must
+      // not keep the whole layout shielded, disable the composer, or cover mobile
+      // navigation. Revalidate in the background for both warm and cold surfaces;
+      // owner/sequence guards prevent a late response from mutating another root.
+      void treeReady.then(startFileEvents);
       this.savePrefs();
       return true;
     },
@@ -10555,9 +10619,9 @@ function portal() {
       this.workspaceSurfaceTransition = true;
       try {
         // A workspace owns the conversation cwd, file tree, preview tabs, and
-        // editor together. Start the tree request first (it changes the owner
-        // synchronously), then fetch the target's small session window and
-        // prewarm its transcript while the tree is still loading.
+        // editor together. Resolve only the target session identity under the
+        // workspace-wide transition. Transcript loading is pane-local and must
+        // not keep the shell shielded or the composer disabled.
         const surfaceReady = Promise.resolve(
           this._changeWorkspaceSurface(path),
         ).catch(() => false);
@@ -10573,13 +10637,12 @@ function portal() {
             || this.workspaceOpenTabIds(path)
               .map(id => this.sessions.find(s => s.id === id)).find(Boolean)
             || workspaceRows[0];
-          if (target) await this._ensureSessionLoaded(target.id);
           return target || null;
         })().catch(() => null);
         const [surfaceOk, target] = await Promise.all([surfaceReady, targetReady]);
         if (switchSeq !== this._workspaceSwitchSeq
             || !surfaceOk || !this._workspaceIsCurrent(path)) return;
-        if (target) await this.openTab(target.id);
+        if (target) await this.openTab(target.id, true, { deferLoad: true });
         else this.newSession({ cwd: path });
         if (switchSeq !== this._workspaceSwitchSeq
             || !this._workspaceIsCurrent(path)) return;
@@ -10772,9 +10835,6 @@ function portal() {
         if (st._streamTimer) clearInterval(st._streamTimer);
         if (st._stallWatch) clearInterval(st._stallWatch);
         if (st._reconnectTimer) clearTimeout(st._reconnectTimer);
-        if (st._historyHydrationRetry) clearTimeout(st._historyHydrationRetry);
-        st._historyHydrationRetry = null;
-        st._historyHydrationEpoch = (Number(st._historyHydrationEpoch) || 0) + 1;
         this._disposeSessionSync(st);
         if (st._virtualSyncFrame) {
           if (typeof cancelAnimationFrame === "function") {
@@ -11085,7 +11145,7 @@ function portal() {
     // ===== tabs =====
     // Switch to (and if needed open) a tab. Used by the picker dropdown to
     // promote a history session into a tab.
-    async openTab(id, makeCurrent = true) {
+    async openTab(id, makeCurrent = true, options = {}) {
       const session = this.sessions.find(s => s.id === id);
       const cwd = session && session.cwd;
       if (cwd && cwd !== this.currentWorkspacePath()
@@ -11104,7 +11164,16 @@ function portal() {
       if (makeCurrent && id !== this.currentId) {
         this._captureChatPosition(this.currentId);
         this.currentId = id;
-        await this.switchSession();
+        const switching = this.switchSession();
+        if (options.deferLoad) {
+          // Workspace switching owns only the shell transition. switchSession()
+          // synchronously commits the selected tab and then waits on the target
+          // transcript; let that wait continue behind the pane-local skeleton so
+          // unrelated controls regain input after the next shell paint.
+          void switching.catch(() => false);
+        } else {
+          await switching;
+        }
       }
       if (cwd) {
         this.workspaceLastSession = { ...this.workspaceLastSession, [cwd]: id };
@@ -11202,18 +11271,11 @@ function portal() {
       const id = this.renamingTabId;
       const name = (this.renameDraft || "").trim();
       this.renamingTabId = "";
-      const draft = this.renameDraft;
       this.renameDraft = "";
       if (!id || !name) return;
       const cur = this.sessions.find(x => x.id === id);
       if (!cur || cur.name === name) return;
-      const r = await fetch("/api/chat/sessions/" + id, {
-        method: "PATCH",
-        headers: { ...this.hdr(), "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
-      });
-      if (r.ok) { await this.refreshSessions(); this.toast(this.t("toast.renamed"), "success"); }
-      else { this.toast(this.lang === "zh" ? "重命名失败" : "Rename failed", "error"); }
+      await this._renameSessionOptimistically(id, name, cur.name, true, "tab");
     },
     cancelRenameTab() { this.renamingTabId = ""; this.renameDraft = ""; },
 
@@ -11397,7 +11459,7 @@ function portal() {
           const loaded = await r.json();
           const localKey = m._k;
           Object.assign(m, loaded, { _k: localKey, body_state: "loaded" });
-          if (m.role === "assistant") m.html = this._renderHistoryMessage(m);
+          if (m.role === "assistant") this._queueHistoryRichRender(m, sid);
           if (m._is_compact_summary) delete m._compactHtml;
           return true;
         } catch (_) {
@@ -11413,18 +11475,55 @@ function portal() {
       })();
       return m._bodyLoadPromise;
     },
+    _queueHistoryRichRender(m, sid = this.currentId, el = null) {
+      if (!m || m.role !== "assistant" || !m.text || m.html || m._richRenderQueued) return;
+      m._richRenderQueued = true;
+      this._historyRichRenderQueue.push({ message: m, sid, el });
+      this._scheduleHistoryRichRender();
+    },
+    _scheduleHistoryRichRender() {
+      if (this._historyRichRenderScheduled) return;
+      this._historyRichRenderScheduled = true;
+      const run = () => {
+        this._historyRichRenderScheduled = false;
+        let pending = null;
+        while (this._historyRichRenderQueue.length && !pending) {
+          const candidate = this._historyRichRenderQueue.shift();
+          const m = candidate && candidate.message;
+          if (m) delete m._richRenderQueued;
+          if (!m || m.html || !m.text) continue;
+          if (candidate.el && !candidate.el.isConnected) continue;
+          const st = this.tabState[candidate.sid];
+          if (!st || !st.messages.includes(m)) continue;
+          pending = candidate;
+        }
+        if (!pending) return;
+        const m = pending.message;
+        m.html = this._renderHistoryMessage(m);
+        if (pending.el && pending.el.isConnected) {
+          this.$nextTick(() => this._afterPaint(() => {
+            if (pending.el.isConnected) {
+              this.highlightCode(".chat-body", [pending.el]);
+            }
+          }));
+        }
+        // A macrotask boundary between every rich bubble is intentional. A frame
+        // budget cannot pre-empt marked/DOMPurify inside one message, but it can
+        // prevent twenty independently-mounted rows from becoming one long task.
+        if (this._historyRichRenderQueue.length) this._scheduleHistoryRichRender();
+      };
+      // Visible text is already present through `.history-plain`; rich decoration
+      // can wait for idle time without hiding content or delaying input handlers.
+      if (typeof window !== "undefined" && window.requestIdleCallback) {
+        window.requestIdleCallback(run, { timeout: 250 });
+      } else {
+        setTimeout(run, 0);
+      }
+    },
     observeAssistantBody(el, m, sid) {
       if (!el || !m || m.role !== "assistant") return;
       if (m.body_state === "loaded" || !m.body_available) {
-        if (m.text && !m.html) {
-          const render = () => {
-            if (el.isConnected && m.text && !m.html) {
-              m.html = this._renderHistoryMessage(m);
-            }
-          };
-          if (typeof requestAnimationFrame === "function") requestAnimationFrame(render);
-          else setTimeout(render, 0);
-        }
+        this._queueHistoryRichRender(m, sid, el);
         return;
       }
       const load = async () => {
@@ -11455,7 +11554,7 @@ function portal() {
             });
           }
         }, {
-          root: (this.$refs && this.$refs.chatBody) || null,
+          root: (this._chatBodyElement()) || null,
           rootMargin: "500% 0px",
         });
       }
@@ -12993,7 +13092,24 @@ function portal() {
 
     async activateTab(tid) {
       if (tid === this.currentId) {
-        this.scrollToBottom(true);
+        const st = this._ensureTabState(tid);
+        const meta = (this.sessions || []).find(session => session.id === tid);
+        const canonicalCount = Math.max(
+          0, Number(meta && meta.message_count) || 0);
+        const canonicalBehind = this._canonicalMetaBehind(st, meta);
+        if ((canonicalBehind || (canonicalCount > 0 && !st.messages.length))
+            && !st.streaming && !st.es) {
+          // Clicking an already-selected tab is also a convergence point. Recover
+          // both an empty stale cache and a non-empty pane missing its canonical
+          // suffix; quiet mode preserves the mounted bubbles and controls.
+          if (!st.messages.length) st._loaded = false;
+          st._pendingExternalUpdate = canonicalBehind;
+          await this._ensureSessionLoaded(tid);
+        }
+        this._ensureNonEmptyMessageRange(st);
+        st.messagesReady = true;
+        this._touchTranscriptPane(tid);
+        this.$nextTick(() => this.scrollToBottom(true));
         return;
       }
       await this.openTab(tid);
@@ -13610,9 +13726,9 @@ function portal() {
         session.name = name;
         session.auto_named = false;
       }
-      // Activity rows carry a denormalized display name.  Patch the current
-      // browser synchronously after the successful request; the backend sends
-      // the same targeted row over Activity SSE so other tabs converge too.
+      // Activity rows carry a denormalized display name. Patch this browser in
+      // the same optimistic update; the backend sends the persisted row over
+      // Activity SSE so other tabs converge after the request succeeds.
       // Never reload the conversation or the full Activity Center for a title
       // change — both are unrelated surfaces and a reload can visibly churn
       // their keyed DOM.
@@ -13625,6 +13741,77 @@ function portal() {
       }
       if (activityChanged) this.activity.events = [...this.activity.events];
     },
+    async _renameSessionOptimistically(
+      sid, name, previousName, announce = false, surface = "modal",
+    ) {
+      // The backend also mirrors the title into the CLI transcript and Activity
+      // ledger, which can take seconds. The local session index is authoritative
+      // for this view, so update immediately and let persistence finish without
+      // making the tab label feel blocked on unrelated disk work.
+      const perfNow = (typeof performance !== "undefined" && performance.now)
+        ? () => performance.now() : () => Date.now();
+      const started = perfNow();
+      const renamePerf = {
+        surface, status: "error", optimistic_apply_ms: 0,
+        optimistic_paint_ms: 0, request_ms: 0, total_ms: 0,
+        long_task_count: 0, longest_task_ms: 0,
+      };
+      let longTaskObserver = null;
+      if (typeof PerformanceObserver !== "undefined") {
+        try {
+          longTaskObserver = new PerformanceObserver(list => {
+            for (const entry of list.getEntries()) {
+              renamePerf.long_task_count++;
+              renamePerf.longest_task_ms = Math.max(
+                renamePerf.longest_task_ms, Math.round(entry.duration || 0));
+            }
+          });
+          longTaskObserver.observe({ entryTypes: ["longtask"] });
+        } catch (_) { longTaskObserver = null; }
+      }
+      this._applyRenamedSession(sid, name);
+      renamePerf.optimistic_apply_ms = Math.round(perfNow() - started);
+      const painted = new Promise(resolve => {
+        this._afterPaint(() => {
+          renamePerf.optimistic_paint_ms = Math.round(perfNow() - started);
+          resolve();
+        });
+      });
+      let response = null;
+      const requestStarted = perfNow();
+      try {
+        response = await fetch("/api/chat/sessions/" + sid, {
+          method: "PATCH",
+          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+      } catch (_) { /* handled by the rollback below */ }
+      renamePerf.request_ms = Math.round(perfNow() - requestStarted);
+      const ok = !!(response && response.ok);
+      if (!ok) {
+        // Do not undo a newer rename that completed while this request was in
+        // flight. Roll back only when our optimistic value still owns the row.
+        const current = this.sessions.find(row => row.id === sid);
+        if (current && current.name === name) {
+          this._applyRenamedSession(sid, previousName);
+          renamePerf.status = "rollback";
+        }
+        this.toast(this.lang === "zh" ? "重命名失败" : "Rename failed", "error", 3000);
+      } else {
+        renamePerf.status = "ok";
+        if (announce) this.toast(this.t("toast.renamed"), "success");
+      }
+      // Hidden/background tabs may suspend requestAnimationFrame indefinitely.
+      // Bound diagnostics so observing first paint can never hold this action open.
+      await Promise.race([
+        painted,
+        new Promise(resolve => setTimeout(resolve, 250)),
+      ]);
+      if (longTaskObserver) longTaskObserver.disconnect();
+      renamePerf.total_ms = Math.round(perfNow() - started);
+      this._reportSessionRenamePerf(renamePerf);
+      return ok;
+    },
     async pickerCommitInlineRename() {
       const sid = this.renamingPickerSid;
       const name = (this.pickerRenameDraft || "").trim();
@@ -13633,16 +13820,7 @@ function portal() {
       if (!sid || !name) return;
       const cur = this.sessions.find(x => x.id === sid);
       if (!cur || cur.name === name) return;
-      const r = await fetch("/api/chat/sessions/" + sid, {
-        method: "PATCH",
-        headers: { ...this.hdr(), "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
-      });
-      if (r.ok) {
-        this._applyRenamedSession(sid, name);
-      } else {
-        this.toast(this.lang === "zh" ? "重命名失败" : "Rename failed", "error", 3000);
-      }
+      await this._renameSessionOptimistically(sid, name, cur.name, false, "picker");
     },
     pickerCancelInlineRename() {
       this.renamingPickerSid = "";
@@ -13988,7 +14166,16 @@ function portal() {
         this.thinkingEnabled = cur.thinking !== false;
       }
       const st = this._ensureTabState(this.currentId);
-      if (!st._loaded) {
+      const canonicalCount = Math.max(0, Number(cur && cur.message_count) || 0);
+      const loadedButMissingCanonical = st._loaded
+        && canonicalCount > 0 && !st.messages.length;
+      const loadedButBehindCanonical = this._canonicalMetaBehind(st, cur);
+      if (!st._loaded || loadedButMissingCanonical || loadedButBehindCanonical) {
+        // `_loaded` is only a cache hint. A runtime handoff from an off-screen
+        // predecessor can leave an empty local clone for a non-empty canonical
+        // session; explicit tab selection must fail open to a real history load.
+        if (loadedButMissingCanonical) st._loaded = false;
+        if (loadedButBehindCanonical) st._pendingExternalUpdate = true;
         const target = this.currentId;
         await this._ensureSessionLoaded(target);
         if (this.currentId === target) this.scrollToBottom(true);
@@ -14001,27 +14188,42 @@ function portal() {
           // skeleton, rebuild directives, or rescan already-highlighted content.
           stCur.messagesReady = true;
           this.$nextTick(() => {
-            if (this.currentId === target) this.scrollToBottom(true);
+            if (this.currentId !== target || this.tabState[target] !== stCur) return;
+            // This callback runs after x-show has exposed the warm target pane.
+            // Position only this switch path immediately; changing the global
+            // scrollToBottom(force) ordering also affected cold page refreshes.
+            stCur.atBottom = true;
+            this._syncMessageViewport(target, true);
+            this._scrollChatTailNow(target, stCur);
+            this._settleScrollToBottom();
           });
         } else {
           // Cold LRU miss: the pane is being reconstructed from normalized state.
           // Paint the tab selection first, then reveal/highlight this new DOM once.
           stCur.messagesReady = false;
-          this._afterPaint(() => {
+          this.$nextTick(() => {
             if (this.currentId !== target) return;
             stCur.messagesReady = true;
-            this._afterPaint(() => {
-              if (this.currentId !== target) return;
-              this.scrollToBottom(true);
-              stCur._highlighted = false;
-              const pane = this._paneElement(target);
-              this.highlightCode(".chat-body", pane ? [pane] : null);
-              stCur._highlighted = true;
+            // Alpine applies the reveal before this callback, while the browser has
+            // not painted it yet. Position the shared scroller now; highlighting is
+            // post-paint work and must not delay or precede the tail jump.
+            this.$nextTick(() => {
+              if (this.currentId !== target || this.tabState[target] !== stCur) return;
+              stCur.atBottom = true;
+              this._syncMessageViewport(target, true);
+              this._scrollChatTailNow(target, stCur);
+              this._settleScrollToBottom();
+              this._afterPaint(() => {
+                if (this.currentId !== target) return;
+                stCur._highlighted = false;
+                const pane = this._paneElement(target);
+                this.highlightCode(".chat-body", pane ? [pane] : null);
+                stCur._highlighted = true;
+              });
             });
           });
         }
       }
-      this._scheduleTransparentHistory(st, false);
     },
     // Run `fn` AFTER the browser has painted the current frame. A single
     // requestAnimationFrame fires before paint; the nested one runs at the top
@@ -14031,6 +14233,62 @@ function portal() {
     _afterPaint(fn) {
       if (typeof requestAnimationFrame !== "function") { setTimeout(fn, 0); return; }
       requestAnimationFrame(() => requestAnimationFrame(fn));
+    },
+    _reportHistoryLoadPerf(fields) {
+      // One privacy-bounded summary per canonical history load. Never include a
+      // session id, message text, URL, model name, or error string.
+      const numeric = [
+        "total_ms", "fetch_ms", "parse_ms", "shape_ms", "markdown_ms",
+        "install_ms", "response_bytes", "block_count", "assistant_blocks",
+        "long_task_count", "longest_task_ms",
+      ];
+      const payload = {
+        status: ["ok", "cancelled", "error"].includes(fields.status)
+          ? fields.status : "error",
+        mode: ["cold", "quiet", "prefetch"].includes(fields.mode)
+          ? fields.mode : "cold",
+        foreground: !!fields.foreground,
+      };
+      for (const name of numeric) {
+        const value = Math.round(Number(fields[name]) || 0);
+        payload[name] = Math.max(0, Math.min(value, 100_000_000));
+      }
+      try {
+        fetch("/api/log/client-perf", {
+          method: "POST",
+          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        }).catch(() => { /* diagnostics must never affect the UI */ });
+      } catch (_) { /* diagnostics must never affect the UI */ }
+    },
+    _reportSessionRenamePerf(fields) {
+      // Rename diagnostics contain timings and closed-set labels only. In
+      // particular, never send the session id or either title value.
+      const numeric = [
+        "optimistic_apply_ms", "optimistic_paint_ms", "request_ms", "total_ms",
+        "long_task_count", "longest_task_ms",
+      ];
+      const payload = {
+        surface: ["tab", "picker", "modal"].includes(fields.surface)
+          ? fields.surface : "modal",
+        status: ["ok", "error", "rollback"].includes(fields.status)
+          ? fields.status : "error",
+        asset_version: String(document.querySelector(
+          'meta[name="muselab-asset-version"]')?.content || "").slice(0, 32),
+      };
+      for (const name of numeric) {
+        const value = Math.round(Number(fields[name]) || 0);
+        payload[name] = Math.max(0, Math.min(value, 100_000_000));
+      }
+      try {
+        fetch("/api/log/session-rename", {
+          method: "POST",
+          headers: { ...this.hdr(), "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        }).catch(() => { /* diagnostics must never affect the UI */ });
+      } catch (_) { /* diagnostics must never affect the UI */ }
     },
     // Background-completion hook: after loadSession populates the
     // JSONL-derived history, ask the backend whether this session has
@@ -14180,13 +14438,9 @@ function portal() {
       if (!sid) return false;
       const st = this._ensureTabState(sid);
       const meta = (this.sessions || []).find(session => session.id === sid);
-      const seen = Number(st._seenUpdated);
-      const updated = Number(meta && meta.updated_at) || 0;
-      const canonicalBehind = st._loaded
-        && st._seenUpdated !== undefined
-        && Number.isFinite(seen)
-        && updated > seen;
+      const canonicalBehind = this._canonicalMetaBehind(st, meta);
       if (st._loaded && !canonicalBehind) return true;
+      if (canonicalBehind) st._pendingExternalUpdate = true;
       // A workspace can have a warm tab whose transcript predates the scoped
       // session row we just fetched. Refresh it off-screen while the tree is
       // loading; quiet mode also keeps an already-visible pane intact when
@@ -14240,7 +14494,7 @@ function portal() {
       // mid-load corrupts the now-active tab (messages not assigned / skeleton
       // stuck / model/effort overwritten by the old session). See loadSession race.
       const isCurrent = sid === this.currentId;
-      const quietScrollEl = quiet && isCurrent ? this.$refs.chatBody : null;
+      const quietScrollEl = quiet && isCurrent ? this._chatBodyElement() : null;
       const quietScrollTop = quietScrollEl ? quietScrollEl.scrollTop : 0;
       const quietAnchor = quietScrollEl && !st.atBottom
         ? this._captureViewportMessageAnchor(quietScrollEl, sid) : null;
@@ -14257,65 +14511,75 @@ function portal() {
       // Set true once we've scheduled the reveal (highlight→show). Guards the
       // finally so error / empty-result paths don't leave the skeleton stuck.
       let scheduledReveal = false;
+      const perfNow = (typeof performance !== "undefined" && performance.now)
+        ? () => performance.now() : () => Date.now();
+      const historyPerf = {
+        status: "cancelled",
+        mode: quiet ? "quiet" : (isCurrent ? "cold" : "prefetch"),
+        foreground: isCurrent,
+        total_ms: 0, fetch_ms: 0, parse_ms: 0, shape_ms: 0,
+        markdown_ms: 0, install_ms: 0, response_bytes: 0,
+        block_count: 0, assistant_blocks: 0,
+        long_task_count: 0, longest_task_ms: 0,
+      };
+      const historyPerfStarted = perfNow();
+      let longTaskObserver = null;
+      if (typeof PerformanceObserver !== "undefined") {
+        try {
+          longTaskObserver = new PerformanceObserver(list => {
+            for (const entry of list.getEntries()) {
+              historyPerf.long_task_count++;
+              historyPerf.longest_task_ms = Math.max(
+                historyPerf.longest_task_ms, Math.round(entry.duration || 0));
+            }
+          });
+          longTaskObserver.observe({ entryTypes: ["longtask"] });
+        } catch (_) { longTaskObserver = null; }
+      }
       try {
-        // Backend windowing (perf): a long / un-compacted session can shape
-        // into thousands of bubbles and many MB of JSON. Shipping + parsing
-        // the whole thing on every entry was the dominant freeze ("卡死").
-        // So unless full mode is requested, ask the server for only the TAIL
-        // we'll actually paint up front. The tail must be wide enough that
-        // pickVisibleStart's "at least 2 user turns" guarantee still holds
-        // (it can rewind up to INITIAL_LOAD*5), so we request that much; we
-        // still render only ~INITIAL_LOAD and stash the rest. Older history
-        // pages in from the server via _fetchOlderWindow on "Load earlier".
-        const _coldEarly = !this.appReady;
-        // Mobile uses the same canonical history window as desktop. Viewport
-        // virtualization, rather than a device-specific message count, bounds
-        // mounted DOM work on smaller screens.
-        const _baseInitialLoad = _coldEarly ? 30 : 60;
-        // QUIET refresh must not shrink the pane. A quiet load is a merge into
-        // an ALREADY-PAINTED pane, and a long agentic turn can leave up to
-        // _historyWindowSize() canonical bubbles in its active request window —
-        // far more than the cold-open window above. Loading the narrow window in
-        // that state spliced several hundred bubbles down to ~60 and pushed the
-        // rest outside the visible range: a violent height collapse + mass DOM teardown,
-        // which is the post-turn half of the "会话区刷新闪烁" report
-        // (2026-08-04). Widen the request (and fetched tail) to preserve the
-        // current canonical window during the in-place morph.
-        // Cold opens and non-quiet loads keep the narrow, freeze-avoiding
-        // window — nothing is painted yet there, so there is nothing to
-        // preserve.
-        const _currentWindowSize = (quiet && Array.isArray(st.messages))
-          ? st.messages.length : 0;
-        const _quietFloor = Math.min(this._historyWindowSize(), _currentWindowSize);
-        const _initialLoadEarly = Math.max(_baseInitialLoad, _quietFloor);
-        // While the user reads history, request at least every canonical block
-        // already loaded so quiet reconciliation cannot drop the visible anchor.
-        const FETCH_TAIL = quiet
-          ? Math.max(_baseInitialLoad * 5, st.messages.length,
-            !st.atBottom ? this._historyReconcileWindowSize() : 0)
-          : Math.max(_baseInitialLoad * 5, _quietFloor);
-        const qs = full ? "?full=1" : ("?tail=" + FETCH_TAIL);
+        // Bound cold session entry by canonical UI-block count. Long transcripts
+        // can contain thousands of tool/thinking/result blocks, so fetching and
+        // parsing the complete JSON response makes the whole app appear frozen.
+        // A normal open gets only the latest viewport-sized page (20 blocks on
+        // phones, 100 on desktop). History remains canonical on the server and
+        // the reader can explicitly prepend another same-sized page through the
+        // "Load earlier" control. Quiet reconciliation keeps blocks the user
+        // already chose to load, but never expands the resident window by itself.
+        const historyPage = this._historyWindowSize();
+        const requestedTail = quiet
+          ? Math.max(historyPage, st.messages.length)
+          : historyPage;
+        const qs = full ? "?full=1" : "?tail=" + requestedTail;
         const controller = new AbortController();
         const timeout = setTimeout(
           () => controller.abort(),
           full ? 60_000 : Math.max(100, Number(this._sessionReadTimeoutMs) || 15000),
         );
         let r;
+        const fetchStarted = perfNow();
         try {
           r = await fetch("/api/chat/sessions/" + sid + qs, {
             headers: this.hdr(), signal: controller.signal,
           });
         } catch (_) {
+          historyPerf.status = "error";
           return false;
         } finally {
+          historyPerf.fetch_ms = Math.round(perfNow() - fetchStarted);
           clearTimeout(timeout);
         }
         if (!r.ok) {
+          historyPerf.status = "error";
           return false;
         }
-        const s = this._retainExpectedSessionSettings(await r.json());
+        historyPerf.response_bytes = Math.max(
+          0, Number(r.headers.get("content-length")) || 0);
+        const parseStarted = perfNow();
+        const parsedSession = await r.json();
+        historyPerf.parse_ms = Math.round(perfNow() - parseStarted);
+        const s = this._retainExpectedSessionSettings(parsedSession);
         if (this.tabState[sid] !== st) return false;
-        if (st.streaming || st.es) return true;
+        if (st.streaming || st.es) return false;
         const loadedRuntimeUiRevision = String(s.runtime_ui_revision || "");
         const currentRuntimeUiRevision = String(st.runtimeUiRevision || "");
         // A different load for this same tab adopted another presentation
@@ -14325,9 +14589,10 @@ function portal() {
         // server revision is picked up by the existing poll/reconcile retry.
         if (currentRuntimeUiRevision !== runtimeUiRevisionAtLoad
             && currentRuntimeUiRevision !== loadedRuntimeUiRevision) {
-          return true;
+          return false;
         }
         const loadedUpdated = Number(s.updated_at) || 0;
+        const shapeStarted = perfNow();
         // Build a lookup of blob preview URLs from the current in-memory
         // messages so we can carry them over after the server rebuild.
         // Server messages only store {mime} for images — no preview URL —
@@ -14375,112 +14640,31 @@ function portal() {
           all = this._preserveCanonicalMessageIdentity(st, all);
         }
         const incomingCount = all.length;
+        historyPerf.block_count = incomingCount;
+        historyPerf.assistant_blocks = all.reduce(
+          (count, message) => count + (message && message.role === "assistant" ? 1 : 0), 0);
+        historyPerf.shape_ms = Math.round(perfNow() - shapeStarted);
         // The response is already server-windowed. Keep every fetched normalized
         // block; viewport virtualization makes a second count-based client trim
         // unnecessary and would discard interaction state on full/around loads.
         const trimmedHead = 0;
-        // Lazy-load thresholds — only render the revealed tail on first paint;
-        // older resident messages get mdRender'd on demand when the user clicks
-        // "Load earlier".
-        // Rationale: a long indie-coding session can rack up hundreds of
-        // assistant messages, each potentially with a 200-line code block.
-        // mdRender + Alpine x-for over all of them locks up the main thread
-        // for several seconds on initial load. Rendering only the recent
-        // 30 keeps switch-to-session snappy; "Load earlier" lets the user
-        // page back in batches of 50 as needed.
-        // Narrower first paint on mobile — WebViews have far less headroom
-        // than desktop, so render fewer bubbles up front and let "Load
-        // earlier" page the rest in on demand.
-        // Cold-boot guard: when this is the FIRST session loaded on app start
-        // (appReady still false), the heavy markdown+highlight render competes
-        // with Alpine's full-tree mount, first-time hljs/mermaid download+parse
-        // and the boot fetches — landing directly in a long session froze the
-        // page ("卡死"). Render far fewer bubbles up front in that window; the
-        // rest page in via "Load earlier" once the app is warm. After boot the
-        // normal thresholds apply, so warm tab-switches are unchanged.
-        const INITIAL_LOAD = _initialLoadEarly;
-        const renderMarkdown = (m) => {
-          if (m.role === "assistant" && m.text && !m.html) {
-            m.html = this._renderHistoryMessage(m);
-          }
-        };
-        // Choose the initial revealed range within the resident repository.
-        //
-        // Naive `slice(-INITIAL_LOAD)` breaks badly when the tail of the
-        // conversation is tool-call heavy: one turn can easily have 20+
-        // tool_use/tool_result/task-update messages, so the last 30 may
-        // contain zero user/assistant TEXT — the user opens the session
-        // and sees only Task-update bubbles with no actual conversation.
-        //
-        // Smarter strategy: rewind from the end until we've included AT
-        // LEAST the last two user messages (so there's at least one full
-        // back-and-forth visible), capped at INITIAL_LOAD * 5 so a
-        // pathological 500-tool-call turn doesn't render everything.
-        const pickVisibleStart = (msgs) => {
-          if (msgs.length <= INITIAL_LOAD) return 0;
-          // Default tail position
-          let start = msgs.length - INITIAL_LOAD;
-          // Walk backwards collecting user-message indices
-          const userIdx = [];
-          for (let j = msgs.length - 1; j >= 0; j--) {
-            if (msgs[j] && msgs[j].role === "user") {
-              userIdx.push(j);
-              if (userIdx.length >= 2) break;
-            }
-          }
-          // Anchor on the 2nd-most-recent user msg if we found one
-          if (userIdx.length >= 2) start = Math.min(start, userIdx[1]);
-          else if (userIdx.length === 1) start = Math.min(start, userIdx[0]);
-          // Safety cap so a single huge turn doesn't render hundreds
-          const HARD_CAP = INITIAL_LOAD * 5;
-          if (msgs.length - start > HARD_CAP) start = msgs.length - HARD_CAP;
-          return Math.max(0, start);
-        };
-        const startIdx = pickVisibleStart(all);
-        const visible = all.slice(startIdx);
-        // E5: when pickVisibleStart rewound `visible` past the bottom
-        // INITIAL_LOAD (agentic / tool-heavy sessions hit HARD_CAP≈90), that
-        // rewound HEAD sits ABOVE the fold once we scroll to the bottom on first
-        // paint. Rendering its markdown synchronously here — marked + DOMPurify +
-        // KaTeX over up to ~90 bubbles, all while the skeleton is up — is the
-        // remaining pre-reveal main-thread FREEZE on long-session open. So render
-        // only the on-screen tail synchronously (messagesReady can flip with real
-        // content immediately) and stash the head for a post-paint, idle-chunked,
-        // scroll-anchored fill (see _fillDeferredHead). Un-rewound windows keep
-        // the original one-shot path — zero behaviour change for short sessions.
-        let _deferHead = null;
-        if (sid === this.currentId && quiet) {
-          // Quiet refresh: render the whole visible window synchronously so the
-          // in-place swap below morphs in fully-rendered bubbles with no
-          // deferred-head dance. Not as costly as it looks even with the
-          // current-window floor above: _preserveCanonicalMessageIdentity has
-          // already reused the live objects, which keep their existing `html`,
-          // so renderMarkdown only does real work for genuinely new rows.
-          visible.forEach(renderMarkdown);
-        } else if (sid === this.currentId) {
-          if (visible.length > INITIAL_LOAD) {
-            const _headCount = visible.length - INITIAL_LOAD;
-            for (let j = _headCount; j < visible.length; j++) renderMarkdown(visible[j]);
-            _deferHead = visible.slice(0, _headCount);
-          } else {
-            // No rewind: the whole window is the first screen — render it now so
-            // html is ready before the skeleton reveals.
-            visible.forEach(renderMarkdown);
-          }
-        } else {
-          // Desktop may prewarm one envelope only; mobile background markdown
-          // work is disabled entirely. No hidden pane DOM is mounted here.
-          if (!this._isMobileLayout() && visible.length) {
-            renderMarkdown(visible[visible.length - 1]);
-          }
-        }
+        // Install the bounded canonical window before rich rendering. Assistant
+        // rows have a complete plain-text fallback, and only physically-mounted
+        // rows enqueue marked/DOMPurify work from observeAssistantBody(). Doing the
+        // rich pass here — even chunked between messages — still lets one giant
+        // Markdown message monopolize the browser main thread before any shell
+        // button or composer input can paint.
+        const startIdx = 0;
+        const visible = all;
+        const _deferHead = null;
+        historyPerf.markdown_ms = 0;
         // The tab may have been disposed/recreated, or a stream may have claimed
         // this state while markdown rendering yielded. Never write into a stale
         // generation or replace an active owner's message array.
-        if (this.tabState[sid] !== st || st.streaming || st.es) return true;
+        if (this.tabState[sid] !== st || st.streaming || st.es) return false;
         // Replace the one repository in place. Quiet reconciliation preserves
         // matching message object identity; cold reveal changes only range coords.
-        if (st.streaming || st.es) return true;
+        if (st.streaming || st.es) return false;
         // _virtualStart/_virtualEnd are LOCAL to the revealed slice. A quiet
         // canonical refresh can move visibleStart from a narrow recent tail to
         // an older coordinate; carrying the same numbers across that change
@@ -14490,10 +14674,33 @@ function portal() {
         const virtualWindowBeforeInstall = quiet
           ? this._captureMessageVirtualWindow(st) : null;
         const followTailAtInstall = quiet && st.atBottom !== false;
+        const quietRangeBeforeInstall = quiet ? {
+          start: Math.max(0, Number(st.messageRange.visibleStart) || 0),
+          end: Math.max(0, Number(st.messageRange.visibleEnd) || 0),
+        } : null;
+        const installStarted = perfNow();
+        // Cold loads start from an empty coordinate and reveal the newest rows in
+        // small batches. Quiet reconciliation is different: matching objects and
+        // keys already own live DOM nodes, so collapsing the range to zero and
+        // replaying every row only forces Alpine to reconcile the growing list over
+        // dozens of frames. Preserve its established range and let one keyed patch
+        // mount only genuinely new/changed rows.
+        const quietStart = quietRangeBeforeInstall
+          ? Math.min(quietRangeBeforeInstall.start, all.length) : startIdx;
+        const quietEnd = quietRangeBeforeInstall
+          ? (followTailAtInstall
+            ? all.length
+            : Math.min(
+              all.length,
+              Math.max(quietStart, quietRangeBeforeInstall.end),
+            ))
+          : startIdx;
+        st.messageRange.visibleStart = quiet ? quietStart : startIdx;
+        st.messageRange.visibleEnd = quiet ? quietEnd : startIdx;
         st.messages.splice(0, st.messages.length, ...all);
         Object.assign(st.messageRange, {
-          visibleStart: startIdx,
-          visibleEnd: (sid === this.currentId && !quiet) ? startIdx : all.length,
+          visibleStart: quiet ? quietStart : startIdx,
+          visibleEnd: quiet ? quietEnd : startIdx,
           offset: (Number.isInteger(s.offset) ? s.offset : 0) + trimmedHead,
           total: Number.isInteger(s.total) ? s.total : incomingCount,
           preTotal: Number.isInteger(s.pre_total) ? s.pre_total : 0,
@@ -14501,8 +14708,20 @@ function portal() {
           generation: s.history_generation || "",
         });
         if (quiet) {
+          await new Promise(resolve => this.$nextTick(resolve));
+        } else {
+          await this._revealMessagesChunked(sid, st, visible, true);
+        }
+        historyPerf.install_ms = Math.round(perfNow() - installStarted);
+        if (this.tabState[sid] !== st || st.streaming || st.es) return false;
+        if (quiet) {
           this._rebaseMessageVirtualWindow(
             st, virtualWindowBeforeInstall, followTailAtInstall);
+        } else if (sid === this.currentId) {
+          // Seed the physical tail synchronously. Waiting for a scheduled viewport
+          // sync left cold refreshes with only the giant top spacer mounted for the
+          // first paint, so scrollHeight existed but no message row was visible.
+          this._rebaseMessageVirtualWindow(st, null, true);
         }
         st.runtimeUiRevision = loadedRuntimeUiRevision;
         // Seed the render-only viewport at the newest end after installing the
@@ -14513,12 +14732,15 @@ function portal() {
           || st.messageRange.offset > 0 || this._preCompactReachable(st);
         // Remember whether this load pulled the full raw-JSONL history, so
         // _scrollToUserMsg knows it can stop retrying after one full reload.
-        st._fullLoaded = full;
+        st._fullLoaded = full || s.history_order === "full";
         st._truncatedFromTop = false;
         // Advance the rendered revision only after this state generation actually
         // accepted the canonical message window. A stream claiming the pane mid-
         // read returns above without falsely marking an unseen revision as loaded.
         if (loadedUpdated) st._seenUpdated = loadedUpdated;
+        st._installedCanonicalCount = Math.max(
+          0, Number(s.message_count) || Number(s.total) || incomingCount,
+        );
         // (The session outline is sourced from the backend via
         // refreshOutlineFromBackend (GET …/outline), not built here.)
         const permissionExpected = st._permissionExpected;
@@ -14602,8 +14824,8 @@ function portal() {
                 st.atBottom = false;
               }
             });
-            if (!full && sid === this.currentId) this._scheduleTransparentHistory(st, false);
             await this._fetchTabUsage(sid);
+            historyPerf.status = "ok";
             return true;
           }
           st.atBottom = true;
@@ -14613,45 +14835,89 @@ function portal() {
           // the chunked highlighter catches up — very visible on mobile.
           // scrollToBottom runs AFTER reveal so it measures the final layout.
           scheduledReveal = true;
-          // Instantiate bubbles in small chunks (yield to the browser between
-          // each) so a long session's first paint never blocks the main thread
-          // in a single multi-second task. The skeleton stays up until this
-          // resolves, so the user sees a responsive page (tabs / sidebar stay
-          // clickable) instead of a frozen one ("卡死").
-          await this._revealMessagesChunked(sid, st, visible);
-          if (this.tabState[sid] !== st || st.streaming || st.es) return true;
-          this.$nextTick(async () => {
-            try { await this.highlightCode(".chat-body"); st._highlighted = true; }
-            catch (_e) { /* highlight best-effort — reveal regardless */ }
-            if (sid === this.currentId) {
-              st.messagesReady = true;
-              this.$nextTick(() => {
-                st.atBottom = true; this.scrollToBottom(true);
-                // E5: the on-screen tail is now painted + pinned to the bottom.
-                // Fill the deferred head above the fold (idle-chunked + scroll-
-                // anchored) so the rewound bubbles are ready before the user
-                // scrolls up, without blocking this first paint.
-                if (_deferHead && _deferHead.length) {
-                  const _kick = () => this._fillDeferredHead(sid, st, _deferHead);
-                  if (typeof window !== "undefined" && window.requestIdleCallback) {
-                    window.requestIdleCallback(_kick, { timeout: 300 });
-                  } else { setTimeout(_kick, 32); }
-                }
-                if (!full) this._scheduleTransparentHistory(st, false);
+          // The canonical fetched range is already resident and viewport
+          // virtualization mounts only the tail rows. Do not replay the obsolete
+          // visibleEnd chunk expansion here: it first collapses the range back to
+          // empty, then repeatedly rebuilds Alpine state before the initial scroll.
+          if (this.tabState[sid] !== st || st.streaming || st.es) return false;
+          this.$nextTick(() => {
+            if (sid !== this.currentId || this.tabState[sid] !== st) return;
+            // Never keep the transcript hidden behind markdown highlighting.
+            // While messagesReady=false CSS removes every `.msg` but leaves the
+            // virtual spacer in layout, producing a huge blank pane at scrollTop=0
+            // on refresh. Reveal first, mount the virtual tail, and position the
+            // physical scroller before any best-effort decoration work.
+            st.messagesReady = true;
+            this.$nextTick(() => {
+              if (sid !== this.currentId || this.tabState[sid] !== st) return;
+              st.atBottom = true;
+              this._syncMessageViewport(sid, true);
+              this._scrollChatTailNow(sid, st);
+              this._settleScrollToBottom();
+              this._afterPaint(async () => {
+                if (sid !== this.currentId || this.tabState[sid] !== st) return;
+                try {
+                  const pane = this._paneElement(sid);
+                  await this.highlightCode(".chat-body", pane ? [pane] : null);
+                  st._highlighted = true;
+                } catch (_e) { /* highlight best-effort */ }
               });
-            }
+              // E5: the on-screen tail is now painted + pinned to the bottom.
+              // Fill the deferred head above the fold (idle-chunked + scroll-
+              // anchored) so the rewound bubbles are ready before the user
+              // scrolls up, without blocking this first paint.
+              if (_deferHead && _deferHead.length) {
+                const _kick = () => this._fillDeferredHead(sid, st, _deferHead);
+                if (typeof window !== "undefined" && window.requestIdleCallback) {
+                  window.requestIdleCallback(_kick, { timeout: 300 });
+                } else { setTimeout(_kick, 32); }
+              }
+            });
           });
         }
         await this._fetchTabUsage(sid);
+        historyPerf.status = "ok";
         return true;
       } finally {
+        if (longTaskObserver) {
+          try {
+            for (const entry of longTaskObserver.takeRecords()) {
+              historyPerf.long_task_count++;
+              historyPerf.longest_task_ms = Math.max(
+                historyPerf.longest_task_ms, Math.round(entry.duration || 0));
+            }
+            longTaskObserver.disconnect();
+          } catch (_) { /* best-effort diagnostics */ }
+        }
+        historyPerf.total_ms = Math.round(perfNow() - historyPerfStarted);
+        historyPerf.foreground = sid === this.currentId;
+        this._reportHistoryLoadPerf(historyPerf);
         // Re-check live: only clear the skeleton if this sid is STILL the
         // active tab. If the user switched away mid-load, the now-active tab
         // owns messagesLoading and must not be cleared by our stale completion.
         if (this.tabState[sid] === st) {
           st.messagesLoading = false;
+          // Readiness must never coexist with a non-empty repository and an empty
+          // revealed slice. This is the final fail-open for any interrupted reveal
+          // path (SSE takeover, tab ownership change, or skipped Alpine callback).
+          this._ensureNonEmptyMessageRange(st);
           if (!scheduledReveal || sid !== this.currentId) st.messagesReady = true;
           if (sid === this.currentId) {
+            // A cold reveal must fail open. If an async highlight/reveal callback
+            // was skipped or superseded, never leave the active transcript hidden
+            // with only its turn separator/spacer in layout. Reassert the tail in
+            // the next Alpine tick; duplicate settle calls cancel by token.
+            if (!quiet && st.messages.length) {
+              st.messagesReady = true;
+              this.$nextTick(() => {
+                if (this.currentId !== sid || this.tabState[sid] !== st
+                    || st.atBottom === false) return;
+                st.atBottom = true;
+                this._syncMessageViewport(sid, true);
+                this._scrollChatTailNow(sid, st);
+                this._settleScrollToBottom();
+              });
+            }
             // The active tab is now warm — opportunistically warm one desktop
             // envelope without mounting another pane.
             this._scheduleIdlePreload();
@@ -14699,9 +14965,10 @@ function portal() {
     _renderMessagesChunked(list, renderFn, budgetMs = 8) {
       return new Promise((resolve) => {
         if (!list || !list.length) { resolve(); return; }
-        const yieldToLoop = (typeof window !== "undefined" && window.requestIdleCallback)
-          ? (fn) => window.requestIdleCallback(fn, { timeout: 200 })
-          : (fn) => setTimeout(fn, 0);
+        // A zero-delay task reliably yields to input/paint and keeps making
+        // progress under continuous interaction. requestIdleCallback can starve
+        // for seconds on a busy long-session mount, even with its timeout.
+        const yieldToLoop = (fn) => setTimeout(fn, 0);
         const nowMs = (typeof performance !== "undefined" && performance.now)
           ? () => performance.now() : () => Date.now();
         let i = 0;
@@ -14718,25 +14985,93 @@ function portal() {
         pump();
       });
     },
-    // Reveal the resident repository in small coordinate steps, yielding a frame
-    // between updates so Alpine instantiates the directive-heavy bubble templates
-    // incrementally. The repository itself never moves; only messageRange's
-    // visible end advances.
-    async _revealMessagesChunked(sid, st, visible) {
-      const CH = this._isMobileLayout() ? 4 : 15;
-      const start = st.messageRange.visibleStart;
-      let i = 0;
-      while (i < visible.length) {
-        if (this.tabState[sid] !== st || st.streaming || st.es) return;
-        i = Math.min(visible.length, i + CH);
-        st.messageRange.visibleEnd = start + i;
-        if (sid !== this.currentId) {
-          st.messageRange.visibleEnd = start + visible.length;
-          return;
+    _yieldHistoryInstall() {
+      if (!this._isMobileLayout()) {
+        return new Promise(resolve => (typeof requestAnimationFrame === "function"
+          ? requestAnimationFrame(() => resolve()) : setTimeout(resolve, 16)));
+      }
+      // Mobile DOM installation shares the UI thread with taps, scrolling and the
+      // soft keyboard. A RAF loop still monopolizes every frame even when it mounts
+      // only one row at a time. Let user-visible work run first, then automatically
+      // continue filling the already-resident history in background/idle tasks.
+      if (typeof window !== "undefined" && window.scheduler
+          && typeof window.scheduler.postTask === "function") {
+        return window.scheduler.postTask(() => {}, { priority: "background" })
+          .catch(() => new Promise(resolve => setTimeout(resolve, 50)));
+      }
+      if (typeof window !== "undefined" && window.requestIdleCallback) {
+        return new Promise(resolve => window.requestIdleCallback(
+          () => resolve(), { timeout: 250 }));
+      }
+      return new Promise(resolve => setTimeout(resolve, 50));
+    },
+    // Reveal the resident repository in small coordinate steps. The newest tail is
+    // immediate; older rows are installed through _yieldHistoryInstall so mobile
+    // input gets priority instead of Alpine occupying every animation frame.
+    async _revealMessagesChunked(sid, st, visible, tailFirst = true) {
+      // Alpine row creation is the remaining dominant long task: one row can
+      // contain many nested directives, tool cards and x-html bodies. Keep each
+      // commit deliberately small so transcript installation yields to shell
+      // buttons and the composer between batches instead of freezing the app.
+      const CH = this._isMobileLayout() ? 1 : 2;
+      if (!tailFirst) {
+        // Quiet canonical reconciliation preserves an existing viewport anchor.
+        // Keep its established chronological expansion; exposing only the tail
+        // first would temporarily remove the anchored row before the final restore.
+        const start = st.messageRange.visibleStart;
+        let i = 0;
+        while (i < visible.length) {
+          if (this.tabState[sid] !== st || st.streaming || st.es) return;
+          i = Math.min(visible.length, i + CH);
+          st.messageRange.visibleEnd = start + i;
+          await new Promise(resolve => this.$nextTick(resolve));
+          if (!this._paneElement(sid)) {
+            st.messageRange.visibleEnd = start + visible.length;
+            break;
+          }
+          if (i < visible.length) {
+            await this._yieldHistoryInstall();
+          }
         }
-        if (i < visible.length) {
-          await new Promise(r => (window.requestAnimationFrame
-            ? requestAnimationFrame(() => r()) : setTimeout(r, 16)));
+        if (this.tabState[sid] === st) this._scheduleHistoryViewport(st, "older");
+        return;
+      }
+      const finalStart = st.messageRange.visibleStart;
+      const finalEnd = finalStart + visible.length;
+      let cursor = finalEnd;
+      while (cursor > finalStart) {
+        const nextStart = Math.max(finalStart, cursor - CH);
+        // Establish a real tail batch before any ownership/cancellation exit.
+        // The previous order first collapsed the range to [finalEnd, finalEnd]
+        // and only expanded it after this guard. If SSE claimed the tab in that
+        // interval, finally marked the pane ready with a permanently empty slice.
+        st.messageRange.visibleStart = nextStart;
+        st.messageRange.visibleEnd = finalEnd;
+        cursor = nextStart;
+        if (this.tabState[sid] !== st || st.streaming || st.es) return;
+        const active = sid === this.currentId;
+        const scrollEl = active ? this._chatBodyElement() : null;
+        const anchor = scrollEl && st.atBottom === false
+          ? this._captureViewportMessageAnchor(scrollEl, sid) : null;
+        // Wait for Alpine to instantiate this keyed batch. As soon as the active
+        // pane owns its newest rows, remove only the transcript skeleton and pin
+        // the physical scroller; the remaining resident rows continue prepending
+        // between frames without blocking the composer or surrounding controls.
+        await new Promise(resolve => this.$nextTick(resolve));
+        if (active && sid === this.currentId && this.tabState[sid] === st) {
+          if (!st.messagesReady) st.messagesReady = true;
+          if (st.atBottom !== false) {
+            this._scrollChatTailNow(sid, st);
+          } else if (scrollEl) {
+            this._restoreMessageAnchor(scrollEl, anchor);
+          }
+        }
+        if (!this._paneElement(sid)) {
+          st.messageRange.visibleStart = finalStart;
+          break;
+        }
+        if (cursor > finalStart) {
+          await this._yieldHistoryInstall();
         }
       }
       if (this.tabState[sid] === st) this._scheduleHistoryViewport(st, "older");
@@ -14770,7 +15105,7 @@ function portal() {
           for (; i < head.length; i++) renderOne(head[i]);
           return;
         }
-        const scrollEl = this.$refs.chatBody;
+        const scrollEl = this._chatBodyElement();
         const oldH = scrollEl ? scrollEl.scrollHeight : 0;
         const oldTop = scrollEl ? scrollEl.scrollTop : 0;
         const end = Math.min(i + CH, head.length);
@@ -15113,8 +15448,9 @@ function portal() {
       return m;
     },
     // Server/history windows are independent of the rendered DOM row count.
-    // Viewport virtualization alone decides which normalized messages mount.
-    _historyWindowSize() { return 300; },
+    // Phones use a smaller explicit page because parsing and installing 100 rich
+    // tool/Markdown blocks can monopolize their main thread. Desktop keeps 100.
+    _historyWindowSize() { return this._isMobileLayout() ? 20 : 100; },
     _historyReconcileWindowSize() { return 800; },
     _scheduleHistoryViewport(st, direction = "newer", anchorUuid = "") {
       if (!st) return;
@@ -15169,15 +15505,9 @@ function portal() {
       scrollEl.scrollTop += el.getBoundingClientRect().top - anchor.top;
       return true;
     },
-    // Reveal the next resident batch of older messages and mdRender them on
-    // demand. Critical: preserve scroll position so the user's current viewport
-    // doesn't jump when the visible range expands above it.
-    LOAD_MORE_BATCH: 80,
-    // How many older bubbles to pull from the server in one backend page
-    // when the resident repository reaches its loaded edge (see
-    // _fetchOlderWindow). Larger than LOAD_MORE_BATCH so several "Load earlier"
-    // clicks reveal resident rows between network round-trips.
-    HISTORY_PAGE: 240,
+    // History is paged in one explicit, count-based unit per viewport: phones
+    // load 20 canonical UI blocks, while desktop keeps 100. The viewport anchor
+    // below keeps the currently-read block stationary when older blocks prepend.
     // Reactivity ping: bumped whenever refreshOutlineFromBackend writes
     // new data. outlineMessages() reads it so Alpine knows to re-render
     // the msg-outline-modal when async fetch completes. Without this,
@@ -15245,122 +15575,6 @@ function portal() {
       return this.loadSession(sid, { quiet: sid === this.currentId });
     },
 
-    _revealResidentHistory(st) {
-      if (!st || !st.messageRange || st.messageRange.visibleStart <= 0) return 0;
-      const sid = st._sid;
-      const count = st.messageRange.visibleStart;
-      const body = sid === this.currentId ? this.$refs && this.$refs.chatBody : null;
-      const anchor = body ? this._captureViewportMessageAnchor(body, sid) : null;
-      this._shiftMessageVirtualWindow(st, count);
-      st.messageRange.visibleStart = 0;
-      st._hasMoreHistory = st.messageRange.offset > 0 || this._preCompactReachable(st);
-      this._scheduleHistoryViewport(st, "older");
-      if (body && anchor) {
-        this.$nextTick(() => {
-          if (this.tabState[sid] !== st || sid !== this.currentId || st.atBottom !== false) return;
-          this._restoreMessageAnchor(body, anchor);
-          this._scheduleMessageViewportSync(sid);
-        });
-      }
-      return count;
-    },
-    _scheduleTransparentHistory(st, urgent = false) {
-      if (!st || !st._sid || this.tabState[st._sid] !== st) return;
-      if (urgent && st._historyHydrationRetry) {
-        clearTimeout(st._historyHydrationRetry);
-        st._historyHydrationRetry = null;
-      }
-      if (st._historyHydrating) {
-        if (urgent) st._historyHydrationUrgent = true;
-        return;
-      }
-      if (st._historyHydrationScheduled && !urgent) return;
-      st._historyHydrationScheduled = true;
-      const sid = st._sid;
-      const run = () => {
-        st._historyHydrationScheduled = false;
-        if (this.tabState[sid] !== st || sid !== this.currentId) return;
-        this._hydrateTransparentHistory(sid, st, urgent);
-      };
-      if (!urgent && typeof window !== "undefined" && window.requestIdleCallback) {
-        window.requestIdleCallback(run, { timeout: 500 });
-      } else if (!urgent) {
-        setTimeout(run, 80);
-      } else {
-        run();
-      }
-    },
-    async _hydrateTransparentHistory(sid, st, urgent = false) {
-      if (!sid || this.tabState[sid] !== st || st._historyHydrating) return;
-      st._historyHydrating = true;
-      st._historyHydrationUrgent = !!urgent;
-      const epoch = ++st._historyHydrationEpoch;
-      try {
-        let failed = false;
-        const yieldToBrowser = async () => {
-          if (st._historyHydrationUrgent) return;
-          await new Promise(resolve => {
-            if (typeof window !== "undefined" && window.requestIdleCallback) {
-              window.requestIdleCallback(() => resolve(), { timeout: 250 });
-            } else {
-              setTimeout(resolve, 32);
-            }
-          });
-        };
-
-        this._revealResidentHistory(st);
-        while (this.tabState[sid] === st && sid === this.currentId
-               && st._historyHydrationEpoch === epoch && st.messageRange.offset > 0) {
-          if (st.streaming && !st._historyHydrationUrgent) break;
-          const loaded = await this._fetchOlderWindow(sid);
-          if (this.tabState[sid] !== st || st._historyHydrationEpoch !== epoch) return;
-          if (loaded <= 0) {
-            failed = st.messageRange.offset > 0;
-            break;
-          }
-          this._revealResidentHistory(st);
-          await yieldToBrowser();
-          st._historyHydrationUrgent = false;
-        }
-
-        // around_uuid/full-order transitions can leave canonical records on both
-        // sides of the current anchor. Fill and reveal the newer side as well so
-        // pagination never resurfaces as a user-visible mode or control.
-        while (this.tabState[sid] === st && sid === this.currentId
-               && st._historyHydrationEpoch === epoch
-               && st.messageRange.offset + st.messages.length < st.messageRange.total) {
-          if (st.streaming && !st._historyHydrationUrgent) break;
-          const loaded = await this._fetchLaterWindow(sid);
-          if (this.tabState[sid] !== st || st._historyHydrationEpoch !== epoch) return;
-          if (loaded <= 0) {
-            failed = true;
-            break;
-          }
-          st.messageRange.visibleEnd = st.messages.length;
-          this._scheduleHistoryViewport(st, "newer");
-          await yieldToBrowser();
-          st._historyHydrationUrgent = false;
-        }
-
-        const missingHistory = st.messageRange.offset > 0
-          || st.messageRange.offset + st.messages.length < st.messageRange.total;
-        st._historyHydrationError = failed && missingHistory;
-      } finally {
-        if (this.tabState[sid] === st) {
-          st._historyHydrating = false;
-          st._hasMoreHistory = st.messageRange.visibleStart > 0
-            || st.messageRange.offset > 0 || this._preCompactReachable(st);
-          if (st._historyHydrationError && !st._historyHydrationRetry) {
-            st._historyHydrationRetry = setTimeout(() => {
-              st._historyHydrationRetry = null;
-              if (this.tabState[sid] === st && sid === this.currentId) {
-                this._scheduleTransparentHistory(st, false);
-              }
-            }, 1500);
-          }
-        }
-      }
-    },
 
     // Pull the next older window of bubbles from the server into the FRONT
     // of the resident repository and rewind its server offset. Used when the range
@@ -15374,9 +15588,10 @@ function portal() {
       const st = this._ensureTabState(sid);
       const range = st.messageRange;
       if (st._fetchingOlder || !(range.offset > 0)) return 0;
-      const pageSize = Math.min(this.HISTORY_PAGE, range.offset);
+      const pageSize = Math.min(this._historyWindowSize(), range.offset);
       const newOffset = range.offset - pageSize;
       st._fetchingOlder = true;
+      st._historyHydrationError = false;
       try {
         const generation = range.generation
           ? "&history_generation=" + encodeURIComponent(range.generation) : "";
@@ -15389,7 +15604,10 @@ function portal() {
           await this._reloadHistoryTailAfterConflict(sid, st);
           return 0;
         }
-        if (!r.ok) return 0;
+        if (!r.ok) {
+          st._historyHydrationError = true;
+          return 0;
+        }
         const data = await r.json();
         if (this.tabState[sid] !== st) return 0;
         const win = this._historyEnvelopes(sid, data.messages || []);
@@ -15405,6 +15623,7 @@ function portal() {
         st._hasMoreHistory = range.visibleStart > 0 || range.offset > 0;
         return win.length;
       } catch (_) {
+        st._historyHydrationError = true;
         return 0;
       } finally {
         st._fetchingOlder = false;
@@ -15418,7 +15637,7 @@ function portal() {
       if (st._fetchingLater) return 0;
       const start = range.offset + st.messages.length;
       if (start >= range.total) return 0;
-      const limit = Math.min(this.HISTORY_PAGE, range.total - start);
+      const limit = Math.min(this._historyWindowSize(), range.total - start);
       st._fetchingLater = true;
       try {
         const generation = range.generation
@@ -15503,7 +15722,7 @@ function portal() {
       // at the fold with the recovered history stacked above it.
       this.$nextTick(() => {
         if (this.tabState[sid] !== st || sid !== this.currentId) return;
-        const body = this.$refs && this.$refs.chatBody;
+        const body = this._chatBodyElement();
         const el = body && body.querySelector(
           `.msg[data-uuid="${CSS.escape(anchorUuid)}"]`);
         if (el) el.scrollIntoView({ block: "start" });
@@ -15521,9 +15740,6 @@ function portal() {
         if (range.visibleStart === 0 && range.offset === 0
             && this._preCompactReachable(st)) {
           const switched = await this._switchToFullOrder(sid);
-          if (switched && this.tabState[sid] === st) {
-            this._scheduleTransparentHistory(st, true);
-          }
           return;
         }
         if (range.visibleStart === 0 && range.offset > 0) {
@@ -15534,7 +15750,7 @@ function portal() {
           st._hasMoreHistory = range.offset > 0 || this._preCompactReachable(st);
           return;
         }
-        const batchSize = this._isMobileLayout() ? 10 : this.LOAD_MORE_BATCH;
+        const batchSize = this._historyWindowSize();
         const nextStart = Math.max(0, range.visibleStart - batchSize);
         const batch = st.messages.slice(nextStart, range.visibleStart);
         const RENDER_CHUNK = this._isMobileLayout() ? 4 : 16;
@@ -15554,7 +15770,7 @@ function portal() {
           }
         }
         if (this.tabState[sid] !== st) return;
-        const scrollEl = sid === this.currentId ? this.$refs.chatBody : null;
+        const scrollEl = sid === this.currentId ? this._chatBodyElement() : null;
         const anchor = this._captureViewportMessageAnchor(scrollEl, sid);
         this._shiftMessageVirtualWindow(st, batch.length);
         range.visibleStart = nextStart;
@@ -15637,20 +15853,13 @@ function portal() {
     async renameSession() {
       const cur = this.sessions.find(x => x.id === this.currentId);
       if (!cur) return;
-      const name = await this.prompt({
+      const answer = await this.prompt({
         title: this.lang === "zh" ? "重命名会话" : "Rename session",
         value: cur.name,
       });
-      if (!name) return;
-      const r = await fetch("/api/chat/sessions/" + cur.id, {
-        method: "PATCH",
-        headers: { ...this.hdr(), "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
-      });
-      if (r.ok) {
-        this._applyRenamedSession(cur.id, name);
-        this.toast(this.t("toast.renamed"), "success");
-      }
+      const name = (answer || "").trim();
+      if (!name || name === cur.name) return;
+      await this._renameSessionOptimistically(cur.id, name, cur.name, true, "modal");
     },
 
     toggleMemoryRecallPopover(ev, message) {
@@ -22323,7 +22532,7 @@ function portal() {
     // (unshift puts them at the front). Stops as soon as it has n, so it's
     // O(n) regardless of how much history is already rendered.
     _leadingMsgEls(n) {
-      const body = this.$refs.chatBody;
+      const body = this._chatBodyElement();
       if (!body || n <= 0) return [];
       const out = [];
       const panes = Array.from(body.querySelectorAll(".msg-pane"))
@@ -22831,7 +23040,7 @@ function portal() {
 
     _chatSelectionHost(node) {
       if (!node || !this.currentId) return null;
-      const body = this.$refs.chatBody;
+      const body = this._chatBodyElement();
       const el = node.nodeType === 1 ? node : node.parentElement;
       if (!body || !el || !body.contains(el) || !el.closest) return null;
       if (el.closest("textarea, input, button, [contenteditable='true'], .edit-msg-wrap")) {
@@ -26413,13 +26622,13 @@ function portal() {
     _captureChatPosition(sid = this.currentId) {
       this._captureComposerState(sid);
       const st = sid && this.tabState && this.tabState[sid];
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!st || !el || sid !== this.currentId) return;
       st.scrollTop = el.scrollTop;
     },
     _restoreChatPosition(sid = this.currentId) {
       const st = sid && this.tabState && this.tabState[sid];
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!st || !el || sid !== this.currentId) return;
       const shouldFollow = st.atBottom !== false;
       if (shouldFollow) {
@@ -26430,7 +26639,7 @@ function portal() {
     },
     onChatScroll() {
       this._queueMemoryRecallPosition();
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!el) return;
       const st = this.currentId && this.tabState && this.tabState[this.currentId];
       if (st) {
@@ -26444,19 +26653,9 @@ function portal() {
         st._virtualScrollVelocity = Math.min(20000, Math.abs(delta) * 1000 / elapsed);
         st._lastVirtualScrollTop = el.scrollTop;
         st._lastVirtualScrollAt = now;
-        // Promote history transport before the reader reaches the loaded edge.
-        // Background hydration normally wins this race; the six-screen guard is
-        // the urgent path for a scrollbar drag or a very fast upward flick.
-        if (el.scrollTop < el.clientHeight * 6) {
-          if (st.messageRange.visibleStart > 0 || st.messageRange.offset > 0) {
-            this._scheduleTransparentHistory(st, true);
-          } else if (this._preCompactReachable(st) && !st._loadingEarlier) {
-            // Crossing the compact boundary needs the server's UUID-based full-
-            // order mapping; trigger it transparently only when the reader has
-            // actually reached that edge so background work never moves them.
-            this.loadEarlierMessages(st._sid);
-          }
-        }
+        // Older history is user-triggered. Do not fetch or mount another page
+        // merely because a wheel/touch gesture reaches the top; that behavior
+        // made long-session scrolling compete with the gesture itself.
       }
       this._scheduleMessageViewportSync(this.currentId);
       // While WE are programmatically pinning to the bottom (the settle loop),
@@ -26506,7 +26705,7 @@ function portal() {
       this._chatTouchY = touch ? touch.clientY : null;
     },
     _userScrollIntent(ev) {
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       let movesTowardHistory = true;
       if (ev && ev.type === "wheel") {
         movesTowardHistory = Number(ev.deltaY) < 0;
@@ -26546,7 +26745,7 @@ function portal() {
       this._autoScrolling = false;
     },
     _ensureChatTailObserver() {
-      const body = this.$refs && this.$refs.chatBody;
+      const body = this._chatBodyElement();
       if (!body || typeof ResizeObserver !== "function") return;
       if (this._chatTailObservedBody === body) return;
       if (this._chatTailResizeObserver) this._chatTailResizeObserver.disconnect();
@@ -26606,7 +26805,7 @@ function portal() {
       observeLayoutOwners();
     },
     _scrollChatTailNow(sid, st) {
-      const el = this.$refs && this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!el || !st || this.currentId !== sid || this.tabState[sid] !== st) return;
       const tail = this.$refs && this.$refs.chatBottom;
       if (tail && typeof tail.scrollIntoView === "function") {
@@ -26619,7 +26818,7 @@ function portal() {
       st.scrollTop = el.scrollTop;
     },
     scrollToBottom(force) {
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       const sid = this.currentId;
       const st = sid && this.tabState && this.tabState[sid];
       if (!el || !st) return;
@@ -26668,7 +26867,7 @@ function portal() {
     // been stable for two consecutive frames (heights realized) or the
     // frame budget is spent.
     _settleScrollToBottom({ maxFrames } = {}) {
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       const sid = this.currentId;
       const st = sid && this.tabState && this.tabState[sid];
       if (!el || !st) return;
@@ -26730,7 +26929,7 @@ function portal() {
     // distance from the top and nudge scrollTop by the residual, so the
     // landing stays accurate even as upstream heights change underfoot.
     _settleScrollToEl(getEl, desiredRelTop = 0, { maxFrames = 40 } = {}) {
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!el) return;
       let frames = 0;
       let onTarget = 0;
@@ -26777,7 +26976,7 @@ function portal() {
     // If nothing is above (already at/above the first question) we snap to
     // the very first user message.
     jumpToPrevUser() {
-      const el = this.$refs.chatBody;
+      const el = this._chatBodyElement();
       if (!el) return;
       // Exclude queued (not-yet-sent) bubbles — they render as .msg.user.queued
       // but jumping to them is meaningless; the FAB should only target real
@@ -26891,6 +27090,17 @@ function portal() {
           : "The previous turn is still stopping; send again in a moment",
         "warn", 2200);
         return false;
+      }
+      if (sendState._optimisticInterrupt && !opts.reconnect && !opts.resumedItem) {
+        // The user is intentionally moving on before the old cancelled event
+        // arrives. Retire only that old transport ownership now; otherwise its
+        // late _markDone would clear the NEW send's streaming flag/timer on this
+        // shared tab state. Backend snapshot persistence continues independently,
+        // and the canonical poll later merges any retained partial output.
+        try { if (sendState.es) sendState.es.close(); } catch (_) {}
+        sendState.es = null;
+        sendState._optimisticInterrupt = false;
+        sendState._pendingExternalUpdate = true;
       }
       // Do not start a new turn between the optimistic selector change and
       // its persisted session update. Otherwise Plan Mode could launch with a
@@ -27427,6 +27637,7 @@ function portal() {
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
         streamState._stopping = false;
+        streamState._optimisticInterrupt = false;
         streamState._serverActiveObserved = false;
         streamState.activeTurnId = "";
         streamState.parentTurnId = "";
@@ -28239,6 +28450,7 @@ function portal() {
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
         streamState._stopping = false;
+        streamState._optimisticInterrupt = false;
         streamState._serverActiveObserved = false;
         // Belt-and-braces for the auto-compact bubble: a turn that dies inside
         // /compact (transport drop, 10-min timeout) may never deliver the
@@ -28257,6 +28469,11 @@ function portal() {
           streamState._streamStartedAt / 1000,
           backgroundPending,
         );
+        // A previous completion/history reconciliation may have been deferred
+        // when this stream claimed the pane. Ownership is clear now; resume it
+        // without waiting for a page refresh or another 10-second list tick.
+        this.$nextTick(() => this._resumePendingCanonicalSync(
+          streamSid, streamState));
         if (authoritativeTerminal) {
           this._setSessionActivityExpectation(
             streamSid,
@@ -28905,24 +29122,18 @@ function portal() {
         if (streamState.es === es) streamState.es = null;
 
         if (attempts > MAX_ATTEMPTS) {
-          // Given up. Surface manual retry UI.
+          // Transport exhaustion is not a server-authenticated terminal result.
+          // Keep the logical turn running and reconcile at low frequency; the
+          // detached backend pump may still complete, settle its queue claim and
+          // start the next queued turn while this browser is offline.
           this.toast(this.lang === "zh"
-                      ? "和 Muse 的连接断开了，重试一下"
-                      : "Lost connection to Muse — try again",
-                      "error");
-          if (!isContinuation) markUserFailed();
-          _markDone(); _stopTimer();
-          if (streamState.pendingQueue && streamState.pendingQueue.length > 0) {
-            // Optimistic — the server also pauses the queue in the turn's
-            // finally (Task 3) when an errored turn has items waiting. Show
-            // the banner now, reconcile with server truth a beat later.
-            streamState._queuePaused = true;
-            setTimeout(() => {
-              if (this.tabState[streamSid] === streamState) {
-                this._syncQueueFromServer(streamSid);
-              }
-            }, 800);
-          }
+                      ? "连接暂时中断，正在后台恢复会话状态"
+                      : "Connection interrupted; recovering session state",
+                      "warn", 4000);
+          streamState._serverActiveObserved = true;
+          this._scheduleCanonicalStreamReload(streamSid, streamState, {
+            minimumWaitMs: 1000,
+          });
           return;
         }
 
@@ -28961,7 +29172,13 @@ function portal() {
               _markDone(false, false, true); _stopTimer();
               this._ackViewedActivity(streamSid, streamState, 3);
               if (this.currentId === streamSid) {
-                this._reloadSessionCoalesced(streamSid, { quiet: true });
+                this._reloadSessionCoalesced(streamSid, { quiet: true }).then(loaded => {
+                  if (loaded && this.tabState[streamSid] === streamState) {
+                    this.$nextTick(() => this._drainPendingQueue(
+                      streamSid, streamState.activeTurnId || "",
+                    ));
+                  }
+                });
               }
               return;
             }
@@ -28992,12 +29209,14 @@ function portal() {
             // the running footer and temporarily unlock the composer even
             // though the server-side turn was still alive.
             if (attempts >= MAX_ATTEMPTS) {
-              _markDone(); _stopTimer();
               this.toast(this.lang === "zh"
-                          ? "和 Muse 的连接断开了，重试一下"
-                          : "Lost connection to Muse — try again",
-                          "error");
-              if (!isContinuation) markUserFailed();
+                          ? "连接暂时中断，正在后台恢复会话状态"
+                          : "Connection interrupted; recovering session state",
+                          "warn", 4000);
+              streamState._serverActiveObserved = true;
+              this._scheduleCanonicalStreamReload(streamSid, streamState, {
+                minimumWaitMs: 1000,
+              });
             } else {
               // Schedule next retry ourselves since the old EventSource is
               // closed and no new transport error will fire.
@@ -29020,7 +29239,10 @@ function portal() {
         flushRender();
         let d = {};
         try { d = JSON.parse(ev.data || "{}"); } catch (_) { d = {}; }
-        this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
+        const alreadySettledOptimistically = !!streamState._optimisticInterrupt;
+        if (!alreadySettledOptimistically) {
+          this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
+        }
         es.close();
         _markDone(true, false, true, {
           model: modelForBubble,
@@ -29104,61 +29326,91 @@ function portal() {
         st.streaming = false;
         st._stopping = false;
         st.streamingModel = "";
+        if (st.pendingQueue && st.pendingQueue.length > 0) {
+          // No backend turn exists yet, but the durable queue may already do.
+          // Persist the same Stop semantics instead of leaving only the local
+          // banner paused while the server remains free to drain it.
+          try {
+            await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/queue/pause`, {
+              method: "POST",
+              headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
+              body: JSON.stringify({ paused: true }),
+            });
+          } catch (_) { /* queue sync below/next activation reconciles */ }
+          this._syncQueueFromServer(sid);
+        }
         this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 1500);
         return;
       }
+      // Optimistic stop: settle the human-facing state in this same click frame.
+      // Keep the EventSource attached so a cancelled event can still persist and
+      // quietly adopt the final partial-output snapshot. A subsequent send may
+      // replace that transport; its ownership guards make late old-turn events no-op.
+      const ownerEs = st.es;
+      st._optimisticInterrupt = true;
+      st.streaming = false;
+      st._stopping = false;
+      if (st._streamTimer) clearInterval(st._streamTimer);
+      if (st._stallWatch) clearInterval(st._stallWatch);
+      st._streamTimer = null;
+      st._stallWatch = null;
+      this._setSessionActivityExpectation(sid, false);
+      this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 1500);
+
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 15000);
-      let waitForTerminalEvent = false;
+      const timeout = setTimeout(() => controller.abort(), 3000);
       try {
         const r = await fetch(
           "/api/chat/interrupt?session_id=" + encodeURIComponent(sid),
           { method: "POST", headers: this.hdr(), signal: controller.signal },
         );
         if (!r.ok) throw new Error("interrupt failed");
-        let stopResult = {};
-        try { stopResult = await r.json(); } catch (_) { stopResult = {}; }
-        const hasInterruptedList = Array.isArray(stopResult.interrupted);
-        // Claude clients are keyed as "session@model" in the pool, while older
-        // backends returned the bare session id. Accept both response shapes.
-        const didInterrupt = !hasInterruptedList || stopResult.interrupted.some(
-          item => item === sid || String(item).startsWith(sid + "@"),
-        );
-        if (this.tabState[sid] !== st) return;
-        // The HTTP response only acknowledges the control request. Keep the
-        // EventSource alive until its cancelled/done event flushes the final
-        // markdown/tool boundary and performs the one authoritative cleanup.
-        // Closing it here used to strand partially rendered blocks and race a
-        // subsequent history reload.
-        waitForTerminalEvent = !!st.streaming;
-        if (!didInterrupt) {
-          // An empty interrupted list means the SDK client was detached or its
-          // best-effort interrupt failed. The backend watchdog is now forcing the
-          // turn down; keep the EventSource/Stop control alive until its terminal
-          // event arrives instead of falsely presenting an idle session.
-          this.toast(this.lang === "zh" ? "正在强制中断当前会话…"
-                                        : "Forcing the current session to stop…",
-                     "warn", 2500);
-          return;
-        }
-        if (waitForTerminalEvent) {
-          this.toast(this.lang === "zh" ? "正在中断当前会话…"
-                                        : "Interrupting the current session…",
-                     "warn", 2000);
-        }
+        // The backend marks the broadcast cancelled and arms its force-stop
+        // watchdog before replying. An empty `interrupted` list therefore still
+        // means the hard-stop path owns convergence; no visible rollback needed.
       } catch (_e) {
-        this.toast(this.lang === "zh"
-                    ? "停止失败，当前会话仍在运行"
-                    : "Could not stop; the session is still running",
-                   "error", 3000);
+        // A failed HTTP response is ambiguous: the request may have reached the
+        // backend before the connection dropped. Probe authoritative liveness
+        // before undoing the optimistic transition, and never overwrite a newer
+        // stream that already replaced this EventSource.
+        let active = null;
+        try {
+          const probeController = new AbortController();
+          const probeTimeout = setTimeout(() => probeController.abort(), 2500);
+          try {
+            const probe = await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/active`, {
+              headers: this.hdr(), signal: probeController.signal,
+            });
+            if (probe.ok) active = !!(await probe.json()).active;
+          } finally { clearTimeout(probeTimeout); }
+        } catch (_) { active = null; }
+        if (this.tabState[sid] === st && st.es === ownerEs && active === true) {
+          st._optimisticInterrupt = false;
+          st.streaming = true;
+          st._sessionActivityExpected = null;
+          this.sessions = (this.sessions || []).map(session => session.id === sid
+            ? { ...session, active: true, turn_active: true, background_active: false }
+            : session);
+          if (st._streamStartedAt && !st._streamTimer) {
+            st._streamTimer = setInterval(() => {
+              st.streamElapsed = Math.max(
+                0, (Date.now() - st._streamStartedAt) / 1000);
+            }, 1000);
+          }
+          this.toast(this.lang === "zh"
+            ? "停止失败，当前会话仍在运行"
+            : "Could not stop; the session is still running",
+          "error", 3000);
+        } else if (active === null) {
+          this.toast(this.lang === "zh"
+            ? "中断请求已提交，正在自动确认最终状态"
+            : "Interrupt requested; confirming the final state",
+          "warn", 3000);
+        }
       } finally {
         clearTimeout(timeout);
-        if (this.tabState[sid] === st) {
-          // A successfully accepted interrupt stays deduplicated until the
-          // stream's terminal event clears _stopping in _markDone().
-          if (!waitForTerminalEvent || !st.streaming) st._stopping = false;
-          this._syncQueueFromServer(sid);
-        }
+        if (this.tabState[sid] === st) this._syncQueueFromServer(sid);
+        this._syncSessionListQuiet();
         setTimeout(() => this.refreshSessions(), 800);
       }
     },
@@ -29600,7 +29852,7 @@ function portal() {
       if (this.currentId !== sid) return;
       // openTab fires loadSession async — give it a tick or two to render.
       const scroll = () => {
-        const body = this.$refs && this.$refs.chatBody;
+        const body = this._chatBodyElement();
         const target = body && body.querySelector(
           `.msg[data-uuid="${CSS.escape(uuid)}"]`);
         if (!target) return false;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -15445,7 +15445,10 @@ function portal() {
       if (tailWasVisible) st.messageRange.visibleEnd = st.messages.length;
       this._scheduleHistoryViewport(st, tailWasVisible ? "newer" : "older");
       this._syncNormalizedHistory(st);
-      return m;
+      // Alpine wraps array entries lazily. Return the entry read back through the
+      // reactive array, not the raw object that was pushed, so streaming text,
+      // completion metadata and optimistic rollback mutations repaint immediately.
+      return st.messages[st.messages.length - 1];
     },
     // Server/history windows are independent of the rendered DOM row count.
     // Phones use a smaller explicit page because parsing and installing 100 rich

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1884,14 +1884,24 @@
             </div>
           </template>
 
-          <!-- History pagination is transport-only. Older canonical windows are
-               filled and revealed automatically; surface only a transient retry
-               state when the local read fails, never a manual load control. -->
+          <!-- Long histories are count-paged explicitly. The browser receives and
+               mounts only the newest 100 canonical blocks until the reader asks
+               for the preceding page; reaching the top never starts background
+               history work. -->
+          <div x-show="hasMoreHistory()" class="load-earlier-wrap">
+            <button type="button"
+                    class="load-earlier-btn"
+                    @click="loadEarlierMessages()"
+                    :disabled="activeSession._loadingEarlier"
+                    x-text="activeSession._loadingEarlier
+                      ? t('history.load_earlier_loading')
+                      : t('history.load_earlier', { n: earlierMessageCount() })"></button>
+          </div>
           <div x-show="activeSession._historyHydrationError"
                class="load-earlier-wrap load-earlier-status"
                role="status"
                aria-live="polite"
-               x-text="lang==='zh' ? '正在重试补齐会话历史…' : 'Retrying conversation history…'"></div>
+               x-text="lang==='zh' ? '更早的会话历史加载失败，请重试' : 'Earlier history failed to load; retry'"></div>
           <!-- Per-message rendering — Alpine 3's reactivity worked
                reliably on this flat messages x-for. The "group into
                assistant turns" experiment broke streaming reactivity
@@ -2827,10 +2837,9 @@
                    exactly the right place (the tail of every turn) and already
                    carried the one fact worth anchoring to (the time), so it
                    becomes the boundary rather than adding a second element.
-                   The streaming dots moved OUT of here to .turn-running-bar:
-                   they were only visible when you happened to be scrolled to
-                   the bottom, and keeping both would pulse two sets of dots
-                   ~20px apart. -->
+                   It is also the single source of live turn status: restrained
+                   dots appear beside "Running" here, avoiding a duplicate
+                   sticky status row at the bottom of the viewport. -->
               <div class="turn-footer"
                    x-show="(m.role !== 'user' || m.turn_status || m._interrupted || m._failed)
                      && (i === paneMsgs.length - 1
@@ -2853,6 +2862,9 @@
                         'background-pending': turnHasPendingBackground(
                           m, pane, i === paneMsgs.length - 1)
                       }]">
+                  <span class="turn-running-dots"
+                        x-show="turnFooterStatus(m, pane) === 'running'"
+                        aria-hidden="true"><span></span><span></span><span></span></span>
                   <span x-text="turnHasPendingBackground(
                                   m, pane, i === paneMsgs.length - 1)
                                 ? t('chat.main_response_completed')
@@ -2901,87 +2913,44 @@
               </div>
             </div>
           </template>
-          <!-- Running indicator, pinned to the bottom of the SCROLL VIEWPORT
-               rather than trailing the last message. An agentic turn can run
-               for dozens of blocks, and the only two "still working" cues used
-               to be (a) the pulsing avatar, which sits on the turn's FIRST
-               message and is long scrolled off-screen, and (b) the dots in the
-               turn-footer under the very last message, which you only see if
-               you happen to be scrolled to the bottom. Anywhere else in a long
-               turn the chat is an undifferentiated wall of tool cards with no
-               state and no time (2026-07-25 report). Sticky keeps the answer
-               on screen at every scroll position; it's inside the pane so each
-               resident tab carries its own. -->
-          <!-- Suppressed while the "Muse 正在思考…" pending bubble is up: that
-               bubble already carries dots + model + elapsed, and the sticky bar
-               parks itself ~20px under it, so the user sees the SAME three
-               facts twice (2026-07-25 screenshot: "运行中 · 9m27s · Opus 5" over
-               "Muse 正在思考… · Opus 5 · 9m27s"). The pending bubble's own
-               condition is "no muse-side msg yet" — mirror it inverted here so
-               exactly one of the two is ever visible. -->
-          <div class="turn-running-bar"
-               x-show="pane && pane.streaming
-                       && !(pane._continuationAwaitingReaction)
-                       && paneMsgs.length
-                       && paneMsgs[paneMsgs.length - 1].role !== 'user'"
-               x-cloak>
-            <span class="thinking-dots"><span></span><span></span><span></span></span>
-            <span class="turn-running-label"
-                  x-text="(lang==='zh' ? '运行中' : 'Running')
-                          + (pane && pane.streamElapsed >= 1
-                              ? ' · ' + fmtStreamElapsed((pane && pane.streamElapsed) || 0) : '')
-                          + (pane && pane.streamingModel
-                              ? ' · ' + modelLabel(pane.streamingModel) : '')"></span>
-          </div>
           </div>
           </template>
-          <!-- /P1 per-tab message panes. Siblings below (pending bubble,
+          <!-- /P1 per-tab message panes. Siblings below (pre-response status,
                pending queue, banners) stay single-instance with active-tab
                semantics through the activeSession façade above. -->
-          <!-- Pending "Muse 正在思考" bubble — only while we're waiting for
-               the very first chunk. Once a streaming assistant message has
-               started accumulating text (its bubble is already rendered
-               above via the x-for), this pending placeholder must hide or
-               we get two stacked bubbles with overlapping model labels. -->
-          <!-- Pending bubble: shown only when streaming AND there's no
-               assistant-side msg yet (i.e. last msg is the user's
-               input, or the message list is empty). Simpler than the
-               old "role NOT in [assistant, tool_use, tool_result,
-               thinking]" exclusion list — that list missed ask_user_
-               question / permission_request / system_note, leaving
-               the pending bubble's avatar duplicated next to those
-               msgs' own avatars. Now: any non-user last msg already
-               has its own avatar — suppress pending. -->
-          <!-- ...and NOT while an auto-compact is running: that fires at the
-               top of the turn, when the last msg is still the user's, so both
-               placeholders would qualify and stack. The 📦 one is strictly
-               more informative, so it wins. -->
+          <!-- Before the first muse-side block exists there is no message tail
+               on which to mount the normal turn footer. Render the SAME footer
+               contract here temporarily instead of reviving a second avatar +
+               "Muse is thinking" bubble. It disappears as soon as any muse-side
+               block arrives, whereupon that block's own footer takes over. -->
+          <!-- Auto-compact has its distinct 📦 placeholder and wins this slot.
+               A continuation waiting for background settlement is deliberately
+               quiet until its reaction stream actually starts. -->
           <div x-show="activeSession.streaming && (!activeSession.messages.length
                                        || activeSession.messages[activeSession.messages.length-1].role === 'user')
-                       && !activeSession.compacting"
-               class="msg assistant">
-            <div class="msg-row">
-              <span class="msg-avatar assistant-avatar is-streaming-avatar" :title="mascotLabel()">
-                <svg viewBox="0 0 24 24"><use :href="mascotHref()"/></svg>
-              </span>
-              <div class="bubble pending">
-                <span class="thinking-dots"><span></span><span></span><span></span></span>
-                <span class="thinking-label">
-                  <span x-text="t('chat.thinking') + ' · ' + modelLabel(activeSession.streamingModel)"></span>
-                  <!-- 2026-05-23: 用统一 fmtStreamElapsed（"12s"/"2m50s"/"1h05m"），
-                       跟下方 turn-footer 一致；之前是 `12.3s` 一种格式，长 turn
-                       会变 187.4s 这种难读的大数字。-->
-                  <span x-show="activeSession.streamElapsed > 1" class="stream-elapsed"
-                        x-text="' · ' + fmtStreamElapsed(activeSession.streamElapsed)"></span>
-                </span>
-              </div>
-            </div>
+                       && !activeSession.compacting
+                       && !activeSession._continuationAwaitingReaction"
+               class="turn-footer turn-pending-footer"
+               x-cloak>
+            <span class="turn-status running">
+              <span class="turn-running-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+              <span x-text="turnStatusLabel('running')"></span>
+            </span>
+            <span x-show="activeSession._streamStartedAt"
+                  class="msg-ts"
+                  x-text="fmtTurnTime(activeSession._streamStartedAt)"></span>
+            <span x-show="activeSession.streamElapsed >= 1"
+                  class="msg-elapsed"
+                  x-text="'· ' + fmtStreamElapsed(activeSession.streamElapsed)"></span>
+            <span x-show="activeSession.streamingModel"
+                  class="turn-model"
+                  :title="activeSession.streamingModel"
+                  x-text="'· ' + modelLabel(activeSession.streamingModel)"></span>
           </div>
 
-          <!-- Standalone .streaming-tail removed — its job is now done
-               by .turn-footer inside the x-for loop, which renders on
-               the tail block of each turn and shows dots while
-               streaming + HH:MM once done. -->
+          <!-- Standalone streaming rows are retired. Before the first response
+               block the temporary separator above owns status; afterwards the
+               per-turn footer inside the message loop owns it. -->
 
           <!-- Pending queue: messages the user sent while Muse was still
                replying (or while a compact was running). They auto-drain on
@@ -3103,12 +3072,10 @@
                     x-text="lang==='zh' ? '清空队列' : 'Discard'"></button>
           </div>
 
-          <!-- Compact-in-progress placeholder bubble. Mirrors the streaming
-               pending bubble above so the user sees a familiar "something is
-               working" cue at the bottom of the chat (not just the silent
-               shimmer in the top ctx-meter). Appears for the full window
-               between native-compact POST and loadSession completing — can
-               be ~20-60s on a long session. -->
+          <!-- Compact-in-progress keeps its distinct 📦 placeholder because it
+               describes conversation maintenance rather than a response turn.
+               Appears for the full window between native-compact POST and
+               loadSession completing — can be ~20-60s on a long session. -->
           <div x-show="activeSession.compacting" class="msg assistant compact-pending">
             <div class="msg-row">
               <span class="msg-avatar assistant-avatar is-streaming-avatar" :title="mascotLabel()">
@@ -3346,7 +3313,7 @@
                actually gets inlined; unsupported types are rejected with
                a clear toast instead of being hidden in the picker. -->
           <input type="file" x-ref="attachInput"
-                 multiple style="display:none" :disabled="workspaceSwitching"
+                 multiple style="display:none"
                  @change="onAttachPicked($event)" />
           <!-- No-provider gate banner: when no model is configured the
                composer below is disabled (every send would 401 + lock the
@@ -3384,7 +3351,7 @@
           <textarea x-ref="chatInput"
                     x-effect="_syncChatInputDom(input, { target: $el })"
                     rows="1"
-                    :disabled="workspaceSwitching || !availableModels.length"
+                    :disabled="!availableModels.length"
                     class="chat-input-textarea"
                     name="muselab-chat-message"
                     inputmode="text"
@@ -3418,7 +3385,6 @@
                  the running turn). -->
             <button @click="$refs.attachInput.click()"
                     class="chat-toolbar-btn"
-                    :disabled="workspaceSwitching"
                     :title="t('attach.title')">
               <svg><use href="#i-paperclip"/></svg>
             </button>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -643,6 +643,10 @@ a:hover { color: var(--c-accent-hover); text-decoration: underline; }
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
   cursor: progress;
+  /* Status only: workspace bootstrap must never become a modal input shield.
+     The active pane may still be loading, but mobile navigation, Activity,
+     Settings and the composer remain independently reachable underneath. */
+  pointer-events: none;
 }
 .workspace-switch-status {
   display: inline-flex;
@@ -2312,15 +2316,11 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   letter-spacing: 0.5px;
 }
 .muse-mascot.greet { animation: muse-bounce .9s ease; }
-/* `.is-streaming` — slow breathing animation. Previously this class was
-   intentionally STATIC ("流式状态由 pending bubble 的 thinking-dots
-   表达") but the pending bubble disappears the moment the first chunk
-   arrives, leaving the user with no in-flight indicator for the rest
-   of the reply. Breathing is gentle enough not to compete with content
-   yet clearly signals "still working". Stream-caret on the bubble itself
-   carries the per-token feedback; mascot carries the session-level one.
-   Note: avoid using the .thinking class name — it has unrelated bubble
-   styling elsewhere that crushes the 20px mascot. */
+/* `.is-streaming` — slow breathing animation. The turn footer carries the
+   explicit in-flight state; breathing remains a gentle secondary cue on
+   mascot instances that are already part of message content. Note: avoid
+   using the .thinking class name — it has unrelated bubble styling elsewhere
+   that crushes the 20px mascot. */
 .muse-mascot.is-streaming {
   color: var(--c-accent);
   animation: muse-breath 2.4s ease-in-out infinite;
@@ -4307,16 +4307,10 @@ pre.text {
      so eager rendering just lets the browser paint the bounded window up front
      instead of stuttering every scroll. */
 }
-/* Desktop keeps several warm conversation panes mounted for instant tab
-   switches. Lay out only the visible slice of a newly revealed history;
-   off-screen bubbles use the per-message intrinsic height estimate already
-   written inline. Phones stay eager because their sequential touch scrolling
-   is more sensitive to on-demand realization and they retain only one pane. */
-@media (min-width: 769px) and (pointer: fine) {
-  .msg-pane .msg {
-    content-visibility: auto;
-  }
-}
+/* Render the bounded resident history eagerly on every device. Combining
+   content-visibility:auto with estimated virtual spacers made fast wheel
+   movement enter unpainted space and repeatedly resize the scrollbar as real
+   heights replaced estimates. Transport paging now bounds history work. */
 /* Paged-in history bubbles ("Load earlier" / live-cap restore) mount as a
    batch of 20+ at once. Each .msg would play the msg-in entrance animation on
    mount, so the whole batch fades+slides in simultaneously the instant you load
@@ -4696,9 +4690,8 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
 
 /* Compact-in-progress placeholder bubble. Sits at the very bottom of the
    message list while native /compact is running (can be 20-60s on a long
-   session). Reuses .bubble.pending layout — adds a 📦 prefix icon + a
-   subtle border-pulse to differentiate it from the assistant-thinking
-   pending bubble (otherwise the two look identical). */
+   session). Reuses .bubble.pending layout and adds a 📦 prefix icon plus a
+   subtle border pulse; normal response startup now uses a turn separator. */
 .compact-pending .bubble.pending {
   border: 1px solid var(--c-accent);
   animation: compact-pending-pulse 1.6s ease-in-out infinite;
@@ -4725,10 +4718,11 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
   display: flex; flex-direction: column;
   gap: 18px;
 }
-/* FIX ⑤: keep already-mounted message rows hidden behind the skeleton until
-   loadSession finishes highlighting (messagesReady). Prevents the half-rendered
-   "partway then stuck" flash on big sessions, especially on mobile. */
-.chat-body.msgs-hidden .msg { display: none; }
+/* Never remove canonical messages from layout while a cold load settles.
+   The old display:none gate left only turn separators / virtual spacers visible
+   whenever messagesReady missed a callback, producing a full-height blank chat
+   that could not be scrolled to its tail. The skeleton remains the loading cue;
+   already-resident rows stay usable underneath it. */
 .chat-skeleton-msg {
   display: flex; gap: 10px;
   align-items: flex-start;
@@ -4797,22 +4791,17 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
   .cost-skeleton-kpis { grid-template-columns: repeat(2, 1fr); }
 }
 
-/* Per-bubble streaming caret retired — the new .streaming-tail row at
-   the bottom of the chat body (see index.html, after the pending
-   bubble) handles "muse is still generating" universally, including
-   when the last block is a thinking card or tool result rather than
-   a text bubble. Avoids double-pulsing dots stacked in two places. */
-/* Per-turn footer. Sits under the tail block of every muse turn —
-   carries the streaming dots while in flight and the HH:MM
-   completion stamp once done. One footer per turn, regardless of
-   how many blocks (thinking / tool_use / tool_result / assistant)
-   are in the turn. Aligned to the muse-side content column (avatar
-   width 32px + gap 8px = 40px gutter). */
-/* Now also the turn SEPARATOR: two hairlines bracket the stamp so the row
-   reads as a boundary rather than a caption hanging off the last card. The
-   40px content-column indent is gone with them — a boundary should span the
-   full width, and there is no longer an avatar-aligned run of dots to line up
-   with (those moved to .turn-running-bar). */
+/* Per-bubble streaming caret retired. The per-turn footer is the single
+   live status source once a muse-side block exists, avoiding duplicate
+   pulsing indicators in the same turn. */
+/* Per-turn footer. Sits under the tail block of every muse turn and carries
+   live state while in flight, then the completion metadata once done. One
+   footer per turn, regardless of how many blocks (thinking / tool_use /
+   tool_result / assistant) are in the turn. */
+/* The footer also acts as the turn SEPARATOR: two hairlines bracket the stamp
+   so the row reads as a boundary rather than a caption hanging off the last
+   card. A boundary spans the full width rather than following the avatar
+   gutter. */
 .turn-footer {
   padding: 0;
   margin: 6px 0 2px;
@@ -4837,7 +4826,37 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
 }
 .turn-status {
   min-width: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
   text-align: right;
+}
+.turn-running-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.turn-running-dots > span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.38;
+  animation: turn-running-wave 1.35s ease-in-out infinite;
+}
+.turn-running-dots > span:nth-child(2) { animation-delay: 0.14s; }
+.turn-running-dots > span:nth-child(3) { animation-delay: 0.28s; }
+@keyframes turn-running-wave {
+  0%, 56%, 100% { opacity: 0.38; transform: translateY(0); }
+  28% { opacity: 0.92; transform: translateY(-1.5px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .turn-running-dots > span {
+    animation: none;
+    opacity: 0.7;
+    transform: none;
+  }
 }
 .turn-status.background-pending {
   min-width: 0;
@@ -4908,38 +4927,13 @@ html[data-theme="light"] .msg.user .bubble { color: white; }
     height: 30px;
   }
 }
-/* Sticky "still running" row — see the comment on .turn-running-bar in
-   index.html for why this exists instead of the trailing dots it replaced.
-   Opaque bg-1 (the chat pane's own background) so message content scrolls
-   UNDER it cleanly; the hairline gives it an edge without a heavy shadow. */
-.turn-running-bar {
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  margin-top: 4px;
-  padding: 6px 2px 4px;
-  background: var(--c-bg-1);
-  border-top: 1px solid var(--c-border);
-}
-.turn-running-label {
-  font-size: var(--fs-xs);
-  color: var(--c-fg-3);
-  font-family: var(--font-mono);
-  letter-spacing: 0.3px;
-}
-
 .thinking-dots { display: inline-flex; gap: var(--sp-1); align-items: center; }
 .thinking-dots span {
   width: 6px; height: 6px; border-radius: 50%; background: var(--c-accent);
   animation: thinking-pulse 1.2s ease-in-out infinite;
 }
-/* `.turn-footer .stream-elapsed` removed: the footer became a turn separator
-   and its elapsed counter moved to .turn-running-bar. The only remaining
-   .stream-elapsed is inside the pending bubble, where it is sibling-inline
-   and inherits .thinking-label's styling — it never needed this rule. */
+/* Turn separators render live and final elapsed values through `.msg-elapsed`;
+   no separate streaming elapsed style is needed. */
 .background-task-footer-label {
   color: var(--c-warn);
   font-size: var(--fs-xs);
@@ -10392,6 +10386,7 @@ html[data-theme="dark"] .bubble :not(pre) > code:not(.has-file-link) * {
   color: var(--c-accent);
 }
 .load-earlier-btn:active { background: var(--c-bg-4); }
+.load-earlier-btn:disabled { opacity: .6; cursor: wait; }
 .load-earlier-truncated-note {
   font-size: var(--fs-xs);
   color: var(--c-fg-3);

--- a/scripts/safe-restart.sh
+++ b/scripts/safe-restart.sh
@@ -16,7 +16,7 @@ STATUS="${MUSELAB_RESTART_STATUS:-/tmp/muselab-safe-restart.status}"
 STARTUP_LOG="${MUSELAB_RESTART_STARTUP_LOG:-$REPO/muselab.log}"
 WATCHDOG_LOG="${MUSELAB_RESTART_WATCHDOG_LOG:-/tmp/muselab-safe-restart.watchdog.log}"
 HEALTH_TIMEOUT="${MUSELAB_RESTART_HEALTH_TIMEOUT:-90}"
-STOP_TIMEOUT="${MUSELAB_RESTART_STOP_TIMEOUT:-30}"
+STOP_TIMEOUT="${MUSELAB_RESTART_STOP_TIMEOUT:-15}"
 POLL_INTERVAL="${MUSELAB_RESTART_POLL_INTERVAL:-1}"
 DETACH_DELAY="${MUSELAB_RESTART_DETACH_DELAY:-2}"
 
@@ -224,11 +224,24 @@ start_screen_service() {
 stop_service() {
   local session="$1" port="$2" expected_pid="${3:-}" pid=""
   "$SCREEN_BIN" -S "$session" -X quit >/dev/null 2>&1 || true
-  wait_for_port_free "$port" && return 0
+
+  # `screen -X quit` removes the terminal session but does not reliably signal
+  # the exec'd listener. Waiting a full stop timeout before the first SIGTERM
+  # added 30 seconds to both preflight cleanup and production switchover. Verify
+  # that the port still belongs to the PID captured by this restart, then begin
+  # the bounded graceful shutdown immediately.
   pid="$(listener_pid "$port" 2>/dev/null || true)"
+  [[ -n "$pid" ]] || return 0
   [[ -n "$expected_pid" && "$pid" == "$expected_pid" ]] || return 1
   kill -TERM "$pid" 2>/dev/null || true
   wait_for_port_free "$port" && return 0
+
+  # Uvicorn has its own 3-second connection drain and MuseLab bounds subsystem
+  # cleanup. If either wedges beyond STOP_TIMEOUT, preserve the existing hard
+  # stop fallback rather than allowing a restart to hang indefinitely.
+  pid="$(listener_pid "$port" 2>/dev/null || true)"
+  [[ -n "$pid" ]] || return 0
+  [[ -n "$expected_pid" && "$pid" == "$expected_pid" ]] || return 1
   kill -KILL "$pid" 2>/dev/null || true
   wait_for_port_free "$port"
 }

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -3433,7 +3433,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             frames.push({
               ready: st.messagesReady,
               loading: st.messagesLoading,
-              visible: !!pane && pane.textContent.includes(text),
+              visible: !!pane && pane.textContent.includes(text.trim()),
               count: pane ? pane.querySelectorAll(".msg").length : 0,
             });
             if (!st._reconcilePromise && i >= 2) break;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -3363,10 +3363,11 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     page.wait_for_function(
         """text => {
           const app = document.querySelector("#app")._x_dataStack[0];
-          const last = app.messages[app.messages.length - 1];
+          const st = app._ensureTabState(app.currentId);
+          const last = st.messages[st.messages.length - 1];
           const pane = Array.from(document.querySelectorAll(".msg-pane"))
             .find(el => getComputedStyle(el).display !== "none");
-          return app.streaming && last?.role === "assistant" && last.text === text
+          return st.streaming && last?.role === "assistant" && last.text === text
             && pane?.querySelector(".msg.assistant");
         }""",
         arg=final_text,
@@ -3375,7 +3376,8 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     live = page.evaluate(
         """() => {
           const app = document.querySelector("#app")._x_dataStack[0];
-          const last = app.messages[app.messages.length - 1];
+          const st = app._ensureTabState(app.currentId);
+          const last = st.messages[st.messages.length - 1];
           const nodes = document.querySelectorAll(".msg-pane .msg.assistant");
           window.__doneReconcileLiveNode = nodes[nodes.length - 1];
           window.__doneReconcileLiveKey = last._k;
@@ -3425,8 +3427,8 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             const pane = Array.from(document.querySelectorAll(".msg-pane"))
               .find(el => getComputedStyle(el).display !== "none");
             frames.push({
-              ready: app.messagesReady,
-              loading: app.messagesLoading,
+              ready: st.messagesReady,
+              loading: st.messagesLoading,
               visible: !!pane && pane.textContent.includes(text),
               count: pane ? pane.querySelectorAll(".msg").length : 0,
             });
@@ -3884,9 +3886,9 @@ def test_fast_completed_queued_turn_reconciles_footer_without_refresh(
     expected_status = _app_eval(
         page, "return app.lang === 'zh' ? '已完成' : 'Completed';"
     )
-    expect(footer.locator(".turn-status > span").first).to_have_text(
-        expected_status
-    )
+    expect(footer.locator(
+        ".turn-status > span:not(.turn-running-dots)"
+    )).to_have_text(expected_status)
     expect(footer.locator(".msg-ts")).to_have_text(expected_time)
     expect(footer.locator(".msg-elapsed")).to_have_text("· 4s")
     expected_model = _app_eval(

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -3409,7 +3409,11 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         })"""
     )
     page.wait_for_function(
-        "() => document.querySelector('#app')._x_dataStack[0].streaming === false",
+        """sid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app._ensureTabState(sid).streaming === false;
+        }""",
+        arg=sid,
         timeout=10000,
     )
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -3365,8 +3365,8 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
           const app = document.querySelector("#app")._x_dataStack[0];
           const st = app._ensureTabState(app.currentId);
           const last = st.messages[st.messages.length - 1];
-          const pane = Array.from(document.querySelectorAll(".msg-pane"))
-            .find(el => getComputedStyle(el).display !== "none");
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(app.currentId)}"]`);
           return st.streaming && last?.role === "assistant" && last.text === text
             && pane?.querySelector(".msg.assistant");
         }""",
@@ -3428,8 +3428,8 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
           const frames = [];
           for (let i = 0; i < 12; i++) {
             await new Promise(resolve => requestAnimationFrame(resolve));
-            const pane = Array.from(document.querySelectorAll(".msg-pane"))
-              .find(el => getComputedStyle(el).display !== "none");
+            const pane = document.querySelector(
+              `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
             frames.push({
               ready: st.messagesReady,
               loading: st.messagesLoading,
@@ -3892,6 +3892,7 @@ def test_fast_completed_queued_turn_reconciles_footer_without_refresh(
     )
     expect(footer.locator(
         ".turn-status > span:not(.turn-running-dots)"
+        ":not(.turn-background-running)"
     )).to_have_text(expected_status)
     expect(footer.locator(".msg-ts")).to_have_text(expected_time)
     expect(footer.locator(".msg-elapsed")).to_have_text("· 4s")

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -161,6 +161,7 @@ def test_pending_send_text_survives_hard_refresh(
           const originalFetch = window.fetch.bind(window);
           window.fetch = (url, init) => {
             if (String(url).includes('/api/chat/stream/start')) {
+              window.__streamStartBlocked = true;
               return new Promise(() => {});
             }
             return originalFetch(url, init);
@@ -173,8 +174,7 @@ def test_pending_send_text_survives_hard_refresh(
           const app = document.querySelector('#app')._x_dataStack[0];
           const store = JSON.parse(localStorage.getItem(
             'muselab_chat_drafts_v1') || '{}');
-          const st = app._ensureTabState(app.currentId);
-          return st.streaming && app.input === ''
+          return window.__streamStartBlocked === true && app.input === ''
             && store.drafts?.[app.currentId]?.pending === marker;
         }""",
         arg=[marker],

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -158,6 +158,7 @@ def test_pending_send_text_survives_hard_refresh(
     page.evaluate(
         """() => {
           const app = document.querySelector('#app')._x_dataStack[0];
+          app._confirmSessionBusy = async () => false;
           const originalFetch = window.fetch.bind(window);
           window.fetch = (url, init) => {
             if (String(url).includes('/api/chat/stream/start')) {

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -173,7 +173,8 @@ def test_pending_send_text_survives_hard_refresh(
           const app = document.querySelector('#app')._x_dataStack[0];
           const store = JSON.parse(localStorage.getItem(
             'muselab_chat_drafts_v1') || '{}');
-          return app.streaming && app.input === ''
+          const st = app._ensureTabState(app.currentId);
+          return st.streaming && app.input === ''
             && store.drafts?.[app.currentId]?.pending === marker;
         }""",
         arg=[marker],

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -984,6 +984,7 @@ def test_workspace_switch_overlaps_tree_sessions_and_transcript_without_early_ac
             savePrefs: app.savePrefs,
             persist: app._scheduleWorkspaceTreePersist,
             toast: app.toast,
+            openActivityCenter: app.openActivityCenter,
           };
           const events = {};
           const opened = [];
@@ -1024,10 +1025,14 @@ def test_workspace_switch_overlaps_tree_sessions_and_transcript_without_early_ac
             events.currentAtPreloadEnd = app.currentId;
             return sid === targetId;
           };
-          app.openTab = async sid => {
+          app.openTab = async (sid, makeCurrent = true, options = {}) => {
             events.currentBeforeOpen = app.currentId;
+            events.openOptions = {...options};
             opened.push(sid);
-            app.currentId = sid;
+            if (makeCurrent) app.currentId = sid;
+            const loading = app._ensureSessionLoaded(sid);
+            if (options.deferLoad) void loading;
+            else await loading;
           };
           app.newSession = () => { newCount += 1; };
           app._startFileEvents = () => {};
@@ -1039,6 +1044,14 @@ def test_workspace_switch_overlaps_tree_sessions_and_transcript_without_early_ac
             const started = performance.now();
             await app.switchWorkspace(targetPath);
             const elapsed = performance.now() - started;
+            events.switchEnd = performance.now();
+            events.shieldAfterSwitch = getComputedStyle(
+              document.querySelector('.workspace-switch-shield')
+            ).display !== 'none';
+            events.activityClicks = 0;
+            app.openActivityCenter = () => { events.activityClicks += 1; };
+            document.querySelector('.activity-center-btn').click();
+            await Promise.resolve();
             return {
               elapsed, events, originalCurrent, targetId,
               current: app.currentId, opened, newCount,
@@ -1060,24 +1073,23 @@ def test_workspace_switch_overlaps_tree_sessions_and_transcript_without_early_ac
             app.savePrefs = originals.savePrefs;
             app._scheduleWorkspaceTreePersist = originals.persist;
             app.toast = originals.toast;
+            app.openActivityCenter = originals.openActivityCenter;
           }
         }"""
     )
     events = result["events"]
-    tree_duration = events["treeEnd"] - events["treeStart"]
-    target_duration = events["preloadEnd"] - events["sessionsStart"]
-    concurrent_duration = max(events["treeEnd"], events["preloadEnd"]) \
-        - min(events["treeStart"], events["sessionsStart"])
     assert abs(events["treeStart"] - events["sessionsStart"]) < 75
-    assert events["preloadStart"] < events["treeEnd"]
-    # Measure the network/preload window directly.  ``elapsed`` also includes
-    # synchronous Alpine surface teardown/capture before either mocked request
-    # starts, which grows under a CPU-starved browser and is unrelated to
-    # whether these two I/O chains overlap.
-    assert concurrent_duration < tree_duration + target_duration - 80
-    assert events["currentAtPreloadStart"] == result["originalCurrent"]
-    assert events["currentAtPreloadEnd"] == result["originalCurrent"]
+    # Tree bootstrap and transcript loading continue behind pane-local state.
+    # Neither may extend the global shield/composer-disabled transition.
+    if "treeEnd" in events:
+        assert events["switchEnd"] < events["treeEnd"]
+    if "preloadEnd" in events:
+        assert events["switchEnd"] < events["preloadEnd"]
+    assert events["currentAtPreloadStart"] == result["targetId"]
     assert events["shieldDuringPreload"] is True
+    assert events["shieldAfterSwitch"] is False
+    assert events["activityClicks"] == 1
+    assert events["openOptions"]["deferLoad"] is True
     assert events["currentBeforeOpen"] == result["originalCurrent"]
     assert events["preloadedSid"] == result["targetId"]
     assert result["stalePresent"] is False

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -16,6 +16,19 @@ def _service(tmp_path, monkeypatch):
         "_metadata",
         lambda sid: (f"Session {sid}", workspace, "ws"),
     )
+    # Service-unit fixtures use synthetic session ids rather than creating full
+    # chat sessions. Treat their ledger rows as live unless a test explicitly
+    # overrides this source to exercise phantom-session filtering.
+    from backend import activity as activity_module
+    monkeypatch.setattr(
+        activity_module.sessions,
+        "list_sessions",
+        lambda: [
+            {"id": row.get("session_id")}
+            for row in service._events
+            if row.get("session_id")
+        ],
+    )
     return service
 
 
@@ -539,6 +552,55 @@ def test_compact_successor_atomically_inherits_activity_lineage_and_placement(
     assert restarted._group_assignments == {"child": group["id"]}
 
 
+def test_successor_does_not_inherit_owner_from_completed_human_turn(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    source = service.start(
+        "source",
+        summary="launch background work",
+        activity_source="direct",
+        owner_id="source-turn",
+    )
+    source_done = service.finish(
+        "source",
+        "completed",
+        activity_source="direct",
+        owner_id="source-turn",
+    )
+    assert source_done["state"] == "completed"
+    assert source_done["owner_id"] == "source-turn"
+    assert "active_owner_ids" not in source_done
+
+    inherited = service.inherit_session("source", "child", successor=True)
+    assert inherited["item"]["session_id"] == "child"
+    assert inherited["item"]["owner_id"] == "source-turn"
+    assert "active_owner_ids" not in inherited["item"]
+
+    child = service.start(
+        "child",
+        summary="independent child turn",
+        activity_source="direct",
+        owner_id="child-turn",
+    )
+    assert child["id"] == source["id"]
+    assert child["owner_id"] == "child-turn"
+    assert "active_owner_ids" not in child
+
+    child_done = service.finish(
+        "child",
+        "completed",
+        activity_source="direct",
+        owner_id="child-turn",
+    )
+    assert child_done["state"] == "completed"
+    assert child_done["session_id"] == "child"
+    assert child_done["owner_id"] == "child-turn"
+    assert "active_owner_ids" not in child_done
+    assert service.summary()["running"] == 0
+
+
 def test_ordinary_fork_inherits_group_without_stealing_source_lineage(
     tmp_path,
     monkeypatch,
@@ -813,13 +875,26 @@ async def test_rename_persists_and_pushes_without_reordering_task(
 
 def test_restart_marks_running_as_failed(tmp_path, monkeypatch):
     service = _service(tmp_path, monkeypatch)
-    service.start("s1", summary="long task")
+    service.start(
+        "s1",
+        summary="long task",
+        owner_id="pre-restart-owner",
+    )
     restarted = _service(tmp_path, monkeypatch)
     row = restarted.list()[0]
     assert row["state"] == "failed"
     assert row["needs_attention"] is False
     assert row["read"] is False
     assert row["updated_at"] == row["finished_at"]
+    assert "owner_id" not in row
+    assert "active_owner_ids" not in row
+
+    resumed = restarted.start("s1", summary="next turn", owner_id="new-owner")
+    assert resumed["owner_id"] == "new-owner"
+    assert "active_owner_ids" not in resumed
+    finished = restarted.finish("s1", "completed", owner_id="new-owner")
+    assert finished["state"] == "completed"
+    assert restarted.summary()["running"] == 0
     assert json.loads((Path(tmp_path) / ".muselab" / "activity.json").read_text())
 
 
@@ -839,6 +914,34 @@ async def test_subscriber_receives_task_transition_without_polling(
     assert payload["summary"]["running"] == 1
     assert payload["summary"]["revision"] == 1
     assert payload["summary"]["generation"] == payload["generation"]
+
+
+@pytest.mark.asyncio
+async def test_sse_summary_excludes_unopenable_unread_rows(
+    tmp_path,
+    monkeypatch,
+):
+    service = _service(tmp_path, monkeypatch)
+    from backend import activity as activity_module
+
+    live_ids = {"deleted", "running"}
+    monkeypatch.setattr(
+        activity_module.sessions,
+        "list_sessions",
+        lambda: [{"id": sid} for sid in sorted(live_ids)],
+    )
+    service.start("deleted", summary="old completed task")
+    service.finish("deleted", "completed")
+    live_ids.remove("deleted")
+
+    async with service.subscribe() as queue:
+        await asyncio.to_thread(
+            service.start, "running", summary="current running task")
+        payload = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert payload["summary"]["running"] == 1
+    assert payload["summary"]["unread"] == 0
+    assert payload["summary"] == service.summary(filter_live=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -7,6 +7,7 @@ fan-out, response shape) runs for real without spawning a CLI.
 import asyncio
 import json
 import os
+from pathlib import Path
 import threading
 from types import SimpleNamespace
 
@@ -121,12 +122,17 @@ def test_session_rename_updates_activity_ledger(chat_mod, client, monkeypatch):
     assert created.status_code == 200, created.text
     sid = created.json()["id"]
     calls = []
+    perf_events = []
 
     def rename_activity(target_sid, name):
         calls.append((target_sid, name))
 
     monkeypatch.setattr(activity_module.activity, "rename_session", rename_activity)
     monkeypatch.setattr(chat_mod, "sdk_rename_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        chat_mod, "_perf_event",
+        lambda event, **fields: perf_events.append((event, fields)),
+    )
 
     response = client.patch(
         f"/api/chat/sessions/{sid}",
@@ -137,6 +143,19 @@ def test_session_rename_updates_activity_ledger(chat_mod, client, monkeypatch):
     assert response.status_code == 200, response.text
     assert chat_mod.sess.get_session(sid)["name"] == "After rename"
     assert calls == [(sid, "After rename")]
+    assert len(perf_events) == 1
+    event, fields = perf_events[0]
+    assert event == "session.rename"
+    assert fields["session"] == sid[:8]
+    assert fields["status"] == "ok"
+    for key in (
+        "lock_wait_ms", "local_index_ms", "sdk_rename_ms", "activity_ms",
+        "total_ms",
+    ):
+        assert isinstance(fields[key], int)
+        assert fields[key] >= 0
+    assert "Before rename" not in repr(perf_events)
+    assert "After rename" not in repr(perf_events)
 
 
 def test_session_effort_and_fast_patch_persist_and_rebuild(
@@ -784,7 +803,7 @@ async def test_session_runtime_cleanup_invalidates_continuation_owner(chat_mod):
 
 
 @pytest.mark.asyncio
-async def test_async_purge_keeps_runtime_mutation_on_event_loop(
+async def test_async_purge_does_not_treat_background_watcher_as_activity(
         chat_mod, monkeypatch):
     from backend import activity as activity_module
 
@@ -814,12 +833,13 @@ async def test_async_purge_keeps_runtime_mutation_on_event_loop(
         lambda activity_sid, status, *, activity_source="", owner_id="", mark_read=None:
             activity_finishes.append((activity_sid, status, activity_source)),
     )
-    chat_mod._background_activity_finishes[sid] = (
-        "completed", "background-owner")
+    watcher = asyncio.create_task(asyncio.sleep(0))
+    await watcher
+    chat_mod._task_watchers[sid] = watcher
 
     assert await chat_mod.purge_session_storage_async(sid) is True
     assert observed_threads == [loop_thread]
-    assert activity_finishes == [(sid, "cancelled", "background")]
+    assert activity_finishes == []
 
 
 @pytest.mark.asyncio
@@ -1269,7 +1289,7 @@ async def test_sync_and_async_purge_from_leaf_clear_full_runtime_lineage(
 
 
 @pytest.mark.asyncio
-async def test_force_stop_tears_down_stuck_turn(chat_mod):
+async def test_force_stop_tears_down_stuck_turn(chat_mod, monkeypatch):
     """The SDK's client.interrupt() is best-effort; for an agentic turn the CLI
     may keep running, pinning the slot in _active_turns and bouncing every
     subsequent send with 'previous turn still running'. The force-stop watchdog
@@ -1277,6 +1297,32 @@ async def test_force_stop_tears_down_stuck_turn(chat_mod):
     sid = "sid-stuck"
     c = _seed(chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
     bc = chat_mod.TurnBroadcast(session_id=sid, model="claude-sonnet-4-6")
+    bc.queue_item_id = "q-stuck"
+    bc.activity_started = True
+    activity_finishes = []
+    queue_releases = []
+    queue_pauses = []
+    memory_clears = []
+    remembered = []
+
+    async def finish_activity(got_sid, got_bc, status):
+        activity_finishes.append((got_sid, got_bc.turn_id, status))
+        got_bc.activity_started = False
+
+    monkeypatch.setattr(chat_mod, "_finish_activity", finish_activity)
+    monkeypatch.setattr(
+        chat_mod.sess, "release_queue_claim",
+        lambda got_sid, item_id, **kwargs: queue_releases.append(
+            (got_sid, item_id, kwargs.get("turn_id"), kwargs.get("pause"))) or True,
+    )
+    monkeypatch.setattr(
+        chat_mod.sess, "pause_queue_if_nonempty", queue_pauses.append)
+    monkeypatch.setattr(
+        chat_mod.mem0, "pop_recall_trace", memory_clears.append)
+    monkeypatch.setattr(
+        chat_mod, "_remember_recent_turn",
+        lambda got_sid, got_bc: remembered.append((got_sid, got_bc.turn_id)),
+    )
     chat_mod._active_turns[sid] = bc
     try:
         # Tiny grace; the (absent) pump never frees the slot, so the watchdog
@@ -1286,7 +1332,51 @@ async def test_force_stop_tears_down_stuck_turn(chat_mod):
         assert sid not in chat_mod._active_turns  # slot freed → next send works
         assert bc.cancelled is True
         assert bc.done is True                    # subscribers get the sentinel
+        assert activity_finishes == [(sid, bc.turn_id, "cancelled")]
+        assert queue_releases == [(sid, "q-stuck", bc.turn_id, True)]
+        assert queue_pauses == [sid]
+        assert memory_clears == [sid]
+        assert remembered == [(sid, bc.turn_id)]
     finally:
+        chat_mod._active_turns.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_force_stop_lets_cancelled_pump_own_terminal_cleanup(
+    chat_mod, monkeypatch,
+):
+    """Cancelling the real pump must not race a second manual settlement."""
+    sid = "sid-pump-cleanup"
+    _seed(chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
+    bc = chat_mod.TurnBroadcast(session_id=sid, model="claude-sonnet-4-6")
+    manual_finishes = []
+    monkeypatch.setattr(
+        chat_mod,
+        "_finish_activity",
+        lambda *args, **kwargs: manual_finishes.append((args, kwargs)),
+    )
+
+    async def pump():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            bc.finish()
+            chat_mod._active_turns.pop(sid, None)
+
+    task = asyncio.create_task(pump())
+    bc.task = task
+    chat_mod._active_turns[sid] = bc
+    await asyncio.sleep(0)
+    try:
+        await chat_mod._force_stop_after_grace(sid, bc, grace=0.01)
+        assert task.done()
+        assert bc.done is True
+        assert sid not in chat_mod._active_turns
+        assert manual_finishes == []
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
         chat_mod._active_turns.pop(sid, None)
 
 
@@ -1570,6 +1660,45 @@ def test_vendor_fork_uses_vendor_session_store_and_restores_env(
     assert response.status_code == 200, response.text
     assert observed["config_dir"] == str(vendor_dir)
     assert os.environ["CLAUDE_CONFIG_DIR"] == "original-config"
+
+
+def test_existing_native_transcript_overrides_third_party_model_store(
+    chat_mod, client, monkeypatch,
+):
+    r = client.post(
+        "/api/chat/sessions",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "native transcript", "model": "claude-sonnet-4-6"},
+    )
+    assert r.status_code == 200, r.text
+    sid = r.json()["id"]
+    chat_mod.sess.update_model(sid, "codex:gpt-5.6-sol")
+    native_path = (
+        Path.home() / ".claude" / "projects" / "-workspace" / f"{sid}.jsonl"
+    )
+    original_find = chat_mod._find_session_jsonl
+    monkeypatch.setattr(
+        chat_mod,
+        "_find_session_jsonl",
+        lambda requested: native_path if requested == sid else original_find(requested),
+    )
+    observed = {}
+
+    def fake_fork(*_args, **_kwargs):
+        observed["config_dir"] = os.environ.get("CLAUDE_CONFIG_DIR")
+        return SimpleNamespace(session_id="21111111-2222-4333-8444-555555555555")
+
+    monkeypatch.setattr(chat_mod, "sdk_fork_session", fake_fork)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "inherited-vendor-config")
+    response = client.post(
+        f"/api/chat/sessions/{sid}/fork",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"title": "native store fork"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert observed["config_dir"] is None
+    assert os.environ["CLAUDE_CONFIG_DIR"] == "inherited-vendor-config"
 
 
 def test_fork_inherits_session_settings_and_records_lineage(
@@ -1931,6 +2060,17 @@ def test_continue_detached_forks_once_hides_source_and_migrates_queue(
     sid = source["id"]
     boundary = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
     child_sid = "11111111-2222-4333-8444-555555555555"
+    chat_mod.sess.update_model(sid, "codex:gpt-5.6-sol")
+    native_path = (
+        Path.home() / ".claude" / "projects" / "-workspace" / f"{sid}.jsonl"
+    )
+    original_find = chat_mod._find_session_jsonl
+    monkeypatch.setattr(
+        chat_mod,
+        "_find_session_jsonl",
+        lambda requested: native_path if requested == sid else original_find(requested),
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "inherited-vendor-config")
     chat_mod.sess.set_runtime_background_boundary(sid, boundary)
     chat_mod._sessions_with_inflight_tasks[sid] = {"task-a"}
     chat_mod.sess.set_runtime_task_overlay(
@@ -1941,8 +2081,10 @@ def test_continue_detached_forks_once_hides_source_and_migrates_queue(
         sid, "continue now", permission="default")
     assert queued["ok"] is True
     fork_calls = []
+    observed = {}
 
     def fake_fork(source_sid, **kwargs):
+        observed["config_dir"] = os.environ.get("CLAUDE_CONFIG_DIR")
         fork_calls.append((source_sid, kwargs))
         return SimpleNamespace(session_id=child_sid)
 
@@ -1967,6 +2109,8 @@ def test_continue_detached_forks_once_hides_source_and_migrates_queue(
     assert second.json()["reused"] is True
     assert len(fork_calls) == 1
     assert fork_calls[0][1]["up_to_message_id"] == boundary
+    assert observed["config_dir"] is None
+    assert os.environ["CLAUDE_CONFIG_DIR"] == "inherited-vendor-config"
     assert chat_mod.sess.get_session_meta(sid)["runtime_shadow"] is True
     child_meta = chat_mod.sess.get_session_meta(child_sid)
     assert child_meta["runtime_predecessor"] == sid

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -1307,6 +1307,47 @@ async def test_drain_waits_while_background_task_pending(
 
 
 @pytest.mark.asyncio
+async def test_drain_hands_off_queue_before_background_task_settles(
+    app_module, monkeypatch,
+):
+    """A safe successor must run queued work without waiting for the task."""
+    from backend import chat
+
+    sess = _sess(app_module)
+    source_sid = sess.create_session()["id"]
+    child_sid = sess.create_session()["id"]
+    sess.enqueue_message(source_sid, "follow-up")
+    chat._sessions_with_inflight_tasks[source_sid] = {"task-1"}
+    handoffs = []
+    scheduled = []
+    starts = []
+
+    async def fake_continue_detached(session_id):
+        handoffs.append(session_id)
+        sess.migrate_queue(source_sid, child_sid)
+        return {"session_id": child_sid}
+
+    async def fake_start_turn(*args, **kwargs):
+        starts.append((args, kwargs))
+
+    monkeypatch.setattr(chat, "_continue_detached_runtime", fake_continue_detached)
+    monkeypatch.setattr(chat, "_schedule_queue_drain", scheduled.append)
+    monkeypatch.setattr(chat, "_start_turn", fake_start_turn)
+    try:
+        await chat._maybe_drain_queue(source_sid)
+    finally:
+        chat._sessions_with_inflight_tasks.pop(source_sid, None)
+
+    assert handoffs == [source_sid]
+    assert scheduled == [child_sid]
+    assert starts == []
+    assert sess.get_queue(source_sid)["items"] == []
+    assert [
+        item["text"] for item in sess.get_queue(child_sid)["items"]
+    ] == ["follow-up"]
+
+
+@pytest.mark.asyncio
 async def test_drain_pauses_missing_attachments_without_sending_text(
     app_module, monkeypatch,
 ):

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -199,6 +199,36 @@ async def test_queue_drain_replays_one_wakeup_coalesced_during_rollover(
     assert sid not in chat_mod._queue_drain_rekicks
 
 
+@pytest.mark.asyncio
+async def test_queue_rollover_conflict_retains_delayed_retry(
+        app_module, monkeypatch):
+    """A transient background-owner 409 must not strand queued work forever."""
+    from fastapi import HTTPException
+    from backend import chat as chat_mod
+
+    sid = "queue-rollover-retry"
+    retried = []
+    chat_mod._sessions_with_inflight_tasks[sid] = {"task-1"}
+    monkeypatch.setattr(
+        chat_mod.sess, "get_queue",
+        lambda got_sid: {"items": [{"id": "q-1"}], "inflight": None}
+        if got_sid == sid else {"items": [], "inflight": None},
+    )
+
+    async def deferred(_sid):
+        raise HTTPException(status_code=409, detail="handoff in progress")
+
+    monkeypatch.setattr(chat_mod, "_continue_detached_runtime", deferred)
+    monkeypatch.setattr(
+        chat_mod, "_schedule_queue_drain_retry", retried.append)
+    try:
+        await chat_mod._maybe_drain_queue(sid)
+    finally:
+        chat_mod._sessions_with_inflight_tasks.pop(sid, None)
+
+    assert retried == [sid]
+
+
 def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypatch):
     """Happy path: assistant text → tool_use → tool_result → done. Assert
     every key frame flows through with the expected shape."""
@@ -226,7 +256,7 @@ def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypa
             usage={"input_tokens": 100, "output_tokens": 20,
                    "cache_read_input_tokens": 0,
                    "cache_creation_input_tokens": 0},
-            uuid="assistant-final-uuid",
+            uuid="assistant-tool-uuid",
         ),
         # SDK emits the tool result wrapped in the AssistantMessage's
         # follow-up; here we send it as a ToolResultBlock-bearing assistant
@@ -239,11 +269,17 @@ def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypa
             model="claude-sonnet-4-6",
             usage={},
         ),
+        AssistantMessage(
+            content=[TextBlock(text="Read completed successfully.")],
+            model="claude-sonnet-4-6", usage={},
+            uuid="assistant-final-uuid",
+        ),
         ResultMessage(
             subtype="success", duration_ms=1500, duration_api_ms=1400,
             is_error=False, num_turns=1, session_id=sid,
             total_cost_usd=0.0042,
             usage={"input_tokens": 100, "output_tokens": 20},
+            result="Read completed successfully.",
         ),
     ]
 
@@ -306,9 +342,9 @@ def test_stream_happy_path_text_tooluse_result_done(stream_env, client, monkeypa
     assert sid not in chat_mod._active_turns
 
 
-def test_tool_only_turn_persists_completion_annotation(
+def test_tool_only_turn_recovers_result_text_and_survives_refresh(
         stream_env, client, monkeypatch):
-    """Completion metadata must survive turns with no streamed assistant text."""
+    """Result-only final prose must appear before done and remain after reload."""
     chat_mod = stream_env
     sid = _make_session(client)
     assistant_uuid = "assistant-tool-only-uuid"
@@ -336,6 +372,7 @@ def test_tool_only_turn_persists_completion_annotation(
             subtype="success", duration_ms=2500, duration_api_ms=2400,
             is_error=False, num_turns=1, session_id=sid,
             total_cost_usd=0.0, usage={},
+            result="Inspection completed with a final summary.",
         ),
     ]
 
@@ -360,36 +397,136 @@ def test_tool_only_turn_persists_completion_annotation(
     assert response.status_code == 200, response.text
     events = _parse_sse(response.text)
     done = next(json.loads(data) for event, data in events if event == "done")
+    kinds = [event for event, _data in events]
+    recovered = [
+        json.loads(data)["text"]
+        for event, data in events if event == "text"
+    ]
 
-    assert done["assistant_uuid"] == assistant_uuid
+    assert kinds.index("text") < kinds.index("done")
+    assert recovered[-1] == "Inspection completed with a final summary."
+    assert done["assistant_uuid"] == ""
     assert done["duration_ms"] == 2500
     assert done["memory_recall"] == recall
-    annotations = chat_mod.sess.get_message_annotations(sid)
-    assert annotations[assistant_uuid]["ts"] == done["completed_at_ms"]
-    assert annotations[assistant_uuid]["elapsed_s"] == 2.5
-    assert annotations[assistant_uuid]["turn_status"] == "completed"
-    persisted_recall = annotations[assistant_uuid]["memory_recall"]
-    assert persisted_recall == {
+    assert done["snapshot_ready"] is True
+    assert done["result_recovered"] is True
+
+    history = client.get(
+        f"/api/chat/sessions/{sid}",
+        params={"tail": 80},
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert history.status_code == 200, history.text
+    messages = history.json()["messages"]
+    terminal = messages[-1]
+    assert terminal["role"] == "assistant"
+    assert terminal["text"] == "Inspection completed with a final summary."
+    assert terminal["turn_status"] == "completed"
+    assert terminal["elapsed"] == 2.5
+    assert terminal["memoryRecall"] == {
         "id": recall["id"], "count": 1, "latency_ms": 4, "status": "ok",
         "items": [{"id": "memory-1", "kind": "preference"}],
     }
-    assert "content" not in persisted_recall["items"][0]
-    persisted = chat_mod._RawMsg(
-        assistant_uuid,
-        "assistant",
-        {"content": [{
-            "type": "tool_use", "id": "tu_tool_only", "name": "Read",
-            "input": {"file_path": "/tmp/tool-only.txt"},
-        }]},
+    assert "content" not in terminal["memoryRecall"]["items"][0]
+
+
+def test_result_race_preserves_turn_owned_cancelled_state(
+        stream_env, client, monkeypatch):
+    """Stop marked on the exact broadcast wins even before pending bookkeeping."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    tool_message = AssistantMessage(
+        content=[ToolUseBlock(
+            id="tu_cancel_race", name="Read",
+            input={"file_path": "/tmp/cancel-race.txt"},
+        )],
+        model="claude-sonnet-4-6", usage={},
+        uuid="assistant-cancel-race",
     )
-    shaped = chat_mod._sdk_messages_to_ui([persisted], annotations)
-    assert shaped[-1]["role"] == "tool_use"
-    assert shaped[-1]["model"] == "claude-sonnet-4-6"
-    assert shaped[-1]["turn_status"] == "completed"
-    assert shaped[-1]["memoryRecall"] == persisted_recall
-    chat_mod._complete_turn_footer_metadata(
-        shaped, "claude-sonnet-4-6", has_later=False)
-    assert shaped[-1]["memoryRecall"] == persisted_recall
+    result = ResultMessage(
+        subtype="success", duration_ms=900, duration_api_ms=800,
+        is_error=False, num_turns=1, session_id=sid,
+        total_cost_usd=0.0, usage={}, result="late result after stop",
+    )
+
+    class CancellingClient(_FakeStreamClient):
+        async def receive_response(self):
+            yield tool_message
+            # Model Result races the route's session-level pending flag, but the
+            # Stop click has already marked this exact broadcast cancelled.
+            chat_mod._active_turns[sid].cancelled = True
+            assert sid not in chat_mod._pending_interrupts
+            yield result
+
+    async def fake_get_client(*_args, **_kwargs):
+        return CancellingClient([])
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=inspect&model=claude-sonnet-4-6",
+    )
+    assert response.status_code == 200, response.text
+    events = _parse_sse(response.text)
+    done = next(json.loads(data) for event, data in events if event == "done")
+
+    assert done["cancelled"] is True
+    assert done["is_error"] is False
+    assert done["result_recovered"] is False
+    assert not [data for event, data in events if event == "text"]
+
+
+def test_tool_only_success_without_result_is_not_false_completed(
+        stream_env, client, monkeypatch):
+    """A successful SDK boundary is not a completed user reply without prose."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    messages = [
+        AssistantMessage(
+            content=[ToolUseBlock(
+                id="tu_missing_final", name="Read",
+                input={"file_path": "/tmp/missing-final.txt"},
+            )],
+            model="claude-sonnet-4-6", usage={},
+            uuid="assistant-missing-final",
+        ),
+        ResultMessage(
+            subtype="success", duration_ms=900, duration_api_ms=800,
+            is_error=False, num_turns=1, session_id=sid,
+            total_cost_usd=0.0, usage={}, result=None,
+        ),
+    ]
+
+    async def fake_get_client(*_args, **_kwargs):
+        return _FakeStreamClient(messages)
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=inspect&model=claude-sonnet-4-6",
+    )
+    assert response.status_code == 200, response.text
+    done = next(
+        json.loads(data)
+        for event, data in _parse_sse(response.text)
+        if event == "done"
+    )
+
+    assert done["is_error"] is True
+    assert done["result_recovered"] is False
+    assert done["snapshot_ready"] is True
+    assert done["assistant_uuid"] == "assistant-missing-final"
+    assert "without a final assistant response" in done["error"]
+
+    history = client.get(
+        f"/api/chat/sessions/{sid}",
+        params={"tail": 80},
+        headers={"X-Auth-Token": TEST_TOKEN},
+    )
+    assert history.status_code == 200, history.text
+    terminal = history.json()["messages"][-1]
+    assert terminal["turn_status"] == "failed"
+    assert "without a final assistant response" in terminal["text"]
 
 
 def test_forced_interrupt_persists_refreshable_footer_and_private_snapshot(
@@ -609,6 +746,92 @@ def test_prevent_continuation_cannot_be_overridden_by_success_result(
         for message in messages
     )
     assert messages[-1]["turn_status"] == "failed"
+
+
+def test_persisted_hook_rejection_beats_generic_canonical_commit_error(
+        stream_env, client, monkeypatch):
+    """Warm streams may omit the SystemMessage even though JSONL persisted it."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    fake = _FakeStreamClient([ResultMessage(
+        subtype="success", duration_ms=50, duration_api_ms=40,
+        is_error=False, num_turns=1, session_id=sid,
+        total_cost_usd=0.0, usage={},
+    )])
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        chat_mod, "_turn_uuids_from_boundary",
+        lambda *_args, **_kwargs: (None, None, True),
+    )
+    monkeypatch.setattr(
+        chat_mod, "_turn_prevented_error_from_boundary",
+        lambda *_args, **_kwargs: {
+            "message": (
+                "UserPromptSubmit operation blocked by hook: "
+                "callback timed out after 3500ms"
+            ),
+            "source": "system_prevent_continuation",
+            "api_error_status": None,
+        },
+    )
+
+    response = client.get(
+        f"/api/chat/stream?token={TEST_TOKEN}&session_id={sid}"
+        "&prompt=hook-timeout&model=claude-sonnet-4-6",
+    )
+    done = next(
+        json.loads(data)
+        for event, data in _parse_sse(response.text)
+        if event == "done"
+    )
+
+    assert done["is_error"] is True
+    assert "callback timed out after 3500ms" in done["error"]
+    assert "conversation history" not in done["error"]
+    assert done["snapshot_ready"] is True
+
+
+def test_persisted_hook_rejection_is_read_after_the_turn_boundary(
+        stream_env, monkeypatch, tmp_path):
+    chat_mod = stream_env
+    entry = {
+        "type": "system",
+        "uuid": "hook-warning",
+        "content": (
+            "UserPromptSubmit operation blocked by hook:\n"
+            "callback timed out after 3500ms"
+        ),
+        "preventContinuation": True,
+    }
+    raw = (json.dumps(entry) + "\n").encode()
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(raw)
+    index = {
+        "source": {},
+        "records": [{
+            "offset": 0,
+            "length": len(raw),
+            "uuid": "hook-warning",
+            "type": "system",
+        }],
+    }
+    monkeypatch.setattr(
+        chat_mod, "_ensure_transcript_index",
+        lambda _sid: (transcript, index),
+    )
+
+    error = chat_mod._turn_prevented_error_from_boundary(
+        "session-id",
+        {"capture_ok": True, "record_count": 0},
+    )
+
+    assert error is not None
+    assert error["source"] == "system_prevent_continuation"
+    assert "timed out after 3500ms" in error["message"]
 
 
 def test_prevent_continuation_without_result_surfaces_hook_error(
@@ -923,14 +1146,13 @@ def test_done_is_published_before_slow_post_turn_bookkeeping(
     asyncio.run(exercise())
 
 
-def test_activity_stays_running_until_background_continuation_finishes(
+def test_activity_finishes_before_background_continuation_settles(
         stream_env, client, monkeypatch):
-    """A main ResultMessage is not the logical end while a task is detached.
+    """The main ResultMessage settles the human task before detached work.
 
-    The tab derives its yellow dot from the task pin.  Activity Center must keep
-    the same session running until that pin settles and the CLI's continuation
-    reaches its own ResultMessage; otherwise opening the center shows no running
-    indicator for work that is visibly still active in the tab strip.
+    The tab and task card keep showing the background process, but Activity
+    Center becomes terminal immediately and the later continuation must not
+    create a second completion transition.
     """
     from backend import activity as activity_module
 
@@ -991,7 +1213,7 @@ def test_activity_stays_running_until_background_continuation_finishes(
             activity_module.activity,
             "finish",
             lambda activity_sid, status, *, activity_source="", owner_id="", mark_read=None: activity_transitions.append(
-                ("finish", activity_sid, status)),
+                ("finish", activity_sid, status, mark_read)),
         )
 
         broadcast = await chat_mod._start_turn(sid, "run a background task")
@@ -1003,18 +1225,16 @@ def test_activity_stays_running_until_background_continuation_finishes(
         )
         assert activity_transitions == [
             ("start", sid, "run a background task"),
+            ("finish", sid, "completed", None),
         ]
         main_done = next(
             event for event in broadcast.replay_events()
             if event.get("event") == "done"
         )
-        assert json.loads(main_done["data"])["activity_source"] == "background"
+        assert json.loads(main_done["data"])["activity_source"] == "direct"
         assert chat_mod._sessions_with_inflight_tasks[sid] == {
             "task_deferred",
         }
-        assert chat_mod._background_activity_finishes[sid] == (
-            "completed", broadcast.turn_id)
-
         await asyncio.wait_for(broadcast.task, timeout=1)
         watcher = chat_mod._task_watchers[sid]
         release_watcher.set()
@@ -1022,16 +1242,14 @@ def test_activity_stays_running_until_background_continuation_finishes(
 
         assert activity_transitions == [
             ("start", sid, "run a background task"),
-            ("finish", sid, "completed"),
+            ("finish", sid, "completed", None),
         ]
         assert sid not in chat_mod._sessions_with_inflight_tasks
-        assert sid not in chat_mod._background_activity_finishes
 
     try:
         asyncio.run(exercise())
     finally:
         chat_mod._sessions_with_inflight_tasks.pop(sid, None)
-        chat_mod._background_activity_finishes.pop(sid, None)
         chat_mod._task_watchers.pop(sid, None)
         chat_mod._active_turns.pop(sid, None)
         recent = chat_mod._recent_turns.pop(sid, None)
@@ -1040,23 +1258,19 @@ def test_activity_stays_running_until_background_continuation_finishes(
         chat_mod._delete_active_turn_sidecar(sid)
 
 
-@pytest.mark.parametrize(
-    ("deferred_status", "expected_status"),
-    [("completed", "failed"), ("cancelled", "cancelled")],
-)
-def test_background_stream_eof_releases_dead_task_and_closes_activity(
-        stream_env, monkeypatch, deferred_status, expected_status):
+def test_background_stream_eof_releases_dead_task_without_reopening_activity(
+        stream_env, monkeypatch):
     """A closed CLI can never deliver the pending task's terminal marker.
 
-    This is the force-teardown path behind the stale yellow tab / Activity
-    Center row: unlike watcher replacement, the watcher is not cancelled; its
-    shared stream ends cleanly with EOF while the task pin is still present.
+    The watcher must still stop the orphaned process and release its task pin,
+    but its failure is conversation-local: the already-settled human Activity
+    row must not be reopened or overwritten.
     """
     from backend import activity as activity_module
 
     chat_mod = stream_env
-    sid = f"sid-eof-{deferred_status}"
-    task_id = f"task-eof-{deferred_status}"
+    sid = "sid-eof-background"
+    task_id = "task-eof-background"
     transitions = []
 
     class _ClosedClient:
@@ -1078,8 +1292,6 @@ def test_background_stream_eof_releases_dead_task_and_closes_activity(
         fake = _ClosedClient()
         chat_mod._pin_background_task(sid, task_id)
         chat_mod._bg_task_descriptions[task_id] = "sleep 30"
-        chat_mod._background_activity_finishes[sid] = (
-            deferred_status, "background-owner")
         await chat_mod._watch_inflight_tasks(
             sid, fake, {task_id: "sleep 30"})
         assert fake.stop_calls == [task_id]
@@ -1093,14 +1305,12 @@ def test_background_stream_eof_releases_dead_task_and_closes_activity(
     )
     try:
         asyncio.run(exercise())
-        assert transitions == [(sid, expected_status)]
+        assert transitions == []
         assert sid not in chat_mod._sessions_with_inflight_tasks
-        assert sid not in chat_mod._background_activity_finishes
         assert task_id not in chat_mod._bg_task_descriptions
         assert task_id not in chat_mod._bg_task_pinned_at
     finally:
         chat_mod._sessions_with_inflight_tasks.pop(sid, None)
-        chat_mod._background_activity_finishes.pop(sid, None)
         chat_mod._bg_task_descriptions.pop(task_id, None)
         chat_mod._bg_task_pinned_at.pop(task_id, None)
         chat_mod._background_turn_started_at.pop(sid, None)
@@ -2728,6 +2938,17 @@ def test_usage_transcript_hydration_does_not_block_event_loop(
 
     asyncio.run(scenario())
     assert ticks >= 5
+
+
+def test_initial_active_turn_persistence_runs_off_event_loop(stream_env):
+    """The first durable prompt write must not block unrelated API/SSE work."""
+    import inspect
+
+    source = inspect.getsource(stream_env._start_turn)
+    write_at = source.index('await obs.to_thread_io(\n        "chat.active_turn_write"')
+    bind_at = source.index("sess.bind_queue_turn(", write_at)
+    assert write_at < bind_at
+    assert "_write_active_turn_sidecar,\n        broadcast" in source[write_at:bind_at]
 
 
 def test_continuation_footer_is_durable_before_terminal_publish(stream_env):

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -770,6 +770,7 @@ def test_workspace_picker_supports_mouse_and_touch_reordering():
 def test_workspace_switch_moves_files_preview_and_conversation_together():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
     start = app.index("async switchWorkspace(path)")
     end = app.index("\n    closeWorkspaceBrowser()", start)
     switch = app[start:end]
@@ -777,7 +778,7 @@ def test_workspace_switch_moves_files_preview_and_conversation_together():
     assert "const surfaceReady = Promise.resolve(" in switch
     assert "this._changeWorkspaceSurface(path)" in switch
     assert "await this._pullWorkspaceSessions(path)" in switch
-    assert "await this._ensureSessionLoaded(target.id)" in switch
+    assert "await this._ensureSessionLoaded(target.id)" not in switch
     assert "await Promise.all([surfaceReady, targetReady])" in switch
     assert "_pullAllSessions()" not in switch
     target_ready = switch[switch.index("const targetReady"):switch.index(
@@ -785,17 +786,31 @@ def test_workspace_switch_moves_files_preview_and_conversation_together():
     assert "this.currentId =" not in target_ready
     assert "this.openTab(" not in target_ready
     assert switch.index("await Promise.all([surfaceReady, targetReady])") < switch.index(
-        "await this.openTab(target.id)")
+        "await this.openTab(target.id, true, { deferLoad: true })")
+    open_start = app.index("async openTab(id, makeCurrent = true, options = {})")
+    open_end = app.index("// Open a session id arriving", open_start)
+    open_tab = app[open_start:open_end]
+    assert "const switching = this.switchSession()" in open_tab
+    assert "if (options.deferLoad)" in open_tab
+    assert "void switching.catch(() => false)" in open_tab
     assert "workspaceSurfaceTransition: false" in app
     assert "const switchSeq = ++this._workspaceSwitchSeq" in switch
     assert "this.workspaceSurfaceTransition = true" in switch
     assert "await this.$nextTick()" in switch
     assert "this.workspaceSurfaceTransition = false" in switch
     assert "const previousMobileTab = this.mobileTab" in switch
+    surface_start = app.index("async _changeWorkspaceSurface(path)")
+    surface_end = app.index("\n    async switchWorkspace(path)", surface_start)
+    surface = app[surface_start:surface_end]
+    assert "await treeReady" not in surface
+    assert "void treeReady.then(startFileEvents)" in surface
     assert "this.setMobileTab(previousMobileTab)" in switch
     assert 'class="workspace-switch-shield"' in html
     assert 'x-show="workspaceSurfaceTransition"' in html
     assert ':aria-busy="workspaceSurfaceTransition"' in html
+    shield_start = css.index(".workspace-switch-shield {")
+    shield_end = css.index("}", shield_start)
+    assert "pointer-events: none" in css[shield_start:shield_end]
     assert "return this.currentWorkspacePath()" in app
     assert "workspaceSurfaces: this.workspaceSurfaces" in app
     files_start = html.index('<aside class="pane files"')
@@ -824,8 +839,8 @@ def test_workspace_switch_uses_scoped_session_window_and_merges_it():
     ensure_start = app.index("async _ensureSessionLoaded(sid)")
     ensure_end = app.index("\n    async loadSession(sid", ensure_start)
     ensure = app[ensure_start:ensure_end]
-    assert "const canonicalBehind = st._loaded" in ensure
-    assert "updated > seen" in ensure
+    assert "const canonicalBehind = this._canonicalMetaBehind(st, meta)" in ensure
+    assert "if (canonicalBehind) st._pendingExternalUpdate = true" in ensure
     assert "canonicalBehind ? { quiet: true } : {}" in ensure
     assert "this._applySessionList([...incoming, ...otherWorkspaces])" in pull
     assert "this._optimisticMetas && this._optimisticMetas[session.id]" in pull
@@ -953,14 +968,34 @@ def test_file_tree_uses_a_bounded_viewport_window():
 def test_session_rename_patches_activity_without_reloading_chat():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     helper_start = app.index("_applyRenamedSession(sid, name) {")
-    helper = app[helper_start:app.index("\n    async pickerCommitInlineRename()", helper_start)]
+    picker_start = app.index("async pickerCommitInlineRename()", helper_start)
+    helper = app[helper_start:picker_start]
+    picker = app[picker_start:app.index("\n    pickerCancelInlineRename()", picker_start)]
     modal_start = app.index("async renameSession() {")
     modal = app[modal_start:app.index("\n    // ===== settings modal", modal_start)]
+    tab_start = app.index("async commitRenameTab() {")
+    tab = app[tab_start:app.index("cancelRenameTab()", tab_start)]
 
     assert "item.session_name = name" in helper
     assert "this.activity.events = [...this.activity.events]" in helper
+    optimistic_start = helper.index("async _renameSessionOptimistically(")
+    optimistic = helper[optimistic_start:]
+    assert optimistic.index("this._applyRenamedSession(sid, name)") < optimistic.index("await fetch(")
+    assert "if (current && current.name === name)" in optimistic
+    assert "this._applyRenamedSession(sid, previousName)" in optimistic
     assert app.count("this._applyRenamedSession(") == 2
+    assert 'this._renameSessionOptimistically(cur.id, name, cur.name, true, "modal")' in modal
+    assert 'this._renameSessionOptimistically(id, name, cur.name, true, "tab")' in tab
+    assert 'this._renameSessionOptimistically(sid, name, cur.name, false, "picker")' in picker
+    assert '_reportSessionRenamePerf(fields) {' in app
+    assert 'fetch("/api/log/session-rename"' in app
+    assert "renamePerf.optimistic_apply_ms" in optimistic
+    assert "renamePerf.optimistic_paint_ms" in optimistic
+    assert "renamePerf.request_ms" in optimistic
+    assert 'renamePerf.status = "rollback"' in optimistic
+    assert "this._reportSessionRenamePerf(renamePerf)" in optimistic
     assert "refreshSessions" not in modal
+    assert "refreshSessions" not in tab
     assert "loadSession" not in helper
     assert "fetchActivity" not in helper
 
@@ -1501,7 +1536,7 @@ def test_failed_transcript_refresh_preserves_last_good_messages():
     load = app[start:end]
     failed = load[
         load.index("if (!r.ok) {"):
-        load.index("const s = this._retainExpectedSessionSettings(await r.json())")
+        load.index("const parsedSession = await r.json()")
     ]
 
     assert "return false" in failed
@@ -2041,7 +2076,7 @@ def test_context_recovery_opens_branch_and_never_reuses_attachment_ids():
     assert "pendingDocs" not in error[error.index("if (hasContextRecovery)"):]
 
 
-def test_workspace_switch_disables_composer_and_gates_programmatic_user_send():
+def test_workspace_switch_keeps_drafting_available_but_gates_user_send():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     start = app.index("async send(opts = {})")
@@ -2050,8 +2085,9 @@ def test_workspace_switch_disables_composer_and_gates_programmatic_user_send():
     textarea = textarea[:textarea.index("</textarea>")]
 
     assert "if (this.workspaceSwitching && !opts.reconnect && !opts.resumedItem) return" in send
-    assert ':disabled="workspaceSwitching || !availableModels.length"' in textarea
-    assert 'multiple style="display:none" :disabled="workspaceSwitching"' in html
+    assert ':disabled="!availableModels.length"' in textarea
+    assert ':disabled="workspaceSwitching || !availableModels.length"' not in textarea
+    assert 'multiple style="display:none" :disabled="workspaceSwitching"' not in html
     assert ':disabled="composerClaimed(currentId) || !!composerDisabledReason(currentId)"' in html
     assert ':disabled="workspaceSwitching || !!(tabState[currentId]' in html
 
@@ -2072,19 +2108,26 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     assert "if (st._stopping) return" in stop
     assert "const r = await fetch(" in stop
     assert "if (!r.ok) throw" in stop
-    assert 'String(item).startsWith(sid + "@")' in stop
-    assert "const timeout = setTimeout(() => controller.abort(), 15000)" in stop
-    assert "waitForTerminalEvent = !!st.streaming" in stop
+    assert "const ownerEs = st.es" in stop
+    assert "st._optimisticInterrupt = true" in stop
+    assert "st.streaming = false" in stop
+    assert "this._setSessionActivityExpectation(sid, false)" in stop
+    assert 'this.toast(this.lang === "zh" ? "已中断"' in stop
+    assert "const timeout = setTimeout(() => controller.abort(), 3000)" in stop
+    assert 'fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/active`' in stop
+    assert "st.es === ownerEs && active === true" in stop
+    assert "st.streaming = true" in stop
     assert "this._retireStaleSessionStream(sid, st)" not in stop
     assert "if (st._renderStreamingHtml) st._renderStreamingHtml()" not in stop
-    assert "if (!didInterrupt)" in stop
-    assert "if (!waitForTerminalEvent || !st.streaming)" in stop
+    assert "waitForTerminalEvent" not in stop
     cancelled_start = app.index('es.addEventListener("cancelled"')
     cancelled_end = app.index("\n      });", cancelled_start)
     cancelled = app[cancelled_start:cancelled_end]
     assert "_markDone(true, false, true, {" in cancelled
     assert 'turnStatus: "cancelled"' in cancelled
     assert "d.snapshot_ready" in cancelled
+    assert "alreadySettledOptimistically" in cancelled
+    assert "if (!alreadySettledOptimistically)" in cancelled
     assert "streamState._seenUpdated = undefined" in cancelled
     assert "quiet: true" in cancelled
     assert "probeActive: false" in cancelled
@@ -2122,6 +2165,14 @@ def test_background_task_gap_rolls_foreground_onto_detached_successor():
     assert "async _handoffBackgroundSession(" in app
     assert "/continue-detached`" in app
     assert "_stateForDetachedSuccessor(" in app
+    successor_start = app.index("_stateForDetachedSuccessor(")
+    successor_end = app.index("_claimDetachedRolloverSlot", successor_start)
+    successor = app[successor_start:successor_end]
+    assert "child._loaded = !!sourceState._loaded && child.messages.length > 0" in successor
+    handoff_start = app.index("async _handoffBackgroundSession(")
+    handoff_end = app.index("_ensureInheritedTaskPoller", handoff_start)
+    handoff = app[handoff_start:handoff_end]
+    assert 'this._requestSessionSync(childSid, "history_load"' in handoff
     assert "_backgroundRolloverAttempted" in app
     assert "owner_session_id" in app
     # A second browser may refresh its list after the first browser hid the
@@ -2374,6 +2425,9 @@ def test_composer_send_has_one_claim_owner_without_exposing_internal_phases():
     assert '_composerSubmitPhase: ""' in app
     assert "if (sendState._composerSubmitToken" in send
     assert 'sendState._composerSubmitPhase = "submitting";' in send
+    assert "if (sendState._optimisticInterrupt" in send
+    assert "if (sendState.es) sendState.es.close()" in send
+    assert "sendState._pendingExternalUpdate = true" in send
     assert "this._releaseComposerClaim(composerSubmitToken);" in send
     assert send.index('sendState._composerSubmitPhase = "submitting";') < send.index(
         "await this._awaitRuntimeSettingPatches(sendSid, sendState)"
@@ -2624,9 +2678,15 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
 
     assert "if (st.streaming || st.es) return false" in load
     assert "this.tabState[sid] !== st || st.streaming || st.es" in load
-    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible)")
+    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true)")
     reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
     assert "this.tabState[sid] !== st || st.streaming || st.es" in reveal
+    assert "const CH = this._isMobileLayout() ? 1 : 2" in reveal
+    assert "let cursor = finalEnd" in reveal
+    assert "st.messageRange.visibleStart = nextStart" in reveal
+    assert "if (!st.messagesReady) st.messagesReady = true" in reveal
+    assert "this._scrollChatTailNow(sid, st)" in reveal
+    assert "await this._yieldHistoryInstall();" in reveal
     assert "const ownsCurBubble = () =>" in send
     assert "this._containsPaneMessage(streamState, curBubble)" in send
     contains_start = app.index("_containsPaneMessage(st, message)")
@@ -2644,6 +2704,10 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     assert "const stillOwned = () => this.tabState[sid] === ownerState" in app
     assert "if (!isContinuation)" in send
     assert "all = this._preserveCanonicalMessageIdentity(st, all)" in load
+    assert "const quietRangeBeforeInstall = quiet ?" in load
+    assert "await new Promise(resolve => this.$nextTick(resolve))" in load
+    assert "this._revealMessagesChunked(sid, st, visible, true)" in load
+    assert "this._revealMessagesChunked(sid, st, visible, !quiet)" not in load
     assert "delete canonicalFields._k" in app
     assert "matched._k = mountedKey" in app
     canonical_start = app.index("_scheduleCanonicalStreamReload(sid, st")
@@ -2661,8 +2725,14 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     transport_finished_start = send.index("if (!d.active)", no_active_end)
     transport_finished_end = send.index(
         "if (d.background && d.attachable === false)", transport_finished_start)
-    assert "this._reloadSessionCoalesced(streamSid, { quiet: true })" in send[
-        transport_finished_start:transport_finished_end]
+    transport_finished = send[transport_finished_start:transport_finished_end]
+    assert "this._reloadSessionCoalesced(streamSid, { quiet: true })" in transport_finished
+    assert "this._drainPendingQueue(" in transport_finished
+    assert "streamState.activeTurnId || \"\"" in transport_finished
+    health_start = app.index("async _runStreamHealthSync(sid, st, options = {})")
+    health_end = app.index("_scheduleCanonicalStreamReload(", health_start)
+    health = app[health_start:health_end]
+    assert "this._drainPendingQueue(" in health
 
 
 def test_fork_banner_and_message_template_are_null_and_key_safe():
@@ -2691,13 +2761,14 @@ def test_quiet_history_reload_restores_visible_block_anchor_not_absolute_scroll(
     load_end = app.index("    // loadSession is per-session safe", load_start)
     load = app[load_start:load_end]
     anchor_start = app.index("    _captureViewportMessageAnchor(scrollEl, sid) {")
-    anchor_end = app.index("    LOAD_MORE_BATCH:", anchor_start)
+    anchor_end = app.index("    outlineVersion:", anchor_start)
     anchors = app[anchor_start:anchor_end]
 
     assert "this._captureViewportMessageAnchor(quietScrollEl, sid)" in load
     assert "quietScrollEl && !st.atBottom" in load
     assert "st.messages.length" in load
-    assert "!st.atBottom ? this._historyReconcileWindowSize() : 0" in load
+    assert "Math.max(historyPage, st.messages.length)" in load
+    assert "_historyReconcileWindowSize()" not in load
     assert "this._restoreMessageAnchor(" in load
     assert "if (!restored) quietScrollEl.scrollTop = quietScrollTop" in load
     assert 'pane.querySelectorAll(".msg[data-message-key]")' in anchors
@@ -2754,14 +2825,34 @@ def test_large_history_bodies_load_by_stable_block_reference():
     assert 'Object.assign(m, loaded' in loader
     assert 'body_state: "loaded"' in loader
     assert 'new IntersectionObserver' in loader
-    assert 'root: (this.$refs && this.$refs.chatBody) || null' in loader
+    assert 'root: (this._chatBodyElement()) || null' in loader
     assert 'rootMargin: "500% 0px"' in loader
-    assert 'm.html = this._renderHistoryMessage(m)' in loader
+    assert 'this._queueHistoryRichRender(m, sid)' in loader
     assert "this._loadMessageBody(m, sid)" in loader
     assert "await this._loadMessageBody(m)" in toggle
     assert 'x-init="observeAssistantBody($el, m, tid)"' in html
     assert "加载完整正文" not in html
     assert "Load full body" not in html
+
+
+def test_history_rich_render_never_blocks_canonical_install_or_batches_one_frame():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    load_start = app.index("    async loadSession(sid, opts = {}) {")
+    load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
+    load = app[load_start:load_end]
+    queue_start = app.index("    _queueHistoryRichRender(m,")
+    queue_end = app.index("    observeAssistantBody(el, m, sid)", queue_start)
+    queue = app[queue_start:queue_end]
+
+    assert "await this._renderMessagesChunked(visible" not in load
+    assert "historyPerf.markdown_ms = 0" in load
+    assert "_historyRichRenderQueue.push" in queue
+    assert "m._richRenderQueued" in queue
+    assert "window.requestIdleCallback(run, { timeout: 250 })" in queue
+    assert "this._renderHistoryMessage(m)" in queue
+    assert "if (this._historyRichRenderQueue.length) this._scheduleHistoryRichRender()" in queue
+    assert "forEach" not in queue
+    assert "const fenced = text.match(" in app
 
 
 def test_message_keys_use_stable_identity_without_repair_or_telemetry():
@@ -2916,7 +3007,7 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     assert "const loaded = await this.loadSession(sid, {" in reconcile
     assert "quiet: true, probeActive: false" in reconcile
     assert "attempt < 30" in reconcile
-    assert "Math.min(2000, 250 + attempt * 100)" in reconcile
+    assert "Math.min(2000, 250 + options.attempt * 100)" in reconcile
 
     continuity_start = app.index("_messageContinuitySignatures(m)")
     continuity_end = app.index(
@@ -2943,7 +3034,6 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
 
 def test_background_settlement_pauses_footer_until_reaction_starts():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
-    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     send_start = app.index("async send(opts = {})")
     send = app[send_start:app.index("async stop()", send_start)]
 
@@ -2951,7 +3041,10 @@ def test_background_settlement_pauses_footer_until_reaction_starts():
     assert "_setContinuationAwaitingReaction(false)" in send
     assert "background_tasks_pending" in send
     assert "_continuationAwaitingReaction: false" in app
-    assert "!(pane._continuationAwaitingReaction)" in html
+    status_start = app.index("turnFooterStatus(m, pane) {")
+    status_end = app.index("turnStatusLabel(status)", status_start)
+    status = app[status_start:status_end]
+    assert "if (pane && pane._continuationAwaitingReaction) return \"\";" in status
 
 
 def test_terminal_event_immediately_settles_tab_activity_snapshot():
@@ -3140,9 +3233,9 @@ def test_explicit_send_scroll_mounts_virtual_tail_without_restoring_old_anchor()
     sync_start = app.index("_syncMessageViewport(tid = this.currentId, forceTail = false)")
     sync_end = app.index("_scheduleMessageViewportSync", sync_start)
     sync = app[sync_start:sync_end]
-    assert "const followTail = forceTail || st.atBottom" in sync
-    assert "const anchor = followTail" in sync
-    assert "if (!followTail) this._restoreMessageAnchor(body, anchor)" in sync
+    assert "Intentionally no-op" in sync
+    assert "void tid" in sync
+    assert "void forceTail" in sync
 
     scroll_start = app.index("    scrollToBottom(force) {")
     scroll_end = app.index("// Re-slam the viewport", scroll_start)
@@ -3174,12 +3267,33 @@ def test_warm_transcript_panes_skip_remount_skeleton_and_full_highlight():
     warm = switch[warm_start:cold_start]
 
     assert "stCur.messagesReady = true" in warm
-    assert "this.scrollToBottom(true)" in warm
+    assert "this._scrollChatTailNow(target, stCur)" in warm
+    assert "this._settleScrollToBottom()" in warm
     assert "messagesReady = false" not in warm
     assert "highlightCode" not in warm
+    cold = switch[cold_start:]
+    assert "stCur.messagesReady = false" in cold
+    assert cold.index("stCur.messagesReady = true") < cold.index("this._scrollChatTailNow(target, stCur)")
+    assert cold.index("this._scrollChatTailNow(target, stCur)") < cold.index("this._afterPaint(() =>")
     assert 'x-for="tid in warmTranscriptTabIds()"' in html
     assert 'x-show="tid === currentId"' in html
 
+
+
+def test_cold_session_restore_replays_active_tab_tail_after_pane_mount():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    init_start = app.index("    async _initSessionsOnce(options = {}) {")
+    init_end = app.index("    // Shared session-list pull", init_start)
+    init = app[init_start:init_end]
+    assert "await this._ensureSessionLoaded(this.currentId)" in init
+    assert "const restoredId = this.currentId" in init
+    assert "this.$nextTick(() => this._afterPaint(() =>" in init
+    assert "restored.messagesReady = true" in init
+    assert "this.scrollToBottom(true)" in init
+    assert init.index("await this._ensureSessionLoaded(this.currentId)") < init.index(
+        "this.scrollToBottom(true)"
+    )
 
 
 def test_tab_selection_and_layout_changes_share_one_tail_follow_controller():
@@ -3196,7 +3310,8 @@ def test_tab_selection_and_layout_changes_share_one_tail_follow_controller():
     switch_end = app.index("    _afterPaint(fn) {", switch_start)
     switch = app[switch_start:switch_end]
     assert "selectedState.atBottom = true" in switch
-    assert switch.count("this.scrollToBottom(true)") >= 2
+    assert "this.scrollToBottom(true)" in switch
+    assert switch.count("this._scrollChatTailNow(target, stCur)") == 2
     assert "this._restoreChatPosition(target)" not in switch
 
     controller_start = app.index("    _ensureChatTailObserver() {")
@@ -3222,43 +3337,38 @@ def test_tab_selection_and_layout_changes_share_one_tail_follow_controller():
     assert "this._settleToken = (this._settleToken || 0) + 1" in intent
 
 
-def test_history_paging_is_transparent_and_fast_scroll_never_enters_blank_rows():
+def test_history_paging_uses_smaller_mobile_pages_only_on_user_request():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
 
-    hydrate_start = app.index("    _revealResidentHistory(st) {")
-    hydrate_end = app.index("    // Pull the next older window", hydrate_start)
-    hydrate = app[hydrate_start:hydrate_end]
-    assert "st.messageRange.visibleStart = 0" in hydrate
-    assert "this._shiftMessageVirtualWindow(st, count)" in hydrate
-    assert "this._fetchOlderWindow(sid)" in hydrate
-    assert "this._fetchLaterWindow(sid)" in hydrate
-    assert "st.messageRange.visibleEnd = st.messages.length" in hydrate
-    assert "window.requestIdleCallback" in hydrate
-    assert "st._historyHydrationRetry = setTimeout" in hydrate
+    load_start = app.index("    async loadSession(sid, opts = {}) {")
+    load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
+    load = app[load_start:load_end]
+    assert "_historyWindowSize() { return this._isMobileLayout() ? 20 : 100; }" in app
+    assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in load
+    assert "const historyPage = this._historyWindowSize()" in load
+    assert "Math.max(historyPage, st.messages.length)" in load
+    assert "this._scheduleTransparentHistory(st, false)" not in load
+
+    earlier_start = app.index("    async loadEarlierMessages(sid) {")
+    earlier_end = app.index("    async returnToLatest(sid)", earlier_start)
+    earlier = app[earlier_start:earlier_end]
+    assert "const batchSize = this._historyWindowSize()" in earlier
+    assert "await this._fetchOlderWindow(sid)" in earlier
+    assert "this._captureViewportMessageAnchor(scrollEl, sid)" in earlier
+    assert "this._restoreMessageAnchor(scrollEl, anchor)" in earlier
 
     scroll_start = app.index("    onChatScroll() {")
     scroll_end = app.index("    // Stamp the last genuine user scroll gesture", scroll_start)
     scroll = app[scroll_start:scroll_end]
-    assert "st._virtualScrollVelocity" in scroll
-    assert "st._virtualScrollDirection" in scroll
-    assert "el.clientHeight * 6" in scroll
-    assert "this._scheduleTransparentHistory(st, true)" in scroll
+    assert "loadEarlierMessages(" not in scroll
+    assert "_scheduleTransparentHistory(" not in scroll
 
-    virtual_start = app.index("    _syncMessageViewport(tid = this.currentId")
-    virtual_end = app.index("    _scheduleMessageViewportSync", virtual_start)
-    virtual = app[virtual_start:virtual_end]
-    assert "const speedScreens = Math.min(" in virtual
-    assert "const topOverscan = overscan" in virtual
-    assert "const bottomOverscan = overscan" in virtual
-    assert "const measurementAnchor = followTail" in virtual
-    assert "if (heightsChanged && measurementAnchor)" in virtual
-
-    assert '@click="loadEarlierMessages()"' not in html
+    assert '@click="loadEarlierMessages()"' in html
+    assert ':disabled="activeSession._loadingEarlier"' in html
+    assert "history.load_earlier" in html
+    assert "earlierMessageCount()" in html
     assert '@click="loadLaterMessages()"' not in html
-    assert 'history.load_earlier' not in html
-    assert 'Load newer' not in html
-    assert 'activeSession._historyHydrationError' in html
     assert 'class="history-plain"' in html
     assert "messageIntrinsicH(pane, m)" in html
 
@@ -3307,16 +3417,15 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "_activated: false" in blank
     for removed in ("_earlierMessages", "_laterMessages", "_allPaneMessages"):
         assert removed not in app
-    assert "_historyWindowSize() { return 300; }" in app
+    assert "_historyWindowSize() { return this._isMobileLayout() ? 20 : 100; }" in app
     assert "_historyReconcileWindowSize() { return 800; }" in app
-    assert "_historyWindowSize() { return this._isMobileLayout()" not in app
     assert "_historyReconcileWindowSize() { return this._isMobileLayout()" not in app
     assert "_MAX_RESIDENT_PANES" not in app
     assert "residentPaneIds" not in app
     assert "_promoteResident" not in app
-    assert "const _baseInitialLoad = _coldEarly ? 30 : 60;" in app
-    assert "const _mobileEarly" not in app
-    assert "_coldEarly ? 8 : 15" not in app
+    assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in app
+    assert "Math.max(historyPage, st.messages.length)" in app
+    assert "const _baseInitialLoad" not in app
     assert "if (cst && cst.streaming) continue" not in app
     assert '"&history_generation="' in app
     assert "if (r.status === 409)" in app
@@ -3352,17 +3461,17 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     virtual = app[virtual_start:virtual_end]
     assert "paneMessageRows(tid)" in virtual
     assert "_syncMessageViewport(tid = this.currentId" in virtual
-    assert "body.clientHeight * 1.5" in virtual
+    assert "return messages.map((message, index) =>" in virtual
+    assert "spacer: false" in virtual
+    assert "Intentionally no-op" in virtual
     assert 'querySelectorAll(".msg[data-message-key]")' in virtual
     assert "st._virtualHeights[key] = height" in virtual
-    assert 'spacer("top", 0, start)' in virtual
-    assert 'spacer("bottom", end, messages.length)' in virtual
-    # Streaming and completed states share one DOM window. A separately-mounted
-    # live tail was torn down by streaming=false and collapsed the completion layout.
+    # Streaming and completed states share one exact-height browser layout. The
+    # removed estimated spacers could expose blank regions during fast touch scroll.
     assert "messages.length - 3" not in virtual
     assert 'spacer("middle"' not in virtual
-    assert "this._captureViewportMessageAnchor(body, tid)" in virtual
-    assert "this._restoreMessageAnchor(body, anchor)" in virtual
+    assert 'spacer("top"' not in virtual
+    assert 'spacer("bottom"' not in virtual
     sync_start = app.index("_syncNormalizedHistory(st) {")
     sync_end = app.index("_captureViewportMessageAnchor", sync_start)
     assert "splice(" not in app[sync_start:sync_end]
@@ -3387,7 +3496,9 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     pane = html[pane_start:pane_end]
     assert 'x-for="tid in warmTranscriptTabIds()"' in html
     assert 'x-show="tid === currentId"' in pane
-    assert "WARM_TRANSCRIPT_LIMIT: 10" in app
+    assert "WARM_TRANSCRIPT_LIMIT: 3" in app
+    assert "const warmLimit = this._isMobileLayout() ? 1 : this.WARM_TRANSCRIPT_LIMIT" in app
+    assert ".slice(0, warmLimit)" in app
     assert "_touchTranscriptPane(id)" in app
     assert "st.streaming || st.es" in app
     assert ".filter(tid => !streamingSet.has(tid))" in app
@@ -3397,15 +3508,93 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "msg-virtual-spacer" in pane
     assert ".msg-virtual-spacer > * { display: none !important; }" in css
     assert "pane.streaming" in pane
-    assert "pane.streamElapsed" in pane
-    # Elapsed reads through a null-guarded pane. `pane` resolves to null while
-    # a closing tab's pane is torn down, and an unguarded property read there
-    # throws inside the Alpine effect.
-    assert "fmtStreamElapsed((pane && pane.streamElapsed) || 0)" in pane
-    assert 'x-text="fmtStreamElapsed(pane.streamElapsed)"' not in pane
+    # The single shared footer reads through the active-session façade rather
+    # than duplicating elapsed timers inside every warm transcript pane.
+    assert "activeSession.streamElapsed" in html
+    assert 'x-text="\'· \' + fmtStreamElapsed(activeSession.streamElapsed)"' in html
     assert "messages.length" not in re.sub(r"<!--.*?-->", "", pane, flags=re.S)
     assert "streaming &&" not in re.sub(r"<!--.*?-->", "", pane, flags=re.S).replace(
         "pane.streaming &&", "")
+
+
+def test_cold_history_reveal_never_marks_a_nonempty_session_with_an_empty_range():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    guard_start = app.index("_ensureNonEmptyMessageRange(st) {")
+    guard_end = app.index("_containsPaneMessage", guard_start)
+    guard = app[guard_start:guard_end]
+    assert "if (!st || !Array.isArray(st.messages) || !st.messages.length)" in guard
+    assert "range.visibleEnd <= range.visibleStart" in guard
+    assert "range.visibleEnd = length" in guard
+    assert "range.visibleStart = Math.max(0, length - 1)" in guard
+
+    visible_start = app.index("_visiblePaneMessages(st) {")
+    visible_end = app.index("_ensureNonEmptyMessageRange(st) {", visible_start)
+    visible_accessor = app[visible_start:visible_end]
+    assert "this._ensureNonEmptyMessageRange(st);" in visible_accessor
+
+    successor_start = app.index("_stateForDetachedSuccessor(")
+    successor_end = app.index("_claimDetachedRolloverSlot", successor_start)
+    successor = app[successor_start:successor_end]
+    clone_range = successor.index("child.messageRange = { ...sourceState.messageRange };")
+    repair_range = successor.index("this._ensureNonEmptyMessageRange(child);")
+    mark_loaded = successor.index(
+        "child._loaded = !!sourceState._loaded && child.messages.length > 0;"
+    )
+    assert clone_range < repair_range < mark_loaded
+
+    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible")
+    reveal_end = app.index("// E5: render the deferred HEAD", reveal_start)
+    reveal = app[reveal_start:reveal_end]
+    assignment = reveal.index("st.messageRange.visibleStart = nextStart")
+    cancellation = reveal.index(
+        "if (this.tabState[sid] !== st || st.streaming || st.es) return",
+        reveal.index("const finalStart = st.messageRange.visibleStart"),
+    )
+    assert assignment < cancellation
+    assert "st.messageRange.visibleStart = finalEnd" not in reveal
+    assert "st.messageRange.visibleEnd = finalEnd" in reveal
+    assert "await this._yieldHistoryInstall();" in reveal
+    assert "requestAnimationFrame(() => r())" not in reveal
+
+    install_yield_start = app.index("_yieldHistoryInstall() {")
+    install_yield_end = app.index(
+        "async _revealMessagesChunked", install_yield_start)
+    install_yield = app[install_yield_start:install_yield_end]
+    assert 'window.scheduler.postTask(() => {}, { priority: "background" })' in install_yield
+    assert "window.requestIdleCallback" in install_yield
+    assert "setTimeout(resolve, 50)" in install_yield
+
+    load_start = app.index("async loadSession(sid, opts = {})")
+    load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
+    load = app[load_start:load_end]
+    fail_open = load.index("this._ensureNonEmptyMessageRange(st);")
+    ready = load.index("st.messagesReady = true", fail_open)
+    assert fail_open < ready
+
+    switch_start = app.index("async switchSession()")
+    switch_end = app.index("// Run `fn` AFTER", switch_start)
+    switch = app[switch_start:switch_end]
+    assert "canonicalCount > 0 && !st.messages.length" in switch
+    assert "loadedButMissingCanonical || loadedButBehindCanonical" in switch
+    assert "if (loadedButMissingCanonical) st._loaded = false" in switch
+    assert "if (loadedButBehindCanonical) st._pendingExternalUpdate = true" in switch
+    assert "await this._ensureSessionLoaded(target);" in switch
+
+    activate_start = app.index("async activateTab(tid)")
+    activate_end = app.index("_scrollTabIntoView(tid)", activate_start)
+    activate = app[activate_start:activate_end]
+    assert "if (tid === this.currentId)" in activate
+    assert "canonicalCount > 0 && !st.messages.length" in activate
+    assert "st._loaded = false" in activate
+    assert "await this._ensureSessionLoaded(tid);" in activate
+    assert "this._ensureNonEmptyMessageRange(st);" in activate
+
+    reconcile_start = app.index("_reconcileOpenSession(next)")
+    reconcile_end = app.index("async _runHistoryRevisionSync", reconcile_start)
+    reconcile = app[reconcile_start:reconcile_end]
+    assert "canonicalMissingLocally" in reconcile
+    assert 'this._requestSessionSync(sid, "history_load"' in reconcile
 
 
 def test_stream_deltas_use_throttled_plain_snapshots_and_final_rich_render():
@@ -3892,7 +4081,7 @@ def test_workspace_cache_uses_delta_without_blocking_or_copying_hidden_bursts():
     change_end = app.index("\n    async switchWorkspace(path)", change_start)
     change = app[change_start:change_end]
     assert "this.loadRoot({ runtimeSnapshot: !!runtime })" in change
-    assert "coldTreeOk = await treeReady" in change
+    assert "await treeReady" not in change
     assert "Promise.allSettled" not in change
     assert "await terminalRefresh" not in change
     assert "this.fetchTerminals({ restore: true })" in change
@@ -4236,49 +4425,35 @@ def test_effort_field_uses_a_short_label_not_the_tooltip_prose():
     assert "Ultra uses maximum reasoning" in i18n
 
 
-def test_running_state_is_pinned_to_the_scroll_viewport_not_the_last_message():
-    """A long agentic turn must show "still running" at every scroll position.
-
-    2026-07-25 report ("这种界面很让人困惑啊 为什么没有footer？"): a screenful of
-    tool cards with no time, no state, no boundary. Three separately-reasonable
-    rules composed into that: (1) one footer per TURN, on its tail message;
-    (2) the HH:MM stamp only lands in the `done` handler, so a running turn has
-    no `ts` anywhere; (3) the pulsing avatar marks the turn's FIRST message,
-    which in a 40-block turn is far off-screen. Net: the only evidence of life
-    was the composer's stop button.
-    """
+def test_running_state_is_rendered_once_in_the_turn_separator():
+    """Live status belongs to the turn separator, not a duplicate sticky row."""
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
 
-    pane_start = html.index('<div class="msg-pane"')
-    pane_end = html.index("<!-- /P1 per-tab message panes", pane_start)
-    pane = html[pane_start:pane_end]
-    # Lives INSIDE the pane: panes are resident per tab, and a single shared
-    # bar would report the active tab's state under every one of them.
-    assert 'class="turn-running-bar"' in pane
-    # The gate also excludes the pending-bubble case — see
-    # test_running_bar_and_pending_bubble_are_mutually_exclusive.
-    assert 'x-show="pane && pane.streaming' in pane
+    assert 'class="turn-running-bar"' not in html
+    assert ".turn-running-bar" not in css
 
-    block = css[css.index(".turn-running-bar {"):]
-    block = block[:block.index("}")]
-    assert "position: sticky" in block
-    assert "bottom: 0" in block
-    # Opaque, or message text shows through as it scrolls underneath.
-    assert "background: var(--c-bg-1)" in block
+    footer = html[html.index('<div class="turn-footer"'):]
+    footer = footer[:footer.index('<button class="turn-fork-btn"')]
+    assert 'class="turn-running-dots"' in footer
+    assert "turnFooterStatus(m, pane) === 'running'" in footer
+    assert "turnFooterElapsed(m, pane)" in footer
+    assert "turnFooterModel(m, pane, tid)" in footer
+
+    assert "@keyframes turn-running-wave" in css
+    assert "transform: translateY(-1.5px)" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
+    assert "animation: none" in css
 
 
-def test_turn_footer_is_a_separator_and_no_longer_hosts_streaming_dots():
-    """The footer became the turn boundary; the dots moved to the sticky bar.
-
-    Keeping both would pulse two sets of dots ~20px apart whenever the user
-    happened to be scrolled to the bottom.
-    """
+def test_turn_footer_is_a_separator_and_hosts_the_only_running_dots():
+    """The turn boundary owns the restrained live-state animation."""
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
 
     footer = html[html.index('<div class="turn-footer"'):]
     footer = footer[:footer.index("</div>")]
+    assert "turn-running-dots" in footer
     assert "thinking-dots" not in footer
     assert "stream-elapsed" not in footer
     # Bracketing hairlines are what make it read as a boundary rather than a
@@ -4442,27 +4617,29 @@ def test_compact_summary_stays_collapsed_until_tapped():
     assert opt_out < fn.index("streaming && i === msgs.length - 1")
 
 
-def test_running_bar_and_pending_bubble_are_mutually_exclusive():
-    """Only one live-state indicator at a time.
-
-    The sticky .turn-running-bar shows dots + elapsed + model. So does the
-    "Muse 正在思考…" pending bubble, and the bar pins itself a few px below it —
-    2026-07-25 screenshot showed "运行中 · 9m27s · Opus 5" stacked directly on
-    "Muse 正在思考… · Opus 5 · 9m27s". The pending bubble renders when there is
-    no muse-side msg yet; the bar must require the inverse.
-    """
+def test_pre_response_state_uses_the_same_turn_separator_not_a_left_bubble():
+    """Before the first muse block, render the shared footer contract temporarily."""
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
 
-    bar = html[html.index('class="turn-running-bar"'):]
-    bar = bar[:bar.index("</div>")]
-    assert "paneMsgs[paneMsgs.length - 1].role !== 'user'" in bar
-    assert "paneMsgs.length" in bar
+    assert 'class="turn-running-bar"' not in html
+    assert 'class="turn-footer turn-pending-footer"' in html
+    pending_start = html.index('class="turn-footer turn-pending-footer"')
+    pending = html[html.rfind("<div", 0, pending_start):html.index("</div>", pending_start)]
+    assert "activeSession.messages[activeSession.messages.length-1].role === 'user'" in pending
+    assert "!activeSession.compacting" in pending
+    assert "!activeSession._continuationAwaitingReaction" in pending
+    assert 'class="msg assistant"' not in pending
+    assert "assistant-avatar" not in pending
+    assert 'class="turn-running-dots"' in pending
+    assert "turnStatusLabel('running')" in pending
+    assert "fmtTurnTime(activeSession._streamStartedAt)" in pending
+    assert "fmtStreamElapsed(activeSession.streamElapsed)" in pending
+    assert "modelLabel(activeSession.streamingModel)" in pending
 
-    # The pending bubble reads the same active-session pane as the sticky bar's
-    # visible resident pane, so the two conditions stay complementary.
-    assert ("activeSession.streaming && (!activeSession.messages.length\n"
-            "                                       || activeSession.messages[activeSession.messages.length-1]"
-            ".role === 'user')") in html
+    footer = html[html.index('<div class="turn-footer"'):]
+    footer = footer[:footer.index('<button class="turn-fork-btn"')]
+    assert "m.role !== 'user'" in footer
+    assert "turnFooterStatus(m, pane) === 'running'" in footer
 
 
 def test_auto_compact_drives_the_same_ui_as_a_manual_one():
@@ -4510,10 +4687,12 @@ def test_auto_compact_drives_the_same_ui_as_a_manual_one():
     done = done[:done.index("this._setBackgroundTaskActive(")]
     assert "streamState.compacting = false;" in done
 
-    # Exactly one placeholder bubble: the auto-compact fires while the last msg
-    # is still the user's, which is also the generic pending bubble's trigger.
-    assert ("&& !activeSession.compacting\"\n"
-            "               class=\"msg assistant\"") in html
+    # Auto-compact fires while the last msg is still the user's, which also
+    # qualifies the pre-response separator. Its explicit exclusion keeps the 📦
+    # maintenance placeholder as the only visible status.
+    assert ("&& !activeSession.compacting\n"
+            "                       && !activeSession._continuationAwaitingReaction\"") in html
+    assert 'x-show="activeSession.compacting" class="msg assistant compact-pending"' in html
 
 
 def test_concise_mode_hides_exactly_three_card_classes():
@@ -4631,7 +4810,8 @@ def test_midturn_reconnect_storm_guards_are_in_place():
     reconcile = js[js.index("    _reconcileOpenSession(next) {"):]
     reconcile = reconcile[:reconcile.index("\n    _sessionsEqual(")]
     assert "const backgroundOnly = !!cur.background_active && !cur.turn_active;" in reconcile
-    assert "const needsRefresh = st._pendingExternalUpdate || visibleNewer;" in reconcile
+    assert "const needsRefresh = st._pendingExternalUpdate" in reconcile
+    assert "|| visibleNewer || canonicalSuffixMissing" in reconcile
     assert "messageCountChanged || turnCountChanged" in reconcile
     assert "!!cur.active || st._pendingExternalUpdate" not in reconcile
     # Attaching to a server-side turn is a separate, pane-preserving path.
@@ -4675,6 +4855,18 @@ def test_midturn_reconnect_storm_guards_are_in_place():
     onopen = js[js.index("      es.onopen = () => {"):]
     onopen = onopen[:onopen.index("      };")]
     assert "_reconnectAttempts" not in onopen
+    exhausted_start = js.index("if (attempts > MAX_ATTEMPTS)")
+    exhausted_end = js.index("// Exponential backoff", exhausted_start)
+    exhausted = js[exhausted_start:exhausted_end]
+    assert "this._scheduleCanonicalStreamReload(streamSid, streamState" in exhausted
+    assert "markUserFailed()" not in exhausted
+    assert "_markDone()" not in exhausted
+    probe_exhausted_start = js.index("if (attempts >= MAX_ATTEMPTS)", exhausted_end)
+    probe_exhausted_end = js.index("} else {", probe_exhausted_start)
+    probe_exhausted = js[probe_exhausted_start:probe_exhausted_end]
+    assert "this._scheduleCanonicalStreamReload(streamSid, streamState" in probe_exhausted
+    assert "markUserFailed()" not in probe_exhausted
+    assert "_markDone()" not in probe_exhausted
 
     # 6. Turn completion refreshes the list quietly instead of via
     #    refreshSessions(), which also drives _recoverStalledStream — i.e. it
@@ -4897,3 +5089,66 @@ def test_slash_controls_run_before_provider_gate_without_consuming_attachments()
     ):
         assert destructive not in slash
     assert slash_start < provider_gate
+
+
+def test_canonical_history_load_never_reports_stream_takeover_as_success():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("    async loadSession(sid, opts = {}) {")
+    end = app.index("\n    // Warm OPEN-but-inactive tabs", start)
+    load = app[start:end]
+
+    assert "if (st.streaming || st.es) return false;" in load
+    assert "if (st.streaming || st.es) return true;" not in load
+    assert "if (this.tabState[sid] !== st || st.streaming || st.es) return true;" not in load
+    assert "st._installedCanonicalCount = Math.max(" in load
+    assert load.index("st.messages.splice(0, st.messages.length, ...all)") < load.index(
+        "st._installedCanonicalCount = Math.max("
+    )
+
+
+def test_nonempty_tabs_detect_and_quiet_merge_a_missing_canonical_suffix():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    reconcile_start = app.index("    _reconcileOpenSession(next) {")
+    reconcile_end = app.index("\n    async _runHistoryRevisionSync", reconcile_start)
+    reconcile = app[reconcile_start:reconcile_end]
+    ensure_start = app.index("    async _ensureSessionLoaded(sid) {")
+    ensure_end = app.index("\n    async loadSession", ensure_start)
+    ensure = app[ensure_start:ensure_end]
+
+    assert "canonicalCount > installedCount" in reconcile
+    assert "canonicalSuffixMissing" in reconcile
+    assert "visibleNewer || canonicalSuffixMissing" in reconcile
+    assert "canonicalCount <= installedCount" in reconcile
+    assert "this._canonicalMetaBehind(st, meta)" in ensure
+    assert "canonicalBehind ? { quiet: true } : {}" in ensure
+
+
+def test_completed_turn_reconciliation_survives_a_new_stream_owner():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    start = app.index("    _canonicalMetaBehind(st, meta) {")
+    end = app.index("\n    _reconcileCompletedContinuation", start)
+    completion = app[start:end]
+    mark_start = app.index("      const _markDone = (")
+    mark_end = app.index("\n      es.addEventListener(\"done\"", mark_start)
+    mark_done = app[mark_start:mark_end]
+
+    assert "ownerState._pendingCompletedTurnSync = options" in completion
+    assert "if (!stillOwned()) return false;" in completion
+    assert "ownerState._pendingCompletedTurnSync = null" in completion
+    assert "_resumePendingCanonicalSync(sid, st)" in completion
+    assert "this.$nextTick(() => this._resumePendingCanonicalSync(" in mark_done
+
+
+def test_tab_activation_checks_canonical_installation_watermark():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    activate_start = app.index("    async activateTab(tid) {")
+    activate_end = app.index("\n    _scrollTabIntoView", activate_start)
+    activate = app[activate_start:activate_end]
+    switch_start = app.index("    async switchSession() {")
+    switch_end = app.index("\n    _afterPaint", switch_start)
+    switch = app[switch_start:switch_end]
+
+    assert "this._canonicalMetaBehind(st, meta)" in activate
+    assert "await this._ensureSessionLoaded(tid)" in activate
+    assert "this._canonicalMetaBehind(st, cur)" in switch
+    assert "loadedButBehindCanonical" in switch

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2967,6 +2967,8 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     assert 'hasOwnProperty.call(m, "forkUuid")' in append
     assert 'hasOwnProperty.call(m, "ts")' in append
     assert 'hasOwnProperty.call(m, "elapsed")' in append
+    assert "return st.messages[st.messages.length - 1]" in append
+    assert "return m;" not in append
 
     mark_start = app.index("const _markDone = (")
     mark_end = app.index("\n      const markUserFailed", mark_start)

--- a/tests/test_main_observability.py
+++ b/tests/test_main_observability.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from tests.conftest import TEST_TOKEN
+
 
 def _scope(*, route: str | None = "/api/items/{item_id}") -> dict:
     scope = {
@@ -174,6 +176,46 @@ async def test_unmatched_error_never_logs_concrete_path(
     assert events[0]["route"] == "<unmatched>"
     assert "private" not in repr(events)
     assert "report.md" not in repr(events)
+
+
+def test_session_rename_client_perf_is_strict_and_title_free(
+    app_module, client, monkeypatch,
+):
+    events = []
+    monkeypatch.setattr(
+        app_module, "perf_event",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    headers = {
+        "X-Auth-Token": TEST_TOKEN,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "surface": "tab",
+        "status": "ok",
+        "asset_version": "1787322486",
+        "optimistic_apply_ms": 1,
+        "optimistic_paint_ms": 17,
+        "request_ms": 2400,
+        "total_ms": 2401,
+        "long_task_count": 2,
+        "longest_task_ms": 95,
+    }
+
+    response = client.post(
+        "/api/log/session-rename", headers=headers, json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert events == [("client.session_rename", payload)]
+
+    invalid = client.post(
+        "/api/log/session-rename", headers=headers,
+        json={**payload, "title": "private title"},
+    )
+    assert invalid.status_code == 422
+    assert invalid.json() == {"ok": False, "error": "invalid_payload"}
+    assert "private title" not in repr(events)
 
 
 def test_event_loop_monitor_emits_only_threshold_crossing(

--- a/tests/test_memory_client.py
+++ b/tests/test_memory_client.py
@@ -172,6 +172,7 @@ def test_recall_hook_times_out_before_sdk_watchdog_and_fails_open(monkeypatch):
 
     _run(scenario())
     assert mc.RECALL_HOOK_TIMEOUT > mc._RECALL_DEADLINE
+    assert mc.RECALL_HOOK_TIMEOUT - mc._SEARCH_TIMEOUT >= 5.0
 
 
 def test_recall_hook_backend_error_fails_open(monkeypatch):

--- a/tests/test_safe_restart_script.py
+++ b/tests/test_safe_restart_script.py
@@ -40,7 +40,9 @@ if [[ ${1:-} == -S && ${3:-} == -X && ${4:-} == quit ]]; then
   file="$state/$2.pid"
   if [[ -f $file ]]; then
     pid=$(<"$file")
-    kill -TERM "$pid" 2>/dev/null || true
+    if [[ ${SCREEN_QUIT_NO_SIGNAL:-0} != 1 ]]; then
+      kill -TERM "$pid" 2>/dev/null || true
+    fi
     rm -f "$file"
   fi
   exit 0
@@ -219,6 +221,51 @@ def test_safe_restart_cold_starts_then_switches_with_new_pid(tmp_path: Path):
         assert final["new_pid"].isdigit()
         assert final["old_pid"] != final["new_pid"]
         assert final["startup_marker"] in startup_log.read_text().splitlines()
+    finally:
+        _stop_screen(screen, state, session)
+
+
+def test_safe_restart_signals_listener_without_waiting_for_screen_timeout(
+        tmp_path: Path):
+    port, preflight_port = _free_port(), _free_port()
+    screen, state = _fake_screen(tmp_path)
+    entry = _good_entry(tmp_path)
+    session = f"muselab-{port}"
+    status = tmp_path / "status"
+    env = _base_env(tmp_path, screen, state)
+    env["SCREEN_QUIT_NO_SIGNAL"] = "1"
+    env["MUSELAB_RESTART_STOP_TIMEOUT"] = "4"
+    _start_baseline(screen, state, session, entry, port)
+    started = time.monotonic()
+    try:
+        subprocess.run(
+            [
+                "bash",
+                str(SCRIPT),
+                "--port",
+                str(port),
+                "--preflight-port",
+                str(preflight_port),
+                "--entry",
+                str(entry),
+                "--session",
+                session,
+                "--status",
+                str(status),
+                "--startup-log",
+                str(tmp_path / "startup.log"),
+                "--watchdog-log",
+                str(tmp_path / "watchdog.log"),
+            ],
+            check=True,
+            env=env,
+        )
+        final = _wait_result(status, "success")
+        elapsed = time.monotonic() - started
+        assert final["phase"] == "done"
+        # The previous implementation spent STOP_TIMEOUT once before sending
+        # SIGTERM to each of the two listeners, so this fixture took >8 seconds.
+        assert elapsed < 7
     finally:
         _stop_screen(screen, state, session)
 

--- a/tests/test_safe_restart_script.py
+++ b/tests/test_safe_restart_script.py
@@ -1,9 +1,17 @@
 import os
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="safe-restart controls Linux screen and /proc process state",
+)
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "safe-restart.sh"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -416,7 +416,8 @@ def test_runtime_task_overlay_owner_and_terminal_state_are_monotonic(app_module)
     )
 
 
-def test_reconcile_runtime_task_overlay_chains_repairs_forward_copies(app_module):
+def test_reconcile_runtime_task_overlay_chains_repairs_forward_copies(
+        app_module, monkeypatch):
     from backend import sessions as sess
 
     source = sess.create_session("runtime-source")["id"]
@@ -449,7 +450,17 @@ def test_reconcile_runtime_task_overlay_chains_repairs_forward_copies(app_module
         description="child launch",
     )
 
+    original_load = sess._load_sidecar
+    mutation_loads = []
+
+    def tracked_load(sid, *, use_cache=True):
+        if not use_cache:
+            mutation_loads.append(sid)
+        return original_load(sid, use_cache=use_cache)
+
+    monkeypatch.setattr(sess, "_load_sidecar", tracked_load)
     assert sess.reconcile_runtime_task_overlay_chains() == 3
+    assert sorted(mutation_loads) == sorted([child, grandchild])
     assert sess.reconcile_runtime_task_overlay_chains() == 0
 
     source_visible = sess.get_authoritative_runtime_task_overlays(source)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -6,7 +6,6 @@ metadata + per-message annotation sidecar layer only. End-to-end transcript
 flows require a live SDK and are not unit-testable here.
 """
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 from pathlib import Path
@@ -742,18 +741,17 @@ def test_sessions_first_page_does_not_wait_for_workspace_jsonl_scan(
 
     monkeypatch.setattr(sess, "sdk_list_sessions", blocked_scan)
     try:
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(
-                client.get, "/api/chat/sessions", headers=auth)
-            # Shared CI runners can pause TestClient scheduling for many seconds.
-            # Keep the scan blocked beyond this deadline so the assertion tests
-            # dependency on the scan rather than runner wall-clock latency.
-            response = future.result(timeout=30)
-        assert response.status_code == 200
-        initial_etag = response.headers["etag"]
-        listed = {row["id"]: row for row in response.json()["sessions"]}
+        # Start the background flight outside TestClient. Starlette waits for
+        # request-owned worker activity on some runners, which makes a wall-clock
+        # assertion measure TestClient shutdown rather than this cache contract.
+        initial, _generation = sess.list_sessions_snapshot()
+        listed = {row["id"]: row for row in initial}
         assert listed[local["id"]]["name"] == "cached metadata"
         assert scan_started.wait(1)
+
+        response = client.get("/api/chat/sessions", headers=auth)
+        assert response.status_code == 200
+        initial_etag = response.headers["etag"]
     finally:
         release_scan.set()
         _wait_for_list_refresh(sess)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -737,7 +737,7 @@ def test_sessions_first_page_does_not_wait_for_workspace_jsonl_scan(
 
     def blocked_scan(**_kwargs):
         scan_started.set()
-        release_scan.wait(2)
+        release_scan.wait(60)
         return [_sdk_session_info(local["id"], title="transcript title")]
 
     monkeypatch.setattr(sess, "sdk_list_sessions", blocked_scan)
@@ -745,7 +745,10 @@ def test_sessions_first_page_does_not_wait_for_workspace_jsonl_scan(
         with ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(
                 client.get, "/api/chat/sessions", headers=auth)
-            response = future.result(timeout=1)
+            # Shared CI runners can pause TestClient scheduling for many seconds.
+            # Keep the scan blocked beyond this deadline so the assertion tests
+            # dependency on the scan rather than runner wall-clock latency.
+            response = future.result(timeout=30)
         assert response.status_code == 200
         initial_etag = response.headers["etag"]
         listed = {row["id"]: row for row in response.json()["sessions"]}


### PR DESCRIPTION
## 变更说明

- 统一会话历史安装水位、流式完成对账和 Tab 切换收敛，修复最新回复需要刷新、非空会话空白及完成状态漂移
- 调整 Activity Center 为人工可处理语义，后台进程不再阻塞主回复完成
- 收口停止、队列、后台 continuation 和 runtime successor 生命周期，增加乐观中断与安全的中断后立即发送
- 优化长会话移动端渲染、纯文本优先展示和安全重启冷启动成本
- 增强中断快照、运行时 overlay、历史窗口和会话恢复的持久化与观测

## 验证

- 受影响回归套件：558 passed
- 前端完整静态回归：155 passed
- JavaScript 语法检查通过
- git diff --check 通过
- 隔离安全重启与冷启动验证通过；未重启当前 8766 服务

## 工作区说明

仅提交 22 个已跟踪源码/测试文件；本地截图、备份脚本、临时 watchdog 和个人记录等未跟踪文件均未纳入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)