### PR TITLE
fix(chat): 同步跨设备活跃会话用户消息

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8352,6 +8352,36 @@ function portal() {
       sync.inheritedTicksLeft = 0;
       return true;
     },
+    _installActiveTurnUser(st, turnId, text = "", images = [], docs = []) {
+      if (!st || !(text || images.length || docs.length)) return null;
+      const messages = st.messages || [];
+      let turnUser = turnId
+        ? messages.find(message => message && message.role === "user"
+          && message._turnId === turnId)
+        : null;
+      let lastUser = null;
+      for (let i = messages.length - 1; i >= 0; i -= 1) {
+        if (messages[i] && messages[i].role === "user") {
+          lastUser = messages[i];
+          break;
+        }
+      }
+      // A canonical history load may already have installed this prompt without
+      // MuseLab's live turn id. Adopt that newest matching row before appending.
+      if (!turnUser && turnId && lastUser && !lastUser._turnId
+          && (lastUser.text || "") === text) {
+        lastUser._turnId = turnId;
+        turnUser = lastUser;
+      }
+      let appended = false;
+      if (!turnUser) {
+        turnUser = this._appendLiveMessage(st, {
+          role: "user", text, images, docs, _turnId: turnId,
+        });
+        appended = true;
+      }
+      return { message: turnUser, appended };
+    },
     // Poll /active + re-subscribe to a server-started turn. Retries a few
     // times because the server's drain runs a beat AFTER it publishes the
     // previous turn's `done` (in the background task's finally), so /active
@@ -8517,28 +8547,10 @@ function portal() {
         // case (loadSession already rebuilt this bubble): adopt an unlabelled
         // matching tail bubble. Identity, not text, is the durable dedupe key:
         // two queued turns are allowed to contain identical prompts.
-        const msgs = st ? st.messages : [];
-        let lastUser = null;
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          if (msgs[i].role === "user") { lastUser = msgs[i]; break; }
-        }
-        let turnUser = turnId
-          ? msgs.find(m => m && m.role === "user" && m._turnId === turnId)
-          : null;
-        if (!turnUser && turnId && lastUser && !lastUser._turnId
-            && (lastUser.text || "") === uText) {
-          lastUser._turnId = turnId;
-          turnUser = lastUser;
-        }
-        if ((uText || uImages.length || uDocs.length) && !turnUser) {
+        const turnUser = this._installActiveTurnUser(
+          st, turnId, uText, uImages, uDocs);
+        if (turnUser && turnUser.appended) {
           this._scheduleLiveMessageViewport(st);
-          turnUser = this._appendLiveMessage(st, {
-            role: "user",
-            text: uText,
-            images: uImages,
-            docs: uDocs,
-            _turnId: turnId,
-          });
           st.atBottom = true;
           this.scrollToBottom(true);
         }
@@ -8782,22 +8794,29 @@ function portal() {
           retry();
           return false;
         }
+        const reconcileTail = this._historyReconcileWindowSize();
         const historyResponse = await fetch(
-          "/api/chat/sessions/" + sid + "?tail=80",
+          "/api/chat/sessions/" + sid + "?tail=" + reconcileTail,
           { headers: this.hdr(), signal: controller.signal },
         );
         if (!stillOwned()) return false;
         if (!historyResponse.ok) { retry(); return false; }
         const history = await historyResponse.json();
         const messages = Array.isArray(history.messages) ? history.messages : [];
-        let turnStart = 0;
+        let latestUserIndex = -1;
         for (let i = messages.length - 1; i >= 0; i -= 1) {
           if (messages[i] && messages[i].role === "user") {
-            turnStart = i + 1;
+            latestUserIndex = i;
             break;
           }
         }
+        const turnStart = latestUserIndex + 1;
         const canonicalTurn = messages.slice(turnStart);
+        // Mobile's normal 20-block window can start inside a tool-heavy turn.
+        // Reconcile at least through this turn's user boundary so canonical
+        // installation never keeps the reply while dropping its prompt.
+        const completedTurnWindow = latestUserIndex >= 0
+          ? messages.length - latestUserIndex : reconcileTail;
         const hasBoundary = canonicalTurn.some(
           m => m && m.role !== "user" && m.uuid,
         );
@@ -8813,6 +8832,7 @@ function portal() {
         if (!stillOwned()) return false;
         const loaded = await this.loadSession(sid, {
           quiet: true, probeActive: false,
+          minimumTail: completedTurnWindow,
         });
         if (!loaded) retry();
         else {
@@ -14342,6 +14362,21 @@ function portal() {
             : Number(st.inheritedBackgroundTaskCount) || 0;
           this._ensureInheritedTaskPoller(sid, predecessorSid);
         }
+        const activeTurnUser = d.active && !d.continuation
+          ? this._installActiveTurnUser(
+              st,
+              String(d.turn_id || ""),
+              String(d.user_text || ""),
+              Array.isArray(d.user_images) ? d.user_images : [],
+              Array.isArray(d.user_docs) ? d.user_docs : [],
+            )
+          : null;
+        if (activeTurnUser && activeTurnUser.appended) {
+          this._scheduleLiveMessageViewport(st);
+          if (this.currentId === sid && st.atBottom !== false) {
+            this.scrollToBottom(true);
+          }
+        }
         if (d.active && d.background && d.attachable === false) {
           st._serverActiveObserved = true;
           if (d.turn_id) st.activeTurnId = d.turn_id;
@@ -14546,9 +14581,11 @@ function portal() {
         // "Load earlier" control. Quiet reconciliation keeps blocks the user
         // already chose to load, but never expands the resident window by itself.
         const historyPage = this._historyWindowSize();
-        const requestedTail = quiet
-          ? Math.max(historyPage, st.messages.length)
-          : historyPage;
+        const minimumTail = Math.max(0, Number(opts.minimumTail) || 0);
+        const requestedTail = Math.max(
+          minimumTail,
+          quiet ? Math.max(historyPage, st.messages.length) : historyPage,
+        );
         const qs = full ? "?full=1" : "?tail=" + requestedTail;
         const controller = new AbortController();
         const timeout = setTimeout(

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2302,6 +2302,30 @@ def test_inherited_task_poller_waits_for_durable_agent_projection():
     assert "sessionMeta.runtime_predecessor" in check
     assert "Math.max(0, Math.floor(inheritedPending))" in check
     assert "this._ensureInheritedTaskPoller(sid, predecessorSid)" in check
+    # A second device attaching to an ordinary active turn must install the
+    # prompt envelope from /active before replaying assistant-only SSE events.
+    assert "this._installActiveTurnUser(" in check
+    assert "String(d.user_text || \"\")" in check
+    assert "Array.isArray(d.user_images) ? d.user_images : []" in check
+    assert "Array.isArray(d.user_docs) ? d.user_docs : []" in check
+    assert "if (activeTurnUser && activeTurnUser.appended)" in check
+    assert check.index("const activeTurnUser =") < check.index(
+        "this.send({ reconnect: true, sessionId: sid")
+
+
+def test_active_turn_user_installation_dedupes_without_repeated_scroll():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    helper_start = app.index("    _installActiveTurnUser(")
+    helper_end = app.index("\n    // Poll /active", helper_start)
+    helper = app[helper_start:helper_end]
+    assert "let appended = false;" in helper
+    assert "appended = true;" in helper
+    assert "return { message: turnUser, appended };" in helper
+
+    queue_start = app.index("    async _runQueueAttach(")
+    queue_end = app.index("\n    // ===== background-task continuation poller", queue_start)
+    queue = app[queue_start:queue_end]
+    assert "if (turnUser && turnUser.appended)" in queue
 
 
 def test_runtime_ui_revision_rejects_out_of_order_session_response():
@@ -3002,7 +3026,10 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     reconcile = app[reconcile_start:reconcile_end]
     assert '"/api/chat/sessions/" + sid + "/active"' in reconcile
     assert "activity.active && !activity.background" in reconcile
-    assert '"/api/chat/sessions/" + sid + "?tail=80"' in reconcile
+    assert "const reconcileTail = this._historyReconcileWindowSize();" in reconcile
+    assert '"/api/chat/sessions/" + sid + "?tail=" + reconcileTail' in reconcile
+    assert "const completedTurnWindow = latestUserIndex >= 0" in reconcile
+    assert "minimumTail: completedTurnWindow" in reconcile
     assert "m && m.role !== \"user\" && m.uuid" in reconcile
     assert "m.role === \"assistant\" && m.uuid" in reconcile
     assert "m && m.uuid === expectedAssistantUuid" in reconcile
@@ -3349,7 +3376,9 @@ def test_history_paging_uses_smaller_mobile_pages_only_on_user_request():
     assert "_historyWindowSize() { return this._isMobileLayout() ? 20 : 100; }" in app
     assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in load
     assert "const historyPage = this._historyWindowSize()" in load
+    assert "const minimumTail = Math.max(0, Number(opts.minimumTail) || 0)" in load
     assert "Math.max(historyPage, st.messages.length)" in load
+    assert "const requestedTail = Math.max(" in load
     assert "this._scheduleTransparentHistory(st, false)" not in load
 
     earlier_start = app.index("    async loadEarlierMessages(sid) {")


### PR DESCRIPTION
## 变更说明
- 设备连接其他终端正在执行的活跃会话时，先安装 `/active` 返回的用户文本、图片和文档，再重放助手 SSE
- 使用 `turn_id` 去重，避免重复用户气泡和重复滚动
- 移动端完成态收敛时按本轮用户边界扩展 canonical tail，避免仅保留回复而丢失提问

## 验证
- JavaScript 语法检查通过
- `tests/test_frontend_lint.py`: 156 passed
- `git diff --check` 通过
- 隔离 Playwright 流程受本机缺少 GTK/ATK 动态库阻塞，未将静态检查表述为真实浏览器完全验证

## 变更范围
- `frontend/app.js`
- `tests/test_frontend_lint.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)