### PR TITLE
fix(terminal): 提高移动端资源加载可靠性

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -20771,8 +20771,12 @@ function portal() {
       if (this._terminalLoadPromise) return this._terminalLoadPromise;
       const assetVersion = String(document.querySelector(
         'meta[name="muselab-asset-version"]')?.content || "");
-      const timeoutMs = 15000;
-      const deadline = Date.now() + 30000;
+      // Mobile Safari on a high-latency proxy can spend most of 15 seconds on
+      // the 489 KB xterm bundle before the tiny fit addon even starts. Give each
+      // request a realistic cellular timeout and keep enough shared budget for
+      // one cache-busting retry.
+      const timeoutMs = 30000;
+      const deadline = Date.now() + 75000;
       const isReady = src => src.endsWith(".css")
         || (src.includes("addon-fit") ? !!window.FitAddon : !!window.Terminal);
       const loadOnce = (src, attempt) => new Promise((resolve, reject) => {
@@ -20860,13 +20864,17 @@ function portal() {
         // loader for retry. Promise.all rejected immediately and left its
         // sibling alive; that stale branch could later remove the fresh DOM
         // node created by the next click.
+        // addon-fit is a standalone UMD bundle: it only needs Terminal when its
+        // exported class is instantiated, not while the script evaluates. Start
+        // all three requests together so a slow xterm download does not postpone
+        // the addon's timeout window on cellular/mobile proxy connections.
         const initial = await Promise.allSettled([
           inject("/static/vendor/xterm/xterm.css"),
           inject("/static/vendor/xterm/xterm.js"),
+          inject("/static/vendor/xterm/addon-fit.js"),
         ]);
         const failed = initial.find(result => result.status === "rejected");
         if (failed) throw failed.reason;
-        await inject("/static/vendor/xterm/addon-fit.js");
         if (!window.Terminal || !window.FitAddon) {
           throw new Error("terminal library globals missing");
         }

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3717,8 +3717,11 @@ def test_terminal_preview_has_local_renderer_and_management_wiring():
     assert "await Promise.allSettled([" in terminal_loader
     assert "node.remove()" in terminal_loader
     assert 'meta[name="muselab-asset-version"]' in terminal_loader
-    assert "const timeoutMs = 15000" in terminal_loader
-    assert "const deadline = Date.now() + 30000" in terminal_loader
+    assert "const timeoutMs = 30000" in terminal_loader
+    assert "const deadline = Date.now() + 75000" in terminal_loader
+    initial_load = terminal_loader[terminal_loader.index("await Promise.allSettled(["):]
+    initial_load = initial_load[:initial_load.index("]);")]
+    assert 'inject("/static/vendor/xterm/addon-fit.js")' in initial_load
     assert "async createTerminal(profileId)" in app
     assert "async renameTerminal(row)" in app
     assert "async closeTerminal(id" in app


### PR DESCRIPTION
## 变更摘要

- 并行加载 xterm CSS、主脚本和 addon-fit，避免高延迟网络下串行等待耗尽 addon 超时窗口
- 将单资源超时从 15 秒提高到 30 秒，总重试预算从 30 秒提高到 75 秒
- 补充前端结构测试，约束 addon-fit 保持在首轮并行加载中

## 验证

- `pytest tests/test_frontend_lint.py -q`：156 passed
- `node --check frontend/app.js`
- `git diff --check origin/main...HEAD`
- 公网终端 API、ticket、WebSocket、PTY 命令输出链路验证通过

## 风险与兼容性

- 不改变终端协议和后端 PTY 生命周期
- 仅延长失败等待上限；正常网络下三项资源并行，终端通常会更快打开

🤖 Generated with [Claude Code](https://claude.com/claude-code)