### PR TITLE
fix(frontend): 优化启动并修复移动端交互

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1462,14 +1462,6 @@ function portal() {
       // double. Cheap to gate at the front; expensive to debug after.
       if (this._initialized) return;
       this._initialized = true;
-      // Prewarm the heavy preview vendor bundles (hljs / katex / mermaid)
-      // during browser idle, AFTER first paint. These are lazy-loaded on
-      // first use, but that cold load + compile (mermaid is ~3.3 MB) runs in
-      // the $nextTick AFTER a markdown preview has already painted — so the
-      // content shows, then the page freezes 2–3 s while the bundle parses.
-      // Warming them up front moves that cost off the click path. Fire-and-
-      // forget; failures fall back to the existing on-demand lazy load.
-      this._prewarmPreviewLibs();
       // 全局快捷键（绑在 document，避免每个 textarea 单独处理）
       document.addEventListener("keydown", e => this.onGlobalKeyDown(e));
       this._registerFocusSurfaceWatchers();
@@ -1814,6 +1806,13 @@ function portal() {
     // `scroll-margin-bottom: 16px` on the textarea (see styles.css) leaves a
     // breathing-room gap so the input isn't flush against the keyboard top.
     onChatInputFocus() {
+      // A group-assignment menu is portalled outside the activity backdrop. On
+      // iOS, focusing the composer can resize the visual viewport before the
+      // delayed outside-click closes that fixed layer, leaving the menu（and a
+      // clipped activity row）visible between the composer and keyboard. Composer
+      // focus is an unambiguous return to chat, so close both surfaces first.
+      if (this.activity.moveMenu.show) this.closeActivityMoveMenu();
+      if (this.activity.show) this.closeActivityCenter();
       document.documentElement.style.setProperty("--kb-inset", "0px");
       document.body.classList.add("kb-open");
       this._reconcileMobileViewport();
@@ -2076,7 +2075,7 @@ function portal() {
       // and let the reconnect banner take over.
       this._splashHardTimeout = setTimeout(() => {
         if (!this.appReady) {
-          this.appReady = true;
+          this._markReady();
           this.connState = "reconnecting";
         }
       }, 8000);
@@ -2094,6 +2093,12 @@ function portal() {
       })).catch(() => false);
       if (!restoredWorkspaceRegistry) await workspaceRegistryReady;
       const rootOwner = this.fileWorkspacePath();
+      // Context cards are the only network dependency that gates splash
+      // readiness. Dispatch them before the file tree, live transports, session
+      // list and decorative snapshots so a high-latency proxy cannot leave the
+      // critical request queued behind non-visible startup work.
+      const contextReady = Promise.resolve(this.fetchContextInfo());
+      void contextReady.catch(() => false);
       // Attach the rejection handler immediately: the rest of boot awaits
       // context/session work before it observes this promise, and a fast tree
       // failure must never surface as an unhandled rejection in that gap.
@@ -2112,7 +2117,7 @@ function portal() {
       // Chat/session/activity transports do not depend on the file index or
       // context cards. Start them before either slow request; the file stream
       // remains gated on rootReady below so its cursor is always trustworthy.
-      this._startLiveConnections({ fileEvents: false });
+      this._startLiveConnections({ fileEvents: false, activitySnapshot: false });
       this.fetchTerminals({ restore: true });
       // Push-notification deep-link: a turn-done notification opens
       // `/?session=<id>` in a fresh tab. After sessions load, jump to that
@@ -2120,16 +2125,6 @@ function portal() {
       // (the already-open-tab case is handled via the SW postMessage above).
       this._openStartupActivityDeeplink();
       this.initSessions().then(() => this._openStartupSessionDeeplink());
-      this.fetchStats();
-      // Trash badge state — light fetch (just count), gated by token
-      // which is already verified at this point. Fire-and-forget;
-      // failures degrade silently to "no badge styling".
-      this.loadTrash();
-      // Surface any in-flight turns that were cut short by a previous
-      // process death (OOM kill / power loss / manual restart mid-stream).
-      // Fire-and-forget — purely informational, doesn't block boot. Backend
-      // returns [] when nothing was interrupted (the common case).
-      this._checkInterruptedTurns();
       // First-run hint — surface key shortcuts so the user doesn't have to
       // hunt for them. Flagged in localStorage so it only fires once. Short
       // delay lets the splash clear first.
@@ -2161,10 +2156,11 @@ function portal() {
       // settles before we override it back to the user's actual last tab.
       // Desktop ignores mobileTab entirely so this is a no-op there.
       this._restorePendingMobileTab();
-      // Block readiness on context-info (the most important one for the
-      // onboarding cards). Others come along in parallel.
+      // Block readiness on the context request dispatched at the start of boot.
+      // Sessions and the file tree continue independently and reveal their own
+      // loading states instead of holding the whole shell behind a waterfall.
       try {
-        await this.fetchContextInfo();
+        await contextReady;
         this._markReady();
       } catch (e) {
         // Will retry via heartbeat
@@ -2185,16 +2181,19 @@ function portal() {
     // of only after a manual refresh. Both underlying starts are idempotent
     // (clearInterval before re-arming), but this is only ever called once per
     // boot path, so there's no double-start.
-    _startLiveConnections({ fileEvents = true } = {}) {
+    _startLiveConnections({ fileEvents = true, activitySnapshot = true } = {}) {
       this._startHeartbeat();
       this._startPresence();
       this._startSessionsSync();
       if (fileEvents) this._startFileEvents();
-      // Source-aware ACK needs the persisted ledger row on a cold boot.  Run
-      // it after the first snapshot instead of racing an empty events array.
-      Promise.resolve(this.fetchActivity()).finally(
-        () => this.ackCurrentActivity(),
-      );
+      // Source-aware ACK needs the persisted ledger row on a cold boot. Saved-
+      // token boot defers this decorative snapshot until after appReady; first
+      // sign-in keeps the original eager behavior through the default option.
+      if (activitySnapshot) {
+        Promise.resolve(this.fetchActivity()).catch(() => false).finally(
+          () => this.ackCurrentActivity(),
+        );
+      }
       this._startActivityEvents();
       this._startTodoEvents();
       this._startMemoryMonitor();
@@ -2234,12 +2233,46 @@ function portal() {
       }, 10_000);
     },
 
+    _scheduleDeferredBootWork() {
+      if (this._deferredBootWorkScheduled) return;
+      this._deferredBootWorkScheduled = true;
+      const run = () => {
+        // These snapshots decorate an already-usable shell. Keeping them off the
+        // critical path prevents six unrelated endpoints and preview bundles
+        // from competing with context/session startup on tunneled connections.
+        void Promise.resolve(this.fetchActivity()).catch(() => false).finally(
+          () => this.ackCurrentActivity(),
+        );
+        void Promise.resolve(this.fetchStats()).catch(() => false);
+        void Promise.resolve(this.loadTrash()).catch(() => false);
+        void Promise.resolve(this._checkInterruptedTurns()).catch(() => false);
+        this._prewarmPreviewLibs();
+      };
+      const schedule = () => {
+        try {
+          if (typeof window !== "undefined" && window.requestIdleCallback) {
+            window.requestIdleCallback(run, { timeout: 1500 });
+          } else {
+            setTimeout(run, 300);
+          }
+        } catch (_) { setTimeout(run, 300); }
+      };
+      // Give Alpine one frame to remove the splash and paint the usable shell
+      // before any best-effort network or parsing work begins.
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(() => requestAnimationFrame(schedule));
+      } else {
+        setTimeout(schedule, 0);
+      }
+    },
+
     _markReady() {
       if (this.appReady) return;
       this.appReady = true;
       clearTimeout(this._splashHintTimer);
       clearTimeout(this._splashHardTimeout);
       this.splashHint = "";
+      this._scheduleDeferredBootWork();
     },
 
     // Friendly "5 min ago" / "刚刚" / "3 h ago" formatter for the
@@ -5059,6 +5092,14 @@ function portal() {
       // Global requests are workspace-agnostic. File and conversation requests
       // add their registered workspace through fileHdr()/conversationHdr().
       return { "X-Auth-Token": this.token };
+    },
+    _staticAssetUrl(path) {
+      if (!path || !path.startsWith("/static/") || /[?&]v=/.test(path)) return path;
+      const version = typeof document !== "undefined"
+        ? document.querySelector('meta[name="muselab-asset-version"]')?.content
+        : "";
+      if (!version || version === "__MUSELAB_ASSET_VERSION__") return path;
+      return `${path}${path.includes("?") ? "&" : "?"}v=${encodeURIComponent(version)}`;
     },
     conversationHdr(path = "") {
       const headers = this.hdr();
@@ -17452,7 +17493,7 @@ function portal() {
     _fileCapabilities() {
       if (!this._fileCapabilitiesPromise) {
         this._fileCapabilitiesPromise = import(
-          "/static/modules/file-capabilities.mjs"
+          this._staticAssetUrl("/static/modules/file-capabilities.mjs")
         ).catch(error => {
           this._fileCapabilitiesPromise = null;
           throw error;
@@ -17463,7 +17504,7 @@ function portal() {
     _persistentCache() {
       if (!this._persistentCachePromise) {
         this._persistentCachePromise = import(
-          "/static/modules/persistent-cache.mjs"
+          this._staticAssetUrl("/static/modules/persistent-cache.mjs")
         ).catch(error => {
           this._persistentCachePromise = null;
           throw error;
@@ -23306,6 +23347,27 @@ function portal() {
         ? (message.displayText || "") : (message.text || "");
     },
 
+    activatePreviewSelectionAction(ev, action) {
+      // iOS Safari can suppress the synthetic click when pointerdown is
+      // preventDefault()'d to preserve a native text selection. Execute real
+      // pointer activation on pointerdown instead, and reserve click for
+      // keyboard／assistive-technology activation（detail === 0）. Ignoring the
+      // later pointer-generated click also prevents a detached button from
+      // running the action twice after the popover has already closed.
+      const pointerDown = ev && ev.type === "pointerdown"
+        && (ev.button == null || ev.button === 0);
+      const keyboardClick = ev && ev.type === "click" && ev.detail === 0;
+      if (!pointerDown && !keyboardClick) return false;
+      if (ev.preventDefault) ev.preventDefault();
+      if (ev.stopPropagation) ev.stopPropagation();
+      if (action === "quote") return this.quotePreviewSelection();
+      if (action === "ask") {
+        this.openPreviewSelectionAsk();
+        return true;
+      }
+      return false;
+    },
+
     quotePreviewSelection() {
       if (!this.currentId || !this.previewQuote.show || !this.previewQuote.text) {
         this.toast(this.lang === "zh" ? "请先打开一个会话" : "Open a chat first", "warn", 2200);
@@ -23789,10 +23851,12 @@ function portal() {
       if (ready()) return Promise.resolve();
       if (this[key]) return this[key];
       const clearOnFail = (err) => { this[key] = null; return Promise.reject(err); };
-      const loadOne = (src) => new Promise((resolve, reject) => {
+      const loadOne = (path) => new Promise((resolve, reject) => {
+        const isCss = path.split(/[?#]/, 1)[0].endsWith(".css");
+        const src = this._staticAssetUrl(path);
         // Already in the DOM (e.g. from a previous lazy-load attempt)? Wait
         // for ready(); don't re-inject the tag.
-        const sel = src.endsWith(".css")
+        const sel = isCss
           ? `link[href="${src}"]`
           : `script[src="${src}"]`;
         if (document.querySelector(sel)) {
@@ -23805,7 +23869,7 @@ function portal() {
           })();
           return;
         }
-        if (src.endsWith(".css")) {
+        if (isCss) {
           const l = document.createElement("link");
           l.rel = "stylesheet"; l.href = src;
           l.onload = resolve; l.onerror = () => reject(new Error("load failed: " + src));
@@ -23845,7 +23909,15 @@ function portal() {
     // never competes with the initial app render. Each step is fire-and-forget
     // and swallows errors — the on-demand lazy loaders remain the fallback.
     _prewarmPreviewLibs() {
-      if (this._previewLibsPrewarmed) return;
+      if (this._previewLibsPrewarmed || !this.appReady) return;
+      // Hidden tabs, data-saver and genuinely slow cellular links should keep
+      // bandwidth and parse budget for user-requested work. On-demand loaders
+      // remain available when the user actually opens rich preview content.
+      if (typeof document !== "undefined" && document.hidden) return;
+      const connection = typeof navigator !== "undefined"
+        ? navigator.connection : null;
+      if (connection && (connection.saveData
+          || ["slow-2g", "2g"].includes(connection.effectiveType))) return;
       this._previewLibsPrewarmed = true;
       // Each job below injects + parses a heavy vendor bundle on the main
       // thread. Firing them all inside ONE idle slice re-creates the freeze
@@ -23902,7 +23974,8 @@ function portal() {
     async _loadHljs() {
       if (window.hljs) return;
       if (this._hljsLoadPromise) return this._hljsLoadPromise;
-      const inject = (src) => new Promise((resolve, reject) => {
+      const inject = (path) => new Promise((resolve, reject) => {
+        const src = this._staticAssetUrl(path);
         if (document.querySelector(`script[src="${src}"]`)) {
           // Already in DOM — just wait for window.hljs to materialize.
           const t0 = Date.now();
@@ -23954,20 +24027,22 @@ function portal() {
       if (window.CodeMirror) return;
       if (this._cmLoadPromise) return this._cmLoadPromise;
       // Inject one asset (css/js), de-duping against an already-present tag.
-      const inject = (src) => new Promise((resolve, reject) => {
-        const sel = src.endsWith(".css")
+      const inject = (path) => new Promise((resolve, reject) => {
+        const isCss = path.split(/[?#]/, 1)[0].endsWith(".css");
+        const src = this._staticAssetUrl(path);
+        const sel = isCss
           ? `link[href="${src}"]` : `script[src="${src}"]`;
         if (document.querySelector(sel)) {
           // Already in flight/loaded from a prior attempt — give it a beat.
           const t0 = Date.now();
           (function wait() {
-            if (src.endsWith(".css") || window.CodeMirror) return resolve();
+            if (isCss || window.CodeMirror) return resolve();
             if (Date.now() - t0 > 5000) return resolve(); // don't hang the chain
             setTimeout(wait, 50);
           })();
           return;
         }
-        const node = src.endsWith(".css")
+        const node = isCss
           ? Object.assign(document.createElement("link"), { rel: "stylesheet", href: src })
           : Object.assign(document.createElement("script"), { src });
         node.onload = resolve;
@@ -24026,7 +24101,7 @@ function portal() {
       };
       this._mermaidLoadPromise = new Promise((resolve, reject) => {
         const s = document.createElement("script");
-        s.src = "/static/vendor/mermaid.min.js";
+        s.src = this._staticAssetUrl("/static/vendor/mermaid.min.js");
         s.onload = () => {
           try {
             // securityLevel: "strict" disables foreign HTML in labels,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,6 +37,10 @@
 <meta name="theme-color" content="#f5f0e0" />
 
 <link rel="stylesheet" href="/static/styles.css" />
+<!-- File-tree hydration imports this tiny module on every authenticated cold
+     boot. Fetch it alongside the main bundle so the high-latency proxy does not
+     add another round trip after app.js starts executing. -->
+<link rel="modulepreload" href="/static/modules/persistent-cache.mjs" />
 <!-- highlight.js theme CSS preloaded (4 KB) so highlighted code blocks
      don't FOUC when hljs lazy-loads. The 124 KB hljs script itself is
      lazy-loaded via `_loadHljs()` in app.js on first highlightCode()
@@ -3632,7 +3636,9 @@
     <template x-if="previewQuote.mode === 'actions'">
       <div class="preview-selection-actions" role="toolbar"
            :aria-label="lang === 'zh' ? '选中内容操作' : 'Selection actions'">
-        <button type="button" @pointerdown.prevent @click="quotePreviewSelection()"
+        <button type="button"
+                @pointerdown="activatePreviewSelectionAction($event, 'quote')"
+                @click="activatePreviewSelectionAction($event, 'quote')"
                 :title="lang === 'zh' ? '作为文本附件引用' : 'Attach as quoted text'">
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M7 17h4V9H5v6a2 2 0 0 0 2 2Zm10 0h2V9h-6v6a2 2 0 0 0 2 2h2Z"/>
@@ -3640,7 +3646,9 @@
           <span x-text="lang === 'zh' ? '引用' : 'Quote'"></span>
         </button>
         <span class="preview-selection-divider" aria-hidden="true"></span>
-        <button type="button" @pointerdown.prevent @click="openPreviewSelectionAsk()"
+        <button type="button"
+                @pointerdown="activatePreviewSelectionAction($event, 'ask')"
+                @click="activatePreviewSelectionAction($event, 'ask')"
                 :title="lang === 'zh' ? '展开独立侧问' : 'Open an independent side question'">
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 3a7 7 0 0 0-4.7 12.2L6 20l4.2-1.4A7 7 0 1 0 12 3Zm0 3.1a2.7 2.7 0 0 1 1.2 5.1c-.8.4-1.2.8-1.2 1.6v.3h-1.8v-.5c0-1.3.6-2.1 1.8-2.7.6-.3.9-.8.9-1.3 0-.7-.5-1.2-1.3-1.2-.7 0-1.3.4-1.8 1.1L8.5 7.4A4 4 0 0 1 12 6.1Zm-1.9 8.4H12V16h-1.9v-1.5Z"/>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2508,6 +2508,7 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   font: inherit;
   font-weight: var(--fw-medium);
   cursor: pointer;
+  touch-action: manipulation;
   transition: color var(--t-fast), background var(--t-fast);
 }
 .preview-selection-actions button:hover,

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -1303,7 +1303,12 @@ def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
         }"""
     )
     expect(page.locator(".preview-selection-actions")).to_be_visible()
-    page.locator(".preview-selection-actions button").first.click()
+    # iOS preserves the native selection by cancelling pointerdown, which can
+    # suppress the follow-up synthetic click. Exercise the real touch path.
+    page.locator(".preview-selection-actions button").first.dispatch_event(
+        "pointerdown",
+        {"pointerType": "touch", "button": 0, "bubbles": True, "cancelable": True},
+    )
     quoted = _app_eval(
         page,
         """
@@ -1367,7 +1372,10 @@ def test_chat_bubble_selection_quotes_as_attachment_and_asks_in_side_session(
             && app.previewQuote.role === 'user';
         }"""
     )
-    page.locator(".preview-selection-actions button").nth(1).click()
+    page.locator(".preview-selection-actions button").nth(1).dispatch_event(
+        "pointerdown",
+        {"pointerType": "touch", "button": 0, "bubbles": True, "cancelable": True},
+    )
     ask = page.locator(".preview-selection-ask textarea")
     expect(ask).to_be_focused()
     ask.fill("这里的结论为什么成立？")
@@ -5452,6 +5460,44 @@ def test_mobile_pwa_tabs_preview_rotation_keep_chat_usable(page: Page, backend_u
     assert page.locator(".msg-pane").count() <= 1
     assert _app_eval(page, "return app.messagesReady === true && !app.messagesLoading;") is True
 
+    _assert_no_browser_errors(page, errors)
+
+
+def test_mobile_composer_focus_closes_activity_group_menu(
+    page: Page, backend_url, auth_token,
+):
+    """Keyboard focus must not leave a portalled task-group menu below chat."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 390, "height": 844})
+    _login(page, backend_url, auth_token)
+    _app_eval(
+        page,
+        """
+        app.mobileTab = 'chat';
+        app.activity.show = true;
+        app.activity.moveMenu = {
+          show: true, eventId: 'stale-menu',
+          style: 'position:fixed;left:8px;top:500px;width:220px;',
+        };
+        return true;
+        """,
+    )
+
+    input_box = page.locator(".chat-input-textarea")
+    input_box.evaluate("el => { el.disabled = false; el.focus(); }")
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const menu = document.querySelector('.activity-move-menu');
+          const backdrop = document.querySelector(
+            '.modal-backdrop .activity-modal')?.parentElement;
+          return !app.activity.show && !app.activity.moveMenu.show
+            && getComputedStyle(menu).display === 'none'
+            && getComputedStyle(backdrop).display === 'none';
+        }""",
+        timeout=2000,
+    )
+    expect(input_box).to_be_focused()
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -293,8 +293,10 @@ def test_preview_selection_quote_attachment_and_side_question_are_safely_wired()
     ]
 
     assert 'class="preview-selection-popover"' in html
-    assert '@click="quotePreviewSelection()"' in html
-    assert '@click="openPreviewSelectionAsk()"' in html
+    assert "@pointerdown=\"activatePreviewSelectionAction($event, 'quote')\"" in html
+    assert "@click=\"activatePreviewSelectionAction($event, 'quote')\"" in html
+    assert "@pointerdown=\"activatePreviewSelectionAction($event, 'ask')\"" in html
+    assert "@click=\"activatePreviewSelectionAction($event, 'ask')\"" in html
     assert '@submit.prevent="sendPreviewSelectionQuestion()"' in html
     assert 'x-ref="previewQuoteInput"' in html
     assert ':href="previewQuoteSourceIcon()"' in html
@@ -4202,9 +4204,15 @@ def test_workspace_cache_uses_delta_without_blocking_or_copying_hidden_bursts():
     boot_end = app.index("\n    // Start the always-on", boot_start)
     boot = app[boot_start:boot_end]
     assert "Promise.resolve(this.loadRoot()).catch(() => false)" in boot
-    assert "this._startLiveConnections({ fileEvents: false })" in boot
-    assert boot.index("this._startLiveConnections({ fileEvents: false })") < boot.index(
-        "await this.fetchContextInfo()")
+    assert (
+        "this._startLiveConnections({ fileEvents: false, activitySnapshot: false })"
+        in boot
+    )
+    assert boot.index("const contextReady = Promise.resolve(this.fetchContextInfo())") < (
+        boot.index("this._startLiveConnections({ fileEvents: false")
+    )
+    assert boot.index("this._startLiveConnections({ fileEvents: false") < boot.index(
+        "await contextReady")
     assert "await rootReady" not in boot
 
     load_start = app.index("loadRoot({\n      runtimeSnapshot = false")

--- a/tests/test_mobile_selection_quote.py
+++ b/tests/test_mobile_selection_quote.py
@@ -1,0 +1,50 @@
+"""Source contracts for native mobile text-selection actions."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / "frontend" / "app.js").read_text(encoding="utf-8")
+INDEX = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+STYLES = (ROOT / "frontend" / "styles.css").read_text(encoding="utf-8")
+
+
+def test_selection_actions_run_on_pointerdown_and_keyboard_click_only():
+    start = APP.index("    activatePreviewSelectionAction(ev, action) {")
+    end = APP.index("\n    quotePreviewSelection()", start)
+    handler = APP[start:end]
+
+    assert 'ev.type === "pointerdown"' in handler
+    assert 'ev.type === "click" && ev.detail === 0' in handler
+    assert "if (!pointerDown && !keyboardClick) return false" in handler
+    assert 'if (action === "quote") return this.quotePreviewSelection()' in handler
+    assert 'if (action === "ask")' in handler
+
+    assert "@pointerdown=\"activatePreviewSelectionAction($event, 'quote')\"" in INDEX
+    assert "@click=\"activatePreviewSelectionAction($event, 'quote')\"" in INDEX
+    assert "@pointerdown=\"activatePreviewSelectionAction($event, 'ask')\"" in INDEX
+    assert "@click=\"activatePreviewSelectionAction($event, 'ask')\"" in INDEX
+    assert "@pointerdown.prevent @click=\"quotePreviewSelection()\"" not in INDEX
+    assert "@pointerdown.prevent @click=\"openPreviewSelectionAsk()\"" not in INDEX
+
+
+def test_composer_focus_closes_portalled_activity_menu_before_keyboard_resize():
+    start = APP.index("    onChatInputFocus() {")
+    end = APP.index("\n    // Paired teardown", start)
+    focus = APP[start:end]
+
+    assert "if (this.activity.moveMenu.show) this.closeActivityMoveMenu();" in focus
+    assert "if (this.activity.show) this.closeActivityCenter();" in focus
+    assert focus.index("this.closeActivityMoveMenu()") < focus.index(
+        'document.body.classList.add("kb-open")'
+    )
+    assert focus.index("this.closeActivityCenter()") < focus.index(
+        'document.body.classList.add("kb-open")'
+    )
+
+
+def test_selection_action_buttons_disable_touch_double_tap_delay():
+    start = STYLES.index(".preview-selection-actions button {")
+    end = STYLES.index("\n}", start)
+    rule = STYLES[start:end]
+    assert "touch-action: manipulation;" in rule

--- a/tests/test_startup_performance.py
+++ b/tests/test_startup_performance.py
@@ -1,0 +1,74 @@
+"""Source contracts for keeping cold-start work off the critical path."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / "frontend" / "app.js").read_text(encoding="utf-8")
+INDEX = (ROOT / "frontend" / "index.html").read_text(encoding="utf-8")
+
+
+def _method(name: str, next_name: str) -> str:
+    start = APP.index(f"    {name}(")
+    end = APP.index(f"\n    {next_name}(", start)
+    return APP[start:end]
+
+
+def test_boot_dispatches_context_before_noncritical_startup_work():
+    boot = _method("async _bootApp", "_startLiveConnections")
+
+    context = "const contextReady = Promise.resolve(this.fetchContextInfo());"
+    assert context in boot
+    assert boot.index(context) < boot.index("this.loadRoot()")
+    assert boot.index(context) < boot.index("this._startLiveConnections(")
+    assert "this.fetchStats();" not in boot
+    assert "this.loadTrash();" not in boot
+    assert "this._checkInterruptedTurns();" not in boot
+    assert "await contextReady;" in boot
+
+
+def test_ready_defers_decorative_snapshots_and_preview_prewarm():
+    deferred = _method("_scheduleDeferredBootWork", "_markReady")
+    ready = _method("_markReady", "_agoLabel")
+
+    for call in (
+        "this.fetchActivity()",
+        "this.fetchStats()",
+        "this.loadTrash()",
+        "this._checkInterruptedTurns()",
+        "this._prewarmPreviewLibs()",
+    ):
+        assert call in deferred
+    assert 'window.requestIdleCallback(run, { timeout: 1500 })' in deferred
+    assert "requestAnimationFrame(() => requestAnimationFrame(schedule))" in deferred
+    assert "this._scheduleDeferredBootWork();" in ready
+
+
+def test_preview_prewarm_respects_readiness_and_slow_networks():
+    prewarm = _method("_prewarmPreviewLibs", "async _loadHljs")
+
+    assert "!this.appReady" in prewarm
+    assert "document.hidden" in prewarm
+    assert "connection.saveData" in prewarm
+    assert '["slow-2g", "2g"].includes(connection.effectiveType)' in prewarm
+    assert prewarm.index("!this.appReady") < prewarm.index(
+        "this._previewLibsPrewarmed = true"
+    )
+
+
+def test_dynamic_modules_and_lazy_assets_share_versioned_urls():
+    assert (
+        '<link rel="modulepreload" '
+        'href="/static/modules/persistent-cache.mjs" />'
+    ) in INDEX
+    assert "_staticAssetUrl(path)" in APP
+    assert (
+        'this._staticAssetUrl("/static/modules/persistent-cache.mjs")'
+        in APP
+    )
+    assert (
+        'this._staticAssetUrl("/static/modules/file-capabilities.mjs")'
+        in APP
+    )
+    assert "const src = this._staticAssetUrl(path);" in APP
+    assert 'this._staticAssetUrl("/static/vendor/mermaid.min.js")' in APP


### PR DESCRIPTION
## 变更摘要

- 提前发起首屏关键的 context 请求，并将统计、回收站、活动快照和中断检查延后到界面 ready 后的空闲阶段。
- 为启动期动态模块和懒加载静态资源统一追加资源版本，预加载持久缓存模块，并避免在隐藏页面、节省流量或 2G 网络下预热大型预览库。
- 修复 iOS Safari 原生文字选区下“引用／询问”按钮可能不触发的问题：真实触摸在 `pointerdown` 执行，键盘和辅助技术保留 `detail === 0` 的 click 路径。
- 聚焦移动端聊天输入框时关闭 portalled 任务分组菜单和活动中心，避免软键盘打开后浮层残留。
- 增加源码契约测试和移动端 Playwright 回归用例。

## 验证

- `node --check frontend/app.js`
- `uv run ruff check tests/test_mobile_selection_quote.py tests/test_startup_performance.py tests/e2e/test_chat_render_perf.py tests/test_frontend_lint.py`
- `uv run pytest tests/test_mobile_selection_quote.py tests/test_startup_performance.py tests/test_preview_prewarm.py tests/test_frontend_lint.py -q`：`164 passed`
- `git diff --check`
- 本地生产服务健康检查返回 HTTP 200，首页已输出版本化的 `persistent-cache.mjs` modulepreload，线上静态 `app.js` 已包含移动选区处理器。

## 风险与兼容性

- 本机缺少 Playwright 浏览器可执行文件，因此新增 E2E 用例交由 PR CI 执行。
- 完整测试套件存在一个与本 PR 无关的既有失败：`tests/test_file_events.py::test_bounded_scan_resumes_until_snapshot_is_complete`。该失败已在未修改的 `ba69fce` 基线上复现。
- 远端默认分支实际为 `main`，因此本 PR 目标为 `main`，不是不存在的 `master`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)