### PR TITLE
Fix closed chat tabs reappearing after refresh

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1566,6 +1566,13 @@ function portal() {
           this.userTodos = this._normalizeUserTodos(
             localStorage.getItem(key) || "[]",
           );
+          return;
+        }
+        if (ev.key === this._chatTabStoreKey) {
+          // Tab-strip state is shared only by same-origin browser pages. Consume
+          // the newest record without writing it back; each page keeps its own
+          // currentId so another window cannot steal focus.
+          void this._applyChatTabStorageEvent();
         }
       });
       // `pagehide` is bfcache-friendly (unlike an unconditional
@@ -6189,16 +6196,78 @@ function portal() {
       });
     },
 
+    _chatTabStoreKey: "muselab_chat_tabs_v1",
+    _chatTabStoreRevision: 0,
+    _readChatTabStore() {
+      const stored = this._getLSJson(this._chatTabStoreKey, null);
+      if (!stored || stored.schema !== 1 || !Array.isArray(stored.openTabIds)) {
+        return null;
+      }
+      return {
+        schema: 1,
+        revision: Math.max(0, Math.floor(Number(stored.revision) || 0)),
+        openTabIds: this._normalizeOpenTabIds(stored.openTabIds),
+      };
+    },
+    _writeChatTabStore(ids = this.openTabIds) {
+      const stored = this._readChatTabStore();
+      const revision = Math.max(
+        this._chatTabStoreRevision,
+        stored ? stored.revision : 0,
+      ) + 1;
+      const openTabIds = this._normalizeOpenTabIds(ids);
+      const ok = this._setLS(this._chatTabStoreKey, JSON.stringify({
+        schema: 1,
+        revision,
+        openTabIds,
+      }));
+      if (ok) this._chatTabStoreRevision = revision;
+      return ok;
+    },
+    _loadChatTabStore(legacyOpenTabIds = []) {
+      const stored = this._readChatTabStore();
+      if (stored) {
+        this._chatTabStoreRevision = stored.revision;
+        this.openTabIds = stored.openTabIds;
+        return;
+      }
+      this.openTabIds = this._normalizeOpenTabIds(legacyOpenTabIds);
+      // Establish the new key even for an empty strip. Once it exists, stale
+      // pages still writing the legacy muselab_prefs field cannot revive tabs.
+      this._writeChatTabStore(this.openTabIds);
+    },
+    async _applyChatTabStorageEvent() {
+      const stored = this._readChatTabStore();
+      if (!stored || stored.revision <= this._chatTabStoreRevision) return;
+      const previousIds = this._normalizeOpenTabIds(this.openTabIds);
+      const previousCurrent = this.currentId;
+      this._chatTabStoreRevision = stored.revision;
+      this.openTabIds = stored.openTabIds;
+      if (!previousCurrent || this.openTabIds.includes(previousCurrent)) return;
+      const previousIndex = previousIds.indexOf(previousCurrent);
+      const currentWorkspace = this.currentWorkspacePath();
+      const sameWorkspace = this.openTabIds.filter(id => {
+        const session = this.sessions.find(row => row.id === id);
+        return !currentWorkspace || (session && session.cwd === currentWorkspace);
+      });
+      const candidates = sameWorkspace.length ? sameWorkspace : this.openTabIds;
+      if (!candidates.length) return;
+      const fallbackIndex = Math.min(
+        Math.max(0, previousIndex), candidates.length - 1,
+      );
+      this.currentId = candidates[fallbackIndex];
+      try { await this.switchSession(); } catch (_) {}
+    },
+
     savePrefs() {
       // Preview-pane state (tabs, selected) persists too so a refresh restores
-      // the exact files the user was looking at — matches the chat-tab strip's
-      // behavior via openTabIds.
+      // the exact files the user was looking at. Chat-tab strip state lives in
+      // muselab_chat_tabs_v1 so unrelated preference saves cannot revive a tab.
       this._setLS("muselab_prefs", JSON.stringify({
-        schema: 9,          // v9 gives the desktop file manager useful room
+        schema: 10,         // v10 moves openTabIds to a versioned standalone key
         model: this.model, defaultModel: this.defaultModel,
         permission: this.permission, defaultPermission: this.defaultPermission,
         currentId: this.currentId,
-        openTabIds: this._normalizeOpenTabIds(this.openTabIds),
         previewTabs: this.tabs.map(t => this._previewTabSnapshot(t)),
         previewSelected: this.selected,
         previewSurface: this.previewSurface,
@@ -6223,10 +6292,10 @@ function portal() {
         // survives a refresh.
         desktopFullPane: this.desktopFullPane,
       }));
-      // Tab strip / preview tab strip / current tab are now device-local
-      // only (persisted in localStorage above). The cross-device ui-state
-      // sync was removed — it yanked the active tab out from under the user
-      // when another device pushed a different state.
+      // Preview tabs and current focus remain browser-local. The chat tab strip
+      // uses its own same-origin localStorage key; no state is sent to the backend.
+      // Cross-device ui-state stays removed because it yanked the active tab out
+      // from under the user when another device pushed a different state.
     },
 
     _scheduleSavePrefs() {
@@ -6285,9 +6354,9 @@ function portal() {
         else if (typeof p.rightWidth === "number") this.previewWidth = p.rightWidth;
         if (typeof p.showHidden === "boolean") this.showHidden = p.showHidden;
         if (p.currentId) this.currentId = p.currentId;
-        if (Array.isArray(p.openTabIds)) {
-          this.openTabIds = this._normalizeOpenTabIds(p.openTabIds);
-        }
+        // The standalone key is authoritative. p.openTabIds is accepted only as
+        // a one-time migration source for users upgrading from schema <= 9.
+        this._loadChatTabStore(p.openTabIds);
         // Preview tabs — restore the strip; the actual content fetch happens
         // lazily when the user clicks back to one (or via restorePreviewSelected
         // which runs once after login).
@@ -6738,7 +6807,10 @@ function portal() {
         newSt._loaded = true;
         newSt.effort = this._normalizeEffort(meta.effort);
         newSt.serviceTier = this._normalizeServiceTier(meta.service_tier);
-        if (!this.openTabIds.includes(meta.id)) this.openTabIds.push(meta.id);
+        if (!this.openTabIds.includes(meta.id)) {
+          this.openTabIds.push(meta.id);
+          this._writeChatTabStore(this.openTabIds);
+        }
         if (this._conversationWorkspaceIsCurrent(ownerWorkspace) && this.currentId === sid) {
           this._captureComposerState(sid);
           this.currentId = meta.id;
@@ -8665,6 +8737,7 @@ function portal() {
           id => id !== sourceSid && id !== childSid);
         if (tabIndex >= 0) this.openTabIds.splice(
           Math.min(tabIndex, this.openTabIds.length), 0, childSid);
+        this._writeChatTabStore(this.openTabIds);
         this._disposeSessionSync(sourceState);
         if (sourceState._streamTimer) clearInterval(sourceState._streamTimer);
         sourceState._streamTimer = null;
@@ -9969,14 +10042,26 @@ function portal() {
         const target = inWorkspace.find(s => s.id === remembered) || inWorkspace[0];
         this.currentId = target.id;
       }
-      // Reconcile openTabIds (restored from prefs) with what still exists on
-      // the server: drop tabs whose session was deleted, then ensure currentId
-      // is in the list. Other tabs are lazy-loaded on first switch.
+      // Reconcile openTabIds (restored from the standalone tab store) with what
+      // still exists on the server: drop deleted sessions, then choose a valid
+      // landing tab without reviving a currentId closed by another page. Other
+      // tabs are lazy-loaded on first switch.
       const validIds = new Set(this.sessions.map(s => s.id));
       this.openTabIds = this._normalizeOpenTabIds(this.openTabIds, validIds);
       if (!this.openTabIds.includes(this.currentId)) {
-        this.openTabIds.push(this.currentId);
+        // A shared tab-strip update may have closed the id saved as this page's
+        // old currentId. Prefer an existing tab instead of reviving that id.
+        const workspaceTab = this.openTabIds.find(id => {
+          const session = this.sessions.find(row => row.id === id);
+          return session && session.cwd === this.currentWorkspacePath();
+        });
+        if (workspaceTab || this.openTabIds.length) {
+          this.currentId = workspaceTab || this.openTabIds[0];
+        } else {
+          this.openTabIds.push(this.currentId);
+        }
       }
+      this._writeChatTabStore(this.openTabIds);
       if (this.currentWorkspacePath() && this.currentId) {
         this.workspaceLastSession = {
           ...this.workspaceLastSession,
@@ -11627,6 +11712,7 @@ function portal() {
         const removedIds = new Set(this.sessions.filter(s => s.cwd === path).map(s => s.id));
         for (const id of removedIds) this._disposeTabRuntime(id);
         this.openTabIds = this.openTabIds.filter(id => !removedIds.has(id));
+        this._writeChatTabStore(this.openTabIds);
         this.sessions = this.sessions.filter(s => !removedIds.has(s.id));
         const surfaces = { ...this.workspaceSurfaces };
         delete surfaces[path];
@@ -11798,7 +11884,10 @@ function portal() {
       st.effort = meta.effort;
       st.serviceTier = meta.service_tier;
       this._activateTabState(id);
-      if (!this.openTabIds.includes(id)) this.openTabIds.push(id);
+      if (!this.openTabIds.includes(id)) {
+        this.openTabIds.push(id);
+        this._writeChatTabStore(this.openTabIds);
+      }
       this._lastNewSessionAt = interactionNow;
       this._lastNewSessionMeta = meta;
       this._touchTranscriptPane(id);
@@ -11821,6 +11910,7 @@ function portal() {
           && this.sessionWorkspaces.some(w => w.path === cwd)) {
         await this._changeWorkspaceSurface(cwd);
       }
+      let opened = false;
       if (!this.openTabIds.includes(id)) {
         const MAX_TABS = 20;
         while (this.openTabIds.length >= MAX_TABS) {
@@ -11829,7 +11919,9 @@ function portal() {
           await this.closeChatTab(oldest);
         }
         this.openTabIds.push(id);
+        opened = true;
       }
+      if (opened) this._writeChatTabStore(this.openTabIds);
       if (makeCurrent && id !== this.currentId) {
         this._captureChatPosition(this.currentId);
         this.currentId = id;
@@ -11912,6 +12004,7 @@ function portal() {
           await this.newSession();
         }
       }
+      this._writeChatTabStore(this.openTabIds);
       this.savePrefs();
       // Closing a tab is a cheap, reversible action (session is still in
       // history picker / sidebar). The previous toast-with-undo was noise
@@ -13935,6 +14028,7 @@ function portal() {
       if (from < 0 || to < 0) return;
       this.openTabIds.splice(from, 1);
       this.openTabIds.splice(to, 0, src);
+      this._writeChatTabStore(this.openTabIds);
       this.savePrefs();
     },
     onTabDragEnd() {
@@ -14641,6 +14735,7 @@ function portal() {
         this._deletePersistedChatDraft(sid);
       }
       this.openTabIds = (this.openTabIds || []).filter(id => !deletedIds.has(id));
+      this._writeChatTabStore(this.openTabIds);
       await this.refreshSessions();
       this.savePrefs();
       const cleared = (resp && resp.deleted) || 0;
@@ -18225,6 +18320,7 @@ function portal() {
           await this.switchSession();
         }
       }
+      this._writeChatTabStore(this.openTabIds);
       this.savePrefs();
       return true;
     },

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -173,7 +173,7 @@ def test_desktop_chat_is_center_primary_pane_and_preview_is_right_rail(
     assert result["restored"]["previewDisplay"] == "flex"
     assert result["restored"]["chat"]["right"] <= result["restored"]["preview"]["left"]
     assert result["restored"]["sameChatNode"] is True
-    assert result["prefs"]["schema"] == 9
+    assert result["prefs"]["schema"] == 10
     assert result["prefs"]["previewOpen"] is True
     assert result["prefs"]["previewWidth"] == 440
     assert "rightOpen" not in result["prefs"]

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -86,6 +86,150 @@ def test_new_and_switch_and_close_tabs(page: Page, backend_url, auth_token):
     expect(page.locator(SEL_TAB)).to_have_count(initial + 1)
 
 
+def test_closed_tab_stays_closed_after_stale_prefs_write_and_hard_refresh(
+        page: Page, backend_url, auth_token):
+    """A legacy/stale prefs writer must not resurrect a closed chat tab."""
+    _login(page, backend_url, auth_token)
+    page.locator(SEL_TAB_NEW).click()
+    page.locator(SEL_TAB_NEW).click()
+    before = page.evaluate(
+        "document.querySelector('#app')._x_dataStack[0].openTabIds.slice()")
+    closed = before[0]
+
+    page.locator(
+        f'{SEL_TAB}[data-tid="{closed}"] {SEL_TAB_CLOSE}').click()
+    page.wait_for_function(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const store = JSON.parse(localStorage.getItem(
+            'muselab_chat_tabs_v1') || '{}');
+          return !app.openTabIds.includes(sid)
+            && !store.openTabIds?.includes(sid);
+        }""",
+        arg=[closed],
+    )
+
+    # Simulate a page still running the pre-v10 code: it rewrites the shared
+    # prefs record with an old tab list while changing an unrelated preference.
+    page.evaluate(
+        """([staleIds]) => {
+          const prefs = JSON.parse(localStorage.getItem('muselab_prefs') || '{}');
+          prefs.openTabIds = staleIds;
+          prefs.leftOpen = !prefs.leftOpen;
+          localStorage.setItem('muselab_prefs', JSON.stringify(prefs));
+        }""",
+        arg=[before],
+    )
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_function(
+        """([sid]) => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          return app && app._sessionsInitialized && app.currentId
+            && !app.openTabIds.includes(sid);
+        }""",
+        arg=[closed],
+    )
+    restored = page.evaluate(
+        """([sid]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const store = JSON.parse(localStorage.getItem(
+            'muselab_chat_tabs_v1') || '{}');
+          return {
+            runtimeHasClosed: app.openTabIds.includes(sid),
+            storedHasClosed: store.openTabIds.includes(sid),
+            prefsStillContainsTabStrip: Array.isArray(JSON.parse(
+              localStorage.getItem('muselab_prefs') || '{}').openTabIds),
+          };
+        }""",
+        arg=[closed],
+    )
+    assert restored == {
+        "runtimeHasClosed": False,
+        "storedHasClosed": False,
+        "prefsStillContainsTabStrip": False,
+    }
+
+
+def test_same_origin_pages_share_strip_without_focus_theft_or_writeback(
+        page: Page, backend_url, auth_token):
+    """Storage events converge the strip but keep each page's active tab local."""
+    _login(page, backend_url, auth_token)
+    page.locator(SEL_TAB_NEW).click()
+    page.locator(SEL_TAB_NEW).click()
+    before = page.evaluate(
+        "document.querySelector('#app')._x_dataStack[0].openTabIds.slice()")
+
+    peer = page.context.new_page()
+    try:
+        _login(peer, backend_url, auth_token)
+        peer_current = before[0]
+        _activate_chat_tab(peer, peer_current)
+        peer.evaluate(
+            """() => {
+              const app = document.querySelector('#app')._x_dataStack[0];
+              window.__chatTabStoreWrites = 0;
+              const original = app._writeChatTabStore.bind(app);
+              app._writeChatTabStore = (...args) => {
+                window.__chatTabStoreWrites += 1;
+                return original(...args);
+              };
+            }"""
+        )
+
+        non_current = before[1]
+        page.locator(
+            f'{SEL_TAB}[data-tid="{non_current}"] {SEL_TAB_CLOSE}').click()
+        peer.wait_for_function(
+            """([sid, current]) => {
+              const app = document.querySelector('#app')._x_dataStack[0];
+              return !app.openTabIds.includes(sid) && app.currentId === current;
+            }""",
+            arg=[non_current, peer_current],
+        )
+        assert peer.evaluate("window.__chatTabStoreWrites") == 0
+
+        # Closing this page's active tab elsewhere selects a local fallback. The
+        # storage-event consumer still must not write the shared strip back.
+        page.locator(
+            f'{SEL_TAB}[data-tid="{peer_current}"] {SEL_TAB_CLOSE}').click()
+        peer.wait_for_function(
+            """([closed]) => {
+              const app = document.querySelector('#app')._x_dataStack[0];
+              return app.currentId !== closed && !app.openTabIds.includes(closed);
+            }""",
+            arg=[peer_current],
+        )
+        assert peer.evaluate("window.__chatTabStoreWrites") == 0
+
+        # Even if the peer's in-memory list is stale, an unrelated savePrefs()
+        # cannot overwrite the standalone authoritative tab record.
+        peer.evaluate(
+            """([staleIds]) => {
+              const app = document.querySelector('#app')._x_dataStack[0];
+              app.openTabIds = staleIds;
+              app.leftOpen = !app.leftOpen;
+              app.savePrefs();
+            }""",
+            arg=[before],
+        )
+        stored = peer.evaluate(
+            "JSON.parse(localStorage.getItem('muselab_chat_tabs_v1'))")
+        assert non_current not in stored["openTabIds"]
+        assert peer_current not in stored["openTabIds"]
+
+        page.reload(wait_until="domcontentloaded")
+        page.wait_for_function(
+            """([closed]) => {
+              const app = document.querySelector('#app')?._x_dataStack?.[0];
+              return app && app._sessionsInitialized
+                && closed.every(id => !app.openTabIds.includes(id));
+            }""",
+            arg=[[non_current, peer_current]],
+        )
+    finally:
+        peer.close()
+
+
 def test_mobile_typing_cannot_duplicate_chat_tabs(page: Page, backend_url, auth_token):
     """Dirty restored ids, Alpine input ticks and duplicate touch activation must
     still produce one DOM tab per session id."""
@@ -99,10 +243,11 @@ def test_mobile_typing_cannot_duplicate_chat_tabs(page: Page, backend_url, auth_
     page.evaluate(
         """([sid]) => {
           const prefs = JSON.parse(localStorage.getItem("muselab_prefs") || "{}");
-          prefs.schema = Math.max(9, Number(prefs.schema) || 0);
+          prefs.schema = 9;
           prefs.currentId = sid;
           prefs.openTabIds = [sid, sid];
           prefs.mobileTab = "chat";
+          localStorage.removeItem("muselab_chat_tabs_v1");
           localStorage.setItem("muselab_prefs", JSON.stringify(prefs));
         }""",
         arg=[sid],

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -703,7 +703,7 @@ def test_desktop_layout_is_files_chat_preview_with_one_canonical_chat_dom():
     assert "leftOpen: this.leftOpen, previewOpen: this.previewOpen" in app
     assert "leftWidth: this.leftWidth, previewWidth: this.previewWidth" in app
     assert 'leftWidth: 340' in app
-    assert 'schema: 9' in app
+    assert 'schema: 10' in app
     assert 'Math.abs(p.leftWidth - 280) <= 1' in app
     assert 'else if (typeof p.rightWidth === "number")' in app
     assert 'if (next === "preview") this.previewOpen = true;' in app
@@ -793,19 +793,51 @@ def test_chat_tab_ids_are_normalized_at_restore_render_and_persist_boundaries():
     assert 'typeof id !== "string" || !id || seen.has(id)' in helper
     assert "seen.add(id)" in helper
 
-    save_start = app.index("savePrefs()")
+    store_start = app.index('_chatTabStoreKey: "muselab_chat_tabs_v1"')
+    store_end = app.index("\n    savePrefs()", store_start)
+    store = app[store_start:store_end]
+    assert "schema: 1" in store
+    assert "revision" in store
+    assert "this._normalizeOpenTabIds(stored.openTabIds)" in store
+    assert "this._normalizeOpenTabIds(ids)" in store
+    assert "stored.revision <= this._chatTabStoreRevision" in store
+
+    save_start = app.index("\n    savePrefs() {")
     save_end = app.index("\n    _scheduleSavePrefs()", save_start)
-    assert "openTabIds: this._normalizeOpenTabIds(this.openTabIds)" in app[
-        save_start:save_end]
+    save = app[save_start:save_end]
+    assert "schema: 10" in save
+    assert "openTabIds:" not in save
+    assert "/api/settings/ui-state" not in save
 
     load_start = app.index("loadPrefs()")
     load_end = app.index("\n    loadNotifyPrefs()", load_start)
-    assert "this._normalizeOpenTabIds(p.openTabIds)" in app[load_start:load_end]
+    load = app[load_start:load_end]
+    assert "this._loadChatTabStore(p.openTabIds)" in load
+
+    storage_start = app.index('window.addEventListener("storage"')
+    storage_end = app.index("\n      });", storage_start)
+    storage = app[storage_start:storage_end]
+    assert "void this._applyChatTabStorageEvent()" in storage
+    event_start = app.index("async _applyChatTabStorageEvent()")
+    event_end = app.index("\n    savePrefs()", event_start)
+    event_handler = app[event_start:event_end]
+    assert "_writeChatTabStore" not in event_handler
+    assert "savePrefs" not in event_handler
 
     init_start = app.index("async _initSessionsOnce(options = {})")
     init_end = app.index("\n    async _pullSessionList", init_start)
-    assert "this._normalizeOpenTabIds(this.openTabIds, validIds)" in app[
-        init_start:init_end]
+    init = app[init_start:init_end]
+    assert "this._normalizeOpenTabIds(this.openTabIds, validIds)" in init
+    assert "this._writeChatTabStore(this.openTabIds)" in init
+
+    close_start = app.index("async closeChatTab(id, ev)")
+    close_end = app.index("\n    // Inline rename", close_start)
+    assert "this._writeChatTabStore(this.openTabIds)" in app[
+        close_start:close_end]
+    new_start = app.index("\n    newSession(options = {}) {")
+    new_end = app.index("\n    async openTab", new_start)
+    assert "this._writeChatTabStore(this.openTabIds)" in app[
+        new_start:new_end]
 
     workspace_start = app.index("workspaceOpenTabIds(path = \"\")")
     workspace_end = app.index("\n    sessionInCurrentWorkspace", workspace_start)


### PR DESCRIPTION
## Summary
- move the open chat-tab strip into a standalone revisioned localStorage record
- reconcile same-origin pages without synchronizing their active conversation or writing storage events back
- migrate legacy prefs once and persist every real tab-strip mutation
- add static contracts and browser regressions for hard refresh, stale writers, multi-page focus, and legacy migration

## Verification
- `tests/test_frontend_lint.py`: 168 passed
- `node --check frontend/app.js`: passed
- E2E tests collected successfully; local browser launch is blocked by the host missing `libatk-bridge-2.0.so.0`, so CI will run the browser matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)