### PR TITLE
feat(chat): multiplex active session streams

### DIFF
--- a/backend/api_scheduler.py
+++ b/backend/api_scheduler.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from .auth import require_token
 from . import scheduler as sched
+from . import observability as obs
 
 
 router = APIRouter(prefix="/api/scheduler", tags=["scheduler"])
@@ -134,22 +135,35 @@ async def delete_task_endpoint(tid: str) -> dict:
     # delete_task() commits the task removal and durable cleanup intent in one
     # replacement. A prior failed attempt therefore reaches the same intent
     # here instead of becoming an unrecoverable 404.
-    if not sched.delete_task(tid, purge_bound_session=False):
-        raise HTTPException(404, "task not found")
+    async def _delete_and_cleanup() -> bool:
+        deleted = await obs.to_thread_io(
+            "scheduler.task_delete",
+            tid,
+            sched.delete_task,
+            tid,
+            purge_bound_session=False,
+            owned=True,
+        )
+        if not deleted:
+            return False
+        await sched.finish_task_cleanup(tid)
+        return True
 
-    cleanup = asyncio.create_task(sched.finish_task_cleanup(tid))
+    owner = asyncio.create_task(_delete_and_cleanup())
     try:
-        await asyncio.shield(cleanup)
+        deleted = await asyncio.shield(owner)
     except asyncio.CancelledError:
-        # Once deletion is durable, an HTTP disconnect must not abandon its
-        # runtime owner. Preserve caller cancellation after cleanup terminates.
-        while not cleanup.done():
+        # Once deletion starts, an HTTP disconnect must not leave a durable
+        # cleanup intent without an owner. Join the complete transaction first.
+        while not owner.done():
             try:
-                await asyncio.shield(cleanup)
+                await asyncio.shield(owner)
             except asyncio.CancelledError:
                 continue
-        cleanup.result()
+        owner.result()
         raise
+    if not deleted:
+        raise HTTPException(404, "task not found")
     return {"deleted": tid}
 
 @router.post("/tasks/{tid}/run", dependencies=[Depends(require_token)])
@@ -161,7 +175,7 @@ async def run_task_now_endpoint(tid: str) -> dict:
 
     Used for: (a) "retry" on a failed history entry; (b) manual smoke-test
     after editing prompt / model without waiting for the next fire window."""
-    task = sched.get_task(tid)
+    task = await asyncio.to_thread(sched.get_task, tid)
     if not task:
         raise HTTPException(404, "task not found")
     await sched.run_task_now(tid)

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -3851,6 +3851,15 @@ async def shutdown_runtime() -> None:
             if isinstance(task, asyncio.Task) and not task.done():
                 protected_cleanup_tasks.add(task)
     tasks.difference_update(protected_cleanup_tasks)
+    # Normal application shutdown runs on the owning loop. Test harnesses and
+    # embedded callers can close that loop before invoking this idempotent cleanup
+    # from a replacement loop; asyncio cannot cancel or wait on those stale tasks.
+    current_loop = asyncio.get_running_loop()
+    tasks = {task for task in tasks if task.get_loop() is current_loop}
+    protected_cleanup_tasks = {
+        task for task in protected_cleanup_tasks
+        if task.get_loop() is current_loop
+    }
     for task in tasks:
         task.cancel()
     if tasks:
@@ -7400,7 +7409,10 @@ def clear_queue_api(sid: str) -> dict:
 
 @router.post("/sessions/{sid}/queue/pause", dependencies=[Depends(require_token)])
 async def pause_queue_api(sid: str, req: QueuePauseReq) -> dict:
-    data = sess.set_queue_paused(sid, req.paused)
+    data = await obs.to_thread_io(
+        "chat.queue_pause", sid, sess.set_queue_paused, sid, req.paused,
+        owned=True,
+    )
     # Resuming kicks the drain in case no turn is currently running for this
     # session (otherwise the next item would wait for a turn that never comes).
     if not req.paused:
@@ -7505,7 +7517,8 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
     # Model, effort, and service tier form one runtime contract. Validate the
     # complete *target* tuple before mutating any field in this request; this
     # makes a rejected cross-model combination side-effect free.
-    current_meta = sess.get_session(sid)
+    current_meta = await obs.to_thread_io(
+        "chat.session_read", sid, sess.get_session, sid)
     runtime_controls_requested = any(
         value is not None
         for value in (req.model, req.effort, req.service_tier)
@@ -7569,25 +7582,33 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
             # Runtime-rollover postlude propagation uses the same lock and rechecks
             # the inherited title inside it, so a user's explicit rename always
             # wins rather than being overwritten by a late automatic sync.
-            lock_started = time.monotonic()
-            with _session_title_lock(sid):
-                lock_wait_ms = round((time.monotonic() - lock_started) * 1000)
-                local_started = time.monotonic()
-                renamed = sess.rename_session(sid, req.name)
-                local_index_ms = round(
-                    (time.monotonic() - local_started) * 1000)
-                # Also propagate to CLI's JSONL so list_sessions() / manual claude
-                # CLI runs see the new title. Silent no-op if JSONL doesn't exist.
-                sdk_started = time.monotonic()
-                try:
-                    sdk_rename_session(
-                        sid, req.name,
-                        directory=str(sess.session_workspace(sid)))
-                except (FileNotFoundError, ValueError):
-                    pass
-                finally:
-                    sdk_rename_ms = round(
+            def _rename_transaction() -> tuple[bool, int, int, int]:
+                lock_started = time.monotonic()
+                with _session_title_lock(sid):
+                    waited = round((time.monotonic() - lock_started) * 1000)
+                    local_started = time.monotonic()
+                    local_renamed = sess.rename_session(sid, req.name)
+                    local_ms = round(
+                        (time.monotonic() - local_started) * 1000)
+                    # Also propagate to CLI's JSONL so list_sessions() / manual
+                    # claude CLI runs see the new title. Silent no-op if absent.
+                    sdk_started = time.monotonic()
+                    try:
+                        sdk_rename_session(
+                            sid, req.name,
+                            directory=str(sess.session_workspace(sid)))
+                    except (FileNotFoundError, ValueError):
+                        pass
+                    sdk_ms = round(
                         (time.monotonic() - sdk_started) * 1000)
+                    return local_renamed, waited, local_ms, sdk_ms
+
+            renamed, lock_wait_ms, local_index_ms, sdk_rename_ms = (
+                await obs.to_thread_io(
+                    "chat.session_rename", sid, _rename_transaction,
+                    owned=True,
+                )
+            )
             ok = renamed or ok
             if renamed:
                 # The task ledger stores one denormalized display name per
@@ -7618,10 +7639,14 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
     if req.tag is not None:
         # Empty string → clear tag. SDK accepts None or str.
         try:
-            sdk_tag_session(
+            await obs.to_thread_io(
+                "chat.session_tag",
+                sid,
+                sdk_tag_session,
                 sid,
                 req.tag or None,
                 directory=str(sess.session_workspace(sid)),
+                owned=True,
             )
             ok = True
         except (FileNotFoundError, ValueError) as e:
@@ -7631,14 +7656,26 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
     if req.pinned is not None:
         # Pin is muselab-local (not stored in CLI JSONL). Always idempotent.
         # set_pin runs the load-mutate-save sequence under _INDEX_LOCK.
-        sess.set_pin(sid, req.pinned)
+        await obs.to_thread_io(
+            "chat.session_pin", sid, sess.set_pin, sid, req.pinned,
+            owned=True,
+        )
         ok = True
     if req.permission is not None:
         permission = _validate_permission(req.permission)
-        current_meta = sess.get_session(sid) or {}
+        current_meta = await obs.to_thread_io(
+            "chat.session_read", sid, sess.get_session, sid)
+        current_meta = current_meta or {}
         current_permission = (current_meta.get("permission") or "").strip()
         changed = current_permission != permission
-        updated = sess.update_permission(sid, permission)
+        updated = await obs.to_thread_io(
+            "chat.session_permission",
+            sid,
+            sess.update_permission,
+            sid,
+            permission,
+            owned=True,
+        )
         ok = updated or ok
         if updated and changed:
             # Permission is a launch contract. A busy session defers the
@@ -7664,11 +7701,15 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
                             f"[chat] interrupt before model swap failed for "
                             f"{sid}: {type(_e).__name__}: {_e}\n")
         if runtime_controls_changed:
-            updated = sess.update_runtime_controls(
+            updated = await obs.to_thread_io(
+                "chat.session_runtime_controls",
+                sid,
+                sess.update_runtime_controls,
                 sid,
                 model=target_model,
                 effort=target_effort,
                 service_tier=target_tier,
+                owned=True,
             )
             ok = updated or ok
             if updated:
@@ -9720,7 +9761,13 @@ async def interrupt(session_id: str) -> dict:
     # SDK interrupt can race the current turn's finally block and dequeue the
     # next item. The helper is atomic with dequeue_message and is a no-op for an
     # empty queue, so ordinary one-off interrupts do not create paused state.
-    sess.pause_queue_if_nonempty(session_id)
+    await obs.to_thread_io(
+        "chat.queue_pause_nonempty",
+        session_id,
+        sess.pause_queue_if_nonempty,
+        session_id,
+        owned=True,
+    )
     async with _lock:
         targets = [(k, c) for k, c in _clients.items() if k[0] == session_id]
     # Mark the active turn user-cancelled up front (BEFORE calling SDK's
@@ -9900,7 +9947,13 @@ async def _force_stop_after_grace(
         # coroutine finally block, the retained attachment/startup state still
         # exists and has one explicit cleanup owner.
         mem0.pop_recall_trace(session_id)
-        sess.pause_queue_if_nonempty(session_id)
+        await obs.to_thread_io(
+            "chat.queue_pause_nonempty",
+            session_id,
+            sess.pause_queue_if_nonempty,
+            session_id,
+            owned=True,
+        )
         await _finish_cancelled_startup(session_id, bc)
     except Exception as e:
         sys.stderr.write(
@@ -13158,6 +13211,41 @@ async def _handoff_task_watcher(session_id: str) -> None:
         _background_origin_turn_id.pop(session_id, None)
 
 
+async def _release_queue_claim_owned(
+    session_id: str,
+    item_id: str,
+    *,
+    turn_id: str = "",
+    pause: bool = False,
+) -> bool:
+    return await obs.to_thread_io(
+        "chat.queue_release",
+        session_id,
+        sess.release_queue_claim,
+        session_id,
+        item_id,
+        turn_id=turn_id,
+        pause=pause,
+        owned=True,
+    )
+
+
+async def _ack_queue_message_owned(
+    session_id: str,
+    item_id: str,
+    turn_id: str,
+) -> bool:
+    return await obs.to_thread_io(
+        "chat.queue_ack",
+        session_id,
+        sess.ack_queue_message,
+        session_id,
+        item_id,
+        turn_id,
+        owned=True,
+    )
+
+
 async def _finish_cancelled_startup(
     session_id: str,
     broadcast: TurnBroadcast,
@@ -13177,7 +13265,7 @@ async def _finish_cancelled_startup(
             queue_settled = False
             if broadcast.queue_item_id:
                 try:
-                    queue_settled = sess.release_queue_claim(
+                    queue_settled = await _release_queue_claim_owned(
                         session_id,
                         broadcast.queue_item_id,
                         turn_id=broadcast.turn_id,
@@ -13352,7 +13440,7 @@ async def _abort_turn_startup(
             snapshot_ready = False
             if broadcast.queue_item_id:
                 try:
-                    queue_settled = sess.release_queue_claim(
+                    queue_settled = await _release_queue_claim_owned(
                         session_id,
                         broadcast.queue_item_id,
                         turn_id=broadcast.turn_id,
@@ -13613,6 +13701,7 @@ async def _admit_turn(
             _write_active_turn_sidecar,
             broadcast,
             file_path=_active_turn_path(session_id),
+            owned=True,
         )
     except asyncio.CancelledError:
         await _settle_admission_cancellation()
@@ -13633,11 +13722,15 @@ async def _admit_turn(
 
     if broadcast.queue_item_id:
         try:
-            sess.bind_queue_turn(
-                session_id, broadcast.queue_item_id, broadcast.turn_id)
-            _durable_attachment_store.mark_queue_turn(
-                session_id, broadcast.queue_item_id, broadcast.turn_id,
-            )
+            def _bind_queue_turn() -> None:
+                sess.bind_queue_turn(
+                    session_id, broadcast.queue_item_id, broadcast.turn_id)
+                _durable_attachment_store.mark_queue_turn(
+                    session_id, broadcast.queue_item_id, broadcast.turn_id,
+                )
+
+            await obs.to_thread_io(
+                "chat.queue_bind", session_id, _bind_queue_turn, owned=True)
         except Exception:
             broadcast.perf_error_kind = "queue_bind"
             broadcast.perf_startup_failure_phase = "accepted"
@@ -13790,35 +13883,39 @@ async def _start_turn(
     # that wins over whatever the frontend's dropdown happens to say. This
     # prevents the "I tried to switch but it didn't take" class of bugs and
     # avoids cross-vendor thinking-signature corruption.
-    s = sess.get_session(session_id) or {}
-    broadcast.activity_hidden = bool(s.get("activity_hidden", False))
-    locked = (s.get("model") or "").strip()
-    if locked:
-        healed = _heal_unreachable_locked_model(session_id, locked, model)
-        model_to_use = healed
-        if healed != locked:
-            sess.update_model(session_id, healed)
-    else:
-        # Virgin session — frontend's choice gets persisted on first send.
-        model_to_use = model or MODEL
-        sess.update_model(session_id, model_to_use)
-    broadcast.model = model_to_use
+    def _persist_launch_settings() -> tuple[dict, str, str]:
+        launch_meta = sess.get_session(session_id) or {}
+        locked = (launch_meta.get("model") or "").strip()
+        if locked:
+            resolved_model = _heal_unreachable_locked_model(
+                session_id, locked, model)
+            if resolved_model != locked:
+                sess.update_model(session_id, resolved_model)
+        else:
+            # Virgin session — frontend's choice gets persisted on first send.
+            resolved_model = model or MODEL
+            sess.update_model(session_id, resolved_model)
 
-    # Permission is a session setting, not a browser-global preference. A
-    # direct request remains authoritative and is persisted for legacy clients
-    # that do not use PATCH. Queue items deliberately replay their enqueue-time
-    # snapshot without rolling the session's newer selection back afterward.
-    if persist_permission:
-        sess.update_permission(session_id, permission)
-        # update_permission captures the previous non-plan mode atomically when
-        # entering Plan Mode. Re-read so this very first plan turn launches with
-        # the correct ExitPlanMode return capability.
-        s = sess.get_session(session_id) or s
-        plan_return_to_use = _normalize_plan_return_permission(
-            permission, s.get("plan_return_permission"))
-    else:
-        plan_return_to_use = _normalize_plan_return_permission(
-            permission, plan_return_permission)
+        # Queue items replay their enqueue-time permission snapshot without
+        # rolling the session's newer selection back afterward.
+        if persist_permission:
+            sess.update_permission(session_id, permission)
+            launch_meta = sess.get_session(session_id) or launch_meta
+            resolved_plan_return = _normalize_plan_return_permission(
+                permission, launch_meta.get("plan_return_permission"))
+        else:
+            resolved_plan_return = _normalize_plan_return_permission(
+                permission, plan_return_permission)
+        return launch_meta, resolved_model, resolved_plan_return
+
+    s, model_to_use, plan_return_to_use = await obs.to_thread_io(
+        "chat.turn_launch_settings",
+        session_id,
+        _persist_launch_settings,
+        owned=True,
+    )
+    broadcast.activity_hidden = bool(s.get("activity_hidden", False))
+    broadcast.model = model_to_use
 
     # Reasoning effort and Fast service are per-session launch controls.
     # Legacy empty effort is normalized to canonical `auto` before it reaches
@@ -15758,6 +15855,7 @@ async def _start_turn(
                 session_id,
                 _persist_session_summary,
                 file_path=sess.INDEX,
+                owned=True,
             )
             # ``done`` is intentionally published before this slower block. A
             # user can therefore roll over the session while these annotations
@@ -16071,6 +16169,7 @@ async def _start_turn(
             _write_active_turn_sidecar,
             broadcast,
             file_path=_active_turn_path(session_id),
+            owned=True,
         )
     except asyncio.CancelledError:
         broadcast.perf_intent_refresh_ms = obs.elapsed_ms(
@@ -16257,23 +16356,27 @@ async def _start_turn(
                         broadcast.canonical_terminal_published = True
                         if broadcast.queue_item_id:
                             if done_data.get("is_error") or done_data.get("cancelled"):
-                                queue_settled = sess.release_queue_claim(
+                                queue_settled = await _release_queue_claim_owned(
                                     session_id,
                                     broadcast.queue_item_id,
                                     turn_id=broadcast.turn_id,
                                     pause=True,
                                 )
                             else:
-                                queue_settled = sess.ack_queue_message(
+                                queue_settled = await _ack_queue_message_owned(
                                     session_id,
                                     broadcast.queue_item_id,
                                     broadcast.turn_id,
                                 )
                                 if queue_settled:
-                                    _durable_attachment_store.finish_queue_item(
+                                    await obs.to_thread_io(
+                                        "chat.queue_attachment_finish",
+                                        session_id,
+                                        _durable_attachment_store.finish_queue_item,
                                         session_id,
                                         broadcast.queue_item_id,
                                         consume=True,
+                                        owned=True,
                                     )
                             if not queue_settled:
                                 raise RuntimeError("queue terminal ownership mismatch")
@@ -16418,7 +16521,7 @@ async def _start_turn(
             if broadcast.queue_item_id and not queue_settled:
                 try:
                     if turn_errored or broadcast.cancelled:
-                        if not sess.release_queue_claim(
+                        if not await _release_queue_claim_owned(
                             session_id,
                             broadcast.queue_item_id,
                             turn_id=broadcast.turn_id,
@@ -16426,17 +16529,21 @@ async def _start_turn(
                         ):
                             raise RuntimeError("queue terminal ownership mismatch")
                     else:
-                        queue_settled = sess.ack_queue_message(
+                        queue_settled = await _ack_queue_message_owned(
                             session_id,
                             broadcast.queue_item_id,
                             broadcast.turn_id,
                         )
                         if not queue_settled:
                             raise RuntimeError("queue terminal ownership mismatch")
-                        _durable_attachment_store.finish_queue_item(
+                        await obs.to_thread_io(
+                            "chat.queue_attachment_finish",
+                            session_id,
+                            _durable_attachment_store.finish_queue_item,
                             session_id,
                             broadcast.queue_item_id,
                             consume=True,
+                            owned=True,
                         )
                 except Exception as e:
                     # Never duplicate a turn by guessing. The durable inflight
@@ -16497,9 +16604,17 @@ async def _start_turn(
                     # Only pause + notify if items are actually waiting —
                     # a lone failed turn with an empty queue is just a normal
                     # error the user already saw in-stream; no need to buzz.
-                    q = sess.get_queue(session_id)
+                    q = await obs.to_thread_io(
+                        "chat.queue_read", session_id, sess.get_queue, session_id)
                     if q.get("items"):
-                        sess.set_queue_paused(session_id, True)
+                        await obs.to_thread_io(
+                            "chat.queue_pause",
+                            session_id,
+                            sess.set_queue_paused,
+                            session_id,
+                            True,
+                            owned=True,
+                        )
                         _notify_queue_paused_on_error(session_id)
                 elif broadcast.cancelled:
                     # User explicitly stopped this turn — pause the queue so
@@ -16508,7 +16623,13 @@ async def _start_turn(
                     # cleanup used to create ``{items: [], paused: true}``;
                     # the next message then entered a queue that could never
                     # drain, which looked like an intermittent send failure.
-                    sess.pause_queue_if_nonempty(session_id)
+                    await obs.to_thread_io(
+                        "chat.queue_pause_nonempty",
+                        session_id,
+                        sess.pause_queue_if_nonempty,
+                        session_id,
+                        owned=True,
+                    )
                 else:
                     await _maybe_drain_queue(session_id)
             except Exception as e:
@@ -16616,7 +16737,14 @@ async def _maybe_drain_queue(session_id: str) -> None:
         if runtime_meta.get("runtime_shadow"):
             if successor_sid:
                 try:
-                    moved = sess.migrate_queue(session_id, successor_sid)
+                    moved = await obs.to_thread_io(
+                        "chat.queue_migrate",
+                        session_id,
+                        sess.migrate_queue,
+                        session_id,
+                        successor_sid,
+                        owned=True,
+                    )
                 except ValueError:
                     return
                 try:
@@ -16640,7 +16768,8 @@ async def _maybe_drain_queue(session_id: str) -> None:
         # final continuation releases the single SDK pump.
         if (_sessions_with_inflight_tasks.get(session_id)
                 or _session_has_live_watcher(session_id)):
-            queued = sess.get_queue(session_id)
+            queued = await obs.to_thread_io(
+                "chat.queue_read", session_id, sess.get_queue, session_id)
             if queued.get("items") or queued.get("inflight"):
                 try:
                     successor = await _continue_detached_runtime(session_id)
@@ -16669,12 +16798,19 @@ async def _maybe_drain_queue(session_id: str) -> None:
             return
         if _runtime_lineage_has_ready_continuation(session_id):
             return
-        item = sess.claim_queue_message(session_id)
+        item = await obs.to_thread_io(
+            "chat.queue_claim",
+            session_id,
+            sess.claim_queue_message,
+            session_id,
+            owned=True,
+        )
         if item is None:
             return
         item_id = str(item.get("id") or "")
         try:
-            _queue_snapshot = sess.get_queue(session_id)
+            _queue_snapshot = await obs.to_thread_io(
+                "chat.queue_read", session_id, sess.get_queue, session_id)
             _queue_depth = (
                 len(_queue_snapshot.get("items") or [])
                 + int(bool(_queue_snapshot.get("inflight")))
@@ -16726,7 +16862,7 @@ async def _maybe_drain_queue(session_id: str) -> None:
                         if aid not in cached_ids and aid not in durable_ids)
             except (DurableAttachmentError, OSError, sqlite3.Error,
                     UnsafePrivatePath) as exc:
-                restored = sess.release_queue_claim(
+                restored = await _release_queue_claim_owned(
                     session_id, item_id, pause=True)
                 sys.stderr.write(
                     f"[chat] queued attachment precheck failed "
@@ -16736,7 +16872,7 @@ async def _maybe_drain_queue(session_id: str) -> None:
                 sys.stderr.flush()
                 return
             if unavailable_count:
-                restored = sess.release_queue_claim(
+                restored = await _release_queue_claim_owned(
                     session_id, item_id, pause=True)
                 sys.stderr.write(
                     f"[chat] queued attachments unavailable "
@@ -16769,7 +16905,8 @@ async def _maybe_drain_queue(session_id: str) -> None:
             # If startup never bound the claim, it is safe to restore. Once a
             # turn id is bound, its detached pump owns acknowledgement; requeueing
             # here would create the executed+queued duplicate seen in production.
-            q = sess.get_queue(session_id)
+            q = await obs.to_thread_io(
+                "chat.queue_read", session_id, sess.get_queue, session_id)
             inflight = q.get("inflight") or {}
             bound_turn_id = str(inflight.get("turn_id") or "")
             active = _active_turns.get(session_id)
@@ -16778,21 +16915,22 @@ async def _maybe_drain_queue(session_id: str) -> None:
                 and active.turn_id == bound_turn_id
                 and active.queue_item_id == item_id
             )
-            if (sess.get_session(session_id) is not None
-                    and not active_owns_claim):
-                sess.release_queue_claim(
+            session_exists = await obs.to_thread_io(
+                "chat.session_read", session_id, sess.get_session, session_id)
+            if session_exists is not None and not active_owns_claim:
+                await _release_queue_claim_owned(
                     session_id, item_id, turn_id=bound_turn_id)
             raise
         except _TurnBusy:
-            sess.release_queue_claim(session_id, item_id)
+            await _release_queue_claim_owned(session_id, item_id)
         except _TurnStartError as exc:
             # If startup failed before binding, this releases the unbound claim.
             # Bound startup failures settle with their exact turn id in _start_turn.
             if not exc.queue_claim_settled:
-                sess.release_queue_claim(session_id, item_id, pause=True)
+                await _release_queue_claim_owned(session_id, item_id, pause=True)
             _notify_queue_paused_on_error(session_id)
         except Exception as e:
-            sess.release_queue_claim(session_id, item_id, pause=True)
+            await _release_queue_claim_owned(session_id, item_id, pause=True)
             sys.stderr.write(
                 f"[chat] queue drain crashed sid={session_id[:8]} "
                 f"exc={type(e).__name__}\n")

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -11761,6 +11761,11 @@ _STREAM_TICKETS_MAX = 64
 # redeeming GET /stream is async (event-loop thread) — mint and redeem touch
 # the dict from different threads, so all access goes through this lock.
 _STREAM_TICKETS_LOCK = threading.Lock()
+_MUX_STREAM_TICKETS: dict[str, tuple[float, dict]] = {}
+_MUX_STREAM_TICKET_TTL_S = 60.0
+_MUX_STREAM_TICKETS_MAX = 64
+_MUX_STREAM_TICKETS_LOCK = threading.Lock()
+_MUX_RECONCILE_INTERVAL_S = 0.2
 
 
 class StreamStartReq(BaseModel):
@@ -11773,6 +11778,26 @@ class StreamStartReq(BaseModel):
     model: str = ""
     permission: str = "bypassPermissions"
     image_ids: str = ""
+    mobile: bool = False
+
+
+class TurnStartReq(BaseModel):
+    prompt: str = ""
+    session_id: str
+    model: str = ""
+    permission: str = "bypassPermissions"
+    image_ids: str = ""
+    mobile: bool = False
+
+
+class MuxCheckpointReq(BaseModel):
+    session_id: str
+    turn_id: str = ""
+    last_event_seq: int = Field(default=0, ge=0)
+
+
+class MuxStreamStartReq(BaseModel):
+    checkpoints: list[MuxCheckpointReq] = Field(default_factory=list)
     mobile: bool = False
 
 
@@ -11803,6 +11828,96 @@ def stream_start(req: StreamStartReq) -> dict:
             "mobile": req.mobile,
         })
     return {"ticket": ticket}
+
+
+@router.post("/turns/start", dependencies=[Depends(require_token)])
+async def turn_start(req: TurnStartReq) -> dict:
+    """Admit and launch a new turn without coupling it to an SSE request."""
+    permission = _validate_permission(req.permission)
+    _gc_images()
+    prompt = req.prompt
+    is_image_only = (not prompt.strip()) and bool((req.image_ids or "").strip())
+    if is_image_only:
+        prompt = _IMAGE_ONLY_PLACEHOLDER
+    elif not prompt.strip():
+        raise HTTPException(422, "prompt or image_ids required for a new turn")
+    try:
+        broadcast = await _admit_accept_launch_turn(
+            req.session_id,
+            prompt,
+            model=req.model,
+            permission=permission,
+            image_ids=req.image_ids,
+        )
+    except _TurnBusy:
+        raise HTTPException(409, "previous turn still running") from None
+    except _TurnStartError as exc:
+        raise HTTPException(exc.status or 503, str(exc)) from None
+    return {
+        "accepted": True,
+        "session_id": req.session_id,
+        "turn_id": broadcast.turn_id,
+        "started_at": broadcast.started_at,
+    }
+
+
+@router.post("/stream/mux/start", dependencies=[Depends(require_token)])
+def mux_stream_start(req: MuxStreamStartReq) -> dict:
+    """Mint a one-time ticket for the aggregate multi-session SSE."""
+    import secrets as _secrets
+
+    checkpoints: dict[str, dict] = {}
+    for checkpoint in req.checkpoints:
+        session_id = checkpoint.session_id.strip()
+        turn_id = checkpoint.turn_id.strip()
+        if not session_id:
+            raise HTTPException(422, "checkpoint session_id required")
+        if checkpoint.last_event_seq > 0 and not turn_id:
+            raise HTTPException(
+                422, "turn_id required when last_event_seq is provided")
+        normalized = {
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "last_event_seq": checkpoint.last_event_seq,
+        }
+        previous = checkpoints.get(session_id)
+        if previous is not None and previous != normalized:
+            raise HTTPException(
+                422, f"contradictory checkpoints for session_id {session_id!r}")
+        checkpoints[session_id] = normalized
+
+    now = time.time()
+    ticket = _secrets.token_urlsafe(32)
+    with _MUX_STREAM_TICKETS_LOCK:
+        for key in [
+            key for key, (expires_at, _) in _MUX_STREAM_TICKETS.items()
+            if expires_at < now
+        ]:
+            _MUX_STREAM_TICKETS.pop(key, None)
+        while len(_MUX_STREAM_TICKETS) >= _MUX_STREAM_TICKETS_MAX:
+            _MUX_STREAM_TICKETS.pop(next(iter(_MUX_STREAM_TICKETS)), None)
+        _MUX_STREAM_TICKETS[ticket] = (
+            now + _MUX_STREAM_TICKET_TTL_S,
+            {"checkpoints": checkpoints, "mobile": req.mobile},
+        )
+    return {"ticket": ticket}
+
+
+@router.get("/stream/mux")
+async def mux_stream(ticket: str = Query(default="")):
+    with _MUX_STREAM_TICKETS_LOCK:
+        entry = _MUX_STREAM_TICKETS.pop(ticket, None) if ticket else None
+    if entry is None or entry[0] < time.time():
+        raise HTTPException(401, "invalid or expired mux stream ticket")
+    params = entry[1]
+    return EventSourceResponse(
+        _subscribe_multiplex(
+            params.get("checkpoints", {}),
+            mobile=bool(params.get("mobile", False)),
+        ),
+        headers=_SSE_HEADERS,
+        ping_message_factory=_sse_ping_event,
+    )
 
 
 @router.get("/stream")
@@ -11942,10 +12057,11 @@ async def stream(
     # lock wait, CLI/MCP startup, attachment preparation and query preflight run
     # under a detached owner so a browser disconnect only drops its subscriber.
     try:
-        broadcast = await _admit_turn(
+        broadcast = await _admit_accept_launch_turn(
             session_id,
             prompt,
             model=model,
+            permission=permission,
             image_ids=image_ids,
         )
     except _TurnBusy:
@@ -11977,34 +12093,6 @@ async def stream(
             ping_message_factory=_sse_ping_event,
         )
 
-    # Write the accepted frame before launching runtime work. If the replay
-    # spool cannot own that frame, fail closed before the prompt can reach the
-    # SDK; otherwise the browser could retry an ambiguously executing turn.
-    try:
-        broadcast.publish_startup("accepted")
-    except Exception:
-        broadcast.perf_error_kind = "startup_event"
-        broadcast.perf_startup_failure_phase = "accepted"
-        await _abort_turn_startup(
-            session_id,
-            broadcast,
-            "failed",
-            pause_queue=True,
-        )
-        async def _startup_spool_err_gen():
-            yield _error_event(
-                "turn could not establish its startup event",
-                activity_source="direct",
-            )
-        return EventSourceResponse(
-            _startup_spool_err_gen(), headers=_SSE_HEADERS)
-    _launch_admitted_turn(
-        broadcast,
-        prompt=prompt,
-        model=model,
-        permission=permission,
-        image_ids=image_ids,
-    )
     _correlate_stream(broadcast)
     return EventSourceResponse(
         _subscribe_broadcast(broadcast, mobile=mobile),
@@ -13826,6 +13914,46 @@ def _launch_admitted_turn(
     task = asyncio.create_task(_owner())
     broadcast.startup_owner_task = task
     return task
+
+
+async def _admit_accept_launch_turn(
+    session_id: str,
+    prompt: str,
+    *,
+    model: str = "",
+    permission: str = "bypassPermissions",
+    image_ids: str = "",
+) -> TurnBroadcast:
+    """Share the new-turn admission boundary across POST and legacy SSE."""
+    broadcast = await _admit_turn(
+        session_id,
+        prompt,
+        model=model,
+        image_ids=image_ids,
+    )
+    if broadcast.done or broadcast.cancelled:
+        return broadcast
+    try:
+        broadcast.publish_startup("accepted")
+    except Exception:
+        broadcast.perf_error_kind = "startup_event"
+        broadcast.perf_startup_failure_phase = "accepted"
+        await _abort_turn_startup(
+            session_id,
+            broadcast,
+            "failed",
+            pause_queue=True,
+        )
+        raise _TurnStartError(
+            "turn could not establish its startup event") from None
+    _launch_admitted_turn(
+        broadcast,
+        prompt=prompt,
+        model=model,
+        permission=permission,
+        image_ids=image_ids,
+    )
+    return broadcast
 
 
 async def _start_turn(
@@ -16973,6 +17101,188 @@ def _schedule_queue_drain(session_id: str) -> None:
                 _schedule_queue_drain, session_id)
 
     task.add_done_callback(_done)
+
+
+def _mux_wrap_event(session_id: str, event: dict) -> dict:
+    wrapped = dict(event)
+    raw_data = event.get("data", "")
+    try:
+        payload = json.loads(raw_data)
+    except (TypeError, ValueError):
+        payload = {"data": raw_data}
+    if not isinstance(payload, dict):
+        payload = {"data": payload}
+    payload["session_id"] = session_id
+    wrapped["data"] = json.dumps(payload, ensure_ascii=False)
+    return wrapped
+
+
+def _mux_session_state_fingerprint(state: dict) -> str:
+    stable = {
+        key: value for key, value in state.items()
+        if key not in {"events_so_far", "runtime_ui_revision"}
+    }
+    return json.dumps(stable, sort_keys=True, ensure_ascii=False)
+
+
+async def _subscribe_multiplex(
+    checkpoints: dict[str, dict],
+    *,
+    mobile: bool = False,
+):
+    """Merge attachable broadcasts while periodically discovering new ones."""
+    # Bound the aggregate handoff so a stalled HTTP client leaves each child
+    # parked on its disk-backed subscriber cursor instead of growing RAM.
+    output: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
+    children: dict[tuple[str, str], asyncio.Task] = {}
+    completed: set[tuple[str, str]] = set()
+    reported_mismatches: set[tuple[str, str, str]] = set()
+    state_fingerprints: dict[str, str] = {}
+
+    async def _pump_child(
+        session_id: str,
+        broadcast: TurnBroadcast,
+        last_event_seq: int,
+    ) -> None:
+        try:
+            async for event in _subscribe_broadcast(
+                broadcast,
+                mobile=mobile,
+                last_event_seq=last_event_seq,
+            ):
+                await output.put(_mux_wrap_event(session_id, event))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await output.put({
+                "event": "resync",
+                "data": json.dumps({
+                    "reason": "child_stream_error",
+                    "fallback": "canonical_history",
+                    "retryable": False,
+                    "session_id": session_id,
+                    "turn_id": broadcast.turn_id,
+                }),
+            })
+
+    def _start_child(
+        session_id: str,
+        broadcast: TurnBroadcast,
+        last_event_seq: int,
+    ) -> None:
+        key = (session_id, broadcast.turn_id)
+        if key in children or key in completed:
+            return
+        children[key] = asyncio.create_task(
+            _pump_child(session_id, broadcast, last_event_seq))
+
+    async def _reconcile() -> None:
+        for key, task in list(children.items()):
+            if task.done():
+                children.pop(key, None)
+                completed.add(key)
+                with suppress(asyncio.CancelledError, Exception):
+                    task.result()
+
+        candidate_ids = set(_active_turns)
+        candidate_ids.update(_sessions_with_inflight_tasks)
+        candidate_ids.update(
+            sid for sid, watcher in _task_watchers.items()
+            if watcher is not None and not watcher.done()
+        )
+        candidate_ids.update(
+            sid for sid, broadcast in _recent_turns.items()
+            if getattr(broadcast, "is_continuation", False)
+            and not getattr(broadcast, "continuation_consumed", False)
+        )
+        candidate_ids.update(checkpoints)
+
+        active_ids: set[str] = set()
+        for session_id in sorted(candidate_ids):
+            state = session_active_status(session_id)
+            checkpoint = checkpoints.get(session_id)
+            checkpoint_recent = None
+            if checkpoint is not None and checkpoint.get("turn_id"):
+                recent = _get_recent_turn(session_id)
+                if (recent is not None
+                        and recent.turn_id == checkpoint.get("turn_id")):
+                    checkpoint_recent = recent
+            if state.get("active"):
+                active_ids.add(session_id)
+                state_payload = dict(state)
+                state_payload["session_id"] = session_id
+                fingerprint = _mux_session_state_fingerprint(state_payload)
+                if state_fingerprints.get(session_id) != fingerprint:
+                    state_fingerprints[session_id] = fingerprint
+                    await output.put({
+                        "event": "session_state",
+                        "data": json.dumps(state_payload, ensure_ascii=False),
+                    })
+
+                if state.get("attachable"):
+                    current_turn_id = str(state.get("turn_id") or "")
+                    broadcast = _active_turns.get(session_id)
+                    if (broadcast is None
+                            or broadcast.turn_id != current_turn_id):
+                        recent = _get_recent_turn(session_id)
+                        broadcast = (
+                            recent if recent is not None
+                            and recent.turn_id == current_turn_id else None
+                        )
+                    if broadcast is not None:
+                        resume_seq = 0
+                        if checkpoint is not None:
+                            requested_turn_id = str(
+                                checkpoint.get("turn_id") or "")
+                            if (requested_turn_id
+                                    and requested_turn_id != current_turn_id
+                                    and checkpoint_recent is None):
+                                mismatch = (
+                                    session_id,
+                                    requested_turn_id,
+                                    current_turn_id,
+                                )
+                                if mismatch not in reported_mismatches:
+                                    reported_mismatches.add(mismatch)
+                                    await output.put({
+                                        "event": "resync",
+                                        "data": json.dumps({
+                                            "reason": "turn_changed",
+                                            "requested_turn_id": requested_turn_id,
+                                            "current_turn_id": current_turn_id,
+                                            "session_id": session_id,
+                                        }),
+                                    })
+                            elif requested_turn_id == current_turn_id:
+                                resume_seq = int(
+                                    checkpoint.get("last_event_seq", 0) or 0)
+                        _start_child(session_id, broadcast, resume_seq)
+
+            if checkpoint_recent is not None:
+                _start_child(
+                    session_id,
+                    checkpoint_recent,
+                    int(checkpoint.get("last_event_seq", 0) or 0),
+                )
+
+        for session_id in list(state_fingerprints):
+            if session_id not in active_ids:
+                state_fingerprints.pop(session_id, None)
+
+    try:
+        while True:
+            await _reconcile()
+            try:
+                event = await asyncio.wait_for(
+                    output.get(), timeout=_MUX_RECONCILE_INTERVAL_S)
+            except asyncio.TimeoutError:
+                continue
+            yield event
+    finally:
+        for task in children.values():
+            task.cancel()
+        if children:
+            await asyncio.gather(*children.values(), return_exceptions=True)
 
 
 async def _subscribe_broadcast(

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2001,6 +2001,12 @@ _session_usage: dict[str, dict] = {}     # sid -> {input_tokens, output_tokens,
                                           #         cache_read_tokens,
                                           #         cache_creation_tokens,
                                           #         total_cost_usd, last_turn_at}
+# Exact logical turn owning each in-memory snapshot. A post-done SDK context
+# probe may finish after the next turn has populated `_session_usage`; late
+# refinement must match this owner rather than write by session id alone.
+_session_usage_turns: dict[str, str] = {}
+_USAGE_SUMMARY_SCHEMA = 1
+_USAGE_SOURCE_UNSET = object()
 
 # Per-model context windows. Used as the meter's denominator when a SDK
 # get_context_usage() truth isn't available (first turn of a session, or
@@ -6982,6 +6988,7 @@ async def _purge_session_storage_async_inner(sid: str) -> bool:
             "session cleanup is still in progress; retry the operation"
         )
     _session_usage.pop(sid, None)
+    _session_usage_turns.pop(sid, None)
     _interrupted_at_startup.pop(sid, None)
     return await asyncio.to_thread(_purge_single_session_storage, sid)
 
@@ -7941,6 +7948,99 @@ async def usage() -> dict:
             )}
 
 
+def _usage_source_signature(path: Path | None) -> dict | None:
+    """Identity and freshness fence for one canonical JSONL generation."""
+    if path is None:
+        return None
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return {
+        "dev": int(stat.st_dev),
+        "inode": int(stat.st_ino),
+        "size": int(stat.st_size),
+        "mtime_ns": int(stat.st_mtime_ns),
+    }
+
+
+def _session_usage_summary_payload(
+    usage_snapshot: dict,
+    *,
+    turn_id: str = "",
+    source: dict | None | object = _USAGE_SOURCE_UNSET,
+    sid: str = "",
+) -> dict | None:
+    if source is _USAGE_SOURCE_UNSET:
+        source = _usage_source_signature(_find_session_jsonl(sid))
+    if source is None:
+        return None
+    return {
+        "schema": _USAGE_SUMMARY_SCHEMA,
+        "source": dict(source),
+        "update": {"turn_id": str(turn_id or ""), "at": time.time()},
+        "normalized": dict(usage_snapshot),
+    }
+
+
+def _persist_session_usage_summary(
+    sid: str,
+    usage_snapshot: dict,
+    *,
+    turn_id: str = "",
+    source: dict | None | object = _USAGE_SOURCE_UNSET,
+    require_matching_turn: bool = False,
+) -> bool:
+    summary = _session_usage_summary_payload(
+        usage_snapshot, turn_id=turn_id, source=source, sid=sid)
+    if summary is None:
+        return False
+    try:
+        if require_matching_turn:
+            return bool(sess.set_session_usage_summary_if_turn_matches(
+                sid, turn_id, summary))
+        return bool(sess.set_session_usage_summary(sid, summary))
+    except Exception as exc:
+        # Hydration repair is best-effort. A corrupt or unwritable sidecar must
+        # remain byte-identical and must never turn readable JSONL into /usage 500.
+        sys.stderr.write(
+            f"[chat-usage] summary write skipped sid={obs.short_id(sid)} "
+            f"exc={type(exc).__name__}\n")
+        return False
+
+
+def _load_session_usage_summary(sid: str) -> tuple[dict, str] | None:
+    source = _usage_source_signature(_find_session_jsonl(sid))
+    if source is None:
+        return None
+    try:
+        summary = sess.get_session_usage_summary(sid)
+    except Exception:
+        return None
+    if not isinstance(summary, dict):
+        return None
+    normalized = summary.get("normalized")
+    update = summary.get("update")
+    if (summary.get("schema") != _USAGE_SUMMARY_SCHEMA
+            or summary.get("source") != source
+            or not isinstance(normalized, dict)
+            or not isinstance(update, dict)):
+        return None
+    return dict(normalized), str(update.get("turn_id") or "")
+
+
+def _refine_session_usage_for_turn(
+    sid: str,
+    turn_id: str,
+    refined: dict,
+) -> bool:
+    """Replace a usage snapshot only while the same exact turn still owns it."""
+    if not turn_id or _session_usage_turns.get(sid) != turn_id:
+        return False
+    _session_usage[sid] = dict(refined)
+    return True
+
+
 def _session_usage_from_jsonl(sid: str) -> dict | None:
     """Rebuild a session_usage snapshot from the CLI JSONL transcript.
 
@@ -8073,31 +8173,55 @@ async def session_usage(session_id: str, model: str = "") -> dict:
     """Per-session context meter — what fraction of the model's window we're at.
 
     Note: this is the cheap path — reads cached per-turn usage values.
-    On cache miss (e.g. fresh process restart, session not yet streamed
-    in this lifetime), lazily rebuilds the snapshot from the CLI JSONL
-    so the meter doesn't show empty for already-running conversations.
+    On process-cache miss it reads the validated sidecar summary. JSONL is only
+    scanned to repair a missing or stale summary, never for routine tab loads.
     For a true breakdown (per CLAUDE.md file, per MCP tool, per skill),
     use /context-breakdown/{session_id} which invokes
     ClaudeSDKClient.get_context_usage() against the live session."""
     u = _session_usage.get(session_id)
     if u is None:
-        rebuilt = await obs.to_thread_io(
-            "chat.usage_hydrate",
+        persisted = await obs.to_thread_io(
+            "chat.usage_summary_read",
             session_id,
-            _session_usage_from_jsonl,
+            _load_session_usage_summary,
             session_id,
-            file_path=lambda: _find_session_jsonl(session_id),
+            file_path=lambda: sess._sidecar_path(session_id),
         )
-        if rebuilt is not None:
-            # Populate the cache so subsequent polls don't re-walk JSONL.
-            _session_usage[session_id] = rebuilt
-            u = rebuilt
+        if persisted is not None:
+            u, summary_turn_id = persisted
+            _session_usage[session_id] = u
+            if summary_turn_id:
+                _session_usage_turns[session_id] = summary_turn_id
         else:
+            rebuilt = await obs.to_thread_io(
+                "chat.usage_hydrate",
+                session_id,
+                _session_usage_from_jsonl,
+                session_id,
+                file_path=lambda: _find_session_jsonl(session_id),
+            )
+            if rebuilt is not None:
+                # Populate the cache and best-effort repair the summary. Sidecar
+                # corruption/write failure stays fail-closed and cannot fail /usage.
+                _session_usage[session_id] = rebuilt
+                u = rebuilt
+                await obs.to_thread_io(
+                    "chat.usage_summary_repair",
+                    session_id,
+                    _persist_session_usage_summary,
+                    session_id,
+                    rebuilt,
+                    file_path=lambda: sess._sidecar_path(session_id),
+                )
+            else:
+                u = None
+        if u is None:
             u = {
                 "input_tokens": 0, "output_tokens": 0,
                 "cache_read_tokens": 0, "cache_creation_tokens": 0,
                 "total_cost_usd": 0.0, "last_turn_at": 0.0,
-                "context_used": 0, "context_used_pct": 0.0, "context_limit": 0,
+                "context_used": 0, "context_used_pct": 0.0,
+                "context_limit": 0,
             }
     m = model or MODEL
     # Claude uses the per-session SDK window persisted across restarts. Codex
@@ -9722,7 +9846,7 @@ def mcp_status() -> dict:
 #       are still fine; what we hide is celebratory toasts / push).
 # Module-level set is fine for the single-user model muselab targets — no
 # cross-user race to worry about.
-_pending_interrupts: set[str] = set()
+_pending_interrupts: set[tuple[str, str]] = set()
 
 # How long the force-stop watchdog waits for the SDK's control-protocol
 # interrupt to drain the turn on its own before tearing the client down.
@@ -9752,15 +9876,69 @@ _INTERRUPT_FORCE_OWNER_JOIN_S = 2.0
 _INTERRUPT_FORCE_DISCONNECT_JOIN_S = 0.25
 
 
+def _interrupt_response(
+    session_id: str,
+    broadcast: "TurnBroadcast | None",
+    *,
+    requested_turn_id: str,
+    interrupted: list[str],
+    note: str = "",
+    phase: str = "",
+    stale: bool = False,
+) -> dict:
+    """Return the authoritative exact-turn state after an interrupt attempt."""
+    current = _active_turns.get(session_id)
+    active = bool(current is not None and not current.done)
+    current_turn_id = current.turn_id if active else ""
+    target_turn_id = requested_turn_id or str(
+        getattr(broadcast, "turn_id", "") or "")
+    owns_requested = bool(
+        active and target_turn_id and current_turn_id == target_turn_id)
+    owner = current if owns_requested else broadcast
+    result = {
+        "ok": True,
+        "interrupted": interrupted,
+        "stale": bool(stale),
+        "requested_turn_id": requested_turn_id,
+        "current_turn_id": current_turn_id,
+        # Preserve the requested owner on inactive responses so a frontend can
+        # settle only that exact stopping turn, never an ABA successor.
+        "turn_id": current_turn_id if active else requested_turn_id,
+        "active": active,
+        "stopping": bool(owns_requested and current.cancelled),
+        "phase": (
+            str(phase or getattr(owner, "startup_phase", "") or "running")
+            if active else "inactive"
+        ),
+    }
+    if note:
+        result["note"] = note
+    return result
+
+
 @router.post("/interrupt", dependencies=[Depends(require_token_header_or_query)])
-async def interrupt(session_id: str) -> dict:
-    """Stop the current turn via SDK control protocol. Keeps the client
-    connected so the next message continues the same conversation without
-    re-spawning the CLI / re-loading CLAUDE.md / re-initializing MCP."""
-    # Stop means "do not continue autonomously". Pause queued work before the
-    # SDK interrupt can race the current turn's finally block and dequeue the
-    # next item. The helper is atomic with dequeue_message and is a no-op for an
-    # empty queue, so ordinary one-off interrupts do not create paused state.
+async def interrupt(
+    session_id: str,
+    turn_id: str = "",
+) -> dict:
+    """Stop one immutable turn via the SDK control protocol."""
+    requested_turn_id = turn_id.strip()
+    bc = _active_turns.get(session_id)
+    if requested_turn_id and (
+        bc is None or bc.done or bc.turn_id != requested_turn_id
+    ):
+        # A delayed Stop from an older browser turn must never pause the queue or
+        # interrupt a newer ABA turn that reused the same session/client.
+        return _interrupt_response(
+            session_id,
+            bc,
+            requested_turn_id=requested_turn_id,
+            interrupted=[],
+            stale=True,
+        )
+    # Stop means "do not continue autonomously". Pause queued work only after
+    # the immutable owner check, before the SDK interrupt can race cleanup and
+    # dequeue the next item.
     await obs.to_thread_io(
         "chat.queue_pause_nonempty",
         session_id,
@@ -9775,7 +9953,6 @@ async def interrupt(session_id: str) -> dict:
     # too early than too late). This also lets the force-stop watchdog and the
     # event_gen error branch convert a teardown-induced transport error into a
     # clean `cancelled` event instead of a red error toast.
-    bc = _active_turns.get(session_id)
     if bc is not None and not bc.done:
         bc.cancelled = True
         if not bc.cancelled_at_ms:
@@ -9802,19 +9979,30 @@ async def interrupt(session_id: str) -> dict:
             startup_owner.cancel()
             cancelled_startup = True
         if cancelled_startup:
-            return {
-                "ok": True,
-                "interrupted": [f"{session_id}@startup"],
-                "phase": "starting",
-            }
+            return _interrupt_response(
+                session_id,
+                bc,
+                requested_turn_id=requested_turn_id,
+                interrupted=[f"{session_id}@startup"],
+                phase="starting",
+            )
     if not targets:
         # No live client in the pool, but a detached pump task may still be
         # holding the _active_turns slot. Schedule the watchdog anyway so the
         # session can't get wedged. Don't set the pending-interrupt flag: with
         # no turn to suppress a push for, leaving it set would wrongly mute the
         # NEXT turn's done-push.
-        return {"ok": True, "interrupted": [], "note": "no live client"}
-    _pending_interrupts.add(session_id)
+        return _interrupt_response(
+            session_id,
+            bc,
+            requested_turn_id=requested_turn_id,
+            interrupted=[],
+            note="no live client",
+        )
+    _pending_interrupts.add((
+        session_id,
+        bc.turn_id if bc is not None else requested_turn_id,
+    ))
 
     async def _interrupt_one(k, c) -> str | None:
         try:
@@ -9837,7 +10025,12 @@ async def interrupt(session_id: str) -> dict:
     interrupted = [result for result in results if result is not None]
     # The watchdog was armed before these control requests, so a slow/broken
     # acknowledgement cannot postpone the hard-stop deadline.
-    return {"ok": True, "interrupted": interrupted}
+    return _interrupt_response(
+        session_id,
+        bc,
+        requested_turn_id=requested_turn_id,
+        interrupted=interrupted,
+    )
 
 
 @router.post("/sessions/{sid}/tasks/{task_id}/stop",
@@ -14001,12 +14194,8 @@ async def _start_turn(
             raise _TurnStartError(
                 "turn could not establish its startup event") from None
 
-    # Defensive: clear any stale "user cancelled" flag carried over from
-    # a previous turn on this session. Normally consumed by the prior
-    # turn's ResultMessage handler, but if that handler never reached
-    # (early exception in pump_claude before ResultMessage arrived) the
-    # flag would persist and wrongly suppress the next turn's push.
-    _pending_interrupts.discard(session_id)
+    # Pending interrupts are keyed by immutable turn id, so an older turn's
+    # delayed terminal bookkeeping cannot suppress this turn's completion.
     # One-session-one-model: if the session already has a locked model,
     # that wins over whatever the frontend's dropdown happens to say. This
     # prevents the "I tried to switch but it didn't take" class of bugs and
@@ -15179,6 +15368,7 @@ async def _start_turn(
                     "context_used": 0, "context_used_pct": 0.0,
                     "context_limit": 0,
                 })
+                _session_usage_turns[session_id] = broadcast.turn_id
                 capability = await _detect_gateway_context_capability(
                     model_to_use)
                 details = _context_limit_details(
@@ -15505,6 +15695,7 @@ async def _start_turn(
                 "context_used": 0, "context_used_pct": 0.0,
                 "context_limit": 0,
             })
+            _session_usage_turns[session_id] = broadcast.turn_id
             sess_u["total_cost_usd"] += cost
             sess_u["last_turn_at"] = time.time()
 
@@ -15520,10 +15711,15 @@ async def _start_turn(
             # ResultMessage can race the later session-level bookkeeping, and
             # overwriting it with ``False`` used to turn a user Stop into a
             # completed/failed result (or recover Result-only prose after Stop).
+            interrupt_key = (session_id, broadcast.turn_id)
+            legacy_interrupt_key = (session_id, "")
             was_cancelled = bool(
-                broadcast.cancelled or session_id in _pending_interrupts
+                broadcast.cancelled
+                or interrupt_key in _pending_interrupts
+                or legacy_interrupt_key in _pending_interrupts
             )
-            _pending_interrupts.discard(session_id)
+            _pending_interrupts.discard(interrupt_key)
+            _pending_interrupts.discard(legacy_interrupt_key)
             broadcast.cancelled = was_cancelled
             _completed_at_ms = int(time.time() * 1000)
             _msg_duration_ms = getattr(msg, "duration_ms", None)
@@ -15721,14 +15917,22 @@ async def _start_turn(
             # bookkeeping below is still running and observe a bare assistant
             # record with no status/model/duration.
             _footer_annotation_uuid = ""
-            if terminal_assistant_uuid:
-                try:
+            _done_usage_source = _usage_source_signature(
+                _find_session_jsonl(session_id))
+            _done_usage_summary = _session_usage_summary_payload(
+                _done_session_usage,
+                turn_id=broadcast.turn_id,
+                source=_done_usage_source,
+            )
+            try:
+                if terminal_assistant_uuid:
                     await obs.to_thread_io(
                         "chat.sidecar_terminal_write",
                         session_id,
-                        sess.set_message_annotation,
+                        sess.set_terminal_annotation_and_usage,
                         session_id,
                         terminal_assistant_uuid,
+                        _done_usage_summary,
                         cost=f"${cost:.4f}",
                         model=model_to_use,
                         ts=_completed_at_ms,
@@ -15738,11 +15942,20 @@ async def _start_turn(
                         file_path=sess._sidecar_path(session_id),
                     )
                     _footer_annotation_uuid = terminal_assistant_uuid
-                except Exception as exc:
-                    sys.stderr.write(
-                        f"[chat] terminal footer annotation failed "
-                        f"sid={session_id[:8]} exc={type(exc).__name__}\n")
-                    sys.stderr.flush()
+                elif _done_usage_summary is not None:
+                    await obs.to_thread_io(
+                        "chat.sidecar_terminal_usage_write",
+                        session_id,
+                        sess.set_session_usage_summary,
+                        session_id,
+                        _done_usage_summary,
+                        file_path=sess._sidecar_path(session_id),
+                    )
+            except Exception as exc:
+                sys.stderr.write(
+                    f"[chat] terminal sidecar write failed "
+                    f"sid={session_id[:8]} exc={type(exc).__name__}\n")
+                sys.stderr.flush()
             yield {"event": "done", "data": json.dumps({
                 "turn_id": broadcast.turn_id,
                 "duration_ms": _msg_duration_ms,
@@ -15798,6 +16011,8 @@ async def _start_turn(
             # numerator. For Codex, the denominator comes from CLIProxyAPI's
             # live catalog; other providers retain their existing SDK/table
             # fallback. The raw SDK figures are diagnostic metadata only.
+            pre_probe_usage = sess_u
+            sess_u = dict(sess_u)
             if endpoints.is_third_party(model_to_use):
                 # Re-anchor context_limit to the runtime effective limit, not the
                 # optimistic catalog value. For Codex Gateway this prevents the UI
@@ -15869,6 +16084,26 @@ async def _start_turn(
                     sys.stderr.write(
                         f"[chat-stream] get_context_usage skipped for "
                         f"sid={session_id[:8]} exc={type(_e).__name__}\n")
+
+            refined_usage = sess_u
+            if _refine_session_usage_for_turn(
+                    session_id, broadcast.turn_id, refined_usage):
+                refined_source = _usage_source_signature(
+                    _find_session_jsonl(session_id))
+                await obs.to_thread_io(
+                    "chat.usage_summary_refine",
+                    session_id,
+                    _persist_session_usage_summary,
+                    session_id,
+                    refined_usage,
+                    turn_id=broadcast.turn_id,
+                    source=refined_source,
+                    require_matching_turn=True,
+                    file_path=lambda: sess._sidecar_path(session_id),
+                )
+            # A successor may have completed during the probe. Keep later
+            # bookkeeping on the currently-authoritative snapshot, not this copy.
+            sess_u = _session_usage.get(session_id, pre_probe_usage)
 
             # Sidecar annotations: resolve UUIDs from the exact pre-query
             # transcript coordinate. A simple "latest assistant" tail scan is
@@ -17138,6 +17373,7 @@ async def _subscribe_multiplex(
     completed: set[tuple[str, str]] = set()
     reported_mismatches: set[tuple[str, str, str]] = set()
     state_fingerprints: dict[str, str] = {}
+    state_payloads: dict[str, dict] = {}
 
     async def _pump_child(
         session_id: str,
@@ -17212,6 +17448,7 @@ async def _subscribe_multiplex(
                 state_payload = dict(state)
                 state_payload["session_id"] = session_id
                 fingerprint = _mux_session_state_fingerprint(state_payload)
+                state_payloads[session_id] = state_payload
                 if state_fingerprints.get(session_id) != fingerprint:
                     state_fingerprints[session_id] = fingerprint
                     await output.put({
@@ -17266,8 +17503,27 @@ async def _subscribe_multiplex(
                 )
 
         for session_id in list(state_fingerprints):
-            if session_id not in active_ids:
-                state_fingerprints.pop(session_id, None)
+            if session_id in active_ids:
+                continue
+            # The child pump owns terminal delivery. Do not publish inactive
+            # while it can still enqueue done/cancelled/error frames; once the
+            # task is done, every child frame is already ahead of this state
+            # transition in the same FIFO output queue.
+            if any(key[0] == session_id for key in children):
+                continue
+            previous = state_payloads.pop(session_id, {"session_id": session_id})
+            state_fingerprints.pop(session_id, None)
+            inactive = {
+                **previous,
+                "session_id": session_id,
+                "active": False,
+                "stopping": False,
+                "attachable": False,
+            }
+            await output.put({
+                "event": "session_state",
+                "data": json.dumps(inactive, ensure_ascii=False),
+            })
 
     try:
         while True:
@@ -17372,6 +17628,7 @@ def session_active_status(sid: str) -> dict:
                 # "no active turn"). A later continuation flips attachable.
                 return {
                     "active": True,
+                    "stopping": False,
                     "attachable": False,
                     "background": True,
                     "continuation": False,
@@ -17390,6 +17647,7 @@ def session_active_status(sid: str) -> dict:
                 }
             return {
                 "active": False,
+                "stopping": False,
                 "background_tasks_pending": 0,
                 "runtime_background_tasks_pending": runtime_background_pending,
                 "runtime_continuation_pending": runtime_continuation_pending,
@@ -17405,6 +17663,7 @@ def session_active_status(sid: str) -> dict:
     _hydrate_staged_attachment_display(b)
     return {
         "active": True,
+        "stopping": bool(b.cancelled),
         "attachable": True,
         "background": False,
         "background_tasks_pending": len(

--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -6,9 +6,9 @@ import asyncio
 import contextlib
 import errno
 import json
+import multiprocessing
 import os
 import sys
-import threading
 from collections import OrderedDict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -25,9 +25,13 @@ from .capability_tickets import tickets
 from .files import INTERNAL_DIR_NAME, TRASH_DIR_NAME
 from .observability import elapsed_ms, is_slow, monotonic, perf_event, short_id
 from .workspace_store import (
+    _SCAN_MAX_FILES,
+    _SCAN_MAX_SECONDS,
     WorkspaceScanCancelled,
+    WorkspaceScanIncomplete,
     WorkspaceStore,
     is_ignored_descendant,
+    workspace_scan_worker,
 )
 from .workspaces import registry, resolve_workspace_root
 
@@ -43,6 +47,8 @@ _RECONCILE_RETRY_MAX_S = 30.0
 _MAX_WATCHED_ROOTS = 16
 _MAX_EVENT_SUBSCRIBERS = 64
 _MAX_CONCURRENT_RECONCILES = 4
+_SCAN_CANCEL_GRACE_S = 0.25
+_PARTIAL_RECONCILE_YIELD_S = 0.01
 _NATIVE_DIRECTORY_WATCH_HARD_CAP = 131_072
 _WATCH_LINGER_S = 30.0
 _MAX_IDLE_WATCHERS = 3
@@ -111,7 +117,9 @@ class _WatchState:
     reconcile_error: Exception | None = None
     ready: asyncio.Event = field(default_factory=asyncio.Event)
     mutation_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    lifecycle_generation: int = 0
     watch_revision: int = 0
+    native_mutation_revision: int = 0
     watch_stop_event: asyncio.Event | None = None
     watch_ready: asyncio.Event = field(default_factory=asyncio.Event)
     watch_paths: tuple[Path, ...] = ()
@@ -123,13 +131,22 @@ class _WatchState:
     reconcile_retry_at: float = 0.0
     reconcile_cancel: asyncio.Event = field(default_factory=asyncio.Event)
     scan_progress: dict[str, Any] = field(default_factory=dict)
-    scan_cancel: threading.Event = field(default_factory=threading.Event)
     stop_task: asyncio.Task[None] | None = None
     queue_overflow_active: bool = False
     native_budget_ready: asyncio.Event = field(default_factory=asyncio.Event)
     native_budget_wait_cost: int = 0
     native_watch_cost: int = 0
     native_budget_degraded: bool = False
+
+
+@dataclass(frozen=True)
+class _ReconcileApplicability:
+    workspace_id: str
+    root: Path
+    lifecycle_generation: int
+    watch_revision: int
+    native_mutation_revision: int
+    cursor: int
 
 
 def _normalise_bootstrap_parents(
@@ -255,12 +272,18 @@ class FileWatchManager:
         self._pending_subscribers = 0
         self._pending_watched_roots: dict[Path, int] = {}
         self._subscription_generation = 0
+        self._lifecycle_generation = 0
         self._subscription_setups: set[asyncio.Task[Any]] = set()
         self._accepting_subscriptions = True
         self._lock = asyncio.Lock()
         self._reconcile_slots = asyncio.Semaphore(
             _MAX_CONCURRENT_RECONCILES,
         )
+        self._scan_worker_lock = asyncio.Lock()
+        self._scan_context = multiprocessing.get_context("spawn")
+        self._scan_process: multiprocessing.Process | None = None
+        self._scan_connection: Any | None = None
+        self._scan_cancel = self._scan_context.Event()
         self._native_watcher_slots = asyncio.Semaphore(
             _MAX_WATCHED_ROOTS,
         )
@@ -597,6 +620,7 @@ class FileWatchManager:
             state = self._states.get(root)
             created = state is None
             if state is None:
+                self._lifecycle_generation += 1
                 state = _WatchState(
                     root=root,
                     workspace_id=entry.id,
@@ -604,11 +628,22 @@ class FileWatchManager:
                     primary=entry.primary,
                     force_polling=_FORCE_POLLING,
                     initialized=bool(status["initialized"]),
+                    lifecycle_generation=self._lifecycle_generation,
                 )
                 if state.initialized:
                     state.ready.set()
                 self._states[root] = state
             else:
+                if (
+                    state.workspace_id != entry.id
+                    or state.root != root
+                    or state.name != entry.name
+                    or state.primary != entry.primary
+                ):
+                    self._lifecycle_generation += 1
+                    state.lifecycle_generation = self._lifecycle_generation
+                    state.scan_progress.clear()
+                state.root = root
                 state.workspace_id = entry.id
                 state.name = entry.name
                 state.primary = entry.primary
@@ -661,6 +696,8 @@ class FileWatchManager:
                 if state.workspace_id != workspace_id:
                     continue
                 self._states.pop(root, None)
+                self._lifecycle_generation += 1
+                state.lifecycle_generation = self._lifecycle_generation
                 self._idle_watchers.pop(root, None)
                 cancel_tasks = [
                     task
@@ -676,7 +713,6 @@ class FileWatchManager:
                 ):
                     reconcile_task = state.reconcile_task
                     state.reconcile_cancel.set()
-                    state.scan_cancel.set()
                     if not state.reconcile_running:
                         reconcile_task.cancel()
                 state.reconcile_pending = False
@@ -1170,13 +1206,162 @@ class FileWatchManager:
             return True
         return False
 
+    def _ensure_scan_worker_locked(self) -> None:
+        """Lazily start the manager's single spawned filesystem scanner."""
+        process = self._scan_process
+        if (
+            process is not None
+            and process.is_alive()
+            and self._scan_connection is not None
+        ):
+            return
+        if self._scan_connection is not None:
+            self._scan_connection.close()
+        if process is not None:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=_SCAN_CANCEL_GRACE_S)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=_SCAN_CANCEL_GRACE_S)
+            process.close()
+        self._scan_cancel.clear()
+        parent, child = self._scan_context.Pipe()
+        process = self._scan_context.Process(
+            target=workspace_scan_worker,
+            args=(child, self._scan_cancel),
+            name="muselab-files-scanner",
+            daemon=True,
+        )
+        try:
+            process.start()
+        except BaseException:
+            parent.close()
+            child.close()
+            process.close()
+            raise
+        child.close()
+        self._scan_process = process
+        self._scan_connection = parent
+
+    def _exchange_scan_request(self, request: tuple[Any, ...]) -> tuple[Any, ...]:
+        connection = self._scan_connection
+        if connection is None:
+            raise RuntimeError("workspace scanner is not running")
+        connection.send(request)
+        response = connection.recv()
+        if not isinstance(response, tuple) or len(response) != 4:
+            raise RuntimeError("workspace scanner returned an invalid response")
+        return response
+
+    async def _stop_scan_worker_locked(self) -> None:
+        """Stop the isolated scanner, escalating to terminate and kill."""
+        connection = self._scan_connection
+        process = self._scan_process
+        self._scan_connection = None
+        self._scan_process = None
+        if process is None:
+            if connection is not None:
+                connection.close()
+            return
+        if connection is not None and process.is_alive():
+            with contextlib.suppress(BrokenPipeError, EOFError, OSError):
+                connection.send(None)
+        await asyncio.to_thread(process.join, _SCAN_CANCEL_GRACE_S)
+        if process.is_alive():
+            process.terminate()
+            await asyncio.to_thread(process.join, _SCAN_CANCEL_GRACE_S)
+        if process.is_alive():
+            process.kill()
+            await asyncio.to_thread(process.join, _SCAN_CANCEL_GRACE_S)
+        if connection is not None:
+            connection.close()
+        process.close()
+
+    async def _cancel_scan_exchange(
+        self,
+        exchange: asyncio.Task[tuple[Any, ...]],
+    ) -> None:
+        """Request cooperative scan cancellation, then terminate if blocked."""
+        self._scan_cancel.set()
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(exchange),
+                timeout=_SCAN_CANCEL_GRACE_S,
+            )
+        except TimeoutError:
+            await self._stop_scan_worker_locked()
+            await asyncio.gather(exchange, return_exceptions=True)
+        except BaseException:
+            await asyncio.gather(exchange, return_exceptions=True)
+
+    async def _scan_workspace(
+        self,
+        state: _WatchState,
+    ) -> tuple[list[Any], dict[str, Any]]:
+        """Run one bounded scan in the reusable spawned worker."""
+        if state.reconcile_cancel.is_set():
+            raise WorkspaceScanCancelled("workspace scan cancelled")
+        async with self._scan_worker_lock:
+            if state.reconcile_cancel.is_set():
+                raise WorkspaceScanCancelled("workspace scan cancelled")
+            self._ensure_scan_worker_locked()
+            self._scan_cancel.clear()
+            request = (
+                str(state.root),
+                _SCAN_MAX_FILES,
+                _SCAN_MAX_SECONDS,
+                state.scan_progress,
+            )
+            exchange = asyncio.create_task(
+                asyncio.to_thread(self._exchange_scan_request, request),
+                name=f"muselab-files-scan-exchange:{state.workspace_id}",
+            )
+            cancelled = asyncio.create_task(state.reconcile_cancel.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {exchange, cancelled},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if cancelled in done:
+                    await self._cancel_scan_exchange(exchange)
+                    raise WorkspaceScanCancelled("workspace scan cancelled")
+                cancelled.cancel()
+                await asyncio.gather(cancelled, return_exceptions=True)
+                response = exchange.result()
+            except asyncio.CancelledError:
+                cancelled.cancel()
+                await self._cancel_scan_exchange(exchange)
+                await asyncio.gather(cancelled, return_exceptions=True)
+                raise
+            except WorkspaceScanCancelled:
+                raise
+            except BaseException:
+                cancelled.cancel()
+                await self._stop_scan_worker_locked()
+                await asyncio.gather(cancelled, return_exceptions=True)
+                raise
+
+            status, rows, report, progress = response
+            state.scan_progress = progress if isinstance(progress, dict) else {}
+            if status == "error":
+                error_type = str(rows or "")
+                detail = str(report or "workspace scan failed")
+                if error_type == "WorkspaceScanIncomplete":
+                    raise WorkspaceScanIncomplete(detail)
+                if error_type == "WorkspaceScanCancelled":
+                    raise WorkspaceScanCancelled(detail)
+                raise RuntimeError(
+                    f"workspace scanner failed ({error_type or 'unknown'})"
+                )
+            if status != "ok" or not isinstance(rows, list) or not isinstance(report, dict):
+                raise RuntimeError("workspace scanner returned invalid scan data")
+            return rows, report
+
     async def _reconcile_after_watch(self, state: _WatchState) -> None:
         """Reconcile downtime after the watcher gets a chance to register."""
         while True:
             state.reconcile_pending = False
-            retry_delay = max(0.0, state.reconcile_retry_at - monotonic())
-            if retry_delay:
-                await asyncio.sleep(retry_delay)
             try:
                 if not await self._wait_for_reconcile_backoff(state):
                     return
@@ -1190,7 +1375,12 @@ class FileWatchManager:
                         return
                 partial = await self._reconcile_and_broadcast(state)
                 if partial:
-                    self._record_reconcile_retry(state)
+                    # An accepted bounded continuation is healthy work. Yield
+                    # briefly for other roots instead of entering failure backoff.
+                    self._reset_reconcile_retry(state)
+                    state.reconcile_retry_at = (
+                        monotonic() + _PARTIAL_RECONCILE_YIELD_S
+                    )
                     state.reconcile_pending = True
                 else:
                     self._reset_reconcile_retry(state)
@@ -1314,6 +1504,53 @@ class FileWatchManager:
             )
         return partial
 
+    async def _capture_reconcile_applicability(
+        self,
+        state: _WatchState,
+    ) -> _ReconcileApplicability:
+        async with self._lock:
+            registered = self._states.get(state.root)
+            if registered is not state and state.lifecycle_generation != 0:
+                raise WorkspaceScanCancelled("workspace lifecycle changed")
+            workspace_id = state.workspace_id
+            root = state.root
+            lifecycle_generation = state.lifecycle_generation
+            watch_revision = state.watch_revision
+            native_mutation_revision = state.native_mutation_revision
+        cursor = await asyncio.to_thread(
+            self.store.current_cursor,
+            workspace_id,
+        )
+        return _ReconcileApplicability(
+            workspace_id=workspace_id,
+            root=root,
+            lifecycle_generation=lifecycle_generation,
+            watch_revision=watch_revision,
+            native_mutation_revision=native_mutation_revision,
+            cursor=cursor,
+        )
+
+    def _applicability_matches_locked(
+        self,
+        state: _WatchState,
+        token: _ReconcileApplicability,
+    ) -> bool:
+        registered = self._states.get(token.root)
+        return (
+            (registered is state or token.lifecycle_generation == 0)
+            and state.workspace_id == token.workspace_id
+            and state.root == token.root
+            and state.lifecycle_generation == token.lifecycle_generation
+            and state.watch_revision == token.watch_revision
+            and state.native_mutation_revision
+            == token.native_mutation_revision
+            and not state.reconcile_cancel.is_set()
+            and (
+                state.task is None
+                or state.watch_ready.is_set()
+            )
+        )
+
     async def _reconcile_and_broadcast_impl(
         self,
         state: _WatchState,
@@ -1322,102 +1559,98 @@ class FileWatchManager:
         broadcast_payload: dict[str, Any] | None = None
         partial = False
         while True:
+            if state.task is not None and not state.watch_ready.is_set():
+                if not await self._wait_for_armed_watcher(state):
+                    raise RuntimeError(
+                        "watcher stopped before closing reconciliation"
+                    )
+                continue
+
             scan_slot_started = monotonic()
             await self._reconcile_slots.acquire()
             metrics["scan_slot_wait_ms"] = int(
                 metrics["scan_slot_wait_ms"]
             ) + elapsed_ms(scan_slot_started)
-            mutation_lock_started = monotonic()
+            stale_snapshot = False
             try:
-                await state.mutation_lock.acquire()
-            except BaseException:
-                self._reconcile_slots.release()
-                raise
-            metrics["mutation_lock_wait_ms"] = int(
-                metrics["mutation_lock_wait_ms"]
-            ) + elapsed_ms(mutation_lock_started)
-            retry_after_arm = False
-            try:
-                # A watcher may restart while this workspace waits for an older
-                # mutation. Never scan inside the replacement generation's gap.
-                if state.task is not None and not state.watch_ready.is_set():
-                    retry_after_arm = True
-                else:
-                    state.reconcile_running = True
-                    # Keep the replay window consistent with watcher mutations.
-                    # Reading `before` or `delta` outside this lock lets a native
-                    # batch commit between them and be broadcast twice.
-                    before = await asyncio.to_thread(
-                        self.store.current_cursor,
-                        state.workspace_id,
-                    )
-                    scan_report: dict[str, Any] = {}
-                    scan_started = monotonic()
+                mutation_lock_started = monotonic()
+                async with state.mutation_lock:
+                    metrics["mutation_lock_wait_ms"] = int(
+                        metrics["mutation_lock_wait_ms"]
+                    ) + elapsed_ms(mutation_lock_started)
+                    if state.task is not None and not state.watch_ready.is_set():
+                        stale_snapshot = True
+                    else:
+                        token = await self._capture_reconcile_applicability(state)
+
+                if stale_snapshot:
+                    continue
+                state.reconcile_running = True
+                scan_started = monotonic()
+                try:
+                    snapshot, scan_report = await self._scan_workspace(state)
+                finally:
+                    metrics["scan_ms"] = int(
+                        metrics["scan_ms"]
+                    ) + elapsed_ms(scan_started)
+                partial = bool(scan_report.get("partial"))
+                metrics["partial"] = partial
+                metrics["partial_reason"] = scan_report.get(
+                    "partial_reason"
+                )
+                metrics["scanned_files"] = int(
+                    scan_report.get("scanned_files") or 0
+                )
+                metrics["snapshot_files"] = int(
+                    scan_report.get("snapshot_files") or 0
+                )
+
+                mutation_lock_started = monotonic()
+                async with state.mutation_lock:
+                    metrics["mutation_lock_wait_ms"] = int(
+                        metrics["mutation_lock_wait_ms"]
+                    ) + elapsed_ms(mutation_lock_started)
+                    apply_started = monotonic()
                     try:
-                        await asyncio.to_thread(
-                            self.store.reconcile,
-                            state.workspace_id,
-                            state.root,
-                            state.name,
-                            primary=state.primary,
-                            cancel_event=state.scan_cancel,
-                            report=scan_report,
-                            scan_progress=state.scan_progress,
-                        )
-                    finally:
-                        metrics["scan_ms"] = int(
-                            metrics["scan_ms"]
-                        ) + elapsed_ms(scan_started)
-                    partial = bool(scan_report.get("partial"))
-                    metrics["partial"] = partial
-                    metrics["partial_reason"] = scan_report.get(
-                        "partial_reason"
-                    )
-                    metrics["scanned_files"] = int(
-                        scan_report.get("scanned_files") or 0
-                    )
-                    metrics["snapshot_files"] = int(
-                        scan_report.get("snapshot_files") or 0
-                    )
-                    replay_started = monotonic()
-                    try:
-                        replay = await asyncio.to_thread(
-                            self.store.delta,
-                            state.workspace_id,
-                            before,
-                            limit=5000,
-                        )
-                        metrics["changes"] = len(
-                            replay.get("changes") or ()
-                        )
-                        metrics["resync"] = bool(
-                            replay.get("resync") or replay.get("has_more")
-                        )
-                        if replay.get("resync") or replay.get("has_more"):
-                            cursor = await asyncio.to_thread(
-                                self.store.current_cursor,
-                                state.workspace_id,
-                            )
-                            broadcast_payload = {
-                                "resync": True,
-                                "changes": [],
-                                "cursor": cursor,
-                            }
-                        elif replay.get("changes"):
-                            broadcast_payload = replay
+                        # Lifecycle/watch changes own the manager lock; native
+                        # batches own mutation_lock. Hold both through the store's
+                        # atomic cursor/root check and payload construction.
+                        async with self._lock:
+                            if not self._applicability_matches_locked(state, token):
+                                stale_snapshot = True
+                            else:
+                                result = await asyncio.to_thread(
+                                    self.store.apply_reconcile_snapshot,
+                                    token.workspace_id,
+                                    token.root,
+                                    state.name,
+                                    snapshot,
+                                    scan_report,
+                                    expected_cursor=token.cursor,
+                                    primary=state.primary,
+                                    cancel_event=state.reconcile_cancel,
+                                )
                     finally:
                         metrics["replay_ms"] = int(
                             metrics["replay_ms"]
-                        ) + elapsed_ms(replay_started)
+                        ) + elapsed_ms(apply_started)
+                    if not stale_snapshot and result.pop("_stale", False):
+                        stale_snapshot = True
+                    if not stale_snapshot:
+                        metrics["changes"] = len(
+                            result.get("changes") or ()
+                        )
+                        metrics["resync"] = bool(result.get("resync"))
+                        if result.get("resync") or result.get("changes"):
+                            broadcast_payload = result
             finally:
-                state.mutation_lock.release()
                 self._reconcile_slots.release()
-            if not retry_after_arm:
-                break
-            if not await self._wait_for_armed_watcher(state):
-                raise RuntimeError(
-                    "watcher stopped before closing reconciliation"
-                )
+            if stale_snapshot:
+                # A token change invalidates accumulated resume state; a new
+                # applicability window must establish its own complete snapshot.
+                state.scan_progress.clear()
+                continue
+            break
         state.initialized = True
         state.reconcile_error = None
         if broadcast_payload is not None:
@@ -1425,7 +1658,7 @@ class FileWatchManager:
         if state.task is not None:
             latest_paths = await self._watch_directories(state)
             if latest_paths != state.watch_paths:
-                self._request_watch_refresh(state)
+                await self._request_watch_refresh(state)
                 await self._schedule_reconcile(state)
         return partial
 
@@ -1435,12 +1668,12 @@ class FileWatchManager:
                 return
             self._queue_reconcile_locked(state)
 
-    @staticmethod
-    def _request_watch_refresh(state: _WatchState) -> None:
-        state.watch_revision += 1
-        state.watch_ready.clear()
-        if state.watch_stop_event is not None:
-            state.watch_stop_event.set()
+    async def _request_watch_refresh(self, state: _WatchState) -> None:
+        async with self._lock:
+            state.watch_revision += 1
+            state.watch_ready.clear()
+            if state.watch_stop_event is not None:
+                state.watch_stop_event.set()
 
     async def _watch_directories(
         self,
@@ -1752,6 +1985,9 @@ class FileWatchManager:
                     if not rows:
                         continue
                     async with state.mutation_lock:
+                        # Every relevant native batch invalidates a detached scan,
+                        # even when durable deduplication emits no replay event.
+                        state.native_mutation_revision += 1
                         payload = await asyncio.to_thread(
                             self.store.apply_changes,
                             state.workspace_id,
@@ -1767,7 +2003,7 @@ class FileWatchManager:
                     if payload.get("resync") or payload["changes"]:
                         self._broadcast(state, payload)
                     if watch_refresh:
-                        self._request_watch_refresh(state)
+                        await self._request_watch_refresh(state)
                     if needs_reconcile or watch_refresh:
                         await self._schedule_reconcile(state)
                     if watch_refresh:
@@ -1911,7 +2147,6 @@ class FileWatchManager:
             ]
             for state in states:
                 state.reconcile_cancel.set()
-                state.scan_cancel.set()
                 if (state.reconcile_task is not None
                         and not state.reconcile_task.done()):
                     reconcile_tasks.append(state.reconcile_task)
@@ -1927,20 +2162,18 @@ class FileWatchManager:
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        # Do not cancel an outer to_thread await: cancellation would detach the
-        # Python worker and let it keep scanning against a store we immediately
-        # close. The cooperative event makes ordinary scans unwind promptly;
-        # runtime_lifecycle still owns the hard shutdown budget for a blocked
-        # kernel/network filesystem call.
         try:
             if reconcile_tasks:
                 await asyncio.gather(*reconcile_tasks, return_exceptions=True)
             if subscription_setups:
                 await asyncio.gather(*subscription_setups, return_exceptions=True)
         finally:
+            # A blocked filesystem syscall lives only in the disposable scanner;
+            # terminating it cannot strand a Python thread against the SQLite
+            # store. The next manager lifecycle starts a fresh spawned worker.
+            async with self._scan_worker_lock:
+                await self._stop_scan_worker_locked()
             # close() only resets lazy state and uses a short RLock section.
-            # Run it synchronously in finally so an outer lifecycle deadline
-            # cannot cancel the to_thread wrapper before this invariant lands.
             self.store.close()
 
 

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -110,6 +110,7 @@ async def to_thread_io(
     *args: Any,
     file_path: Path | Callable[[], Path | None] | None = None,
     file_size: int | None = None,
+    owned: bool = False,
     **kwargs: Any,
 ) -> _T:
     """Run blocking I/O off-loop and report only slow, privacy-safe calls.
@@ -136,7 +137,24 @@ async def to_thread_io(
             measured["file_size"] = size
 
     try:
-        return await asyncio.to_thread(invoke)
+        if not owned:
+            return await asyncio.to_thread(invoke)
+        worker = asyncio.create_task(asyncio.to_thread(invoke))
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            # A commit-point write may not outlive its owner: cleanup must observe
+            # the real disk result before deciding whether rollback is necessary.
+            while not worker.done():
+                try:
+                    await asyncio.shield(worker)
+                except asyncio.CancelledError:
+                    continue
+            try:
+                worker.result()
+            except Exception:
+                pass
+            raise
     finally:
         duration = measured.get("duration_ms")
         if duration is not None and is_slow(duration, threshold_ms=slow_io_ms()):

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -33,6 +33,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
 from .settings import ROOT, atomic_write_text, env_int, is_chinese_locale
+from . import observability as obs
 
 
 def _scheduled_label_prefix() -> str:
@@ -975,7 +976,8 @@ async def finish_task_cleanup(tid: str) -> bool:
     """Finish one durable deletion intent; safe to retry by task id."""
     ensure_available()
     async with _cleanup_lock(tid):
-        intent = get_task_cleanup(tid)
+        intent = await obs.to_thread_io(
+            "scheduler.cleanup_read", tid, get_task_cleanup, tid)
         if intent is None:
             return tid in _REVOKED_TASK_IDS
 
@@ -986,10 +988,14 @@ async def finish_task_cleanup(tid: str) -> bool:
         )
         record_error: Exception | None = None
         try:
-            refreshed = _record_task_cleanup_runtime_sessions(
+            refreshed = await obs.to_thread_io(
+                "scheduler.cleanup_record",
+                tid,
+                _record_task_cleanup_runtime_sessions,
                 tid,
                 intent["cleanup_id"],
                 runtime_session_ids,
+                owned=True,
             )
             if refreshed is not None:
                 intent = refreshed
@@ -1026,10 +1032,18 @@ async def finish_task_cleanup(tid: str) -> bool:
             from .chat import purge_session_storage_async
             await purge_session_storage_async(intent["session_id"])
 
-        if _complete_task_cleanup(tid, intent["cleanup_id"]):
+        if await obs.to_thread_io(
+            "scheduler.cleanup_complete",
+            tid,
+            _complete_task_cleanup,
+            tid,
+            intent["cleanup_id"],
+            owned=True,
+        ):
             return True
         # Another idempotent cleaner may have acknowledged the same record.
-        if get_task_cleanup(tid) is None:
+        if await obs.to_thread_io(
+            "scheduler.cleanup_read", tid, get_task_cleanup, tid) is None:
             return True
         raise RuntimeError("scheduler cleanup intent changed during completion")
 
@@ -1206,12 +1220,16 @@ async def _run_sdk_task_turn(
                 # owner-specific missing-row finish is a no-op, so a failure
                 # before persistence cannot synthesize a ghost event.
                 _mark_current_run_activity_started()
-                _activity.start(
+                await obs.to_thread_io(
+                    "scheduler.activity_start",
+                    session_id,
+                    _activity.start,
                     session_id,
                     summary=activity_summary or prompt,
                     kind="scheduled",
                     source_id=activity_source_id,
                     owner_id=activity_owner_id,
+                    owned=True,
                 )
             except Exception as e:
                 sys.stderr.write(
@@ -1313,8 +1331,13 @@ async def run_task_now(tid: str) -> bool:
     Useful as a "retry" affordance after a failure, and as a smoke test
     after editing a task without having to wait for the next fire window."""
     ensure_available()
-    with _STATE_LOCK:
-        task = _state["tasks"].get(tid)
+
+    def _read_task_for_run() -> dict | None:
+        with _STATE_LOCK:
+            return _state["tasks"].get(tid)
+
+    task = await obs.to_thread_io(
+        "scheduler.task_read", tid, _read_task_for_run)
     if not task:
         return False
     t = _track_task(
@@ -1371,34 +1394,62 @@ async def _execute_task(task: dict) -> None:
             sid = ""
             try:
                 from . import sessions as sess
+
+                def _delete_fresh_session() -> None:
+                    sess.begin_session_delete(sid)
+                    sess.delete_session(sid)
+
                 ts_label = datetime.now().strftime("%m-%d %H:%M")
-                sess_meta = sess.create_session(
+                sess_meta = await obs.to_thread_io(
+                    "scheduler.session_create",
+                    tid,
+                    sess.create_session,
                     name=f"{_scheduled_label_prefix()}{task['name']} · {ts_label}",
-                    model=task.get("model", ""))
+                    model=task.get("model", ""),
+                    owned=True,
+                )
                 sid = sess_meta["id"]
-                with _STATE_LOCK:
-                    snapshot = copy.deepcopy(_state)
-                    revoked = tid in _REVOKED_TASK_IDS
-                    if not revoked:
-                        # "most recent run" pointer
-                        task["session_id"] = sid
-                        try:
-                            _save_state()
-                        except Exception:
-                            _restore_state(snapshot)
-                            raise
+
+                def _commit_fresh_session() -> bool:
+                    with _STATE_LOCK:
+                        snapshot = copy.deepcopy(_state)
+                        is_revoked = tid in _REVOKED_TASK_IDS
+                        if not is_revoked:
+                            # "most recent run" pointer
+                            task["session_id"] = sid
+                            try:
+                                _save_state()
+                            except Exception:
+                                _restore_state(snapshot)
+                                raise
+                        return is_revoked
+
+                revoked = await obs.to_thread_io(
+                    "scheduler.fresh_session_commit",
+                    tid,
+                    _commit_fresh_session,
+                    owned=True,
+                )
                 if revoked:
                     # A synchronous compatibility caller can revoke while
                     # create_session is doing disk I/O in another thread.
                     # This run never owned the freshly minted empty session.
-                    sess.begin_session_delete(sid)
-                    sess.delete_session(sid)
+                    await obs.to_thread_io(
+                        "scheduler.session_delete",
+                        tid,
+                        _delete_fresh_session,
+                        owned=True,
+                    )
                     return
             except Exception as e:
                 if sid:
                     try:
-                        sess.begin_session_delete(sid)
-                        sess.delete_session(sid)
+                        await obs.to_thread_io(
+                            "scheduler.session_delete",
+                            tid,
+                            _delete_fresh_session,
+                            owned=True,
+                        )
                     except Exception as cleanup_error:
                         sys.stderr.write(
                             "[scheduler] failed to roll back fresh session "
@@ -1415,28 +1466,36 @@ async def _execute_task(task: dict) -> None:
                 # remain visible in history when that history can be saved.
                 if not isinstance(e, SchedulerPersistenceError):
                     now = time.time()
-                    with _STATE_LOCK:
-                        snapshot = copy.deepcopy(_state)
-                        if tid not in _REVOKED_TASK_IDS:
-                            _state["history"].append({
-                                "task_id": tid,
-                                "task_name": task["name"],
-                                "session_id": "",
-                                "ts": now,
-                                "ok": False,
-                                "error": (
-                                    "session mint failed: "
-                                    f"{type(e).__name__}: {e}"
-                                ),
-                                "reply_preview": None,
-                            })
-                            _state["unread_count"] = (
-                                _state.get("unread_count", 0) + 1
-                            )
-                            try:
-                                _save_state()
-                            except Exception:
-                                _restore_state(snapshot)
+                    mint_error = f"{type(e).__name__}: {e}"
+
+                    def _persist_mint_failure() -> None:
+                        with _STATE_LOCK:
+                            snapshot = copy.deepcopy(_state)
+                            if tid not in _REVOKED_TASK_IDS:
+                                _state["history"].append({
+                                    "task_id": tid,
+                                    "task_name": task["name"],
+                                    "session_id": "",
+                                    "ts": now,
+                                    "ok": False,
+                                    "error": f"session mint failed: {mint_error}",
+                                    "reply_preview": None,
+                                })
+                                _state["unread_count"] = (
+                                    _state.get("unread_count", 0) + 1
+                                )
+                                try:
+                                    _save_state()
+                                except Exception:
+                                    _restore_state(snapshot)
+                                    raise
+
+                    await obs.to_thread_io(
+                        "scheduler.mint_failure",
+                        tid,
+                        _persist_mint_failure,
+                        owned=True,
+                    )
                 return
         else:
             sid = task["session_id"]
@@ -1498,17 +1557,19 @@ async def _execute_task(task: dict) -> None:
                 "error": error,
                 "reply_preview": preview if error is None else None,
             }
-            with _STATE_LOCK:
-                revoked = (
-                    tid in _REVOKED_TASK_IDS
-                    or session_store.session_is_deleting(sid)
-                )
-                if not revoked:
+            def _persist_run_result() -> bool:
+                with _STATE_LOCK:
+                    is_revoked = (
+                        tid in _REVOKED_TASK_IDS
+                        or session_store.session_is_deleting(sid)
+                    )
+                    if is_revoked:
+                        return True
                     snapshot = copy.deepcopy(_state)
                     task["last_run"] = now
                     _state["history"].append(entry)
-                    # Successful runs bump unread; errors also bump so the
-                    # user notices them — but they show as red in the UI.
+                    # Successful runs and errors both bump unread so the result
+                    # remains visible in the bell drawer.
                     _state["unread_count"] = (
                         _state.get("unread_count", 0) + 1
                     )
@@ -1516,13 +1577,25 @@ async def _execute_task(task: dict) -> None:
                         _state["history"] = _state["history"][-_HISTORY_CAP:]
                     try:
                         _save_state()
-                    except SchedulerPersistenceError as exc:
+                    except SchedulerPersistenceError:
                         _restore_state(snapshot)
-                        error = f"SchedulerPersistenceError: {exc}"
-                        sys.stderr.write(
-                            f"[scheduler] task {tid} result was not persisted; "
-                            "in-memory mutation rolled back\n"
-                        )
+                        raise
+                    return False
+
+            try:
+                revoked = await obs.to_thread_io(
+                    "scheduler.run_result",
+                    tid,
+                    _persist_run_result,
+                    owned=True,
+                )
+            except SchedulerPersistenceError as exc:
+                revoked = False
+                error = f"SchedulerPersistenceError: {exc}"
+                sys.stderr.write(
+                    f"[scheduler] task {tid} result was not persisted; "
+                    "in-memory mutation rolled back\n"
+                )
             try:
                 from .activity import activity as _activity
                 current = asyncio.current_task()
@@ -1532,11 +1605,15 @@ async def _execute_task(task: dict) -> None:
                         or current in _RUN_ACTIVITY_STARTED
                     )
                 if should_finish_activity:
-                    _activity.finish(
+                    await obs.to_thread_io(
+                        "scheduler.activity_finish",
+                        sid,
+                        _activity.finish,
                         sid,
                         "cancelled" if (cancelled or revoked) else (
                             "failed" if error else "completed"),
                         owner_id=activity_owner_id,
+                        owned=True,
                     )
             except Exception as e:
                 sys.stderr.write(
@@ -1628,31 +1705,44 @@ async def _scheduler_loop() -> None:
     while True:
         try:
             now = time.time()
-            with _STATE_LOCK:
-                snapshot = list(_state["tasks"].values())
-            for task in snapshot:
-                if not task.get("enabled", True):
-                    continue
-                nr = task.get("next_run")
-                if nr and nr <= now:
-                    # Advance next_run optimistically so a long-running
-                    # task doesn't fire twice if we tick again before it
-                    # finishes.
-                    with _STATE_LOCK:
-                        state_snapshot = copy.deepcopy(_state)
+
+            committed_due: list[dict] = []
+
+            def _advance_due_tasks() -> list[dict]:
+                with _STATE_LOCK:
+                    due = [
+                        task for task in _state["tasks"].values()
+                        if task.get("enabled", True)
+                        and task.get("next_run")
+                        and task["next_run"] <= now
+                    ]
+                    if not due:
+                        return []
+                    state_snapshot = copy.deepcopy(_state)
+                    for task in due:
+                        # Persist advancement before launch so a long-running
+                        # task cannot fire twice on a later scheduler tick.
                         task["next_run"] = _compute_next_run(task["schedule"])
-                        # A `once` task fires exactly once — after firing it
-                        # has no future next_run, so disable it too. This
-                        # flips the UI toggle off so the user sees it's spent,
-                        # instead of a dead-enabled task that can never fire
-                        # again.
                         if (task.get("schedule") or {}).get("kind") == "once":
                             task["enabled"] = False
-                        try:
-                            _save_state()
-                        except Exception:
-                            _restore_state(state_snapshot)
-                            raise
+                    try:
+                        _save_state()
+                    except Exception:
+                        _restore_state(state_snapshot)
+                        raise
+                    committed_due.extend(due)
+                    return due
+
+            try:
+                due_tasks = await obs.to_thread_io(
+                    "scheduler.advance_due", "scheduler", _advance_due_tasks,
+                    owned=True,
+                )
+            except asyncio.CancelledError:
+                # owned I/O joined the commit. Preserve launch-after-commit even
+                # when shutdown arrives during fsync, then propagate cancellation.
+                due_tasks = list(committed_due)
+                for task in due_tasks:
                     task_obj = _track_task(
                         asyncio.create_task(_execute_task(task)),
                         task_id=str(task.get("id") or ""),
@@ -1662,7 +1752,20 @@ async def _scheduler_loop() -> None:
                             else ""
                         ),
                     )
-                    task_obj.add_done_callback(_make_task_done(task.get("id", "?")))
+                    task_obj.add_done_callback(
+                        _make_task_done(task.get("id", "?")))
+                raise
+            for task in due_tasks:
+                task_obj = _track_task(
+                    asyncio.create_task(_execute_task(task)),
+                    task_id=str(task.get("id") or ""),
+                    session_id=(
+                        str(task.get("session_id") or "")
+                        if _effective_session_mode(task) == "reuse"
+                        else ""
+                    ),
+                )
+                task_obj.add_done_callback(_make_task_done(task.get("id", "?")))
         except Exception as e:
             sys.stderr.write(f"[scheduler] loop error: {e}\n")
         await asyncio.sleep(60)
@@ -1692,39 +1795,61 @@ async def start_scheduler() -> None:
     # generous enough to cover overnight outages while filtering
     # actually-stale entries.
     _CATCHUP_MAX_AGE_S = 24 * 3600
-    with _STATE_LOCK:
-        _load_state()
-        state_snapshot = copy.deepcopy(_state)
-        for task in _state["tasks"].values():
-            sched = task.get("schedule")
-            if not sched:
-                continue
-            nr = task.get("next_run")
-            # If next_run is in the past AND the task is enabled, the window
-            # was missed while we were down. Disabled tasks just get next_run
-            # rolled forward (no catch-up), matching their "don't fire" intent.
-            if (nr and nr <= now and task.get("enabled", True)
-                    and (now - nr) < _CATCHUP_MAX_AGE_S):
-                missed.append(task)
-            elif nr and nr <= now and task.get("enabled", True):
-                sys.stderr.write(
-                    f"[scheduler] skipping stale catch-up for task "
-                    f"{task.get('id','?')} ({task.get('name','?')}): "
-                    f"missed {(now - nr) / 3600:.1f}h ago, beyond 24h window\n")
-            task["next_run"] = _compute_next_run(sched)
-            # A spent `once` task (date in the past → no future next_run)
-            # should be disabled, not left dead-enabled. Covers both tasks
-            # that just missed their window (already queued for catch-up
-            # above, so they still fire one final time) and ones that fired
-            # in a previous run but stayed enabled. Future-dated `once` tasks
-            # keep next_run set, so they stay enabled until they fire.
-            if sched.get("kind") == "once" and task["next_run"] is None:
-                task["enabled"] = False
-        try:
-            _save_state()
-        except Exception:
-            _restore_state(state_snapshot)
-            raise
+    startup_snapshot: dict | None = None
+
+    def _load_and_advance_startup() -> list[dict]:
+        nonlocal startup_snapshot
+        startup_missed: list[dict] = []
+        with _STATE_LOCK:
+            _load_state()
+            state_snapshot = copy.deepcopy(_state)
+            startup_snapshot = state_snapshot
+            for task in _state["tasks"].values():
+                sched = task.get("schedule")
+                if not sched:
+                    continue
+                nr = task.get("next_run")
+                # Enabled tasks missed within the bounded outage window catch up
+                # once; stale or disabled tasks only roll their schedule forward.
+                if (nr and nr <= now and task.get("enabled", True)
+                        and (now - nr) < _CATCHUP_MAX_AGE_S):
+                    startup_missed.append(task)
+                elif nr and nr <= now and task.get("enabled", True):
+                    sys.stderr.write(
+                        f"[scheduler] skipping stale catch-up for task "
+                        f"{task.get('id','?')} ({task.get('name','?')}): "
+                        f"missed {(now - nr) / 3600:.1f}h ago, beyond 24h window\n")
+                task["next_run"] = _compute_next_run(sched)
+                if sched.get("kind") == "once" and task["next_run"] is None:
+                    task["enabled"] = False
+            try:
+                _save_state()
+            except Exception:
+                _restore_state(state_snapshot)
+                raise
+        return startup_missed
+
+    try:
+        missed = await obs.to_thread_io(
+            "scheduler.startup_state", "scheduler", _load_and_advance_startup,
+            owned=True,
+        )
+    except asyncio.CancelledError:
+        # Startup did not reach its catch-up launch boundary. Restore the exact
+        # pre-advance schedule so the next process can recover the missed window.
+        if startup_snapshot is not None:
+            def _rollback_startup_advance() -> None:
+                with _STATE_LOCK:
+                    _restore_state(startup_snapshot)
+                    _save_state()
+
+            await obs.to_thread_io(
+                "scheduler.startup_rollback",
+                "scheduler",
+                _rollback_startup_advance,
+                owned=True,
+            )
+        raise
     # Resolve crash-interrupted deletions before starting new scheduled work.
     # Failures are logged and retain their exact durable intent, so scheduler
     # availability does not depend on one damaged external session tree.

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1958,34 +1958,102 @@ def sidecar_signature(sid: str) -> tuple[float, int] | None:
         return None
 
 
+def get_session_usage_summary(sid: str) -> dict | None:
+    """Return the persisted usage summary without hiding malformed schemas."""
+    summary = _load_sidecar(sid).get("usage_summary")
+    return dict(summary) if isinstance(summary, dict) else None
+
+
+def set_session_usage_summary(sid: str, summary: dict) -> bool:
+    """Persist usage hydration under the deletion and corruption fences."""
+    with session_lifecycle_lock(sid):
+        with _QUEUE_LOCK:
+            if sid in _DELETED_SESSION_IDS:
+                return False
+        with _SIDECAR_LOCK:
+            data = _load_sidecar(sid, use_cache=False)
+            data["usage_summary"] = dict(summary)
+            _save_sidecar(sid, data)
+            return True
+
+
+def set_session_usage_summary_if_turn_matches(
+    sid: str,
+    expected_turn_id: str,
+    summary: dict,
+) -> bool:
+    """Refine usage only while the same terminal turn owns the sidecar."""
+    with session_lifecycle_lock(sid):
+        with _QUEUE_LOCK:
+            if sid in _DELETED_SESSION_IDS:
+                return False
+        with _SIDECAR_LOCK:
+            data = _load_sidecar(sid, use_cache=False)
+            current = data.get("usage_summary")
+            update = current.get("update") if isinstance(current, dict) else None
+            current_turn_id = (
+                str(update.get("turn_id") or "")
+                if isinstance(update, dict) else ""
+            )
+            if not expected_turn_id or current_turn_id != expected_turn_id:
+                return False
+            data["usage_summary"] = dict(summary)
+            _save_sidecar(sid, data)
+            return True
+
+
+def set_terminal_annotation_and_usage(
+    sid: str,
+    msg_uuid: str,
+    summary: dict | None,
+    **fields: Any,
+) -> bool:
+    """Persist the terminal footer and optional usage summary in one replace."""
+    with session_lifecycle_lock(sid):
+        with _QUEUE_LOCK:
+            if sid in _DELETED_SESSION_IDS:
+                return False
+        with _SIDECAR_LOCK:
+            data = _load_sidecar(sid, use_cache=False)
+            _merge_message_annotation(data, msg_uuid, fields)
+            if isinstance(summary, dict):
+                data["usage_summary"] = dict(summary)
+            _save_sidecar(sid, data)
+            return True
+
+
+def _merge_message_annotation(
+    data: dict,
+    msg_uuid: str,
+    fields: dict[str, Any],
+) -> None:
+    msgs = data.setdefault("messages", {})
+    cur = msgs.setdefault(msg_uuid, {})
+    sticky_cancelled = (
+        cur.get("turn_status") == "cancelled"
+        and fields.get("turn_status") not in (None, "cancelled")
+    )
+    for key, value in fields.items():
+        if value is None:
+            continue
+        if sticky_cancelled and key in {"turn_status", "ts", "elapsed_s"}:
+            continue
+        cur[key] = value
+
+
 def set_message_annotation(sid: str, msg_uuid: str, **fields: Any) -> None:
     """Update one message's annotations (cost, model, images, etc.).
     Fields with value None are skipped (use update with explicit empty
     if you want to clear). Atomic per-call write."""
-    # Linearize terminal footer writes with explicit deletion. A Result worker
-    # every worker arriving after the tombstone is a no-op and cannot recreate
-    # the deleted sidecar.
+    # Linearize terminal footer writes with explicit deletion. Every worker
+    # arriving after the tombstone is a no-op and cannot recreate the sidecar.
     with session_lifecycle_lock(sid):
         with _QUEUE_LOCK:
             if sid in _DELETED_SESSION_IDS:
                 return
         with _SIDECAR_LOCK:
             data = _load_sidecar(sid, use_cache=False)
-            msgs = data.setdefault("messages", {})
-            cur = msgs.setdefault(msg_uuid, {})
-            # Explicit user cancellation is monotonic truth.  A force-stopped
-            # CLI can append its AssistantMessage/ResultMessage late; generic
-            # terminal bookkeeping then attempts to write ``completed``.
-            sticky_cancelled = (
-                cur.get("turn_status") == "cancelled"
-                and fields.get("turn_status") not in (None, "cancelled")
-            )
-            for k, v in fields.items():
-                if v is None:
-                    continue
-                if sticky_cancelled and k in {"turn_status", "ts", "elapsed_s"}:
-                    continue
-                cur[k] = v
+            _merge_message_annotation(data, msg_uuid, fields)
             _save_sidecar(sid, data)
 
 

--- a/backend/workspace_store.py
+++ b/backend/workspace_store.py
@@ -8,7 +8,7 @@ import shutil
 import sqlite3
 import threading
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -243,6 +243,75 @@ def scan_workspace(
         if complete_paths is not None:
             report["_snapshot_paths"] = complete_paths
     return rows
+
+
+ScanRow = tuple[str, bool, int, float, int, int, int]
+
+
+def compact_scan_rows(rows: Iterable[dict[str, Any]]) -> list[ScanRow]:
+    """Encode filesystem rows compactly for scanner-process IPC."""
+    return [
+        (
+            row["path"],
+            bool(row["is_dir"]),
+            int(row["size"]),
+            float(row["mtime"]),
+            int(row["mtime_ns"]),
+            int(row["ctime_ns"]),
+            int(row["inode"]),
+        )
+        for row in rows
+    ]
+
+
+def expand_scan_rows(
+    rows: Iterable[ScanRow | Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Decode compact IPC rows while accepting direct in-process test rows."""
+    expanded: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            expanded.append(dict(row))
+            continue
+        path, is_dir, size, mtime, mtime_ns, ctime_ns, inode = row
+        expanded.append({
+            "path": path,
+            "name": Path(path).name,
+            "is_dir": is_dir,
+            "size": size,
+            "mtime": mtime,
+            "mtime_ns": mtime_ns,
+            "ctime_ns": ctime_ns,
+            "inode": inode,
+        })
+    return expanded
+
+
+def workspace_scan_worker(connection: Any, cancel_event: Any) -> None:
+    """Serve compact scan requests in one reusable spawned worker process."""
+    try:
+        while True:
+            request = connection.recv()
+            if request is None:
+                return
+            root, max_files, max_seconds, progress = request
+            report: dict[str, Any] = {}
+            try:
+                rows = scan_workspace(
+                    Path(root),
+                    cancel_event=cancel_event,
+                    max_files=max_files,
+                    max_seconds=max_seconds,
+                    report=report,
+                    progress=progress,
+                )
+                connection.send(("ok", compact_scan_rows(rows), report, progress))
+            except BaseException as exc:
+                connection.send(("error", type(exc).__name__, str(exc), progress))
+    except (EOFError, BrokenPipeError, OSError):
+        return
+    finally:
+        connection.close()
 
 
 class WorkspaceStore:
@@ -593,31 +662,35 @@ class WorkspaceStore:
         max_seconds: float | None = _SCAN_MAX_SECONDS,
         report: dict[str, Any] | None = None,
         scan_progress: dict[str, Any] | None = None,
-    ) -> int:
-        """Scan disk, update only changed rows, and log offline changes."""
+        snapshot: list[dict[str, Any]] | None = None,
+        expected_cursor: int | None = None,
+        return_payload: bool = False,
+    ) -> int | dict[str, Any]:
+        """Scan or apply a snapshot, logging offline changes atomically."""
         root = root.resolve()
         scan_report: dict[str, Any] = report if report is not None else {}
-        # Keep a watcher batch from committing after our snapshot but before the
-        # reconciliation transaction. Different workspaces may still scan in
-        # parallel, while bootstrap/delta reads keep using the last-good index.
+        # Filesystem walking may happen in a separate process. The workspace lock
+        # serializes only durable application and native watcher transactions.
         with self._workspace_lock(workspace_id):
-            snapshot = scan_workspace(
-                root,
-                cancel_event=cancel_event,
-                max_files=max_files,
-                max_seconds=max_seconds,
-                report=scan_report,
-                progress=scan_progress,
-            )
+            if snapshot is None:
+                snapshot = scan_workspace(
+                    root,
+                    cancel_event=cancel_event,
+                    max_files=max_files,
+                    max_seconds=max_seconds,
+                    report=scan_report,
+                    progress=scan_progress,
+                )
             partial = bool(scan_report.get("partial"))
             if cancel_event is not None and cancel_event.is_set():
                 raise WorkspaceScanCancelled("workspace scan cancelled")
-            self.register_workspace(
-                workspace_id,
-                root,
-                name,
-                primary=primary,
-            )
+            if expected_cursor is None:
+                self.register_workspace(
+                    workspace_id,
+                    root,
+                    name,
+                    primary=primary,
+                )
             if cancel_event is not None and cancel_event.is_set():
                 raise WorkspaceScanCancelled("workspace scan cancelled")
             with self._connect() as db:
@@ -626,13 +699,27 @@ class WorkspaceStore:
                 db.execute("BEGIN IMMEDIATE")
                 state = db.execute(
                     """
-                    SELECT initialized, current_seq
+                    SELECT initialized, current_seq, path
                     FROM workspaces WHERE id = ?
                     """,
                     (workspace_id,),
                 ).fetchone()
-                initialized = bool(state["initialized"]) if state else False
-                seq = int(state["current_seq"]) if state else 0
+                if state is None:
+                    db.rollback()
+                    raise KeyError(f"unknown workspace: {workspace_id}")
+                initialized = bool(state["initialized"])
+                seq = int(state["current_seq"])
+                if expected_cursor is not None and (
+                    seq != expected_cursor
+                    or state["path"] != str(root)
+                ):
+                    db.rollback()
+                    return {
+                        "_stale": True,
+                        "cursor": seq,
+                        "changes": [],
+                        "resync": True,
+                    }
                 old = {
                     row["path"]: row
                     for row in self._file_rows(db, workspace_id)
@@ -645,6 +732,7 @@ class WorkspaceStore:
                 resumed = bool(scan_report.get("resumed"))
 
                 changes: list[dict[str, Any]] = []
+                resync = False
                 if not initialized:
                     # A failed first scan may have left watcher-created rows. A
                     # complete baseline replaces them authoritatively; a bounded
@@ -687,6 +775,7 @@ class WorkspaceStore:
                         )
                         self._insert_files(db, workspace_id, snapshot)
                         seq = self._reset_replay(db, workspace_id, seq)
+                        resync = True
                     else:
                         if deleted:
                             db.executemany(
@@ -706,6 +795,7 @@ class WorkspaceStore:
                             # Preserve the incrementally assembled index but use
                             # a cursor gap instead of retaining a huge replay.
                             seq = self._reset_replay(db, workspace_id, seq)
+                            resync = True
                         else:
                             changes.extend(
                                 {"type": "deleted", "path": path}
@@ -745,7 +835,40 @@ class WorkspaceStore:
                 if cancel_event is not None and cancel_event.is_set():
                     raise WorkspaceScanCancelled("workspace scan cancelled")
                 db.commit()
+                if return_payload:
+                    return {
+                        "cursor": seq,
+                        "changes": [] if resync else self._wire_changes(changes),
+                        "resync": resync,
+                    }
                 return seq
+
+    def apply_reconcile_snapshot(
+        self,
+        workspace_id: str,
+        root: Path,
+        name: str,
+        snapshot: Iterable[ScanRow],
+        scan_report: dict[str, Any],
+        *,
+        expected_cursor: int,
+        primary: bool = False,
+        cancel_event: threading.Event | None = None,
+    ) -> dict[str, Any]:
+        """Verify the durable cursor, apply a scan, and return its exact payload."""
+        result = self.reconcile(
+            workspace_id,
+            root,
+            name,
+            primary=primary,
+            cancel_event=cancel_event,
+            report=scan_report,
+            snapshot=expand_scan_rows(snapshot),
+            expected_cursor=expected_cursor,
+            return_payload=True,
+        )
+        assert isinstance(result, dict)
+        return result
 
     def apply_changes(
         self,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9671,9 +9671,9 @@ function portal() {
       this._fetchTabUsage(id);
     },
 
-    // Retain ten recently-used virtualized transcript panes. Each pane mounts
-    // only its viewport rows/spacers, so this avoids repeated Alpine/Markdown DOM
-    // reconstruction without retaining a second full-history representation.
+    // Retain a bounded set of recently-used virtualized transcript panes. Stream
+    // transport/state outlives its pane, so inactive live sessions must obey the
+    // same limit instead of keeping an unbounded hidden Alpine tree mounted.
     _touchTranscriptPane(id) {
       if (!id) return false;
       const open = new Set(this.workspaceOpenTabIds());
@@ -9683,18 +9683,8 @@ function portal() {
       const previousLru = (this._transcriptPaneLru || []).filter(tid => open.has(tid));
       const lru = [id, ...previousLru.filter(tid => tid !== id)];
       this._transcriptPaneLru = lru;
-      // A background stream keeps mutating its pane. Never evict that live DOM;
-      // once it settles, the next activation naturally trims it by LRU again.
-      const streaming = Array.from(open).filter(tid => {
-        const st = this.tabState && this.tabState[tid];
-        return st && (st.streaming || st.es);
-      });
-      const streamingSet = new Set(streaming);
       const warmLimit = this._isMobileLayout() ? 1 : this.WARM_TRANSCRIPT_LIMIT;
-      const ordinary = lru
-        .filter(tid => !streamingSet.has(tid))
-        .slice(0, warmLimit);
-      const desired = [...ordinary, ...streaming];
+      const desired = lru.slice(0, warmLimit);
       const desiredSet = new Set(desired);
       // Preserve mount order for panes that remain warm. Reordering the x-for on
       // every click would physically move several large DOM subtrees and recreate
@@ -14940,9 +14930,13 @@ function portal() {
       // Switch the visible tab. We do NOT touch other tabs' streams — each
       // tab's ES is in its own tabState[id], and stream callbacks write
       // there directly. Switching is just "show that tab".
-      // The active pane and the nine most-recent panes stay mounted as bounded
+      // The active pane and a bounded set of recent panes stay mounted as
       // virtualized DOM views. Canonical messages remain owned by tabState.
       this._activateTabState(this.currentId);
+      const activatedState = this.tabState && this.tabState[this.currentId];
+      if (activatedState && typeof activatedState._flushLivePresentation === "function") {
+        activatedState._flushLivePresentation();
+      }
       // Selecting a conversation means opening its latest state, not restoring a
       // stale historical viewport. Reader-controlled position is preserved only
       // while staying inside the same active tab; every explicit tab selection
@@ -29147,6 +29141,9 @@ function portal() {
       // tab is active).
       let curBubble = null;
       let acc = "";
+      let thinkingBubble = null;
+      let thinkingAcc = "";
+      const pendingTaskProgress = new Map();
       if (isReconnect && resumeEventSeq > 0 && !isContinuation) {
         const existing = streamState.messages;
         const tail = existing[existing.length - 1];
@@ -29259,6 +29256,7 @@ function portal() {
         pendingTimer = null;
         pendingFrame = null;
         if (!ownsCurBubble()) { curBubble = null; acc = ""; return; }
+        if (this.currentId !== streamSid) return;
         curBubble.text = acc;
         curBubble._streamText = acc;
         curBubble._streamPlain = true;
@@ -29267,7 +29265,7 @@ function portal() {
         _scrollIfActive();
       };
       const schedulePlainPaint = () => {
-        if (pendingTimer || pendingFrame) return;
+        if (this.currentId !== streamSid || pendingTimer || pendingFrame) return;
         const queueFrame = () => {
           pendingTimer = null;
           if (typeof requestAnimationFrame === "function") {
@@ -29297,7 +29295,28 @@ function portal() {
         if (ownsCurBubble()) renderFinal();
         else { cancelPendingPaint(); curBubble = null; acc = ""; }
       };
-      const closeAsst = () => { flushRender(); curBubble = null; acc = ""; };
+      const flushPlainBoundary = () => {
+        cancelPendingPaint();
+        if (!ownsCurBubble()) { curBubble = null; acc = ""; return; }
+        curBubble.text = acc;
+        curBubble._streamText = acc;
+        curBubble._streamPlain = true;
+        if (this.currentId === streamSid) _scrollIfActive();
+      };
+      const closeAsst = () => {
+        flushPlainBoundary();
+        curBubble = null;
+        acc = "";
+      };
+      const flushThinking = () => {
+        if (!ownsStreamState() || !thinkingBubble) return;
+        thinkingBubble.text = thinkingAcc;
+      };
+      const closeThinking = () => {
+        flushThinking();
+        thinkingBubble = null;
+        thinkingAcc = "";
+      };
       const _setContinuationAwaitingReaction = (waiting) => {
         if (!isContinuation) return;
         const next = !!waiting;
@@ -29368,11 +29387,44 @@ function portal() {
           taskCardByTaskId.set(String(card.task_status.task_id), card);
         }
       };
+      const taskProgressKey = (toolUseId, patch) => String(
+        toolUseId || (patch && patch.task_id) || "",
+      );
+      const queueTaskProgress = (toolUseId, patch) => {
+        const key = taskProgressKey(toolUseId, patch);
+        if (!key) return;
+        const pending = pendingTaskProgress.get(key);
+        pendingTaskProgress.set(key, {
+          toolUseId,
+          patch: Object.assign({}, pending ? pending.patch : {}, patch),
+        });
+      };
+      const flushTaskProgress = () => {
+        if (!ownsStreamState() || !pendingTaskProgress.size) return;
+        for (const pending of pendingTaskProgress.values()) {
+          applyTaskStatus(pending.toolUseId, pending.patch);
+        }
+        pendingTaskProgress.clear();
+      };
+      const flushLivePresentation = () => {
+        if (!ownsStreamState() || this.currentId !== streamSid) return false;
+        if (ownsCurBubble()) paintPlainNow();
+        flushThinking();
+        flushTaskProgress();
+        return true;
+      };
+      streamState._flushLivePresentation = flushLivePresentation;
+      const flushTerminalPresentation = () => {
+        closeAsst();
+        closeThinking();
+        flushTaskProgress();
+      };
 
       es.addEventListener("text", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         _setContinuationAwaitingReaction(false);
+        closeThinking();
         if (!openAsst()) return;
         acc += d.text;
         // Keep the currently painted snapshot stable while the user selects it.
@@ -29389,27 +29441,26 @@ function portal() {
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         _setContinuationAwaitingReaction(false);
         closeAsst();
-        // Backend yields one SSE event per thinking_delta. Coalesce them
-        // into the most recent thinking message so we see ONE block per
-        // reasoning segment, not N tiny ones. If the tail isn't a thinking
-        // message (e.g. previous was tool_use), start a new one.
-        const msgs = streamState.messages;
-        const last = msgs[msgs.length - 1];
-        let pushed = false;
-        if (last && last.role === "thinking") {
-          last.text = (last.text || "") + (d.text || "");
-        } else {
-          this._appendLiveMessage(streamState, { role: "thinking", text: d.text || "" });
-          pushed = true;
+        // Keep one thinking row per contiguous reasoning segment, but publish
+        // token-rate text only for the visible tab. Background streams retain
+        // the complete closure accumulator and flush once on activation/boundary.
+        if (!thinkingBubble) {
+          thinkingBubble = this._appendLiveMessage(
+            streamState, { role: "thinking", text: "" });
+          thinkingAcc = "";
         }
-
-        _scrollIfActive();
+        thinkingAcc += d.text || "";
+        if (this.currentId === streamSid) {
+          thinkingBubble.text = thinkingAcc;
+          _scrollIfActive();
+        }
       });
       es.addEventListener("tool_use", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         _setContinuationAwaitingReaction(false);
         closeAsst();
+        closeThinking();
         // `id` is the SDK's toolu_xxx tool_use_id. Critical for
         // _taskSubjectMapForMessages — it pairs each TaskCreate
         // tool_use with the tool_result that carries the assigned
@@ -29482,16 +29533,19 @@ function portal() {
       es.addEventListener("task_progress", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
-        applyTaskStatus(d.tool_use_id, {
+        const patch = {
           task_id: d.task_id,
           state: "running",
           usage: d.usage || null,
           last_tool_name: d.last_tool_name || "",
-        });
+        };
+        if (this.currentId === streamSid) applyTaskStatus(d.tool_use_id, patch);
+        else queueTaskProgress(d.tool_use_id, patch);
       });
       es.addEventListener("task_notification", ev => {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
+        flushTaskProgress();
         // SDK status ∈ {completed, failed, stopped}; map unknown → "done"
         // so a future status value still renders a terminal (not stuck)
         // state instead of silently staying on ⏳.
@@ -29564,6 +29618,7 @@ function portal() {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         closeAsst();
+        closeThinking();
         // Pre-populate pendingAnswers with one key per question (multiSelect
         // → []; single → null). Without this, Alpine's Proxy doesn't reliably
         // re-evaluate :class={picked: ...} when we add a brand-new key on
@@ -29593,6 +29648,7 @@ function portal() {
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { return; }
         closeAsst();
+        closeThinking();
         const exitPlan = d.kind === "exit_plan"
           || d.kind === "exit_plan_mode"
           || d.tool === "ExitPlanMode";
@@ -29779,6 +29835,10 @@ function portal() {
         streamState.streamPhase = "";
         streamState._continuationAwaitingReaction = false;
         streamState.es = null;
+        if (streamState._flushLivePresentation === flushLivePresentation) {
+          streamState._flushLivePresentation = null;
+        }
+        pendingTaskProgress.clear();
         if (followedTail) {
           this._boundLiveMessageRange(streamState, true);
           streamState.atBottom = true;
@@ -29980,7 +30040,7 @@ function portal() {
         }
       };
       es.addEventListener("done", ev => {
-        flushRender();
+        flushTerminalPresentation();
         // Guard JSON.parse: a malformed/empty `done` payload must NOT throw
         // before es.close()/_markDone()/_stopTimer() run below, else the
         // EventSource + timer interval leak and the UI stays streaming=true
@@ -30178,7 +30238,7 @@ function portal() {
         this.$nextTick(() => this._ensureBgContPoller(streamSid));
       });
       es.addEventListener("resync", ev => {
-        flushRender();
+        flushTerminalPresentation();
         let payload = {};
         try { payload = JSON.parse(ev.data) || {}; } catch (_) {}
         const reason = payload.reason || "replay_truncated";
@@ -30189,6 +30249,10 @@ function portal() {
         if (streamState._stallWatch) clearInterval(streamState._stallWatch);
         streamState._stallWatch = null;
         streamState.es = null;
+        if (streamState._flushLivePresentation === flushLivePresentation) {
+          streamState._flushLivePresentation = null;
+        }
+        pendingTaskProgress.clear();
         if (streamMobile && reason === "replay_truncated") {
           this.toast(this.lang === "zh"
             ? "回复数据量较大，完成后会自动从会话记录同步"
@@ -30203,7 +30267,7 @@ function portal() {
         streamState._canonicalResyncReason = reason;
       });
       es.addEventListener("error", async ev => {
-        flushRender();
+        flushTerminalPresentation();
         // One terminal server error may be followed by EventSource's own EOF
         // error. Busy handoff performs async durable persistence, so claim the
         // transport before its first await and make every later callback a
@@ -30576,7 +30640,7 @@ function portal() {
         });
       });
       es.addEventListener("cancelled", ev => {
-        flushRender();
+        flushTerminalPresentation();
         let d = {};
         try { d = JSON.parse(ev.data || "{}"); } catch (_) { d = {}; }
         const alreadySettledOptimistically = !!streamState._optimisticInterrupt;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -31587,6 +31587,7 @@ function portal() {
           workspacePath: String(group.workspace_path || ""),
         },
       ]));
+      const customGroupCount = lookup.size;
       lookup.set("__ungrouped__", {
         key: "custom:__ungrouped__",
         label: this.lang === "zh" ? "未分组" : "Ungrouped",
@@ -31596,8 +31597,26 @@ function portal() {
         color: "gray",
         builtin: true,
       });
+      let customIndex = 0;
       return this.normalizeActivityGroupOrder()
-        .map(groupId => lookup.get(groupId)).filter(Boolean);
+        .map(groupId => lookup.get(groupId)).filter(Boolean)
+        .map(group => {
+          if (group.builtin) {
+            return {
+              ...group,
+              boardColumn: 3,
+              boardRow: 1,
+              boardRowSpan: Math.max(1, Math.ceil(customGroupCount / 2)),
+            };
+          }
+          const index = customIndex++;
+          return {
+            ...group,
+            boardColumn: (index % 2) + 1,
+            boardRow: Math.floor(index / 2) + 1,
+            boardRowSpan: 1,
+          };
+        });
     },
     activityMatchesGroup(item, key) {
       if (!item) return false;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10288,23 +10288,43 @@ function portal() {
       const sid = String(payload && payload.session_id || "");
       if (!sid) return;
       const meta = (this.sessions || []).find(session => session.id === sid);
-      if (meta) {
-        meta.active = !!payload.active;
-        meta.turn_active = !!payload.active && !payload.background;
-        meta.background_active = !!payload.active && !!payload.background;
-      }
       const existingState = this.tabState && this.tabState[sid];
       if (!payload.active) {
-        this._chatMuxPendingEvents.delete(sid);
         const inactiveTurnId = String(payload.turn_id || "");
-        if (existingState && inactiveTurnId
-            && existingState._stoppingTurnId === inactiveTurnId) {
-          existingState._stoppingTurnId = "";
+        const currentTurnId = String(existingState && existingState.activeTurnId || "");
+        if (inactiveTurnId && currentTurnId && inactiveTurnId !== currentTurnId) {
+          // A delayed inactive frame for turn A must not retire or relabel its
+          // already-admitted successor turn B in the same session.
+          return;
+        }
+        if (meta) {
+          meta.active = false;
+          meta.turn_active = false;
+          meta.background_active = false;
+        }
+        this._chatMuxPendingEvents.delete(sid);
+        const ownsInactiveTurn = !!(existingState && inactiveTurnId
+          && currentTurnId === inactiveTurnId);
+        if (ownsInactiveTurn) {
+          if (existingState._stoppingTurnId === inactiveTurnId) {
+            existingState._stoppingTurnId = "";
+          }
+          this._retireStaleSessionStream(sid, existingState);
+          this._setSessionActivityExpectation(sid, false);
+          existingState._pendingExternalUpdate = true;
+          this._scheduleCanonicalStreamReload(
+            sid, existingState, { minimumWaitMs: 0 });
+          return;
         }
         if (existingState && !existingState.streaming) {
           this._setBackgroundTaskActive(sid, false, payload.started_at, 0);
         }
         return;
+      }
+      if (meta) {
+        meta.active = true;
+        meta.turn_active = !payload.background;
+        meta.background_active = !!payload.background;
       }
       if (payload.attachable === false) {
         // Watcher-only ownership has no replayable turn yet. Preserve its blue

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -310,6 +310,47 @@ function _pruneChatResourceTicketCache(now) {
   }
 }
 
+const CHAT_MUX_STREAM_EVENTS = [
+  "startup", "text", "thinking", "tool_use", "tool_result",
+  "compact_progress", "task_started", "task_progress", "task_notification",
+  "rate_limit", "ask_user_question", "permission_request",
+  "permission_request_resolved", "permission_mode_changed",
+  "permission_mode_change_failed", "ping", "done", "error", "cancelled",
+  "resync",
+];
+const CHAT_MUX_BOOTSTRAP_MAX_EVENTS = 512;
+const CHAT_MUX_BOOTSTRAP_MAX_BYTES = 2 * 1024 * 1024;
+
+class ChatMuxSessionChannel extends EventTarget {
+  constructor(sessionId, turnId, onClose) {
+    super();
+    this.sessionId = sessionId;
+    this.turnId = turnId;
+    this.readyState = 0;
+    this.onopen = null;
+    this._onClose = onClose;
+    this._muxChannel = true;
+  }
+
+  open() {
+    if (this.readyState === 1 || this.readyState === 2) return;
+    this.readyState = 1;
+    const event = new Event("open");
+    if (this.onopen) this.onopen(event);
+    this.dispatchEvent(event);
+  }
+
+  disconnect() {
+    if (this.readyState !== 2) this.readyState = 0;
+  }
+
+  close() {
+    if (this.readyState === 2) return;
+    this.readyState = 2;
+    if (this._onClose) this._onClose(this);
+  }
+}
+
 function portal() {
   return {
     // ===== auth =====
@@ -331,6 +372,15 @@ function portal() {
     _presenceVisibilityHandler: null,
     _presencePagehideHandler: null,
     _sessionsSyncTimer: null,
+    _chatMuxSource: null,
+    _chatMuxChannels: new Map(),
+    _chatMuxPendingEvents: new Map(),
+    _chatMuxAttachPromises: new Map(),
+    _chatMuxStartPromise: null,
+    _chatMuxReconnectTimer: null,
+    _chatMuxReconnectAttempts: 0,
+    _chatMuxSupported: null,
+    _chatMuxConnected: false,
     _splashHintTimer: null,
     _splashHardTimeout: null,
 
@@ -9986,6 +10036,309 @@ function portal() {
       st._virtualRevision++;
     },
 
+    _chatMuxCheckpoints() {
+      const rows = [];
+      const seen = new Set();
+      for (const [sid, channel] of this._chatMuxChannels) {
+        if (!channel || channel.readyState === 2) continue;
+        const st = this.tabState && this.tabState[sid];
+        const turnId = String((st && st.activeTurnId) || channel.turnId || "");
+        if (!turnId) continue;
+        rows.push({
+          session_id: sid,
+          turn_id: turnId,
+          last_event_seq: Math.max(0, Number(st && st.lastEventSeq) || 0),
+        });
+        seen.add(sid);
+      }
+      for (const meta of (this.sessions || [])) {
+        if (!meta || !meta.active || seen.has(meta.id)) continue;
+        const st = this.tabState && this.tabState[meta.id];
+        const turnId = String((st && st.activeTurnId) || meta.turn_id || "");
+        if (!turnId) continue;
+        rows.push({
+          session_id: meta.id,
+          turn_id: turnId,
+          last_event_seq: Math.max(0, Number(st && st.lastEventSeq) || 0),
+        });
+      }
+      return rows;
+    },
+    async _bootstrapChatMuxHistory() {
+      const active = (this.sessions || []).filter(meta => meta && meta.active && meta.id);
+      const concurrency = this._isMobileLayout() ? 1 : 2;
+      let next = 0;
+      const worker = async () => {
+        while (next < active.length) {
+          const meta = active[next++];
+          const st = this._ensureTabState(meta.id);
+          if (st.streaming || st.es || st._loaded) continue;
+          try {
+            await this.loadSession(meta.id, { quiet: true, probeActive: false });
+          } catch (_) { /* the mux replay remains authoritative */ }
+        }
+      };
+      await Promise.all(Array.from(
+        { length: Math.min(concurrency, active.length) }, () => worker()));
+    },
+    _setChatMuxUnsupported() {
+      this._chatMuxSupported = false;
+      this._chatMuxConnected = false;
+      if (this._chatMuxReconnectTimer) clearTimeout(this._chatMuxReconnectTimer);
+      this._chatMuxReconnectTimer = null;
+      try { if (this._chatMuxSource) this._chatMuxSource.close(); } catch (_) {}
+      this._chatMuxSource = null;
+      for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+    },
+    _scheduleChatMuxReconnect() {
+      if (this._chatMuxSupported === false || !this.token
+          || this._chatMuxReconnectTimer) return;
+      const attempts = ++this._chatMuxReconnectAttempts;
+      const delay = Math.min(10_000, 500 * (2 ** Math.min(attempts - 1, 4)));
+      this._chatMuxReconnectTimer = setTimeout(() => {
+        this._chatMuxReconnectTimer = null;
+        void this._ensureChatMux({ reconnect: true });
+      }, delay);
+    },
+    async _ensureChatMux(options = {}) {
+      if (this._chatMuxSupported === false || !this.token
+          || typeof EventSource === "undefined") return false;
+      if (this._chatMuxSource && !options.reconnect) return true;
+      if (this._chatMuxStartPromise) return await this._chatMuxStartPromise;
+      this._chatMuxStartPromise = this._openChatMux();
+      try {
+        return await this._chatMuxStartPromise;
+      } finally {
+        this._chatMuxStartPromise = null;
+      }
+    },
+    async _openChatMux() {
+      try { if (this._chatMuxSource) this._chatMuxSource.close(); } catch (_) {}
+      this._chatMuxSource = null;
+      this._chatMuxConnected = false;
+      for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+      let response;
+      try {
+        response = await fetch("/api/chat/stream/mux/start", {
+          method: "POST",
+          headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
+          body: JSON.stringify({
+            checkpoints: this._chatMuxCheckpoints(),
+            mobile: this._isMobileLayout(),
+          }),
+        });
+      } catch (_) {
+        this._scheduleChatMuxReconnect();
+        return false;
+      }
+      if (response.status === 404 || response.status === 405) {
+        this._setChatMuxUnsupported();
+        return false;
+      }
+      if (!response.ok) {
+        this._scheduleChatMuxReconnect();
+        return false;
+      }
+      let payload;
+      try { payload = await response.json(); } catch (_) { payload = {}; }
+      if (!payload.ticket) {
+        this._scheduleChatMuxReconnect();
+        return false;
+      }
+      this._chatMuxSupported = true;
+      const source = new EventSource(
+        "/api/chat/stream/mux?ticket=" + encodeURIComponent(payload.ticket));
+      this._chatMuxSource = source;
+      source.onopen = () => {
+        if (this._chatMuxSource !== source) return;
+        this._chatMuxConnected = true;
+        this._chatMuxReconnectAttempts = 0;
+        for (const channel of this._chatMuxChannels.values()) {
+          if (channel._activated) channel.open();
+        }
+      };
+      source.addEventListener("session_state", ev => {
+        if (this._chatMuxSource !== source) return;
+        let state = {};
+        try { state = JSON.parse(ev.data) || {}; } catch (_) {}
+        void this._handleChatMuxSessionState(state);
+      });
+      for (const type of CHAT_MUX_STREAM_EVENTS) {
+        source.addEventListener(type, ev => {
+          if (this._chatMuxSource !== source) return;
+          if (type === "error" && (ev.data === undefined || ev.data === "")) {
+            this._handleChatMuxDisconnect(source);
+            return;
+          }
+          if (type === "ping" && !ev.data) {
+            for (const channel of this._chatMuxChannels.values()) {
+              if (channel._activated && channel.readyState !== 2) {
+                channel.dispatchEvent(new MessageEvent("ping", { data: "" }));
+              }
+            }
+            return;
+          }
+          this._dispatchChatMuxEvent(type, ev.data);
+        });
+      }
+      source.onerror = ev => {
+        if (ev && ev.data !== undefined && ev.data !== "") return;
+        this._handleChatMuxDisconnect(source);
+      };
+      return true;
+    },
+    _handleChatMuxDisconnect(source) {
+      if (this._chatMuxSource !== source) return;
+      try { source.close(); } catch (_) {}
+      this._chatMuxSource = null;
+      this._chatMuxConnected = false;
+      for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+      // The per-session reducers retain logical ownership while the one native
+      // transport reconnects. In particular, do not synthesize `error`/`done`.
+      this._scheduleChatMuxReconnect();
+    },
+    _queueChatMuxEvent(sid, type, data) {
+      let pending = this._chatMuxPendingEvents.get(sid);
+      if (!pending) {
+        pending = [];
+        pending._bytes = 0;
+      }
+      const bytes = String(data || "").length;
+      if (pending.length >= CHAT_MUX_BOOTSTRAP_MAX_EVENTS
+          || pending._bytes + bytes > CHAT_MUX_BOOTSTRAP_MAX_BYTES) {
+        if (!pending._overflowed) {
+          pending.length = 0;
+          pending._bytes = 0;
+          pending._overflowed = true;
+          pending.push({
+            type: "resync",
+            data: JSON.stringify({
+              session_id: sid,
+              reason: "bootstrap_overflow",
+              fallback: "canonical_history",
+              retryable: false,
+            }),
+          });
+        }
+      } else if (!pending._overflowed) {
+        pending.push({ type, data });
+        pending._bytes += bytes;
+      }
+      this._chatMuxPendingEvents.set(sid, pending);
+    },
+    _dispatchChatMuxEvent(type, data) {
+      let payload = null;
+      try { payload = JSON.parse(data); } catch (_) {}
+      const sid = String(payload && payload.session_id || "");
+      if (!sid) return;
+      const turnId = String(payload.turn_id || "");
+      const channel = this._chatMuxChannels.get(sid);
+      if (!channel || !channel._activated
+          || (channel.turnId && turnId && channel.turnId !== turnId)) {
+        this._queueChatMuxEvent(sid, type, data);
+        return;
+      }
+      channel.dispatchEvent(new MessageEvent(type, { data }));
+    },
+    _chatMuxChannel(sid, turnId) {
+      const existing = this._chatMuxChannels.get(sid);
+      if (existing && existing.readyState !== 2
+          && (!turnId || !existing.turnId || existing.turnId === turnId)) {
+        if (!existing.turnId && turnId) existing.turnId = turnId;
+        return existing;
+      }
+      if (existing) existing.close();
+      const channel = new ChatMuxSessionChannel(sid, turnId, closed => {
+        if (this._chatMuxChannels.get(sid) === closed) {
+          this._chatMuxChannels.delete(sid);
+        }
+      });
+      this._chatMuxChannels.set(sid, channel);
+      return channel;
+    },
+    _activateChatMuxChannel(channel) {
+      if (!channel || channel.readyState === 2) return;
+      channel._activated = true;
+      if (this._chatMuxConnected) channel.open();
+      const pending = this._chatMuxPendingEvents.get(channel.sessionId) || [];
+      this._chatMuxPendingEvents.delete(channel.sessionId);
+      for (const event of pending) {
+        let payload = null;
+        try { payload = JSON.parse(event.data); } catch (_) {}
+        const turnId = String(payload && payload.turn_id || "");
+        if (channel.turnId && turnId && channel.turnId !== turnId) continue;
+        channel.dispatchEvent(new MessageEvent(event.type, { data: event.data }));
+      }
+    },
+    async _handleChatMuxSessionState(payload) {
+      const sid = String(payload && payload.session_id || "");
+      if (!sid) return;
+      const meta = (this.sessions || []).find(session => session.id === sid);
+      if (meta) {
+        meta.active = !!payload.active;
+        meta.turn_active = !!payload.active && !payload.background;
+        meta.background_active = !!payload.active && !!payload.background;
+      }
+      const existingState = this.tabState && this.tabState[sid];
+      if (!payload.active) {
+        this._chatMuxPendingEvents.delete(sid);
+        if (existingState && !existingState.streaming) {
+          this._setBackgroundTaskActive(sid, false, payload.started_at, 0);
+        }
+        return;
+      }
+      if (payload.attachable === false) {
+        // Watcher-only ownership has no replayable turn yet. Preserve its blue
+        // dot/background state, but do not create a reducer runtime until the
+        // continuation broadcast becomes attachable.
+        if (existingState && !existingState.streaming) {
+          this._setBackgroundTaskActive(
+            sid, true, payload.started_at, payload.background_tasks_pending);
+        }
+        return;
+      }
+      const turnId = String(payload.turn_id || "");
+      if (!turnId) return;
+      if (existingState && existingState.es
+          && existingState.activeTurnId === turnId) return;
+      if (existingState && existingState.es && existingState.es._muxChannel
+          && existingState.activeTurnId
+          && existingState.activeTurnId !== turnId) {
+        // The aggregate state frame is authoritative for ABA turn changes. Retire
+        // only the stale logical adapter; the root EventSource remains shared.
+        this._retireStaleSessionStream(sid, existingState);
+        existingState._pendingExternalUpdate = true;
+      }
+      if (this._chatMuxAttachPromises.has(sid)) return;
+      const attach = (async () => {
+        const st = this._ensureTabState(sid);
+        if (!st._loaded && !st.streaming && !st.es) {
+          await this.loadSession(sid, { quiet: true, probeActive: false });
+        }
+        if (st.streaming || st.es || this.tabState[sid] !== st) return;
+        st.parentTurnId = String(payload.parent_turn_id || "");
+        await this.send({
+          reconnect: true,
+          sessionId: sid,
+          turnId,
+          startedAt: payload.started_at,
+          continuation: !!payload.continuation,
+          _muxAttach: true,
+        });
+      })();
+      this._chatMuxAttachPromises.set(sid, attach);
+      try { await attach; } finally {
+        if (this._chatMuxAttachPromises.get(sid) === attach) {
+          this._chatMuxAttachPromises.delete(sid);
+        }
+      }
+    },
+    async _startChatMuxCoordinator() {
+      if (this._chatMuxSupported === false) return false;
+      await this._bootstrapChatMuxHistory();
+      return await this._ensureChatMux();
+    },
+
     async initSessions(options = {}) {
       if (this._sessionInitPromise) return this._sessionInitPromise;
       this._sessionInitPromise = this._initSessionsOnce(options);
@@ -10084,6 +10437,10 @@ function portal() {
       }));
       this._sessionsInitialized = true;
       this._scheduleSavePrefs();
+      // Session discovery and the initial bounded transcript tail are now ready.
+      // Start exactly one root chat EventSource; every active session attaches to
+      // it through a lightweight EventSource-compatible channel.
+      void this._startChatMuxCoordinator();
       return true;
     },
     // Shared session-list pull behind both the explicit refresh and the 10s
@@ -10396,6 +10753,10 @@ function portal() {
         return Promise.resolve(false);
       }
       const ownerEs = st.es;
+      if (ownerEs && ownerEs._muxChannel && !this._chatMuxConnected) {
+        this._scheduleChatMuxReconnect();
+        return Promise.resolve(false);
+      }
       const observedActivity = Number(st._lastSseActivity)
         || Number(st._streamStartedAt) || Date.now();
       const transportClosed = !!(ownerEs && Number(ownerEs.readyState) === 2);
@@ -28897,41 +29258,21 @@ function portal() {
         this.scrollToBottom(true);
       }
 
-      // Ticket flow: POST the prompt + params with header auth, get a
-      // one-time ticket, open the SSE with ONLY the ticket in the URL.
-      // Keeps the user's prompt and the auth token out of access logs /
-      // browser history (EventSource can't send headers or a body).
-      // Legacy query-param fallback ONLY when the endpoint doesn't exist
-      // (old backend → 404/405). A 5xx or network blip must NOT silently
-      // downgrade to putting the prompt + token back into the URL — retry
-      // the ticket once, then surface the failure instead.
+      // Mux flow: one root EventSource receives every session. This send only
+      // admits a new turn, then installs an EventSource-compatible per-session
+      // channel so the reducer below remains the sole event/state implementation.
+      // Legacy per-session SSE is used only after an explicit 404/405 capability
+      // response from the mux or turn-start endpoint.
       let url;
+      let es;
+      let useMux = false;
       this._setComposerClaimPhase(sendState, composerSubmitToken, "stream_start");
       const streamStartController = new AbortController();
       streamState._streamStartController = streamStartController;
       streamState._cancelBeforeStream = false;
-      const _mintTicket = async () => {
-        const tr = await fetch("/api/chat/stream/start", {
-          method: "POST",
-          headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
-          signal: streamStartController.signal,
-          body: JSON.stringify({
-            prompt: text,
-            session_id: streamSid,
-            turn_id: expectedTurnId,
-            last_event_seq: resumeEventSeq,
-            model: sendModel,
-            permission: sendPermission,
-            image_ids: attachIds.length ? attachIds.join(",") : "",
-            mobile: streamMobile,
-          }),
-        });
-        return tr;
-      };
-      // Stop/ticket failure before EventSource opens means no backend turn was
-      // created. Remove the optimistic bubble, restore the full local payload,
-      // and reset every stream flag/timer without relying on the later-scoped
-      // _markDone closure.
+      // Stop/start failure before a channel opens removes the optimistic bubble,
+      // restores the full local payload and resets every stream flag/timer without
+      // relying on the later-scoped _markDone closure.
       const rollbackUnstartedSend = (restoreDraft = true) => {
         if (sentUserBubble) {
           this._removePaneMessage(streamState, sentUserBubble);
@@ -28958,38 +29299,115 @@ function portal() {
         streamState.lastEventSeq = 0;
         streamState.streamingModel = "";
       };
+      const _mintLegacyTicket = async () => await fetch("/api/chat/stream/start", {
+        method: "POST",
+        headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
+        signal: streamStartController.signal,
+        body: JSON.stringify({
+          prompt: text,
+          session_id: streamSid,
+          turn_id: expectedTurnId,
+          last_event_seq: resumeEventSeq,
+          model: sendModel,
+          permission: sendPermission,
+          image_ids: attachIds.length ? attachIds.join(",") : "",
+          mobile: streamMobile,
+        }),
+      });
       try {
-        let tr = await _mintTicket();
-        if (tr.status === 404 || tr.status === 405) {
-          // Old backend without /stream/start — legacy URL is the contract.
-          url = "/api/chat/stream"
-            + "?prompt=" + encodeURIComponent(text)
-            + "&session_id=" + encodeURIComponent(streamSid)
-            + "&turn_id=" + encodeURIComponent(expectedTurnId)
-            + "&last_event_seq=" + encodeURIComponent(resumeEventSeq)
-            + "&model=" + encodeURIComponent(sendModel)
-            + "&permission=" + encodeURIComponent(sendPermission)
-            + "&mobile=" + (streamMobile ? "1" : "0")
-            + (attachIds.length ? "&image_ids=" + encodeURIComponent(attachIds.join(",")) : "")
-            + "&token=" + encodeURIComponent(this.token);
-        } else {
-          if (!tr.ok) {
-            // Transient 5xx — one retry before giving up.
-            tr = await _mintTicket();
+        const muxReady = await this._ensureChatMux();
+        if (muxReady) {
+          useMux = true;
+          let admittedTurnId = expectedTurnId;
+          if (!isReconnect) {
+            const startTurn = async () => await fetch("/api/chat/turns/start", {
+              method: "POST",
+              headers: Object.assign({ "Content-Type": "application/json" }, this.hdr()),
+              signal: streamStartController.signal,
+              body: JSON.stringify({
+                prompt: text,
+                session_id: streamSid,
+                model: sendModel,
+                permission: sendPermission,
+                image_ids: attachIds.length ? attachIds.join(",") : "",
+                mobile: streamMobile,
+              }),
+            });
+            let tr = await startTurn();
+            if (tr.status === 404 || tr.status === 405) {
+              this._setChatMuxUnsupported();
+              useMux = false;
+            } else {
+              if (tr.status === 409 && !resumed) {
+                const queued = await this._enqueueMessage(streamSid, {
+                  text,
+                  displayText: hasDetachedText ? detachedDisplayText : composerInput,
+                  pendingImages: hasDetachedText ? [] : composerImages,
+                  pendingDocs: hasDetachedText ? [] : composerDocs,
+                  pendingQuotes: hasDetachedText ? [] : composerQuotes,
+                  permission: sendPermission,
+                  plan_return_permission: sendPlanReturnPermission,
+                });
+                if (queued) {
+                  rollbackUnstartedSend(false);
+                  if (isComposerSubmission) {
+                    this._commitChatRecoveryDraft(sendSid, composerInput);
+                  }
+                  this.toast(this.lang === "zh"
+                    ? "当前任务仍在收尾，消息已加入队列"
+                    : "The current task is still finishing; message queued",
+                  "info", 2800);
+                  return true;
+                }
+              }
+              if (!tr.ok) tr = await startTurn();
+              if (!tr.ok) throw new Error("turn start " + tr.status);
+              const admitted = await tr.json();
+              if (admitted.accepted === false || !admitted.turn_id) {
+                throw new Error("turn not accepted");
+              }
+              admittedTurnId = String(admitted.turn_id);
+              streamState.activeTurnId = admittedTurnId;
+              streamState.parentTurnId = "";
+              streamState.lastEventSeq = 0;
+              if (sentUserBubble) sentUserBubble._turnId = admittedTurnId;
+              if (Number(admitted.started_at) > 0) {
+                streamState._streamStartedAt = Number(admitted.started_at) * 1000;
+              }
+            }
           }
-          if (!tr.ok) throw new Error("ticket " + tr.status);
-          const td = await tr.json();
-          url = "/api/chat/stream?ticket=" + encodeURIComponent(td.ticket);
+          if (useMux) {
+            es = this._chatMuxChannel(streamSid, admittedTurnId);
+          }
+        } else if (this._chatMuxSupported !== false) {
+          throw new Error("mux unavailable");
+        }
+        if (!useMux) {
+          let tr = await _mintLegacyTicket();
+          if (tr.status === 404 || tr.status === 405) {
+            url = "/api/chat/stream"
+              + "?prompt=" + encodeURIComponent(text)
+              + "&session_id=" + encodeURIComponent(streamSid)
+              + "&turn_id=" + encodeURIComponent(expectedTurnId)
+              + "&last_event_seq=" + encodeURIComponent(resumeEventSeq)
+              + "&model=" + encodeURIComponent(sendModel)
+              + "&permission=" + encodeURIComponent(sendPermission)
+              + "&mobile=" + (streamMobile ? "1" : "0")
+              + (attachIds.length ? "&image_ids=" + encodeURIComponent(attachIds.join(",")) : "")
+              + "&token=" + encodeURIComponent(this.token);
+          } else {
+            if (!tr.ok) tr = await _mintLegacyTicket();
+            if (!tr.ok) throw new Error("ticket " + tr.status);
+            const td = await tr.json();
+            url = "/api/chat/stream?ticket=" + encodeURIComponent(td.ticket);
+          }
+          es = new EventSource(url);
         }
       } catch (_e) {
         if (streamState._cancelBeforeStream) {
-          // stop() already performed the authoritative local cleanup. The
-          // ticket was never consumed, so no backend turn/transcript exists.
           rollbackUnstartedSend();
           return false;
         }
-        // Could not mint a ticket (server error / network) — fail the send
-        // visibly rather than leaking prompt+token into the URL.
         rollbackUnstartedSend();
         this.toast(this.lang === "zh"
           ? "发送失败：无法建立流式连接，请重试"
@@ -29002,12 +29420,9 @@ function portal() {
         }
       }
       if (streamState._cancelBeforeStream) {
-        // Ticket minted but Stop landed first — same rollback. The ticket is
-        // never consumed and expires on its own.
         rollbackUnstartedSend();
         return false;
       }
-      const es = new EventSource(url);
       streamState.es = es;
       // NOTE — a successful open deliberately does NOT reset
       // _reconnectAttempts. Every reconnect DOES open successfully (the
@@ -29125,10 +29540,14 @@ function portal() {
           || (sync.pending && sync.pending.stream_health)
         ));
         if (silentMs > 40000 && !healthProbePending) {
-          // 40s of total silence (server pings every 15s → ≥2 missed) means
-          // the connection is dead in a way onerror never caught. Tear down
-          // the watchdog and drive the existing reconnect logic via a
-          // synthetic error (no ev.data → JSON.parse throws → transport path).
+          // A mux channel never owns the native socket. Reconnect the one root
+          // transport without sending a synthetic per-session terminal/error.
+          if (es._muxChannel) {
+            this._scheduleChatMuxReconnect();
+            this._recoverStalledStream(streamSid);
+            return;
+          }
+          // Legacy per-session SSE keeps the existing transparent retry path.
           clearInterval(streamState._stallWatch);
           streamState._stallWatch = null;
           try { es.dispatchEvent(new Event("error")); } catch (_) {}
@@ -30698,6 +31117,7 @@ function portal() {
             }, 800);
         }
       });
+      if (useMux) this._activateChatMuxChannel(es);
       // NOTE: errors are owned exclusively by the addEventListener("error")
       // handler above (rich classification + exponential-backoff transparent
       // reconnect). A redundant `es.onerror` here used to also fire on the

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9430,14 +9430,12 @@ function portal() {
         const hasBoundary = canonicalTurn.some(
           m => m && m.role !== "user" && m.uuid,
         );
-        const hasExpectedAssistant = !expectedAssistantUuid
-          || canonicalTurn.some(m => m && m.uuid === expectedAssistantUuid);
         const hasFinal = expectedAssistantUuid
-          ? hasExpectedAssistant
-          : (!expectedText || canonicalTurn.some(
+          ? canonicalTurn.some(m => m && m.uuid === expectedAssistantUuid)
+          : !!expectedText && canonicalTurn.some(
               m => m && m.role === "assistant" && m.uuid
                 && (m.text || "") === expectedText,
-            ));
+            );
         if (!hasBoundary || !hasFinal) { retry(); return false; }
         if (!stillOwned()) return false;
         const loaded = await this.loadSession(sid, {
@@ -15429,7 +15427,12 @@ function portal() {
           minimumTail,
           quiet ? Math.max(historyPage, st.messages.length) : historyPage,
         );
-        const qs = full ? "?full=1" : "?tail=" + requestedTail;
+        const preserveFullOrder = quiet && st.messageRange.order === "full";
+        const qs = full
+          ? "?full=1"
+          : preserveFullOrder
+            ? "?full=1&tail=" + requestedTail
+            : "?tail=" + requestedTail;
         let r;
         const fetchStarted = perfNow();
         try {
@@ -29415,9 +29418,15 @@ function portal() {
       };
       streamState._flushLivePresentation = flushLivePresentation;
       const flushTerminalPresentation = () => {
-        closeAsst();
+        const completedBubble = ownsCurBubble() ? curBubble : null;
+        if (completedBubble) flushRender();
+        else { cancelPendingPaint(); curBubble = null; acc = ""; }
         closeThinking();
         flushTaskProgress();
+        const completedText = completedBubble ? (completedBubble.text || "") : "";
+        curBubble = null;
+        acc = "";
+        return { bubble: completedBubble, text: completedText };
       };
 
       es.addEventListener("text", ev => {
@@ -30040,7 +30049,7 @@ function portal() {
         }
       };
       es.addEventListener("done", ev => {
-        flushTerminalPresentation();
+        const completedAssistant = flushTerminalPresentation();
         // Guard JSON.parse: a malformed/empty `done` payload must NOT throw
         // before es.close()/_markDone()/_stopTimer() run below, else the
         // EventSource + timer interval leak and the UI stays streaming=true
@@ -30048,11 +30057,11 @@ function portal() {
         // d.* read below is null-safe on a missing field.
         let d;
         try { d = JSON.parse(ev.data); } catch (_) { d = {}; }
-        if (d.total_cost_usd != null && ownsCurBubble()) {
-          curBubble.cost = "$" + d.total_cost_usd.toFixed(4);
+        if (d.total_cost_usd != null && completedAssistant.bubble) {
+          completedAssistant.bubble.cost = "$" + d.total_cost_usd.toFixed(4);
         }
-        if (d.memory_recall && ownsCurBubble()) {
-          curBubble.memoryRecall = d.memory_recall;
+        if (d.memory_recall && completedAssistant.bubble) {
+          completedAssistant.bubble.memoryRecall = d.memory_recall;
         }
         if (d.stats) this.stats = { ...this.stats, ...d.stats };
         if (d.session_usage) {
@@ -30118,7 +30127,7 @@ function portal() {
         // stop — stop closes the ES). The relevant case for this branch
         // is page-reload-then-reconnect picking up a turn that finished
         // after being cancelled before reload.
-        const completedFinalText = ownsCurBubble() ? (curBubble.text || "") : "";
+        const completedFinalText = completedAssistant.text;
         const continuationFinalText = isContinuation ? completedFinalText : "";
         const backgroundPending = !d.cancelled
           ? Math.max(0, Number(d.background_tasks_pending) || 0)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7697,12 +7697,8 @@ function portal() {
         parentTurnId: "",
         lastEventSeq: 0,
         es: null,
-        // Deduplicate stop taps while the interrupt request is in flight.
-        _stopping: false,
-        // The Stop button settles the visible turn immediately while the backend
-        // interrupt/watchdog confirms asynchronously. This marker suppresses a
-        // duplicate terminal toast and lets a failed /active probe restore truth.
-        _optimisticInterrupt: false,
+        // Exact immutable backend turn whose interrupt is still settling.
+        _stoppingTurnId: "",
         // Abort the POST /stream/start ticket request when Stop is clicked
         // before EventSource exists. Without this, the backend has no active
         // turn/client to interrupt yet and the reply starts after Stop.
@@ -7893,9 +7889,6 @@ function portal() {
       }
       if (st._sessionActivityExpected === undefined) {
         st._sessionActivityExpected = null;
-      }
-      if (st._optimisticInterrupt === undefined) {
-        st._optimisticInterrupt = false;
       }
       if (!Number.isFinite(Number(st._installedCanonicalCount))) {
         st._installedCanonicalCount = 0;
@@ -8211,7 +8204,7 @@ function portal() {
       }
       const st = this.tabState && this.tabState[sid];
       if (!st) return zh ? "正在准备会话" : "Preparing the session";
-      if (st._stopping) {
+      if (st._stoppingTurnId) {
         return zh ? "正在中断上一条任务" : "Stopping the previous turn";
       }
       if (st._permissionChangePending) return this.t("perm.switching");
@@ -10103,8 +10096,10 @@ function portal() {
     async _ensureChatMux(options = {}) {
       if (this._chatMuxSupported === false || !this.token
           || typeof EventSource === "undefined") return false;
-      if (this._chatMuxSource && !options.reconnect) return true;
       if (this._chatMuxStartPromise) return await this._chatMuxStartPromise;
+      if (this._chatMuxSource && !options.reconnect) {
+        return this._chatMuxConnected;
+      }
       this._chatMuxStartPromise = this._openChatMux();
       try {
         return await this._chatMuxStartPromise;
@@ -10149,10 +10144,27 @@ function portal() {
       const source = new EventSource(
         "/api/chat/stream/mux?ticket=" + encodeURIComponent(payload.ticket));
       this._chatMuxSource = source;
+      let openSettled = false;
+      let settleOpen;
+      const opened = new Promise(resolve => { settleOpen = resolve; });
+      const finishOpen = value => {
+        if (openSettled) return;
+        openSettled = true;
+        settleOpen(value);
+      };
+      const openTimeout = setTimeout(() => {
+        if (this._chatMuxSource !== source || this._chatMuxConnected) return;
+        try { source.close(); } catch (_) {}
+        this._chatMuxSource = null;
+        finishOpen(false);
+        this._scheduleChatMuxReconnect();
+      }, 5000);
       source.onopen = () => {
         if (this._chatMuxSource !== source) return;
+        clearTimeout(openTimeout);
         this._chatMuxConnected = true;
         this._chatMuxReconnectAttempts = 0;
+        finishOpen(true);
         for (const channel of this._chatMuxChannels.values()) {
           if (channel._activated) channel.open();
         }
@@ -10183,9 +10195,11 @@ function portal() {
       }
       source.onerror = ev => {
         if (ev && ev.data !== undefined && ev.data !== "") return;
+        clearTimeout(openTimeout);
+        finishOpen(false);
         this._handleChatMuxDisconnect(source);
       };
-      return true;
+      return await opened;
     },
     _handleChatMuxDisconnect(source) {
       if (this._chatMuxSource !== source) return;
@@ -10282,6 +10296,11 @@ function portal() {
       const existingState = this.tabState && this.tabState[sid];
       if (!payload.active) {
         this._chatMuxPendingEvents.delete(sid);
+        const inactiveTurnId = String(payload.turn_id || "");
+        if (existingState && inactiveTurnId
+            && existingState._stoppingTurnId === inactiveTurnId) {
+          existingState._stoppingTurnId = "";
+        }
         if (existingState && !existingState.streaming) {
           this._setBackgroundTaskActive(sid, false, payload.started_at, 0);
         }
@@ -10299,6 +10318,9 @@ function portal() {
       }
       const turnId = String(payload.turn_id || "");
       if (!turnId) return;
+      if (existingState && payload.stopping) {
+        existingState._stoppingTurnId = turnId;
+      }
       if (existingState && existingState.es
           && existingState.activeTurnId === turnId) return;
       if (existingState && existingState.es && existingState.es._muxChannel
@@ -10335,8 +10357,13 @@ function portal() {
     },
     async _startChatMuxCoordinator() {
       if (this._chatMuxSupported === false) return false;
+      // Establish the one authoritative live transport before any background
+      // transcript warmup. A turn can start while history is loading; mux-first
+      // startup guarantees its accepted/session_state events already have a sink.
+      const connected = await this._ensureChatMux();
+      if (!connected) return false;
       await this._bootstrapChatMuxHistory();
-      return await this._ensureChatMux();
+      return true;
     },
 
     async initSessions(options = {}) {
@@ -16080,7 +16107,6 @@ function portal() {
                 st.atBottom = false;
               }
             });
-            await this._fetchTabUsage(sid);
             historyPerf.status = "ok";
             return true;
           }
@@ -16131,7 +16157,6 @@ function portal() {
             });
           });
         }
-        await this._fetchTabUsage(sid);
         historyPerf.status = "ok";
         return true;
       } finally {
@@ -28762,23 +28787,12 @@ function portal() {
       // interrupt endpoint's atomic pause and the turn cleanup's second pause;
       // that new item then appeared accepted but remained paused.  Keep the
       // draft intact and make the short wait explicit instead.
-      if (sendState._stopping && !opts.reconnect && !opts.resumedItem) {
+      if (sendState._stoppingTurnId && !opts.reconnect && !opts.resumedItem) {
         this.toast(this.lang === "zh"
           ? "正在中断上一条任务，请稍候再发送"
           : "The previous turn is still stopping; send again in a moment",
         "warn", 2200);
         return false;
-      }
-      if (sendState._optimisticInterrupt && !opts.reconnect && !opts.resumedItem) {
-        // The user is intentionally moving on before the old cancelled event
-        // arrives. Retire only that old transport ownership now; otherwise its
-        // late _markDone would clear the NEW send's streaming flag/timer on this
-        // shared tab state. Backend snapshot persistence continues independently,
-        // and the canonical poll later merges any retained partial output.
-        try { if (sendState.es) sendState.es.close(); } catch (_) {}
-        sendState.es = null;
-        sendState._optimisticInterrupt = false;
-        sendState._pendingExternalUpdate = true;
       }
       // Do not start a new turn between the optimistic selector change and
       // its persisted session update. Otherwise Plan Mode could launch with a
@@ -29291,8 +29305,7 @@ function portal() {
         streamState.es = null;
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
-        streamState._stopping = false;
-        streamState._optimisticInterrupt = false;
+        streamState._stoppingTurnId = "";
         streamState._serverActiveObserved = false;
         streamState.activeTurnId = "";
         streamState.parentTurnId = "";
@@ -29424,6 +29437,7 @@ function portal() {
         return false;
       }
       streamState.es = es;
+      const streamTurnId = String(streamState.activeTurnId || expectedTurnId || "");
       // NOTE — a successful open deliberately does NOT reset
       // _reconnectAttempts. Every reconnect DOES open successfully (the
       // backend replays the turn happily), so resetting here made the
@@ -30274,8 +30288,10 @@ function portal() {
         this._enforceMessageRangeInvariant(streamState);
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
-        streamState._stopping = false;
-        streamState._optimisticInterrupt = false;
+        const terminalTurnId = streamTurnId || String(streamState.activeTurnId || "");
+        if (streamState._stoppingTurnId === terminalTurnId) {
+          streamState._stoppingTurnId = "";
+        }
         streamState._serverActiveObserved = false;
         // Belt-and-braces for the auto-compact bubble: a turn that dies inside
         // /compact (transport drop, 10-min timeout) may never deliver the
@@ -31071,10 +31087,7 @@ function portal() {
         flushTerminalPresentation();
         let d = {};
         try { d = JSON.parse(ev.data || "{}"); } catch (_) { d = {}; }
-        const alreadySettledOptimistically = !!streamState._optimisticInterrupt;
-        if (!alreadySettledOptimistically) {
-          this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
-        }
+        this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 2000);
         es.close();
         _markDone(true, false, true, {
           model: modelForBubble,
@@ -31141,29 +31154,16 @@ function portal() {
       const sid = this.currentId;
       if (!sid || !this.isTabStreaming(sid)) return;
       const st = this._ensureTabState(sid);
-      if (st._stopping) return;
-      st._stopping = true;
+      const ownerTurnId = String(st.activeTurnId || "");
+      if (ownerTurnId && st._stoppingTurnId === ownerTurnId) return;
       if (st.pendingQueue && st.pendingQueue.length > 0) st._queuePaused = true;
-      // The earliest Stop window is before EventSource exists, while send()
-      // is still minting its one-time ticket. No backend turn exists yet, so
-      // /interrupt cannot find anything. Abort locally and restore idle state
-      // immediately; the ticket is never consumed and expires harmlessly.
-      if (st._streamStartController && !st.es) {
+      // Before a channel and immutable turn id exist, abort only the start
+      // request. send() rollback remains the sole owner of stream flags, timers,
+      // channel state and the draft; Stop must not manufacture optimistic idle.
+      if (st._streamStartController && !st.es && !ownerTurnId) {
         st._cancelBeforeStream = true;
         st._streamStartController.abort();
-        st._streamStartController = null;
-        if (st._streamTimer) clearInterval(st._streamTimer);
-        st._streamTimer = null;
-        st._streamStartedAt = 0;
-        st.streamElapsed = 0;
-        st.streaming = false;
-        st.streamPhase = "";
-        st._stopping = false;
-        st.streamingModel = "";
         if (st.pendingQueue && st.pendingQueue.length > 0) {
-          // No backend turn exists yet, but the durable queue may already do.
-          // Persist the same Stop semantics instead of leaving only the local
-          // banner paused while the server remains free to drain it.
           try {
             await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/queue/pause`, {
               method: "POST",
@@ -31173,42 +31173,54 @@ function portal() {
           } catch (_) { /* queue sync below/next activation reconciles */ }
           this._syncQueueFromServer(sid);
         }
-        this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 1500);
         return;
       }
-      // Optimistic stop: settle the human-facing state in this same click frame.
-      // Keep the EventSource attached so a cancelled event can still persist and
-      // quietly adopt the final partial-output snapshot. A subsequent send may
-      // replace that transport; its ownership guards make late old-turn events no-op.
+      if (!ownerTurnId) return;
+
       const ownerEs = st.es;
-      st._optimisticInterrupt = true;
-      st.streaming = false;
-      st.streamPhase = "";
-      st._stopping = false;
-      if (st._streamTimer) clearInterval(st._streamTimer);
-      if (st._stallWatch) clearInterval(st._stallWatch);
-      st._streamTimer = null;
-      st._stallWatch = null;
-      this._setSessionActivityExpectation(sid, false);
-      this.toast(this.lang === "zh" ? "已中断" : "Interrupted", "warn", 1500);
+      st._stoppingTurnId = ownerTurnId;
+      const stillOwnsTurn = () => this.tabState[sid] === st
+        && st.es === ownerEs
+        && String(st.activeTurnId || "") === ownerTurnId;
+      const applyAuthoritativeStatus = payload => {
+        if (!payload || !stillOwnsTurn()) return "stale";
+        const active = !!payload.active;
+        const turnId = String(payload.turn_id || payload.current_turn_id || "");
+        if (active && turnId !== ownerTurnId) return "successor";
+        if (!active) {
+          if (turnId && turnId !== ownerTurnId) return "successor";
+          if (st._stoppingTurnId === ownerTurnId) st._stoppingTurnId = "";
+          this._retireStaleSessionStream(sid, st);
+          this._setSessionActivityExpectation(sid, false);
+          st._pendingExternalUpdate = true;
+          this._scheduleCanonicalStreamReload(sid, st, { minimumWaitMs: 0 });
+          return "inactive";
+        }
+        if (payload.stopping) return "stopping";
+        if (st._stoppingTurnId === ownerTurnId) st._stoppingTurnId = "";
+        st._sessionActivityExpected = null;
+        this.sessions = (this.sessions || []).map(session => session.id === sid
+          ? { ...session, active: true, turn_active: true, background_active: false }
+          : session);
+        return "running";
+      };
 
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 3000);
       try {
         const r = await fetch(
-          "/api/chat/interrupt?session_id=" + encodeURIComponent(sid),
+          "/api/chat/interrupt?session_id=" + encodeURIComponent(sid)
+            + "&turn_id=" + encodeURIComponent(ownerTurnId),
           { method: "POST", headers: this.hdr(), signal: controller.signal },
         );
         if (!r.ok) throw new Error("interrupt failed");
-        // The backend marks the broadcast cancelled and arms its force-stop
-        // watchdog before replying. An empty `interrupted` list therefore still
-        // means the hard-stop path owns convergence; no visible rollback needed.
+        applyAuthoritativeStatus(await r.json());
       } catch (_e) {
-        // A failed HTTP response is ambiguous: the request may have reached the
-        // backend before the connection dropped. Probe authoritative liveness
-        // before undoing the optimistic transition, and never overwrite a newer
-        // stream that already replaced this EventSource.
-        let active = null;
+        // The request may have reached the backend before the response failed.
+        // Probe exact ownership and apply the same state matrix: retain matching
+        // active+stopping, restore matching active+running, settle inactive, and
+        // never mutate an ABA successor.
+        let status = null;
         try {
           const probeController = new AbortController();
           const probeTimeout = setTimeout(() => probeController.abort(), 2500);
@@ -31216,27 +31228,16 @@ function portal() {
             const probe = await fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/active`, {
               headers: this.hdr(), signal: probeController.signal,
             });
-            if (probe.ok) active = !!(await probe.json()).active;
+            if (probe.ok) status = await probe.json();
           } finally { clearTimeout(probeTimeout); }
-        } catch (_) { active = null; }
-        if (this.tabState[sid] === st && st.es === ownerEs && active === true) {
-          st._optimisticInterrupt = false;
-          st.streaming = true;
-          st._sessionActivityExpected = null;
-          this.sessions = (this.sessions || []).map(session => session.id === sid
-            ? { ...session, active: true, turn_active: true, background_active: false }
-            : session);
-          if (st._streamStartedAt && !st._streamTimer) {
-            st._streamTimer = setInterval(() => {
-              st.streamElapsed = Math.max(
-                0, (Date.now() - st._streamStartedAt) / 1000);
-            }, 1000);
-          }
+        } catch (_) { status = null; }
+        const resolution = applyAuthoritativeStatus(status);
+        if (resolution === "running") {
           this.toast(this.lang === "zh"
             ? "停止失败，当前会话仍在运行"
             : "Could not stop; the session is still running",
           "error", 3000);
-        } else if (active === null) {
+        } else if (status === null) {
           this.toast(this.lang === "zh"
             ? "中断请求已提交，正在自动确认最终状态"
             : "Interrupt requested; confirming the final state",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6204,6 +6204,11 @@
         </div>
         <template x-for="group in activityVisibleGroups()" :key="group.key">
           <section class="activity-group"
+                   :style="group.boardColumn ? {
+                     '--activity-board-column': group.boardColumn,
+                     '--activity-board-row': group.boardRow,
+                     '--activity-board-row-span': group.boardRowSpan
+                   } : null"
                    x-show="activityEvents(group).length
                      || (group.custom && !activitySearchQuery())"
                    :class="{

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -4020,7 +4020,7 @@ pre.text {
     min-height:0;
     max-height:none;
     display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
+    grid-template-columns:repeat(3,minmax(0,1fr));
     /* One lane starts at roughly a header + three session cards. Additional
        sessions stay in the lane and are reached by its own scrollbar. */
     grid-auto-rows:300px;
@@ -4098,6 +4098,8 @@ pre.text {
    empty drop target. The ledger/status views keep their compact row styling. */
 @media (min-width:721px) {
   .activity-body.is-group-board > .activity-group.is-custom {
+    grid-column:var(--activity-board-column);
+    grid-row:var(--activity-board-row) / span var(--activity-board-row-span);
     min-width:0;
     min-height:300px;
     height:100%;

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -1139,6 +1139,85 @@ def test_custom_groups_show_empty_sections_and_move_sessions(
     assert any(call["path"] == "/api/activity/groups" for call in calls)
 
 
+def test_group_board_pins_ungrouped_to_third_desktop_column(
+        page: Page, backend_url, auth_token):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          app._stopActivityEvents();
+          await Promise.allSettled(Object.values(app._activityFetchPromises || {}));
+          app.lang = 'zh';
+          app.activity.viewLoaded = true;
+          app.activity.view = 'groups';
+          app.activity.loading = false;
+          app.activity.events = [];
+          app.activity.customGroups = [
+            {id: 'research', name: 'Research', color: 'violet'},
+            {id: 'delivery', name: 'Delivery', color: 'green'},
+            {id: 'planning', name: 'Planning', color: 'cyan'},
+            {id: 'review', name: 'Review', color: 'amber'},
+          ];
+          app.activity.groupOrder = [
+            'research', 'delivery', 'planning', 'review', '__ungrouped__',
+          ];
+          app.activity.show = true;
+          await new Promise(resolve => app.$nextTick(resolve));
+        }"""
+    )
+
+    expect(page.locator(".activity-group.is-custom")).to_have_count(5)
+    desktop = page.evaluate(
+        """() => {
+          const body = document.querySelector('.activity-body.is-group-board');
+          const lanes = Array.from(body.querySelectorAll('.activity-group.is-custom'));
+          return {
+            columns: getComputedStyle(body).gridTemplateColumns.split(' ').length,
+            lanes: lanes.map(lane => {
+              const rect = lane.getBoundingClientRect();
+              return {
+                name: lane.querySelector('.activity-custom-group-head > strong')?.textContent,
+                left: Math.round(rect.left), top: Math.round(rect.top),
+                height: Math.round(rect.height),
+              };
+            }),
+          };
+        }"""
+    )
+    assert desktop["columns"] == 3
+    by_name = {lane["name"]: lane for lane in desktop["lanes"]}
+    assert by_name["Research"]["left"] == by_name["Planning"]["left"]
+    assert by_name["Delivery"]["left"] == by_name["Review"]["left"]
+    assert by_name["Research"]["left"] < by_name["Delivery"]["left"]
+    assert by_name["Delivery"]["left"] < by_name["未分组"]["left"]
+    assert by_name["Research"]["top"] == by_name["Delivery"]["top"]
+    assert by_name["Planning"]["top"] == by_name["Review"]["top"]
+    assert by_name["Planning"]["top"] > by_name["Research"]["top"]
+    assert by_name["未分组"]["top"] == by_name["Research"]["top"]
+    assert by_name["未分组"]["height"] > by_name["Research"]["height"] * 1.9
+
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.wait_for_timeout(100)
+    mobile = page.evaluate(
+        """() => {
+          const body = document.querySelector('.activity-body.is-group-board');
+          const lanes = Array.from(body.querySelectorAll('.activity-group.is-custom'));
+          return {
+            display: getComputedStyle(body).display,
+            rects: lanes.map(lane => {
+              const rect = lane.getBoundingClientRect();
+              return {left: Math.round(rect.left), top: Math.round(rect.top)};
+            }),
+          };
+        }"""
+    )
+    assert mobile["display"] != "grid"
+    assert len({rect["left"] for rect in mobile["rects"]}) == 1
+    assert [rect["top"] for rect in mobile["rects"]] == sorted(
+        rect["top"] for rect in mobile["rects"])
+
+
 def test_mobile_move_menu_is_bottom_sheet_and_cleans_up_lifecycle(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -184,6 +184,15 @@ def _install_fake_event_source(page: Page) -> None:
         """
         (() => {
           const streams = [];
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (url, init) => {
+            if (String(url).includes("/api/chat/stream/mux/start")) {
+              return Promise.resolve(new Response("{}", {
+                status: 404, headers: {"Content-Type": "application/json"},
+              }));
+            }
+            return originalFetch(url, init);
+          };
           class FakeEventSource extends EventTarget {
             constructor(url) {
               super();
@@ -219,6 +228,49 @@ def _install_fake_event_source(page: Page) -> None:
     )
 
 
+def _install_fake_mux_event_source(page: Page) -> None:
+    page.add_init_script(
+        """
+        (() => {
+          const streams = [];
+          class FakeEventSource extends EventTarget {
+            constructor(url) {
+              super();
+              this.url = url;
+              this.readyState = 0;
+              streams.push(this);
+              setTimeout(() => {
+                if (this.readyState === 2) return;
+                this.readyState = 1;
+                if (this.onopen) this.onopen(new Event("open"));
+                this.dispatchEvent(new Event("open"));
+              }, 0);
+            }
+            close() { this.readyState = 2; this.closed = true; }
+          }
+          window.EventSource = FakeEventSource;
+          window.__fakeMuxStreams = () => streams.filter(
+            es => String(es.url || "").includes("/api/chat/stream/mux?")
+          );
+          window.__emitMux = (type, payload, index = -1) => {
+            const mux = window.__fakeMuxStreams();
+            const es = mux[index < 0 ? mux.length - 1 : index];
+            if (!es) throw new Error("no fake mux EventSource");
+            es.dispatchEvent(new MessageEvent(type, {
+              data: typeof payload === "string" ? payload : JSON.stringify(payload || {}),
+            }));
+          };
+          window.__disconnectMux = () => {
+            const mux = window.__fakeMuxStreams();
+            const es = mux[mux.length - 1];
+            if (!es) throw new Error("no fake mux EventSource");
+            es.dispatchEvent(new Event("error"));
+          };
+        })();
+        """
+    )
+
+
 def _visible_pane_with_text_snapshot(page: Page, text: str):
     return page.evaluate(
         """expected => {
@@ -234,6 +286,173 @@ def _visible_pane_with_text_snapshot(page: Page, text: str):
         }""",
         text,
     )
+
+
+def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_runtime(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    mux_starts: list[dict] = []
+    turn_starts: list[dict] = []
+
+    def handle_mux_start(route) -> None:
+        mux_starts.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": f"mux-{len(mux_starts)}"}),
+        )
+
+    def handle_turn_start(route) -> None:
+        turn_starts.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "accepted": True,
+                "session_id": route.request.post_data_json["session_id"],
+                "turn_id": "turn-local",
+                "started_at": int(time.time()),
+            }),
+        )
+
+    page.route("**/api/chat/stream/mux/start", handle_mux_start)
+    page.route("**/api/chat/turns/start", handle_turn_start)
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    watcher_sid = "mux-watcher-session"
+    initial = page.evaluate(
+        """async watcherSid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const localSid = app.currentId;
+          app._confirmSessionBusy = async () => false;
+          app._awaitRuntimeSettingPatches = async () => true;
+          app.availableModels = [{
+            model: 'mux-e2e-model', label: 'Mux E2E', group: 'e2e',
+            supports_thinking: true,
+          }];
+          app.model = 'mux-e2e-model';
+          app.permission = 'default';
+          app.sessions = app.sessions.map(session => session.id === localSid
+            ? {...session, model: 'mux-e2e-model', permission: 'default'} : session);
+          app._ensureTabState(localSid).permission = 'default';
+          app.sessions.push({
+            id: watcherSid, name: 'Watcher session', model: 'mux-e2e-model',
+            permission: 'default', cwd: app.currentWorkspacePath(), active: true,
+          });
+          window.__emitMux('session_state', {
+            session_id: watcherSid, active: true, attachable: false,
+            background: true, continuation: false, turn_id: 'watcher-gap',
+            started_at: Math.floor(Date.now() / 1000),
+            background_tasks_pending: 1,
+          });
+          await new Promise(resolve => setTimeout(resolve, 30));
+          const watcherCreatedDuringGap = !!app.tabState[watcherSid];
+          const watcher = app._ensureTabState(watcherSid);
+          watcher._loaded = true;
+          if (!app.openTabIds.includes(watcherSid)) app.openTabIds.push(watcherSid);
+          window.__emitMux('session_state', {
+            session_id: watcherSid, active: true, attachable: true,
+            background: false, continuation: true, turn_id: 'turn-watcher',
+            parent_turn_id: 'watcher-gap', started_at: Math.floor(Date.now() / 1000),
+          });
+          for (let i = 0; i < 100 && !watcher.es; i++) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          const local = app._ensureTabState(localSid);
+          local.draft.input = 'MUX_LOCAL_PROMPT';
+          app._activateComposerState(localSid);
+          await app.send();
+          return {
+            localSid,
+            watcherCreatedDuringGap,
+            watcherAttached: !!watcher.es,
+            nativeStreamCount: window.__fakeMuxStreams().length,
+          };
+        }""",
+        watcher_sid,
+    )
+    assert initial == {
+        "localSid": initial["localSid"],
+        "watcherCreatedDuringGap": False,
+        "watcherAttached": True,
+        "nativeStreamCount": 1,
+    }
+
+    page.evaluate(
+        """({localSid, watcherSid}) => {
+          window.__emitMux('text', {
+            session_id: localSid, turn_id: 'turn-local', event_seq: 1,
+            text: 'MUX_LOCAL_REPLY',
+          });
+          window.__emitMux('text', {
+            session_id: watcherSid, turn_id: 'turn-watcher', event_seq: 1,
+            text: 'MUX_BACKGROUND_REPLY',
+          });
+        }""",
+        {"localSid": initial["localSid"], "watcherSid": watcher_sid},
+    )
+    page.wait_for_function(
+        """sid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.tabState[sid]?.lastEventSeq === 1;
+        }""",
+        initial["localSid"],
+    )
+    page.evaluate(
+        """async sid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          await app.activateTab(sid);
+        }""",
+        watcher_sid,
+    )
+    page.wait_for_function(
+        """sid => document.querySelector('#app')._x_dataStack[0]
+          .tabState[sid].messages.some(m => m.text === 'MUX_BACKGROUND_REPLY')""",
+        watcher_sid,
+    )
+
+    page.evaluate("window.__disconnectMux()")
+    page.wait_for_function("window.__fakeMuxStreams().length === 2", timeout=5000)
+    state = page.evaluate(
+        """({localSid, watcherSid}) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            localStreaming: app.tabState[localSid].streaming,
+            watcherStreaming: app.tabState[watcherSid].streaming,
+            localSeq: app.tabState[localSid].lastEventSeq,
+            watcherSeq: app.tabState[watcherSid].lastEventSeq,
+            nativeStreamCount: window.__fakeMuxStreams().length,
+          };
+        }""",
+        {"localSid": initial["localSid"], "watcherSid": watcher_sid},
+    )
+    assert state == {
+        "localStreaming": True,
+        "watcherStreaming": True,
+        "localSeq": 1,
+        "watcherSeq": 1,
+        "nativeStreamCount": 2,
+    }
+    assert len(turn_starts) == 1
+    assert turn_starts[0] == {
+        "prompt": "MUX_LOCAL_PROMPT",
+        "session_id": initial["localSid"],
+        "model": "mux-e2e-model",
+        "permission": "default",
+        "image_ids": "",
+        "mobile": False,
+    }
+    assert len(mux_starts) == 2
+    checkpoints = {
+        (row["session_id"], row["turn_id"]): row["last_event_seq"]
+        for row in mux_starts[1]["checkpoints"]
+    }
+    assert checkpoints[(initial["localSid"], "turn-local")] == 1
+    assert checkpoints[(watcher_sid, "turn-watcher")] == 1
+    _assert_no_browser_errors(page, errors)
 
 
 def test_deferred_history_bodies_load_without_manual_body_action(

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -201,13 +201,16 @@ def _install_fake_event_source(page: Page) -> None:
           window.__fakeChatStreams = () => streams.filter(
             es => String(es.url || "").includes("/api/chat/stream?")
           );
-          window.__emitSse = (type, payload) => {
-            const chatStreams = window.__fakeChatStreams();
-            const es = chatStreams[chatStreams.length - 1];
-            if (!es) throw new Error("no fake chat EventSource");
+          window.__emitSseAt = (index, type, payload) => {
+            const es = window.__fakeChatStreams()[index];
+            if (!es) throw new Error("no fake chat EventSource at index " + index);
             es.dispatchEvent(new MessageEvent(type, {
               data: typeof payload === "string" ? payload : JSON.stringify(payload || {}),
             }));
+          };
+          window.__emitSse = (type, payload) => {
+            const chatStreams = window.__fakeChatStreams();
+            window.__emitSseAt(chatStreams.length - 1, type, payload);
           };
         })();
         """
@@ -2505,7 +2508,7 @@ def test_mobile_long_history_switching_does_not_blank(page: Page, backend_url, a
 def test_desktop_session_switch_keeps_bounded_warm_panes_and_composer_stable(
     page: Page, backend_url: str, auth_token: str,
 ):
-    """Desktop keeps a bounded warm-pane cache without footer/layout jumps."""
+    """Desktop bounds warm panes even when every inactive session is streaming."""
     errors = _capture_browser_errors(page)
     page.set_viewport_size({"width": 1440, "height": 900})
     _login(page, backend_url, auth_token)
@@ -2543,6 +2546,7 @@ def test_desktop_session_switch_keeps_bounded_warm_panes_and_composer_stable(
           st.messagesReady = true;
           st.messagesLoading = false;
           st.atBottom = true;
+          st.streaming = true;
           app.tabState[id] = st;
           app._ensureTabState(id);
         }
@@ -6670,6 +6674,132 @@ def test_mobile_composer_footer_is_compact_and_never_overflows(
         _assert_no_browser_errors(page, errors)
     finally:
         context.close()
+
+
+def test_background_stream_buffers_token_rate_presentation_until_activation(
+    page: Page, backend_url: str, auth_token: str,
+):
+    """Inactive SSE streams retain complete state without token-rate paints."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _install_fake_event_source(page)
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"e2e-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    ids = ["background-buffer-a", "background-buffer-b"]
+    _app_eval(
+        page,
+        """
+        app.refreshSessions = async () => {};
+        app._fetchTabUsage = async () => {};
+        app._scheduleIdlePreload = () => {};
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = app.defaultModel = "e2e-model";
+        app.sessions = arg.map((id, index) => ({
+          id, name: `Buffered ${index}`, updated_at: Date.now() / 1000,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }));
+        app.openTabIds = arg.slice();
+        app.tabState = {};
+        for (const id of arg) {
+          const st = app._blankTabState();
+          st._loaded = true;
+          st.messagesReady = true;
+          st.messagesLoading = false;
+          st.atBottom = true;
+          app.tabState[id] = st;
+        }
+        app.currentId = arg[0];
+        app._activateTabState(arg[0]);
+        app.input = "start stream a";
+        return true;
+        """,
+        ids,
+    )
+    _app_eval(page, "app.send(); return true;")
+    page.wait_for_function("() => window.__fakeChatStreams().length === 1")
+    _app_eval(
+        page,
+        """
+        app.currentId = arg;
+        await app.switchSession();
+        app.input = "start stream b";
+        app.send();
+        return true;
+        """,
+        ids[1],
+    )
+    page.wait_for_function("() => window.__fakeChatStreams().length === 2")
+
+    page.evaluate(
+        """() => {
+          for (let i = 0; i < 200; i++) {
+            window.__emitSseAt(0, "text", { text: `BG_TEXT_${i} ` });
+          }
+          for (let i = 0; i < 200; i++) {
+            window.__emitSseAt(0, "thinking", { text: `BG_THINK_${i} ` });
+          }
+        }"""
+    )
+    before = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        const thinking = [...st.messages].reverse().find(m => m.role === "thinking");
+        return {
+          currentId: app.currentId,
+          streaming: st.streaming,
+          thinkingText: thinking ? thinking.text : null,
+          plainPaints: st._streamPlainRenderCount,
+        };
+        """,
+        ids[0],
+    )
+    assert before["currentId"] == ids[1]
+    assert before["streaming"] is True
+    assert before["thinkingText"] == ""
+    assert before["plainPaints"] == 0
+
+    _app_eval(
+        page,
+        """
+        app.currentId = arg;
+        await app.switchSession();
+        return true;
+        """,
+        ids[0],
+    )
+    page.wait_for_function(
+        """sid => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(sid);
+          const thinking = [...st.messages].reverse().find(m => m.role === "thinking");
+          return app.currentId === sid
+            && thinking?.text.includes("BG_THINK_199")
+            && document.querySelector(`.msg-pane[data-tid="${sid}"]`)
+              ?.textContent.includes("BG_THINK_199");
+        }""",
+        arg=ids[0],
+    )
+    assert _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg);
+        return st.messages.some(m => m.role === "assistant"
+          && m.text.includes("BG_TEXT_199"));
+        """,
+        ids[0],
+    )
+    _assert_no_browser_errors(page, errors)
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -456,6 +456,123 @@ def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_
     _assert_no_browser_errors(page, errors)
 
 
+def test_mux_inactive_retires_matching_turn_without_harming_successor(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    page.route(
+        "**/api/chat/stream/mux/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "mux-inactive-settlement"}),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          const meta = app.sessions.find(session => session.id === sid);
+          const originalReload = app._scheduleCanonicalStreamReload;
+          let reloads = 0;
+          app._scheduleCanonicalStreamReload = () => { reloads += 1; return true; };
+          try {
+            st._loaded = true;
+            st.messages = [{ role: 'assistant', text: 'VISIBLE_COMPLETED_REPLY' }];
+            st.streaming = true;
+            st.streamPhase = 'runtime';
+            st.activeTurnId = 'turn-a';
+            st._stoppingTurnId = 'turn-a';
+            st.es = app._chatMuxChannel(sid, 'turn-a');
+            app._activateChatMuxChannel(st.es);
+            st._streamStartedAt = Date.now() - 5000;
+            st.streamElapsed = 5;
+            st._streamTimer = setInterval(() => {}, 1000);
+            st._stallWatch = setInterval(() => {}, 1000);
+            if (meta) meta.active = true;
+
+            window.__emitMux('session_state', {
+              session_id: sid, turn_id: 'turn-a', active: false,
+              stopping: false, attachable: false,
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const matching = {
+              streaming: st.streaming,
+              phase: st.streamPhase,
+              es: st.es,
+              timer: st._streamTimer,
+              stall: st._stallWatch,
+              stoppingTurn: st._stoppingTurnId,
+              elapsed: st.streamElapsed,
+              reloads,
+              text: st.messages[0] && st.messages[0].text,
+              metaActive: meta && meta.active,
+            };
+
+            st.streaming = true;
+            st.streamPhase = 'runtime';
+            st.activeTurnId = 'turn-b';
+            st._stoppingTurnId = '';
+            st.es = app._chatMuxChannel(sid, 'turn-b');
+            app._activateChatMuxChannel(st.es);
+            st._streamTimer = setInterval(() => {}, 1000);
+            st._stallWatch = setInterval(() => {}, 1000);
+            if (meta) meta.active = true;
+            const successorEs = st.es;
+            const successorTimer = st._streamTimer;
+
+            window.__emitMux('session_state', {
+              session_id: sid, turn_id: 'turn-a', active: false,
+              stopping: false, attachable: false,
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const successor = {
+              streaming: st.streaming,
+              phase: st.streamPhase,
+              sameEs: st.es === successorEs,
+              sameTimer: st._streamTimer === successorTimer,
+              activeTurnId: st.activeTurnId,
+              reloads,
+              metaActive: meta && meta.active,
+            };
+            clearInterval(st._streamTimer);
+            clearInterval(st._stallWatch);
+            if (st.es) st.es.close();
+            return { matching, successor };
+          } finally {
+            app._scheduleCanonicalStreamReload = originalReload;
+          }
+        }"""
+    )
+    assert result["matching"] == {
+        "streaming": False,
+        "phase": "",
+        "es": None,
+        "timer": None,
+        "stall": None,
+        "stoppingTurn": "",
+        "elapsed": 0,
+        "reloads": 1,
+        "text": "VISIBLE_COMPLETED_REPLY",
+        "metaActive": False,
+    }
+    assert result["successor"] == {
+        "streaming": True,
+        "phase": "runtime",
+        "sameEs": True,
+        "sameTimer": True,
+        "activeTurnId": "turn-b",
+        "reloads": 1,
+        "metaActive": True,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
 def test_mux_coordinator_connects_before_background_history_warmup(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -151,6 +151,7 @@ def _route_windowed_session(page: Page, sid: str, messages: list[dict]) -> list[
             window = messages[offset:offset + limit]
         requests.append({
             "url": url,
+            "full": "full" in qs,
             "tail": int(qs["tail"][0]) if "tail" in qs else None,
             "offset": offset,
             "limit": int(qs["limit"][0]) if "limit" in qs else None,
@@ -169,6 +170,7 @@ def _route_windowed_session(page: Page, sid: str, messages: list[dict]) -> list[
                 "offset": offset,
                 "total": total,
                 "has_more": offset > 0,
+                "history_order": "full" if "full" in qs else "normal",
                 "history_generation": "gen-e2e-1",
             }),
         )
@@ -3998,8 +4000,14 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     _install_fake_event_source(page)
     sid = "perf-done-canonical-identity"
     prompt = "DOM_IDENTITY_USER_PROMPT"
+    history_marker = "FULL_ORDER_HISTORY_SURVIVES_LRU_REMOUNT"
     final_text = "DOM_IDENTITY_FINAL_REPLY " + ("stable canonical text " * 40)
-    canonical_messages: list[dict] = []
+    canonical_messages: list[dict] = [{
+        "role": "assistant",
+        "text": history_marker,
+        "uuid": "done-full-history-assistant",
+        "ts": 1_700_019_999,
+    }]
     requests = _route_windowed_session(page, sid, canonical_messages)
     page.route(
         "**/api/chat/stream/start",
@@ -4037,6 +4045,16 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         const st = app._ensureTabState(sid);
         st._loaded = true;
         st._seenUpdated = 1;
+        st.messages.push({
+          role: "assistant", text: arg.historyMarker,
+          html: `<p>${arg.historyMarker}</p>`,
+          uuid: "done-full-history-assistant",
+          _k: `${sid}:uuid:done-full-history-assistant`, _noAnim: true,
+        });
+        Object.assign(st.messageRange, {
+          visibleStart: 0, visibleEnd: 1, offset: 0, total: 1,
+          preTotal: 0, order: "full", generation: "gen-e2e-1",
+        });
         app.currentId = sid;
         app._activateTabState(sid);
         app._ensureTabState(app.currentId).messagesReady = true;
@@ -4046,7 +4064,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         app._ensureTabState(app.currentId).atBottom = true;
         return true;
         """,
-        {"sid": sid, "prompt": prompt},
+        {"sid": sid, "prompt": prompt, "historyMarker": history_marker},
     )
 
     _app_eval(page, "app.send(); return true;")
@@ -4103,6 +4121,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     page.evaluate(
         """() => window.__emitSse("done", {
           total_cost_usd: 0.001,
+          memory_recall: { count: 2, query: "private-query" },
           session_usage: { context_used_pct: 5, context_used: 500, context_limit: 100000 },
           turn_id: "done-reconcile-turn", event_seq: 2,
         })"""
@@ -4149,19 +4168,82 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             key: last._k,
             uuid: last.uuid || "",
             text: last.text || "",
+            cost: last.cost || "",
+            memoryCount: Number(last.memoryRecall?.count) || 0,
+            historyOrder: st.messageRange.order,
           };
         }""",
         {"sid": sid, "text": final_text},
     )
 
     assert requests, "canonical reconciliation did not request session history"
+    assert any(req["full"] and req["tail"] for req in requests), requests
     assert result["sameNode"] is True, result
     assert result["key"] == result["oldKey"]
     assert result["uuid"] == "done-canonical-assistant"
     assert result["text"] == final_text
+    assert result["cost"] == "$0.0010"
+    assert result["memoryCount"] == 2
+    assert result["historyOrder"] == "full"
     assert result["frames"]
     assert all(frame["ready"] and not frame["loading"] for frame in result["frames"]), result
     assert all(frame["visible"] and frame["count"] > 0 for frame in result["frames"]), result
+
+    remount = _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        const dummyIds = ["done-lru-a", "done-lru-b", "done-lru-c"];
+        app.sessions = [app.sessions.find(s => s.id === sid), ...dummyIds.map((id, i) => ({
+          id, name: `LRU ${i}`, updated_at: 10 + i,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }))];
+        app.openTabIds = [sid, ...dummyIds];
+        app.currentId = sid;
+        app._touchTranscriptPane(sid);
+        await new Promise(resolve => app.$nextTick(resolve));
+        for (const id of dummyIds) {
+          const st = app._blankTabState();
+          st._loaded = true;
+          st.messagesReady = true;
+          st.messagesLoading = false;
+          st.messages.push({
+            role: "assistant", text: id, html: `<p>${id}</p>`,
+            uuid: `${id}-assistant`, _k: `${id}:uuid:${id}-assistant`, _noAnim: true,
+          });
+          Object.assign(st.messageRange, {
+            visibleStart: 0, visibleEnd: 1, offset: 0, total: 1,
+            preTotal: 0, order: "normal", generation: "gen-e2e-1",
+          });
+          app.tabState[id] = st;
+          app.currentId = id;
+          app._touchTranscriptPane(id);
+          app._activateTabState(id);
+          await new Promise(resolve => app.$nextTick(resolve));
+        }
+        const evicted = !app.warmTranscriptTabIds().includes(sid);
+        app.currentId = sid;
+        app._touchTranscriptPane(sid);
+        app._activateTabState(sid);
+        await new Promise(resolve => app.$nextTick(
+          () => requestAnimationFrame(resolve)));
+        const pane = document.querySelector(
+          `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+        return {
+          evicted,
+          warmCount: app.warmTranscriptTabIds().length,
+          markerVisible: !!pane && pane.textContent.includes(arg.historyMarker),
+          finalVisible: !!pane && pane.textContent.includes(arg.finalText.trim()),
+          historyOrder: app._ensureTabState(sid).messageRange.order,
+        };
+        """,
+        {"sid": sid, "historyMarker": history_marker, "finalText": final_text},
+    )
+    assert remount["evicted"] is True, remount
+    assert remount["warmCount"] <= 3, remount
+    assert remount["markerVisible"] is True, remount
+    assert remount["finalVisible"] is True, remount
+    assert remount["historyOrder"] == "full"
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -71,7 +71,8 @@ def _app_eval(page: Page, body: str, arg=None):
     return page.evaluate(
         """([body, arg]) => {
             const app = document.querySelector("#app")._x_dataStack[0];
-            return (new Function("app", "arg", body))(app, arg);
+            const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+            return (new AsyncFunction("app", "arg", body))(app, arg);
         }""",
         [body, arg],
     )
@@ -399,7 +400,7 @@ def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_
           const app = document.querySelector('#app')._x_dataStack[0];
           return app.tabState[sid]?.lastEventSeq === 1;
         }""",
-        initial["localSid"],
+        arg=initial["localSid"],
     )
     page.evaluate(
         """async sid => {
@@ -411,7 +412,7 @@ def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_
     page.wait_for_function(
         """sid => document.querySelector('#app')._x_dataStack[0]
           .tabState[sid].messages.some(m => m.text === 'MUX_BACKGROUND_REPLY')""",
-        watcher_sid,
+        arg=watcher_sid,
     )
 
     page.evaluate("window.__disconnectMux()")
@@ -453,6 +454,41 @@ def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_
     assert checkpoints[(initial["localSid"], "turn-local")] == 1
     assert checkpoints[(watcher_sid, "turn-watcher")] == 1
     _assert_no_browser_errors(page, errors)
+
+
+def test_mux_coordinator_connects_before_background_history_warmup(
+    page: Page, backend_url, auth_token,
+):
+    """The root live transport owns events before background history starts."""
+    _login(page, backend_url, auth_token)
+    order = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          if (app._chatMuxStartPromise) {
+            try { await app._chatMuxStartPromise; } catch (_) {}
+          }
+          app._setChatMuxUnsupported();
+          const originalEnsure = app._ensureChatMux;
+          const originalHistory = app._bootstrapChatMuxHistory;
+          const order = [];
+          app._chatMuxSupported = true;
+          app._ensureChatMux = async () => {
+            order.push('mux:start');
+            await Promise.resolve();
+            order.push('mux:connected');
+            return true;
+          };
+          app._bootstrapChatMuxHistory = async () => order.push('history:start');
+          try {
+            await app._startChatMuxCoordinator();
+            return order;
+          } finally {
+            app._ensureChatMux = originalEnsure;
+            app._bootstrapChatMuxHistory = originalHistory;
+          }
+        }"""
+    )
+    assert order == ["mux:start", "mux:connected", "history:start"]
 
 
 def test_deferred_history_bodies_load_without_manual_body_action(
@@ -5881,16 +5917,20 @@ def test_failed_queue_edit_never_duplicates_and_stopping_turn_rejects_send(
             busy: Object.keys(st._queueMutating || {}),
           };
 
-          st._stopping = true;
-          st.streaming = true;
+          st.activeTurnId = 'authoritative-stop-turn';
+          st._stoppingTurnId = st.activeTurnId;
+          st.streaming = false;
           st.draft.input = 'SEND DURING STOP';
           app._activateComposerState(sid);
+          const disabledReason = app.composerDisabledReason(sid);
           const sendResult = await app.send();
           return {
             afterEdit,
+            disabledReason,
             sendResult,
             stoppingDraft: st.draft.input,
             pendingAfterStop: st.pendingQueue.length,
+            composerClaim: st._composerSubmitToken,
           };
         }""",
         sid,
@@ -5903,9 +5943,13 @@ def test_failed_queue_edit_never_duplicates_and_stopping_turn_rejects_send(
         "draft": "",
         "busy": [],
     }
+    assert result["disabledReason"] in {
+        "Stopping the previous turn", "正在中断上一条任务",
+    }
     assert result["sendResult"] is False
     assert result["stoppingDraft"] == "SEND DURING STOP"
     assert result["pendingAfterStop"] == 1
+    assert result["composerClaim"] is None
 
 
 def test_background_task_gap_leaves_composer_usable_without_empty_reconnect(
@@ -6998,7 +7042,10 @@ def test_background_stream_buffers_token_rate_presentation_until_activation(
         page,
         """
         app.refreshSessions = async () => {};
-        app._fetchTabUsage = async () => {};
+        window.__backgroundUsageFetches = [];
+        app._fetchTabUsage = async sid => {
+          window.__backgroundUsageFetches.push(sid);
+        };
         app._scheduleIdlePreload = () => {};
         app.availableModels = [{
           model: "e2e-model", label: "E2E model", group: "e2e",
@@ -7061,6 +7108,7 @@ def test_background_stream_buffers_token_rate_presentation_until_activation(
           streaming: st.streaming,
           thinkingText: thinking ? thinking.text : null,
           plainPaints: st._streamPlainRenderCount,
+          usageFetches: window.__backgroundUsageFetches.slice(),
         };
         """,
         ids[0],
@@ -7069,6 +7117,7 @@ def test_background_stream_buffers_token_rate_presentation_until_activation(
     assert before["streaming"] is True
     assert before["thinkingText"] == ""
     assert before["plainPaints"] == 0
+    assert ids[0] not in before["usageFetches"]
 
     _app_eval(
         page,

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -31,6 +31,55 @@ def _login(page: Page, base: str, token: str) -> None:
     )
 
 
+def _install_fake_mux_chat_transport(page: Page, turn_bodies: list[dict]) -> None:
+    page.add_init_script(
+        """
+        (() => {
+          class FakeEventSource extends EventTarget {
+            constructor(url) {
+              super();
+              this.url = url;
+              this.readyState = 0;
+              setTimeout(() => {
+                if (this.readyState === 2) return;
+                this.readyState = 1;
+                if (this.onopen) this.onopen(new Event('open'));
+                this.dispatchEvent(new Event('open'));
+              }, 0);
+            }
+            close() { this.readyState = 2; }
+          }
+          window.EventSource = FakeEventSource;
+        })();
+        """
+    )
+
+    page.route(
+        "**/api/chat/stream/mux/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"preview-mux-ticket"}',
+        ),
+    )
+
+    def handle_turn_start(route) -> None:
+        body = route.request.post_data_json
+        turn_bodies.append(body)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "accepted": True,
+                "session_id": body["session_id"],
+                "turn_id": f"preview-turn-{len(turn_bodies)}",
+                "started_at": 1_700_000_000,
+            }),
+        )
+
+    page.route("**/api/chat/turns/start", handle_turn_start)
+
+
 def _select_rendered_preview_text(page: Page) -> str:
     # Alpine can publish ``previewMode`` one render tick before the Markdown
     # body is mounted.  Wait for the actual selectable surface so callers do
@@ -995,40 +1044,17 @@ def test_selection_side_question_window_supports_touch_drag(
 
 def test_detached_preview_question_uses_send_pipeline_without_touching_draft(
         page: Page, backend_url, auth_token):
+    turn_bodies: list[dict] = []
+    _install_fake_mux_chat_transport(page, turn_bodies)
     _login(page, backend_url, auth_token)
-    ticket_bodies: list[dict] = []
-
-    def handle_ticket(route) -> None:
-        ticket_bodies.append(route.request.post_data_json)
-        route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({"ticket": "preview-detached-ticket"}),
-        )
-
-    page.route("**/api/chat/stream/start", handle_ticket)
     result = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
           app.availableModels = [{model: 'e2e-model', label: 'E2E', group: 'e2e'}];
           app.model = 'e2e-model';
-          class FakeEventSource extends EventTarget {
-            constructor(url) {
-              super();
-              this.url = url;
-              this.readyState = 0;
-              setTimeout(() => {
-                this.readyState = 1;
-                if (this.onopen) this.onopen(new Event('open'));
-              }, 0);
-            }
-            close() { this.readyState = 2; }
-          }
-          const originalEventSource = window.EventSource;
           const originalBusy = app._confirmSessionBusy;
           const originalRuntimeWait = app._awaitRuntimeSettingPatches;
           const originalCommit = app._commitChatRecoveryDraft;
-          window.EventSource = FakeEventSource;
           app._confirmSessionBusy = async () => false;
           app._awaitRuntimeSettingPatches = async () => true;
           let recoveryCommits = 0;
@@ -1061,7 +1087,6 @@ def test_detached_preview_question_uses_send_pipeline_without_touching_draft(
             };
           } finally {
             app.tabState[app.currentId]?.es?.close();
-            window.EventSource = originalEventSource;
             app._confirmSessionBusy = originalBusy;
             app._awaitRuntimeSettingPatches = originalRuntimeWait;
             app._commitChatRecoveryDraft = originalCommit;
@@ -1069,9 +1094,9 @@ def test_detached_preview_question_uses_send_pipeline_without_touching_draft(
         }"""
     )
 
-    assert len(ticket_bodies) == 1
-    assert ticket_bodies[0]["prompt"] == "DETACHED PREVIEW QUESTION"
-    assert ticket_bodies[0]["image_ids"] == ""
+    assert len(turn_bodies) == 1
+    assert turn_bodies[0]["prompt"] == "DETACHED PREVIEW QUESTION"
+    assert turn_bodies[0]["image_ids"] == ""
     assert result["sendResult"] == "undefined"
     assert result["input"] == result["draft"] == "PRESERVE THIS DRAFT"
     assert result["images"] == ["draft-image"]
@@ -1085,39 +1110,16 @@ def test_detached_preview_question_uses_send_pipeline_without_touching_draft(
 
 def test_composer_quote_sends_context_without_rewriting_visible_text(
         page: Page, backend_url, auth_token):
+    turn_bodies: list[dict] = []
+    _install_fake_mux_chat_transport(page, turn_bodies)
     _login(page, backend_url, auth_token)
-    ticket_bodies: list[dict] = []
-
-    def handle_ticket(route) -> None:
-        ticket_bodies.append(route.request.post_data_json)
-        route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({"ticket": "selection-quote-ticket"}),
-        )
-
-    page.route("**/api/chat/stream/start", handle_ticket)
     result = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
           app.availableModels = [{model: 'e2e-model', label: 'E2E', group: 'e2e'}];
           app.model = 'e2e-model';
-          class FakeEventSource extends EventTarget {
-            constructor(url) {
-              super();
-              this.url = url;
-              this.readyState = 0;
-              setTimeout(() => {
-                this.readyState = 1;
-                if (this.onopen) this.onopen(new Event('open'));
-              }, 0);
-            }
-            close() { this.readyState = 2; }
-          }
-          const originalEventSource = window.EventSource;
           const originalBusy = app._confirmSessionBusy;
           const originalRuntimeWait = app._awaitRuntimeSettingPatches;
-          window.EventSource = FakeEventSource;
           app._confirmSessionBusy = async () => false;
           app._awaitRuntimeSettingPatches = async () => true;
           try {
@@ -1146,15 +1148,14 @@ def test_composer_quote_sends_context_without_rewriting_visible_text(
             };
           } finally {
             app.tabState[app.currentId]?.es?.close();
-            window.EventSource = originalEventSource;
             app._confirmSessionBusy = originalBusy;
             app._awaitRuntimeSettingPatches = originalRuntimeWait;
           }
         }"""
     )
 
-    assert len(ticket_bodies) == 1
-    prompt = ticket_bodies[0]["prompt"]
+    assert len(turn_bodies) == 1
+    prompt = turn_bodies[0]["prompt"]
     assert "引用自 `README.md`" in prompt
     assert "SELECTED CONTEXT" in prompt
     assert prompt.endswith("VISIBLE QUESTION")

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -414,7 +414,7 @@ def test_pending_send_text_survives_hard_refresh(
           app._confirmSessionBusy = async () => false;
           const originalFetch = window.fetch.bind(window);
           window.fetch = (url, init) => {
-            if (String(url).includes('/api/chat/stream/start')) {
+            if (String(url).includes('/api/chat/turns/start')) {
               window.__streamStartBlocked = true;
               return new Promise(() => {});
             }
@@ -457,11 +457,11 @@ def test_pending_send_text_survives_hard_refresh(
     expect(page.locator(".chat-input-textarea")).to_have_value(marker)
 
 
-def test_ticket_failure_restores_draft_and_idle_state(
+def test_turn_start_failure_restores_draft_and_idle_state(
         page: Page, backend_url, auth_token):
     attempts = 0
 
-    def reject_ticket(route) -> None:
+    def reject_turn_start(route) -> None:
         nonlocal attempts
         attempts += 1
         route.fulfill(
@@ -470,7 +470,7 @@ def test_ticket_failure_restores_draft_and_idle_state(
             body='{"detail":"ticket unavailable"}',
         )
 
-    page.route("**/api/chat/stream/start", reject_ticket)
+    page.route("**/api/chat/turns/start", reject_turn_start)
     _login(page, backend_url, auth_token)
     marker = "ticket-failure-recovered"
     page.locator(".chat-input-textarea").fill(marker)

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -217,7 +217,16 @@ def test_same_origin_pages_share_strip_without_focus_theft_or_writeback(
         assert non_current not in stored["openTabIds"]
         assert peer_current not in stored["openTabIds"]
 
-        page.reload(wait_until="domcontentloaded")
+        # Two same-origin pages already hold the app's long-lived SSE surfaces.
+        # Retire both root mux transports before navigation so Chromium always
+        # has a connection available for the reload itself; the fresh document
+        # starts its own coordinator after session initialization.
+        for browser_page in (page, peer):
+            browser_page.evaluate(
+                """() => document.querySelector('#app')._x_dataStack[0]
+                  ._setChatMuxUnsupported()"""
+            )
+        page.reload(wait_until="domcontentloaded", timeout=15000)
         page.wait_for_function(
             """([closed]) => {
               const app = document.querySelector('#app')?._x_dataStack?.[0];

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -398,7 +398,44 @@ def test_interrupt_calls_sdk_and_marks_pending(chat_mod, client):
     assert body["ok"] is True
     assert body["interrupted"] == ["sid-int@claude-sonnet-4-6"]
     assert c.interrupted is True
-    assert "sid-int" in chat_mod._pending_interrupts
+    assert ("sid-int", "") in chat_mod._pending_interrupts
+
+
+def test_interrupt_rejects_stale_turn_before_touching_client_or_queue(
+        chat_mod, client, monkeypatch):
+    sid = "sid-stale-stop"
+    sdk_client = _seed(
+        chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
+    current = chat_mod.TurnBroadcast(sid)
+    chat_mod._active_turns[sid] = current
+    pauses = []
+    monkeypatch.setattr(
+        chat_mod.sess,
+        "pause_queue_if_nonempty",
+        lambda stopped_sid: pauses.append(stopped_sid),
+    )
+    try:
+        response = client.post(
+            f"/api/chat/interrupt?session_id={sid}&turn_id=older-turn"
+            f"&token={TEST_TOKEN}")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "ok": True,
+            "interrupted": [],
+            "stale": True,
+            "requested_turn_id": "older-turn",
+            "current_turn_id": current.turn_id,
+            "turn_id": current.turn_id,
+            "active": True,
+            "stopping": False,
+            "phase": "running",
+        }
+        assert sdk_client.interrupted is False
+        assert pauses == []
+        assert (sid, "older-turn") not in chat_mod._pending_interrupts
+    finally:
+        chat_mod._active_turns.pop(sid, None)
+        current.close()
 
 
 def test_interrupt_swallows_sdk_error_but_still_marks_pending(chat_mod, client):
@@ -413,7 +450,7 @@ def test_interrupt_swallows_sdk_error_but_still_marks_pending(chat_mod, client):
     body = r.json()
     assert body["ok"] is True
     assert body["interrupted"] == []   # failing client omitted
-    assert "sid-boom" in chat_mod._pending_interrupts
+    assert ("sid-boom", "") in chat_mod._pending_interrupts
 
 
 def test_stop_background_task_uses_sdk_control_channel(chat_mod, client):
@@ -474,7 +511,7 @@ def test_interrupt_does_not_inherit_sdk_60_second_ack_timeout(
 
     assert response.status_code == 200, response.text
     assert response.json()["interrupted"] == []
-    assert sid in chat_mod._pending_interrupts
+    assert (sid, "") in chat_mod._pending_interrupts
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -233,6 +233,44 @@ def test_mux_watcher_state_can_become_attachable_dynamically(
     placeholder.close()
 
 
+def test_mux_emits_inactive_state_with_finished_turn_identity(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    broadcast = chat_mod.TurnBroadcast("becomes-inactive")
+    phase = {"active": True}
+
+    def state(_sid):
+        if phase["active"]:
+            return _active_state(broadcast)
+        return {"active": False, "background_tasks_pending": 0}
+
+    chat_mod._active_turns[broadcast.session_id] = broadcast
+    monkeypatch.setattr(chat_mod, "session_active_status", state)
+
+    async def exercise():
+        stream = chat_mod._subscribe_multiplex({})
+        active = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert json.loads(active["data"])["active"] is True
+        broadcast.publish({
+            "event": "done",
+            "data": json.dumps({"turn_id": broadcast.turn_id}),
+        })
+        broadcast.finish()
+        phase["active"] = False
+        chat_mod._active_turns.pop(broadcast.session_id, None)
+        terminal = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert terminal["event"] == "done"
+        inactive = await asyncio.wait_for(anext(stream), timeout=0.2)
+        payload = json.loads(inactive["data"])
+        assert inactive["event"] == "session_state"
+        assert payload["active"] is False
+        assert payload["turn_id"] == broadcast.turn_id
+        await stream.aclose()
+
+    asyncio.run(exercise())
+    broadcast.close()
+
+
 def test_mux_exact_recent_checkpoint_replays_without_cold_recent_discovery(
         chat_mod, monkeypatch):
     monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -1,0 +1,357 @@
+import asyncio
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from tests.conftest import TEST_TOKEN
+
+
+@pytest.fixture()
+def chat_mod(app_module):
+    from backend import chat
+    return chat
+
+
+def _active_state(broadcast, *, attachable=True, background=False):
+    return {
+        "active": True,
+        "attachable": attachable,
+        "background": background,
+        "continuation": bool(getattr(broadcast, "is_continuation", False)),
+        "turn_id": broadcast.turn_id if attachable else "watcher-origin",
+        "started_at": broadcast.started_at,
+        "events_so_far": broadcast.replay_count(),
+        "background_tasks_pending": 1 if background else 0,
+        "runtime_background_tasks_pending": 0,
+        "runtime_continuation_pending": 0,
+        "runtime_ui_revision": 0,
+        "activity_source": "background" if background else "direct",
+        "user_text": broadcast.user_text,
+        "user_images": [],
+        "user_docs": [],
+    }
+
+
+def test_turn_start_admits_accepts_and_launches(
+        chat_mod, client, monkeypatch):
+    broadcast = chat_mod.TurnBroadcast("turn-start-session", model="model-a")
+    launched = []
+
+    async def admit(session_id, prompt, *, model="", image_ids="", **_kwargs):
+        assert session_id == "turn-start-session"
+        assert prompt == "hello"
+        assert model == "model-a"
+        assert image_ids == ""
+        chat_mod._active_turns[session_id] = broadcast
+        return broadcast
+
+    def launch(bc, **kwargs):
+        launched.append((bc, kwargs))
+        return None
+
+    monkeypatch.setattr(chat_mod, "_admit_turn", admit)
+    monkeypatch.setattr(chat_mod, "_launch_admitted_turn", launch)
+
+    response = client.post(
+        "/api/chat/turns/start",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={
+            "prompt": "hello",
+            "session_id": "turn-start-session",
+            "model": "model-a",
+            "permission": "bypassPermissions",
+            "image_ids": "",
+            "mobile": False,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "accepted": True,
+        "session_id": broadcast.session_id,
+        "turn_id": broadcast.turn_id,
+        "started_at": broadcast.started_at,
+    }
+    assert launched == [(broadcast, {
+        "prompt": "hello",
+        "model": "model-a",
+        "permission": "bypassPermissions",
+        "image_ids": "",
+    })]
+    assert broadcast.startup_phase == "accepted"
+
+
+def test_turn_start_is_new_turn_only(chat_mod, client):
+    unauthenticated = client.post(
+        "/api/chat/turns/start",
+        json={"prompt": "hello", "session_id": "no-auth"},
+    )
+    assert unauthenticated.status_code == 401
+
+    response = client.post(
+        "/api/chat/turns/start",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={"prompt": "", "session_id": "no-reconnect"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "prompt or image_ids required for a new turn")
+
+
+def test_mux_ticket_validation_dedupes_and_is_single_use(
+        chat_mod, client):
+    unauthenticated = client.post(
+        "/api/chat/stream/mux/start", json={"checkpoints": []})
+    assert unauthenticated.status_code == 401
+
+    missing_turn = client.post(
+        "/api/chat/stream/mux/start",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={
+            "checkpoints": [{
+                "session_id": "s1",
+                "turn_id": "",
+                "last_event_seq": 1,
+            }],
+            "mobile": False,
+        },
+    )
+    assert missing_turn.status_code == 422
+
+    contradictory = client.post(
+        "/api/chat/stream/mux/start",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={
+            "checkpoints": [
+                {"session_id": "s1", "turn_id": "t1", "last_event_seq": 1},
+                {"session_id": "s1", "turn_id": "t1", "last_event_seq": 2},
+            ],
+        },
+    )
+    assert contradictory.status_code == 422
+
+    accepted = client.post(
+        "/api/chat/stream/mux/start",
+        headers={"X-Auth-Token": TEST_TOKEN},
+        json={
+            "checkpoints": [
+                {"session_id": "s1", "turn_id": "t1", "last_event_seq": 1},
+                {"session_id": "s1", "turn_id": "t1", "last_event_seq": 1},
+            ],
+        },
+    )
+    assert accepted.status_code == 200, accepted.text
+    ticket = accepted.json()["ticket"]
+
+    response = asyncio.run(chat_mod.mux_stream(ticket))
+    assert response.status_code == 200
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(chat_mod.mux_stream(ticket))
+    assert exc_info.value.status_code == 401
+
+
+def test_mux_auto_discovers_wraps_events_and_disconnect_only_unsubscribes(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    broadcast = chat_mod.TurnBroadcast("auto-discovered")
+    broadcast.publish({"event": "text", "data": json.dumps({"text": "hello"})})
+    chat_mod._active_turns[broadcast.session_id] = broadcast
+    monkeypatch.setattr(
+        chat_mod,
+        "session_active_status",
+        lambda sid: _active_state(chat_mod._active_turns[sid]),
+    )
+
+    async def exercise():
+        owner = asyncio.create_task(asyncio.sleep(10))
+        broadcast.startup_owner_task = owner
+        stream = chat_mod._subscribe_multiplex({}, mobile=False)
+        first = await anext(stream)
+        second = await anext(stream)
+
+        assert first["event"] == "session_state"
+        assert json.loads(first["data"])["session_id"] == broadcast.session_id
+        assert second["event"] == "text"
+        assert json.loads(second["data"]) == {
+            "text": "hello",
+            "turn_id": broadcast.turn_id,
+            "event_seq": 1,
+            "session_id": broadcast.session_id,
+        }
+        assert len(broadcast.subscribers) == 1
+
+        await stream.aclose()
+        assert not broadcast.subscribers
+        assert not owner.done()
+        owner.cancel()
+        await asyncio.gather(owner, return_exceptions=True)
+
+    asyncio.run(exercise())
+
+
+def test_mux_watcher_state_can_become_attachable_dynamically(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    sid = "watcher-to-turn"
+    placeholder = chat_mod.TurnBroadcast(sid)
+    phase = {"attachable": False}
+    chat_mod._sessions_with_inflight_tasks[sid] = {"task-1"}
+
+    def state(_sid):
+        if not phase["attachable"]:
+            return _active_state(
+                placeholder, attachable=False, background=True)
+        return _active_state(chat_mod._active_turns[sid])
+
+    monkeypatch.setattr(chat_mod, "session_active_status", state)
+
+    async def exercise():
+        stream = chat_mod._subscribe_multiplex({}, mobile=False)
+        watcher_state = await anext(stream)
+        watcher_payload = json.loads(watcher_state["data"])
+        assert watcher_state["event"] == "session_state"
+        assert watcher_payload["active"] is True
+        assert watcher_payload["attachable"] is False
+        assert watcher_payload["session_id"] == sid
+
+        broadcast = chat_mod.TurnBroadcast(sid)
+        broadcast.publish({
+            "event": "tool_result", "data": json.dumps({"id": "r1"})})
+        chat_mod._active_turns[sid] = broadcast
+        phase["attachable"] = True
+
+        attachable_state = await asyncio.wait_for(anext(stream), timeout=0.2)
+        wrapped_event = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert attachable_state["event"] == "session_state"
+        assert json.loads(attachable_state["data"])["turn_id"] == broadcast.turn_id
+        assert wrapped_event["event"] == "tool_result"
+        assert json.loads(wrapped_event["data"])["session_id"] == sid
+        await stream.aclose()
+
+    asyncio.run(exercise())
+    placeholder.close()
+
+
+def test_mux_exact_recent_checkpoint_replays_without_cold_recent_discovery(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    exact = chat_mod.TurnBroadcast("recent-exact")
+    exact.publish({"event": "text", "data": json.dumps({"text": "A"})})
+    exact.publish({"event": "text", "data": json.dumps({"text": "B"})})
+    exact.finish()
+    ordinary = chat_mod.TurnBroadcast("recent-ordinary")
+    ordinary.publish({"event": "text", "data": json.dumps({"text": "do not replay"})})
+    ordinary.finish()
+    chat_mod._recent_turns[exact.session_id] = exact
+    chat_mod._recent_turns[ordinary.session_id] = ordinary
+    monkeypatch.setattr(
+        chat_mod,
+        "session_active_status",
+        lambda _sid: {"active": False},
+    )
+
+    async def exercise():
+        stream = chat_mod._subscribe_multiplex({
+            exact.session_id: {
+                "session_id": exact.session_id,
+                "turn_id": exact.turn_id,
+                "last_event_seq": 1,
+            },
+        })
+        replayed = await asyncio.wait_for(anext(stream), timeout=0.2)
+        payload = json.loads(replayed["data"])
+        assert replayed["event"] == "text"
+        assert payload["text"] == "B"
+        assert payload["session_id"] == exact.session_id
+        await stream.aclose()
+
+    asyncio.run(exercise())
+
+
+def test_mux_turn_mismatch_resyncs_and_still_attaches_current_turn(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    broadcast = chat_mod.TurnBroadcast("changed-session")
+    broadcast.publish({
+        "event": "text", "data": json.dumps({"text": "new turn"})})
+    chat_mod._active_turns[broadcast.session_id] = broadcast
+    monkeypatch.setattr(
+        chat_mod,
+        "session_active_status",
+        lambda sid: _active_state(chat_mod._active_turns[sid]),
+    )
+
+    async def exercise():
+        stream = chat_mod._subscribe_multiplex({
+            broadcast.session_id: {
+                "session_id": broadcast.session_id,
+                "turn_id": "stale-turn",
+                "last_event_seq": 3,
+            },
+        })
+        seen = [
+            await asyncio.wait_for(anext(stream), timeout=0.2)
+            for _ in range(3)
+        ]
+        decoded = [(event["event"], json.loads(event["data"])) for event in seen]
+        assert any(
+            name == "resync"
+            and payload["reason"] == "turn_changed"
+            and payload["current_turn_id"] == broadcast.turn_id
+            for name, payload in decoded
+        )
+        assert any(
+            name == "text" and payload["text"] == "new turn"
+            for name, payload in decoded
+        )
+        await stream.aclose()
+
+    asyncio.run(exercise())
+
+
+def test_mux_child_resync_does_not_close_other_sessions(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    gap = chat_mod.TurnBroadcast(
+        "gap-session", replay_max_events=2, replay_max_bytes=1024 * 1024)
+    for index in range(4):
+        gap.publish({"event": "tool_result", "data": json.dumps({"id": index})})
+    good = chat_mod.TurnBroadcast("good-session")
+    good.publish({"event": "text", "data": json.dumps({"text": "still live"})})
+    chat_mod._active_turns[gap.session_id] = gap
+    chat_mod._active_turns[good.session_id] = good
+    monkeypatch.setattr(
+        chat_mod,
+        "session_active_status",
+        lambda sid: _active_state(chat_mod._active_turns[sid]),
+    )
+
+    async def exercise():
+        stream = chat_mod._subscribe_multiplex({
+            gap.session_id: {
+                "session_id": gap.session_id,
+                "turn_id": gap.turn_id,
+                "last_event_seq": 1,
+            },
+        })
+        seen = []
+        while len(seen) < 4:
+            seen.append(await asyncio.wait_for(anext(stream), timeout=0.2))
+
+        decoded = [(event["event"], json.loads(event["data"])) for event in seen]
+        assert any(
+            name == "resync"
+            and payload["reason"] == "replay_gap"
+            and payload["session_id"] == gap.session_id
+            for name, payload in decoded
+        )
+        assert any(
+            name == "text"
+            and payload["text"] == "still live"
+            and payload["session_id"] == good.session_id
+            for name, payload in decoded
+        )
+        await stream.aclose()
+
+    asyncio.run(exercise())

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -2899,7 +2899,102 @@ async def test_watcher_shutdown_partial_never_projects_completed_bubble(
         chat_mod._delete_cancelled_turn_snapshots(child_sid)
 
 
-def test_usage_transcript_hydration_does_not_block_event_loop(
+def test_usage_reads_valid_sidecar_summary_without_scanning_transcript(
+        stream_env, monkeypatch):
+    sid = "12345678-usage-summary"
+    stream_env._session_usage.pop(sid, None)
+    durable = {
+        "input_tokens": 40,
+        "output_tokens": 5,
+        "context_used": 40,
+        "context_limit": 200_000,
+    }
+    source = {"dev": 1, "inode": 2, "size": 20, "mtime_ns": 10}
+    monkeypatch.setattr(
+        stream_env, "_find_session_jsonl", lambda _sid: object())
+    monkeypatch.setattr(
+        stream_env, "_usage_source_signature", lambda _path: source)
+    monkeypatch.setattr(
+        stream_env.sess,
+        "get_session_usage_summary",
+        lambda _sid: {
+            "schema": 1,
+            "source": source,
+            "update": {"turn_id": "turn-usage", "at": 1.0},
+            "normalized": durable,
+        },
+    )
+    monkeypatch.setattr(
+        stream_env,
+        "_session_usage_from_jsonl",
+        lambda _sid: pytest.fail("valid summary must not scan JSONL"),
+    )
+
+    async def no_capability(_model):
+        return {}
+
+    monkeypatch.setattr(
+        stream_env, "_detect_gateway_context_capability", no_capability)
+    result = asyncio.run(stream_env.session_usage(sid))
+    assert result["input_tokens"] == 40
+    assert result["context_used"] == 40
+    assert stream_env._session_usage_turns[sid] == "turn-usage"
+    stream_env._session_usage.pop(sid, None)
+    stream_env._session_usage_turns.pop(sid, None)
+
+
+def test_usage_summary_requires_full_transcript_identity(stream_env, monkeypatch):
+    sid = "12345678-usage-identity"
+    source = {"dev": 1, "inode": 2, "size": 20, "mtime_ns": 10}
+    monkeypatch.setattr(stream_env, "_find_session_jsonl", lambda _sid: object())
+    monkeypatch.setattr(
+        stream_env, "_usage_source_signature", lambda _path: source)
+    monkeypatch.setattr(
+        stream_env.sess,
+        "get_session_usage_summary",
+        lambda _sid: {
+            "schema": 1,
+            "source": {**source, "inode": 999},
+            "update": {"turn_id": "old-turn", "at": 1.0},
+            "normalized": {"input_tokens": 40},
+        },
+    )
+    assert stream_env._load_session_usage_summary(sid) is None
+
+
+def test_late_usage_refinement_cannot_overwrite_successor(stream_env):
+    sid = "12345678-usage-refine"
+    stream_env._session_usage[sid] = {"context_used": 20}
+    stream_env._session_usage_turns[sid] = "turn-2"
+    try:
+        assert stream_env._refine_session_usage_for_turn(
+            sid, "turn-1", {"context_used": 10}) is False
+        assert stream_env._session_usage[sid] == {"context_used": 20}
+        assert stream_env._refine_session_usage_for_turn(
+            sid, "turn-2", {"context_used": 25}) is True
+        assert stream_env._session_usage[sid] == {"context_used": 25}
+    finally:
+        stream_env._session_usage.pop(sid, None)
+        stream_env._session_usage_turns.pop(sid, None)
+
+
+def test_usage_summary_repair_is_best_effort(stream_env, monkeypatch):
+    source = {"dev": 1, "inode": 2, "size": 20, "mtime_ns": 10}
+    monkeypatch.setattr(
+        stream_env.sess,
+        "set_session_usage_summary",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("corrupt sidecar")),
+    )
+    assert stream_env._persist_session_usage_summary(
+        "12345678-usage-corrupt",
+        {"input_tokens": 1},
+        turn_id="turn-1",
+        source=source,
+    ) is False
+
+
+def test_usage_transcript_repair_does_not_block_event_loop(
     stream_env, monkeypatch,
 ):
     import time
@@ -6375,6 +6470,7 @@ def test_watcher_without_a_task_pin_is_not_user_visible_active(stream_env):
         chat_mod._task_watchers[sid] = LiveWatcher()
         assert chat_mod.session_active_status(sid) == {
             "active": False,
+            "stopping": False,
             "background_tasks_pending": 0,
             "runtime_background_tasks_pending": 0,
             "runtime_continuation_pending": False,

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -7304,8 +7304,11 @@ async def test_queue_bind_failure_uses_shared_startup_abort(
     sid = "queue-bind-failure"
     releases = []
 
-    async def persisted(*_args, **_kwargs):
-        return True
+    async def persisted(_site, _sid, func, *args, **kwargs):
+        kwargs.pop("file_path", None)
+        kwargs.pop("file_size", None)
+        kwargs.pop("owned", None)
+        return func(*args, **kwargs)
 
     monkeypatch.setattr(chat.obs, "to_thread_io", persisted)
     monkeypatch.setattr(chat.sess, "bind_queue_turn", lambda *_args: True)

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -851,49 +851,45 @@ async def test_shutdown_waits_for_pending_subscription_registration(
 
 
 @pytest.mark.asyncio
-async def test_reconcile_budget_caps_threads_without_holding_workspace_lock(
+async def test_reconcile_scans_share_one_worker_without_holding_workspace_lock(
     app_module,
     temp_root,
+    monkeypatch,
 ):
     import backend.file_events as file_events
 
     class CappedStore:
-        def __init__(self):
-            self.lock = threading.Lock()
-            self.four_entered = threading.Event()
-            self.release = threading.Semaphore(0)
-            self.calls = 0
-            self.active = 0
-            self.max_active = 0
-
         def current_cursor(self, _workspace_id):
             return 0
 
-        def reconcile(self, *_args, **_kwargs):
-            with self.lock:
-                self.calls += 1
-                self.active += 1
-                self.max_active = max(self.max_active, self.active)
-                if self.calls >= 4:
-                    self.four_entered.set()
-            assert self.release.acquire(timeout=3)
-            with self.lock:
-                self.active -= 1
-            return 0
-
-        def delta(self, *_args, **_kwargs):
-            return {
-                "cursor": 0,
-                "changes": [],
-                "resync": False,
-                "has_more": False,
-            }
+        def apply_reconcile_snapshot(self, *_args, **_kwargs):
+            return {"cursor": 0, "changes": [], "resync": False}
 
         def close(self):
             return None
 
-    store = CappedStore()
-    manager = file_events.FileWatchManager(store)
+    manager = file_events.FileWatchManager(CappedStore())
+    entered = threading.Event()
+    release = threading.Semaphore(0)
+    lock = threading.Lock()
+    calls = 0
+    active = 0
+    max_active = 0
+
+    def controlled_exchange(_request):
+        nonlocal calls, active, max_active
+        with lock:
+            calls += 1
+            active += 1
+            max_active = max(max_active, active)
+            entered.set()
+        assert release.acquire(timeout=3)
+        with lock:
+            active -= 1
+        return ("ok", [], {}, {})
+
+    monkeypatch.setattr(manager, "_ensure_scan_worker_locked", lambda: None)
+    monkeypatch.setattr(manager, "_exchange_scan_request", controlled_exchange)
     states = [
         file_events._WatchState(
             root=temp_root / f"scan-budget-{index}",
@@ -906,34 +902,70 @@ async def test_reconcile_budget_caps_threads_without_holding_workspace_lock(
         asyncio.create_task(manager._reconcile_and_broadcast(state))
         for state in states
     ]
-    assert await asyncio.to_thread(store.four_entered.wait, 1)
+    assert await asyncio.to_thread(entered.wait, 1)
     await asyncio.sleep(0.02)
-    assert store.calls == 4
-    assert store.max_active == 4
+    assert calls == 1
+    assert max_active == 1
 
     # Waiters do not consume their workspace mutation lock while queued behind
-    # the process-wide scan gate.
+    # the single process exchange.
     await asyncio.wait_for(states[4].mutation_lock.acquire(), timeout=0.2)
     states[4].mutation_lock.release()
-    heartbeat = asyncio.Event()
-    asyncio.get_running_loop().call_soon(heartbeat.set)
-    await asyncio.wait_for(heartbeat.wait(), timeout=0.2)
-
     tasks[5].cancel()
     with pytest.raises(asyncio.CancelledError):
         await tasks[5]
-    store.release.release()
-    for _ in range(100):
-        if store.calls == 5:
-            break
-        await asyncio.sleep(0.01)
-    assert store.calls == 5
-    for _ in range(4):
-        store.release.release()
+    for expected_calls in range(2, 6):
+        release.release()
+        for _ in range(100):
+            if calls == expected_calls:
+                break
+            await asyncio.sleep(0.01)
+        assert calls == expected_calls
+    release.release()
     await asyncio.gather(*tasks[:5])
-    assert store.max_active == 4
+    assert max_active == 1
     assert manager._reconcile_slots._value == 4
     await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_spawned_scanner_is_reused_and_recovers_after_exit(
+    app_module,
+    temp_root,
+):
+    import backend.file_events as file_events
+
+    manager = file_events.FileWatchManager(
+        file_events.WorkspaceStore(temp_root)
+    )
+    state = file_events._WatchState(
+        root=temp_root.resolve(),
+        workspace_id="spawned-scanner",
+    )
+    first_snapshot, _ = await manager._scan_workspace(state)
+    assert first_snapshot
+    assert all(isinstance(row, tuple) for row in first_snapshot)
+    first_process = manager._scan_process
+    assert first_process is not None
+    assert first_process.is_alive()
+    first_pid = first_process.pid
+
+    second_snapshot, _ = await manager._scan_workspace(state)
+    assert manager._scan_process is first_process
+    assert second_snapshot == first_snapshot
+
+    first_process.terminate()
+    await asyncio.to_thread(first_process.join, 1)
+    recovered_snapshot, _ = await manager._scan_workspace(state)
+    recovered_process = manager._scan_process
+    assert recovered_process is not None
+    assert recovered_process.is_alive()
+    assert recovered_process.pid != first_pid
+    assert recovered_snapshot == first_snapshot
+
+    await manager.shutdown()
+    assert manager._scan_process is None
+    assert manager._scan_connection is None
 
 
 @pytest.mark.asyncio
@@ -1242,7 +1274,7 @@ async def test_native_directory_budget_reprices_refreshed_paths(
     assert manager._native_directory_watches == 2
     assert state.native_watch_cost == 2
 
-    manager._request_watch_refresh(state)
+    await manager._request_watch_refresh(state)
     await asyncio.wait_for(second_started.wait(), timeout=1)
     assert awatch_calls == [
         (root, nested),
@@ -1399,6 +1431,7 @@ async def test_failed_generation_reconciles_only_after_retry_is_armed(
     monkeypatch,
 ):
     import backend.file_events as file_events
+    from backend.workspace_store import scan_workspace
     from backend.workspaces import registry
 
     store = file_events.WorkspaceStore(temp_root)
@@ -1409,15 +1442,21 @@ async def test_failed_generation_reconciles_only_after_retry_is_armed(
     second_armed = asyncio.Event()
     generations = 0
     reconciles = 0
-    real_reconcile = store.reconcile
 
-    def guarded_reconcile(*args, **kwargs):
+    async def guarded_scan(state):
         nonlocal reconciles
         reconciles += 1
         # The synchronously failed first `anext` must not set watch_ready or
         # permit a closing scan before the polling/native retry is installed.
         assert second_armed.is_set()
-        return real_reconcile(*args, **kwargs)
+        report = {}
+        snapshot = await asyncio.to_thread(
+            scan_workspace,
+            state.root,
+            report=report,
+            progress=state.scan_progress,
+        )
+        return snapshot, report
 
     async def flaky_awatch(*_paths, **options):
         nonlocal generations
@@ -1431,10 +1470,10 @@ async def test_failed_generation_reconciles_only_after_retry_is_armed(
         return
         yield set()
 
-    monkeypatch.setattr(store, "reconcile", guarded_reconcile)
     monkeypatch.setattr(file_events, "awatch", flaky_awatch)
     monkeypatch.setattr(file_events, "_WATCH_RETRY_S", 0)
     manager = file_events.FileWatchManager(store)
+    monkeypatch.setattr(manager, "_scan_workspace", guarded_scan)
     async with manager.subscribe(temp_root):
         await asyncio.wait_for(second_armed.wait(), timeout=1)
         state = manager._states[temp_root.resolve()]
@@ -1486,6 +1525,41 @@ def test_reconcile_backoff_is_scoped_to_each_workspace(
 
 
 @pytest.mark.asyncio
+async def test_partial_reconcile_uses_fairness_yield_not_failure_backoff(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    monkeypatch.setattr(file_events, "_PARTIAL_RECONCILE_YIELD_S", 0.02)
+    manager = file_events.FileWatchManager(file_events.WorkspaceStore(temp_root))
+    state = file_events._WatchState(
+        root=temp_root,
+        workspace_id="partial-fairness",
+        initialized=True,
+    )
+    calls: list[float] = []
+
+    async def partial_then_complete(_state):
+        calls.append(file_events.monotonic())
+        return len(calls) == 1
+
+    monkeypatch.setattr(
+        manager,
+        "_reconcile_and_broadcast",
+        partial_then_complete,
+    )
+    await manager._reconcile_after_watch(state)
+
+    assert len(calls) == 2
+    assert calls[1] - calls[0] >= 0.015
+    assert state.reconcile_failures == 0
+    assert state.reconcile_retry_at == 0.0
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_perf_event_splits_wait_scan_and_replay(
     app_module,
     temp_root,
@@ -1497,15 +1571,11 @@ async def test_reconcile_perf_event_splits_wait_scan_and_replay(
         def current_cursor(self, _workspace_id):
             return 9
 
-        def reconcile(self, *_args, **_kwargs):
-            return 9
-
-        def delta(self, *_args, **_kwargs):
+        def apply_reconcile_snapshot(self, *_args, **_kwargs):
             return {
                 "cursor": 9,
-                "changes": [{"path": "private-replay.txt"}],
-                "resync": False,
-                "has_more": True,
+                "changes": [],
+                "resync": True,
             }
 
         def close(self):
@@ -1518,6 +1588,11 @@ async def test_reconcile_perf_event_splits_wait_scan_and_replay(
         lambda event, **fields: events.append((event, fields)),
     )
     manager = file_events.FileWatchManager(FakeStore())
+
+    async def fake_scan(_state):
+        return [], {}
+
+    monkeypatch.setattr(manager, "_scan_workspace", fake_scan)
     state = file_events._WatchState(
         root=temp_root,
         workspace_id="workspace-sensitive-identifier",
@@ -1546,7 +1621,7 @@ async def test_reconcile_perf_event_splits_wait_scan_and_replay(
     assert fields["snapshot_files"] == 0
     assert fields["partial"] is False
     assert fields["partial_reason"] is None
-    assert fields["changes"] == 1
+    assert fields["changes"] == 0
     assert fields["resync"] is True
     assert fields["total_ms"] >= 10
     captured = repr(events)
@@ -1556,140 +1631,96 @@ async def test_reconcile_perf_event_splits_wait_scan_and_replay(
 
 
 @pytest.mark.asyncio
-async def test_workspace_reconciles_run_independently_off_event_loop(
+async def test_detached_scan_retries_after_watcher_mutation(
     app_module,
     temp_root,
+    monkeypatch,
 ):
     import backend.file_events as file_events
 
     class ConcurrentStore:
         def __init__(self):
-            self.lock = threading.Lock()
-            self.entered = threading.Event()
-            self.release = threading.Event()
-            self.active = 0
-            self.max_active = 0
-            self.calls = 0
-            self.block_delta = False
-            self.delta_entered = threading.Event()
-            self.delta_release = threading.Event()
-            self.delta_release.set()
+            self.cursor = 0
+            self.applications = 0
+            self.apply_entered = threading.Event()
+            self.apply_release = threading.Event()
 
         def current_cursor(self, _workspace_id):
-            return 0
+            return self.cursor
 
-        def reconcile(self, *_args, **_kwargs):
-            with self.lock:
-                self.calls += 1
-                self.active += 1
-                self.max_active = max(self.max_active, self.active)
-                self.entered.set()
-            assert self.release.wait(timeout=3)
-            with self.lock:
-                self.active -= 1
-
-        def delta(self, *_args, **_kwargs):
-            if self.block_delta:
-                self.delta_entered.set()
-                assert self.delta_release.wait(timeout=3)
+        def apply_reconcile_snapshot(self, *_args, expected_cursor=None, **_kwargs):
+            if expected_cursor != self.cursor:
+                return {
+                    "_stale": True,
+                    "cursor": self.cursor,
+                    "changes": [],
+                    "resync": True,
+                }
+            self.applications += 1
+            self.apply_entered.set()
+            assert self.apply_release.wait(timeout=3)
             return {
-                "cursor": 0,
+                "cursor": self.cursor,
                 "changes": [],
                 "resync": False,
-                "has_more": False,
             }
+
+        def delta(self, *_args, **_kwargs):
+            raise AssertionError("reconcile must return its atomic payload directly")
 
         def close(self):
             return None
 
     store = ConcurrentStore()
     manager = file_events.FileWatchManager(store)
-    first = file_events._WatchState(
-        root=temp_root / "first",
-        workspace_id="first",
-        name="first",
+    state = file_events._WatchState(
+        root=temp_root / "detached",
+        workspace_id="detached",
         initialized=True,
     )
-    second = file_events._WatchState(
-        root=temp_root / "second",
-        workspace_id="second",
-        name="second",
-        initialized=True,
-    )
-    first_task = asyncio.create_task(
-        manager._reconcile_and_broadcast(first)
-    )
-    assert await asyncio.to_thread(store.entered.wait, 1)
-    second_task = asyncio.create_task(
-        manager._reconcile_and_broadcast(second)
-    )
-    for _ in range(20):
-        if store.calls == 2:
-            break
-        await asyncio.sleep(0.01)
-    assert store.calls == 2
-    assert store.max_active == 2
+    first_scan_entered = asyncio.Event()
+    release_first_scan = asyncio.Event()
+    scan_calls = 0
 
-    # Both blocking scans are worker-thread work: the event loop must continue
-    # servicing unrelated coroutines while neither filesystem pass can finish.
+    async def controlled_scan(_state):
+        nonlocal scan_calls
+        scan_calls += 1
+        if scan_calls == 1:
+            first_scan_entered.set()
+            await release_first_scan.wait()
+        return [], {}
+
+    monkeypatch.setattr(manager, "_scan_workspace", controlled_scan)
+    reconcile = asyncio.create_task(manager._reconcile_and_broadcast(state))
+    await asyncio.wait_for(first_scan_entered.wait(), timeout=1)
+
+    # The filesystem walk no longer owns the watcher mutation lock. A native
+    # batch can commit and advance the applicability cursor while it is running.
+    async with state.mutation_lock:
+        store.cursor += 1
+        state.native_mutation_revision += 1
     heartbeat = asyncio.Event()
     asyncio.get_running_loop().call_soon(heartbeat.set)
     await asyncio.wait_for(heartbeat.wait(), timeout=0.2)
-    store.release.set()
-    await asyncio.gather(first_task, second_task)
+    release_first_scan.set()
 
-    # A watcher can restart while its own mutation lock is queued. The pass must
-    # follow the replacement generation and wait for it to arm instead of
-    # scanning inside the new watch gap.
-    async def parked_watcher():
-        await asyncio.Future()
-
-    queued = file_events._WatchState(
-        root=temp_root / "queued",
-        workspace_id="queued",
-        name="queued",
-        initialized=True,
-        task=asyncio.create_task(parked_watcher()),
-    )
-    queued.watch_ready.set()
-    queued.watch_paths = (queued.root,)
-    await queued.mutation_lock.acquire()
-    queued_scan = asyncio.create_task(
-        manager._reconcile_and_broadcast(queued)
-    )
-    await asyncio.sleep(0.02)
-    queued.watch_ready.clear()
-    queued.mutation_lock.release()
-    await asyncio.sleep(0.05)
-    assert store.calls == 2
-    queued.watch_ready.set()
-    await asyncio.wait_for(queued_scan, timeout=1)
-    assert store.calls == 3
-    queued.task.cancel()
-    await asyncio.gather(queued.task, return_exceptions=True)
-    queued.task = None
-
-    # The watcher mutation lock covers cursor-before through replay-after, not
-    # just the scan itself, so a native batch cannot slip into the replay window
-    # and get broadcast twice.
-    store.block_delta = True
-    store.delta_release.clear()
-    window_task = asyncio.create_task(
-        manager._reconcile_and_broadcast(first)
-    )
-    assert await asyncio.to_thread(store.delta_entered.wait, 1)
+    # The stale first result is discarded. The fresh result is applied once and
+    # its exact payload is built while the mutation lock is still owned.
+    assert await asyncio.to_thread(store.apply_entered.wait, 1)
     mutation_acquired = asyncio.Event()
 
     async def watcher_mutation():
-        async with first.mutation_lock:
+        async with state.mutation_lock:
             mutation_acquired.set()
 
-    mutation_task = asyncio.create_task(watcher_mutation())
+    mutation = asyncio.create_task(watcher_mutation())
     await asyncio.sleep(0.05)
     assert mutation_acquired.is_set() is False
-    store.delta_release.set()
-    await asyncio.gather(window_task, mutation_task)
-    assert mutation_acquired.is_set() is True
+    store.apply_release.set()
+    await asyncio.gather(reconcile, mutation)
+    assert scan_calls == 2
+    assert store.applications == 1
+    assert state.scan_progress == {}
     await manager.shutdown()
 
 
@@ -1797,6 +1828,7 @@ async def test_manager_start_is_nonblocking_and_reconciles_on_first_use(
     monkeypatch,
 ):
     import backend.file_events as file_events
+    from backend.workspace_store import scan_workspace
     from backend.workspaces import registry
 
     store = file_events.WorkspaceStore(temp_root)
@@ -1806,20 +1838,25 @@ async def test_manager_start_is_nonblocking_and_reconciles_on_first_use(
 
     entered = threading.Event()
     release = threading.Event()
-    real_reconcile = store.reconcile
-
-    def blocking_reconcile(*args, **kwargs):
+    async def blocking_scan(state):
         entered.set()
-        assert release.wait(timeout=5)
-        return real_reconcile(*args, **kwargs)
+        assert await asyncio.to_thread(release.wait, 5)
+        report = {}
+        snapshot = await asyncio.to_thread(
+            scan_workspace,
+            state.root,
+            report=report,
+            progress=state.scan_progress,
+        )
+        return snapshot, report
 
     async def fake_awatch(*_args, **_kwargs):
         await asyncio.Future()
         yield set()
 
-    monkeypatch.setattr(store, "reconcile", blocking_reconcile)
     monkeypatch.setattr(file_events, "awatch", fake_awatch)
     manager = file_events.FileWatchManager(store)
+    monkeypatch.setattr(manager, "_scan_workspace", blocking_scan)
 
     await asyncio.wait_for(manager.start(), timeout=1)
     assert manager._started is True
@@ -1947,18 +1984,17 @@ async def test_remove_waits_for_inflight_reconcile_thread(
     entry = registry.register(extra_root, "race")
     store = file_events.WorkspaceStore(temp_root)
     manager = file_events.FileWatchManager(store)
-    reconcile_started = threading.Event()
-    allow_reconcile = threading.Event()
-    real_reconcile = store.reconcile
+    reconcile_started = asyncio.Event()
+    allow_reconcile = asyncio.Event()
 
-    def paused_reconcile(*args, **kwargs):
+    async def paused_scan(_state):
         reconcile_started.set()
-        assert allow_reconcile.wait(timeout=2)
-        return real_reconcile(*args, **kwargs)
+        await allow_reconcile.wait()
+        return [], {}
 
-    monkeypatch.setattr(store, "reconcile", paused_reconcile)
+    monkeypatch.setattr(manager, "_scan_workspace", paused_scan)
     state = await manager.ensure_workspace(extra_root)
-    assert await asyncio.to_thread(reconcile_started.wait, 2)
+    await asyncio.wait_for(reconcile_started.wait(), timeout=2)
 
     registry.remove(extra_root)
     remove_task = asyncio.create_task(
@@ -2041,20 +2077,20 @@ async def test_failed_initial_reconcile_retries_on_next_ensure(
     import backend.file_events as file_events
 
     store = file_events.WorkspaceStore(temp_root)
-    real_reconcile = store.reconcile
+    manager = file_events.FileWatchManager(store)
+    real_scan = manager._scan_workspace
     calls = 0
 
-    def fail_once(*args, **kwargs):
+    async def fail_once(state):
         nonlocal calls
         calls += 1
         if calls == 1:
             raise file_events.WorkspaceScanIncomplete(
                 "synthetic transient scan failure"
             )
-        return real_reconcile(*args, **kwargs)
+        return await real_scan(state)
 
-    monkeypatch.setattr(store, "reconcile", fail_once)
-    manager = file_events.FileWatchManager(store)
+    monkeypatch.setattr(manager, "_scan_workspace", fail_once)
     with pytest.raises(file_events.HTTPException) as first:
         await manager.bootstrap(temp_root)
     assert first.value.status_code == 503
@@ -2080,20 +2116,21 @@ async def test_reconcile_failures_back_off_coalesce_and_reset(
     import backend.file_events as file_events
 
     store = file_events.WorkspaceStore(temp_root)
-    real_reconcile = store.reconcile
+    manager = file_events.FileWatchManager(store)
+    real_scan = manager._scan_workspace
     calls = 0
     events = []
 
-    def fail_twice(*args, **kwargs):
+    async def fail_twice(state):
         nonlocal calls
         calls += 1
         if calls <= 2:
             raise file_events.WorkspaceScanIncomplete(
                 f"private failure under {temp_root}/secret-{calls}"
             )
-        return real_reconcile(*args, **kwargs)
+        return await real_scan(state)
 
-    monkeypatch.setattr(store, "reconcile", fail_twice)
+    monkeypatch.setattr(manager, "_scan_workspace", fail_twice)
     monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_START_S", 0.02)
     monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_CAP_S", 0.04)
     monkeypatch.setattr(
@@ -2101,7 +2138,6 @@ async def test_reconcile_failures_back_off_coalesce_and_reset(
         "perf_event",
         lambda event, **fields: events.append((event, fields)),
     )
-    manager = file_events.FileWatchManager(store)
 
     with pytest.raises(file_events.HTTPException) as first:
         await manager.bootstrap(temp_root)
@@ -2267,6 +2303,7 @@ async def test_http_exception_after_sse_ready_becomes_clean_eof(
 async def test_large_reconcile_reloads_cursor_without_bad_arguments(
     app_module,
     temp_root,
+    monkeypatch,
 ):
     from backend.file_events import FileWatchManager, _WatchState
 
@@ -2278,19 +2315,26 @@ async def test_large_reconcile_reloads_cursor_without_bad_arguments(
             self.cursor_calls.append(workspace_id)
             return 9001
 
-        def reconcile(self, *_args, **_kwargs):
-            return 9001
+        def apply_reconcile_snapshot(self, *_args, **_kwargs):
+            return {
+                "cursor": 9001,
+                "changes": [],
+                "resync": True,
+            }
 
         def delta(self, *_args, **_kwargs):
-            return {
-                "cursor": 5000,
-                "changes": [],
-                "resync": False,
-                "has_more": True,
-            }
+            raise AssertionError("reconcile must not perform a separate delta")
+
+        def close(self):
+            return None
 
     store = FakeStore()
     manager = FileWatchManager(store)
+
+    async def fake_scan(_state):
+        return [], {}
+
+    monkeypatch.setattr(manager, "_scan_workspace", fake_scan)
     queue = asyncio.Queue()
     state = _WatchState(
         root=temp_root,
@@ -2301,12 +2345,13 @@ async def test_large_reconcile_reloads_cursor_without_bad_arguments(
         subscribers={queue},
     )
     await manager._reconcile_and_broadcast(state)
-    assert store.cursor_calls == ["workspace-id", "workspace-id"]
+    assert store.cursor_calls == ["workspace-id"]
     assert queue.get_nowait() == {
         "resync": True,
         "changes": [],
         "cursor": 9001,
     }
+    await manager.shutdown()
 
 
 @pytest.mark.asyncio
@@ -2338,6 +2383,83 @@ async def test_watcher_broadcasts_large_batch_resync(
         "cursor": 42,
         "changes": [],
         "resync": True,
+    }
+    assert state.native_mutation_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_relevant_native_noop_invalidates_detached_scan_token(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    class NoopStore:
+        def apply_changes(self, *_args, **_kwargs):
+            return {"cursor": 7, "changes": []}
+
+        def close(self):
+            return None
+
+    target = temp_root / "unchanged.txt"
+    target.write_text("same", encoding="utf-8")
+
+    async def fake_awatch(*_args, **_kwargs):
+        yield {(Change.modified, str(target))}
+
+    monkeypatch.setattr(file_events, "awatch", fake_awatch)
+    manager = file_events.FileWatchManager(NoopStore())
+    state = file_events._WatchState(
+        root=temp_root,
+        workspace_id="workspace-id",
+        initialized=True,
+    )
+    await manager._watch(state)
+
+    assert state.native_mutation_revision == 1
+    await manager.shutdown()
+
+
+def test_detached_snapshot_rejects_a_changed_cursor(
+    app_module,
+    temp_root,
+):
+    import backend.workspace_store as workspace_store
+    from backend.workspaces import registry
+
+    workspace_id = registry.id_for(temp_root)
+    store = workspace_store.WorkspaceStore(temp_root)
+    store.reconcile(workspace_id, temp_root, "root", primary=True)
+    before = store.current_cursor(workspace_id)
+    report = {}
+    snapshot = workspace_store.scan_workspace(temp_root, report=report)
+
+    added = temp_root / "after-detached-scan.txt"
+    added.write_text("newer\n", encoding="utf-8")
+    store.apply_changes(
+        workspace_id,
+        temp_root,
+        [{"type": "added", "path": added.name}],
+    )
+    stale = store.apply_reconcile_snapshot(
+        workspace_id,
+        temp_root,
+        "root",
+        workspace_store.compact_scan_rows(snapshot),
+        report,
+        primary=True,
+        expected_cursor=before,
+    )
+    assert stale == {
+        "_stale": True,
+        "cursor": before + 1,
+        "changes": [],
+        "resync": True,
+    }
+
+    assert added.name in {
+        row["path"] for row in store.bootstrap(workspace_id)["entries"]
     }
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -121,6 +121,16 @@ def test_chat_stream_mux_keeps_one_root_source_and_reuses_the_send_reducer():
     assert "this._handleChatMuxDisconnect(source)" in app
     assert "do not synthesize `error`/`done`" in app
     assert "return await opened" in app
+    mux_state = app[
+        app.index("async _handleChatMuxSessionState(payload)"):
+        app.index("async _startChatMuxCoordinator()")
+    ]
+    assert "inactiveTurnId !== currentTurnId" in mux_state
+    assert "currentTurnId === inactiveTurnId" in mux_state
+    assert "this._retireStaleSessionStream(sid, existingState)" in mux_state
+    assert "this._setSessionActivityExpectation(sid, false)" in mux_state
+    assert "existingState._pendingExternalUpdate = true" in mux_state
+    assert "this._scheduleCanonicalStreamReload(" in mux_state
     coordinator = app[app.index("async _startChatMuxCoordinator()"):
                       app.index("async initSessions(")]
     assert coordinator.index("await this._ensureChatMux()") < coordinator.index(

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -120,6 +120,21 @@ def test_chat_stream_mux_keeps_one_root_source_and_reuses_the_send_reducer():
     assert "if (tr.status === 404 || tr.status === 405)" in app
     assert "this._handleChatMuxDisconnect(source)" in app
     assert "do not synthesize `error`/`done`" in app
+    assert "return await opened" in app
+    coordinator = app[app.index("async _startChatMuxCoordinator()"):
+                      app.index("async initSessions(")]
+    assert coordinator.index("await this._ensureChatMux()") < coordinator.index(
+        "await this._bootstrapChatMuxHistory()")
+
+
+def test_background_history_load_does_not_hydrate_usage():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    load_start = app.index("async loadSession(")
+    load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
+    assert "_fetchTabUsage" not in app[load_start:load_end]
+    activate_start = app.index("_activateTabState(id)")
+    activate_end = app.index("_touchTranscriptPane(id)", activate_start)
+    assert "this._fetchTabUsage(id)" in app[activate_start:activate_end]
 
 
 def test_i18n_zh_en_key_parity():
@@ -2461,24 +2476,24 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
 
     assert 'x-show="isTabStreaming(currentId)"' in html
     assert "chat-toolbar-stop" in html
-    assert "if (st._stopping)" in app
+    assert "if (st._stoppingTurnId)" in app
     assert "正在中断上一条任务" in app
     assert "sendButtonHint(currentId)" in html
     assert "撤回队尾" not in html
     assert "removePendingQueueItem" not in stop
-    assert "if (st._stopping) return" in stop
+    assert "st._stoppingTurnId = ownerTurnId" in stop
     assert "const r = await fetch(" in stop
     assert "if (!r.ok) throw" in stop
     assert "const ownerEs = st.es" in stop
-    assert "st._optimisticInterrupt = true" in stop
-    assert "st.streaming = false" in stop
-    assert "this._setSessionActivityExpectation(sid, false)" in stop
-    assert 'this.toast(this.lang === "zh" ? "已中断"' in stop
+    assert "st.streaming = false" not in stop
+    assert "clearInterval(st._streamTimer)" not in stop
+    assert "clearInterval(st._stallWatch)" not in stop
     assert "const timeout = setTimeout(() => controller.abort(), 3000)" in stop
     assert 'fetch(`/api/chat/sessions/${encodeURIComponent(sid)}/active`' in stop
-    assert "st.es === ownerEs && active === true" in stop
-    assert "st.streaming = true" in stop
-    assert "this._retireStaleSessionStream(sid, st)" not in stop
+    assert "const applyAuthoritativeStatus = payload =>" in stop
+    assert 'String(st.activeTurnId || "") === ownerTurnId' in stop
+    assert "if (payload.stopping) return \"stopping\"" in stop
+    assert "this._retireStaleSessionStream(sid, st)" in stop
     assert "if (st._renderStreamingHtml) st._renderStreamingHtml()" not in stop
     assert "waitForTerminalEvent" not in stop
     cancelled_start = app.index('es.addEventListener("cancelled"')
@@ -2487,15 +2502,18 @@ def test_stop_control_interrupts_session_and_never_removes_queue_items():
     assert "_markDone(true, false, true, {" in cancelled
     assert 'turnStatus: "cancelled"' in cancelled
     assert "d.snapshot_ready" in cancelled
-    assert "alreadySettledOptimistically" in cancelled
-    assert "if (!alreadySettledOptimistically)" in cancelled
+    assert "alreadySettledOptimistically" not in cancelled
+    assert 'this.toast(this.lang === "zh" ? "已中断"' in cancelled
     assert "streamState._seenUpdated = undefined" in cancelled
     assert "quiet: true" in cancelled
     assert "probeActive: false" in cancelled
     mark_done_start = app.index("const _markDone = (")
     mark_done_end = app.index("\n      };", mark_done_start)
-    assert "streamState._stopping = false" in app[
-        mark_done_start:mark_done_end]
+    mark_done = app[mark_done_start:mark_done_end]
+    assert "streamState._stoppingTurnId === terminalTurnId" in mark_done
+    assert 'streamState._stoppingTurnId = ""' in mark_done
+    assert "turn_id=" in stop
+    assert "encodeURIComponent(ownerTurnId)" in stop
     assert "this.isTabStreaming(this.currentId)" in app
 
 
@@ -2812,9 +2830,8 @@ def test_composer_send_has_one_claim_owner_without_exposing_internal_phases():
     assert '_composerSubmitPhase: ""' in app
     assert "if (sendState._composerSubmitToken" in send
     assert 'sendState._composerSubmitPhase = "submitting";' in send
-    assert "if (sendState._optimisticInterrupt" in send
-    assert "if (sendState.es) sendState.es.close()" in send
-    assert "sendState._pendingExternalUpdate = true" in send
+    assert "if (sendState._optimisticInterrupt" not in send
+    assert "if (sendState.es) sendState.es.close()" not in send
     assert "this._releaseComposerClaim(composerSubmitToken);" in send
     assert send.index('sendState._composerSubmitPhase = "submitting";') < send.index(
         "await this._awaitRuntimeSettingPatches(sendSid, sendState)"
@@ -2865,7 +2882,7 @@ def test_composer_disabled_state_covers_failures_without_blocking_durable_queue(
     disabled = app[disabled_start:end]
 
     for state in (
-        "workspaceSwitching", "_stopping",
+        "workspaceSwitching", "_stoppingTurnId",
         "_permissionChangePending", "runtimeSettingsPending(sid)",
         "_sendWaitingForUpload", "item.uploading", "item.error || !item.id",
     ):
@@ -5043,8 +5060,8 @@ def test_queue_controls_validate_mutations_and_block_send_during_interrupt():
     send_start = app.index("async send(opts = {})")
     send_end = app.index("\n    // ====== ask_user_question", send_start)
     send = app[send_start:send_end]
-    assert "if (sendState._stopping && !opts.reconnect && !opts.resumedItem)" in send
-    assert "if (st._stopping)" in app
+    assert "if (sendState._stoppingTurnId && !opts.reconnect && !opts.resumedItem)" in send
+    assert "if (st._stoppingTurnId)" in app
     assert "queueActionBusy(currentId, 'edit:' + q.id)" in html
     assert "queueActionBusy(currentId, 'remove:' + q.id)" in html
     assert '"chat.queue_pause_nonempty"' in chat
@@ -5329,7 +5346,7 @@ def test_stop_aborts_stream_start_before_channel_opens():
     """A Stop click during turn admission must prevent a later live channel."""
     js = (FRONTEND / "app.js").read_text(encoding="utf-8")
 
-    state = js[js.index("_stopping: false,"):]
+    state = js[js.index('_stoppingTurnId: "",'):]
     state = state[:state.index("streamingModel:", 0)]
     assert "_streamStartController: null" in state
     assert "_cancelBeforeStream: false" in state
@@ -5342,9 +5359,11 @@ def test_stop_aborts_stream_start_before_channel_opens():
 
     stop = js[js.index("async stop() {"):]
     stop = stop[:stop.index("// ====== ask_user_question UI helpers")]
-    assert "if (st._streamStartController && !st.es)" in stop
+    assert "if (st._streamStartController && !st.es && !ownerTurnId)" in stop
     assert "st._streamStartController.abort()" in stop
-    assert "st.streaming = false" in stop
+    assert "st.streaming = false" not in stop
+    assert "st._streamTimer = null" not in stop
+    assert "st.streamPhase = \"\"" not in stop
 
 
 def test_midturn_reconnect_storm_guards_are_in_place():

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1829,6 +1829,10 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert 'activity.view === "groups"' in app
     assert "activityCustomGroupSections()" in app
     assert 'key: "custom:__ungrouped__"' in app
+    assert "boardColumn: 3" in app
+    assert "boardRowSpan: Math.max(1, Math.ceil(customGroupCount / 2))" in app
+    assert "boardColumn: (index % 2) + 1" in app
+    assert "boardRow: Math.floor(index / 2) + 1" in app
     assert '"/api/activity/groups"' in app
     assert '"/api/activity/groups/order"' in app
     assert '}/group`' in app
@@ -1874,7 +1878,13 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     assert "width:min(1120px,calc(100vw - 64px))" in css
     assert "height:auto" in css
     assert "flex:1 1 auto" in css
-    assert "grid-template-columns:repeat(auto-fit,minmax(300px,1fr))" in css
+    assert "grid-template-columns:repeat(3,minmax(0,1fr))" in css
+    assert "repeat(auto-fit,minmax(300px,1fr))" not in css
+    assert "grid-column:var(--activity-board-column)" in css
+    assert "grid-row:var(--activity-board-row) / span var(--activity-board-row-span)" in css
+    assert "'--activity-board-column': group.boardColumn" in html
+    assert "'--activity-board-row': group.boardRow" in html
+    assert "'--activity-board-row-span': group.boardRowSpan" in html
     assert "grid-auto-rows:300px" in css
     assert ".activity-body.is-group-board > .activity-group.is-custom" in css
     assert "ACTIVITY_CUSTOM_GROUP_CAP: 50" in app

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3349,7 +3349,12 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     done_start = app.index('es.addEventListener("done"')
     done_end = app.index('es.addEventListener("error"', done_start)
     done = app[done_start:done_end]
-    assert "const completedFinalText = ownsCurBubble()" in done
+    assert "const completedAssistant = flushTerminalPresentation();" in done
+    assert done.index("const completedAssistant = flushTerminalPresentation();") \
+        < done.index("try { d = JSON.parse(ev.data);")
+    assert "completedAssistant.bubble.cost" in done
+    assert "completedAssistant.bubble.memoryRecall" in done
+    assert "const completedFinalText = completedAssistant.text;" in done
     assert "} else if (!d.cancelled) {" in done
     assert "this._reconcileCompletedTurn(" in done
     assert "streamSid, streamState, d.is_error ? \"\" : completedFinalText" in done
@@ -3371,10 +3376,19 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     assert "m && m.role !== \"user\" && m.uuid" in reconcile
     assert "m.role === \"assistant\" && m.uuid" in reconcile
     assert "m && m.uuid === expectedAssistantUuid" in reconcile
+    assert ": !!expectedText && canonicalTurn.some(" in reconcile
+    assert "!expectedText || canonicalTurn.some(" not in reconcile
     assert "const loaded = await this.loadSession(sid, {" in reconcile
     assert "quiet: true, probeActive: false" in reconcile
     assert "attempt < 30" in reconcile
     assert "Math.min(2000, 250 + options.attempt * 100)" in reconcile
+
+    load_start = app.index("    async loadSession(sid, opts = {}) {")
+    load_end = app.index("\n    async renameSession()", load_start)
+    load = app[load_start:load_end]
+    assert 'const preserveFullOrder = quiet && st.messageRange.order === "full";' in load
+    assert '? "?full=1&tail=" + requestedTail' in load
+    assert ': "?tail=" + requestedTail;' in load
 
     continuity_start = app.index("_messageContinuitySignatures(m)")
     continuity_end = app.index(
@@ -3713,7 +3727,9 @@ def test_history_paging_uses_smaller_mobile_pages_only_on_user_request():
     load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
     load = app[load_start:load_end]
     assert "_historyWindowSize() { return this._isMobileLayout() ? 20 : 100; }" in app
-    assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in load
+    assert 'const preserveFullOrder = quiet && st.messageRange.order === "full";' in load
+    assert '? "?full=1&tail=" + requestedTail' in load
+    assert ': "?tail=" + requestedTail;' in load
     assert "const historyPage = this._historyWindowSize()" in load
     assert "const minimumTail = Math.max(0, Number(opts.minimumTail) || 0)" in load
     assert "Math.max(historyPage, st.messages.length)" in load
@@ -3849,7 +3865,9 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "_MAX_RESIDENT_PANES" not in app
     assert "residentPaneIds" not in app
     assert "_promoteResident" not in app
-    assert 'const qs = full ? "?full=1" : "?tail=" + requestedTail' in app
+    assert 'const preserveFullOrder = quiet && st.messageRange.order === "full";' in app
+    assert '? "?full=1&tail=" + requestedTail' in app
+    assert ': "?tail=" + requestedTail;' in app
     assert "Math.max(historyPage, st.messages.length)" in app
     assert "const _baseInitialLoad" not in app
     assert "if (cst && cst.streaming) continue" not in app
@@ -3934,7 +3952,13 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "if (this.currentId !== streamSid) return;" in app
     assert "const flushPlainBoundary = () =>" in app
     assert "const closeAsst = () => {\n        flushPlainBoundary();" in app
-    assert "flushTerminalPresentation();" in app
+    terminal_start = app.index("const flushTerminalPresentation = () => {")
+    terminal_end = app.index("\n\n      es.addEventListener", terminal_start)
+    terminal = app[terminal_start:terminal_end]
+    assert "const completedBubble = ownsCurBubble() ? curBubble : null;" in terminal
+    assert "if (completedBubble) flushRender();" in terminal
+    assert terminal.index("const completedText") < terminal.rindex("curBubble = null;")
+    assert "return { bubble: completedBubble, text: completedText };" in terminal
     assert ':data-tid="tid"' in pane
     assert 'x-for="row in paneRows" :key="row.key"' in pane
     assert "paneMessageRows(tid)" in pane

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -95,6 +95,33 @@ def test_app_js_has_no_duplicate_method_definitions():
     )
 
 
+def test_chat_stream_mux_keeps_one_root_source_and_reuses_the_send_reducer():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    assert "class ChatMuxSessionChannel extends EventTarget" in app
+    assert 'fetch("/api/chat/stream/mux/start"' in app
+    assert '"/api/chat/stream/mux?ticket="' in app
+    assert "checkpoints: this._chatMuxCheckpoints()" in app
+    assert "last_event_seq: Math.max(0, Number(st && st.lastEventSeq) || 0)" in app
+    assert 'fetch("/api/chat/turns/start"' in app
+    assert "es = this._chatMuxChannel(streamSid, admittedTurnId)" in app
+    assert "if (useMux) this._activateChatMuxChannel(es)" in app
+    assert "await this.loadSession(meta.id, { quiet: true, probeActive: false })" in app
+    assert "const concurrency = this._isMobileLayout() ? 1 : 2" in app
+    assert "CHAT_MUX_BOOTSTRAP_MAX_EVENTS = 512" in app
+    assert "CHAT_MUX_BOOTSTRAP_MAX_BYTES = 2 * 1024 * 1024" in app
+    assert 'reason: "bootstrap_overflow"' in app
+    assert "if (payload.attachable === false)" in app
+    assert app.index("if (payload.attachable === false)") < app.index(
+        "const st = this._ensureTabState(sid);",
+        app.index("async _handleChatMuxSessionState(payload)"),
+    )
+    assert "if (response.status === 404 || response.status === 405)" in app
+    assert "if (tr.status === 404 || tr.status === 405)" in app
+    assert "this._handleChatMuxDisconnect(source)" in app
+    assert "do not synthesize `error`/`done`" in app
+
+
 def test_i18n_zh_en_key_parity():
     """Both language sections in i18n/index.js must define the same set of
     keys. A missing translation causes `t('foo.bar')` to fall back to the
@@ -5298,8 +5325,8 @@ def test_concise_mode_is_a_device_preference_and_defaults_off():
     assert "Failed tools still show" in i18n
 
 
-def test_stop_aborts_stream_ticket_before_backend_turn_exists():
-    """A Stop click during POST /stream/start must prevent the later turn."""
+def test_stop_aborts_stream_start_before_channel_opens():
+    """A Stop click during turn admission must prevent a later live channel."""
     js = (FRONTEND / "app.js").read_text(encoding="utf-8")
 
     state = js[js.index("_stopping: false,"):]
@@ -5307,10 +5334,11 @@ def test_stop_aborts_stream_ticket_before_backend_turn_exists():
     assert "_streamStartController: null" in state
     assert "_cancelBeforeStream: false" in state
 
-    ticket = js[js.index("const streamStartController = new AbortController()"):]
-    ticket = ticket[:ticket.index("const es = new EventSource(url)")]
-    assert "signal: streamStartController.signal" in ticket
-    assert "if (streamState._cancelBeforeStream)" in ticket
+    start = js[js.index("const streamStartController = new AbortController()"):
+               js.index("streamState.es = es;", js.index(
+                   "const streamStartController = new AbortController()"))]
+    assert "signal: streamStartController.signal" in start
+    assert "if (streamState._cancelBeforeStream)" in start
 
     stop = js[js.index("async stop() {"):]
     stop = stop[:stop.index("// ====== ask_user_question UI helpers")]

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3926,8 +3926,15 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert "const warmLimit = this._isMobileLayout() ? 1 : this.WARM_TRANSCRIPT_LIMIT" in app
     assert ".slice(0, warmLimit)" in app
     assert "_touchTranscriptPane(id)" in app
-    assert "st.streaming || st.es" in app
-    assert ".filter(tid => !streamingSet.has(tid))" in app
+    assert "const desired = lru.slice(0, warmLimit)" in app
+    assert "st.streaming || st.es" not in app[
+        app.index("_touchTranscriptPane(id)"):app.index("warmTranscriptTabIds()")
+    ]
+    assert "streamState._flushLivePresentation = flushLivePresentation" in app
+    assert "if (this.currentId !== streamSid) return;" in app
+    assert "const flushPlainBoundary = () =>" in app
+    assert "const closeAsst = () => {\n        flushPlainBoundary();" in app
+    assert "flushTerminalPresentation();" in app
     assert ':data-tid="tid"' in pane
     assert 'x-for="row in paneRows" :key="row.key"' in pane
     assert "paneMessageRows(tid)" in pane
@@ -4989,7 +4996,9 @@ def test_queue_controls_validate_mutations_and_block_send_during_interrupt():
     assert "if (st._stopping)" in app
     assert "queueActionBusy(currentId, 'edit:' + q.id)" in html
     assert "queueActionBusy(currentId, 'remove:' + q.id)" in html
-    assert "sess.pause_queue_if_nonempty(session_id)" in chat
+    assert '"chat.queue_pause_nonempty"' in chat
+    assert "sess.pause_queue_if_nonempty" in chat
+    assert "owned=True" in chat
 
 
 def test_per_message_timestamps_are_plumbed_but_only_shown_on_expand():

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -113,3 +113,31 @@ def test_to_thread_io_offloads_and_logs_only_bounded_metadata(
     assert events[0][1]["duration_ms"] >= 1
     assert "private-transcript-name" not in repr(events)
     assert "rest-is-private" not in repr(events)
+
+
+def test_owned_to_thread_io_joins_worker_before_propagating_cancellation():
+    from backend import observability as obs
+
+    entered = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def commit():
+        entered.set()
+        release.wait(timeout=5)
+        completed.set()
+
+    async def scenario():
+        task = asyncio.create_task(obs.to_thread_io(
+            "chat.commit", "session-private", commit, owned=True,
+        ))
+        await asyncio.to_thread(entered.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert completed.is_set()
+
+    asyncio.run(scenario())

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -539,6 +539,16 @@ def test_corrupt_sidecar_is_never_overwritten_by_a_mutator(app_module):
 
     with pytest.raises(RuntimeError, match="cannot parse session sidecar"):
         sess.set_message_annotation(meta["id"], "msg-1", cost="$1")
+    with pytest.raises(RuntimeError, match="cannot parse session sidecar"):
+        sess.set_session_usage_summary(
+            meta["id"],
+            {
+                "schema": 1,
+                "source": {"dev": 1, "inode": 2, "size": 3, "mtime_ns": 4},
+                "update": {"turn_id": "turn-corrupt", "at": 1.0},
+                "normalized": {"input_tokens": 1},
+            },
+        )
 
     assert path.read_text(encoding="utf-8") == broken
 
@@ -965,6 +975,83 @@ def test_annotation_partial_update_preserves_other_fields(app_module):
     assert anns["uuid-x"]["cost"] == "$0.01"
     assert anns["uuid-x"]["model"] == "m1"
     assert anns["uuid-x"]["images"] == [{"mime": "image/png"}]
+
+
+def test_terminal_annotation_and_usage_summary_share_one_sidecar_write(app_module):
+    from backend import sessions as sess
+
+    sid = sess.create_session()["id"]
+    usage = {
+        "input_tokens": 12,
+        "output_tokens": 3,
+        "context_used": 12,
+        "context_limit": 200_000,
+    }
+    summary = {
+        "schema": 1,
+        "source": {"dev": 7, "inode": 11, "size": 4321, "mtime_ns": 99},
+        "update": {"turn_id": "turn-1", "at": 1_700_000_000.0},
+        "normalized": usage,
+    }
+    sess.set_terminal_annotation_and_usage(
+        sid,
+        "uuid-terminal",
+        summary,
+        turn_status="completed",
+        cost="$0.0100",
+    )
+
+    assert sess.get_message_annotations(sid)["uuid-terminal"] == {
+        "turn_status": "completed",
+        "cost": "$0.0100",
+    }
+    assert sess.get_session_usage_summary(sid) == summary
+
+
+def test_usage_summary_refinement_requires_matching_terminal_turn(app_module):
+    from backend import sessions as sess
+
+    sid = sess.create_session()["id"]
+    original = {
+        "schema": 1,
+        "source": {"dev": 1, "inode": 2, "size": 3, "mtime_ns": 4},
+        "update": {"turn_id": "turn-new", "at": 2.0},
+        "normalized": {"input_tokens": 20},
+    }
+    stale = {
+        **original,
+        "update": {"turn_id": "turn-old", "at": 3.0},
+        "normalized": {"input_tokens": 10},
+    }
+    sess.set_session_usage_summary(sid, original)
+
+    assert sess.set_session_usage_summary_if_turn_matches(
+        sid, "turn-old", stale) is False
+    assert sess.get_session_usage_summary(sid) == original
+    assert sess.set_session_usage_summary_if_turn_matches(
+        sid, "turn-new", {**original, "normalized": {"input_tokens": 21}})
+    assert sess.get_session_usage_summary(sid)["normalized"] == {
+        "input_tokens": 21,
+    }
+
+
+def test_usage_summary_write_respects_session_deletion_fence(app_module):
+    from backend import sessions as sess
+
+    sid = "00000000-0000-4000-8000-00000000f001"
+    path = sess._sidecar_path(sid)
+    path.unlink(missing_ok=True)
+    sess.begin_session_delete(sid)
+    assert sess.set_session_usage_summary(
+        sid,
+        {
+            "schema": 1,
+            "source": {"dev": 1, "inode": 2, "size": 3, "mtime_ns": 4},
+            "update": {"turn_id": "turn-deleted", "at": 1.0},
+            "normalized": {"input_tokens": 1},
+        },
+    ) is False
+    assert not path.exists()
 
 
 def test_cancelled_annotation_is_not_downgraded_by_late_completion(app_module):

--- a/tests/test_workspace_store_concurrency.py
+++ b/tests/test_workspace_store_concurrency.py
@@ -153,6 +153,44 @@ def test_cancelled_reconcile_rolls_back_before_commit(
     assert store.bootstrap(workspace_id) == baseline
 
 
+def test_detached_apply_verifies_cursor_and_root_in_one_transaction(
+    app_module,
+    temp_root: Path,
+):
+    from backend.workspace_store import (
+        WorkspaceStore,
+        compact_scan_rows,
+        scan_workspace,
+    )
+    from backend.workspaces import registry
+
+    workspace_id = registry.id_for(temp_root)
+    store = WorkspaceStore(temp_root)
+    store.reconcile(workspace_id, temp_root, "root", primary=True)
+    cursor = store.current_cursor(workspace_id)
+    report = {}
+    rows = compact_scan_rows(scan_workspace(temp_root, report=report))
+
+    stale = store.apply_reconcile_snapshot(
+        workspace_id,
+        temp_root.parent / "different-root",
+        "root",
+        rows,
+        report,
+        expected_cursor=cursor,
+        primary=True,
+    )
+
+    assert stale == {
+        "_stale": True,
+        "cursor": cursor,
+        "changes": [],
+        "resync": True,
+    }
+    assert store.current_cursor(workspace_id) == cursor
+    assert store.bootstrap(workspace_id)["root"] == str(temp_root.resolve())
+
+
 def test_compact_bootstrap_caps_each_expanded_directory(
     app_module,
     temp_root: Path,


### PR DESCRIPTION
## Summary

- multiplex all active chat session streams over one root SSE connection while preserving per-session replay, checkpoints, and resync isolation
- keep background transcript rendering bounded and move durable persistence work off the asyncio event loop
- preserve full historical transcript reconciliation across terminal flushes and Pane eviction
- retain the legacy per-session SSE transport as an explicit compatibility fallback

## Verification

- 347 affected backend/frontend regression tests passed
- 177 focused multiplex contract tests passed after final buffer-bound changes
- project lint and Python compilation checks passed
- safely deployed and restarted MuseLab on port 8766
- deployed mux ticket/SSE endpoints exercised without sending model prompts
- post-restart health returned HTTP 200 and logs contained no new traceback
- Playwright GUI execution remains blocked by host browser dynamic-library incompatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)