### PR TITLE
fix(chat): flush idle mux SSE handshake

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -17366,6 +17366,16 @@ async def _subscribe_multiplex(
     mobile: bool = False,
 ):
     """Merge attachable broadcasts while periodically discovering new ones."""
+    # Flush the SSE response headers before discovery. Starlette's global
+    # GZipMiddleware deliberately skips compressing ``text/event-stream``, but
+    # its responder still buffers ``http.response.start`` until it sees the
+    # first body frame. An idle mux (no checkpoints and no active turns) has no
+    # session event to yield, so without this handshake frame the browser waits
+    # for sse-starlette's 15-second heartbeat and our 5-second EventSource open
+    # timeout fires first. ``ping`` is already part of the mux protocol and is
+    # ignored by panes that have no active channel.
+    yield {"event": "ping", "data": ""}
+
     # Bound the aggregate handoff so a stalled HTTP client leaves each child
     # parked on its disk-backed subscriber cursor instead of growing RAM.
     output: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)

--- a/backend/main.py
+++ b/backend/main.py
@@ -692,10 +692,10 @@ async def runtime_cleanup_timeout_handler(
 # assets (app.js / index.html / styles.css) plus JSON-heavy API responses
 # (cost-dashboard / settings / skills) — all highly compressible (~75-80%).
 # This is the single biggest cold-load TTI win and costs one line.
-# SSE streams are NOT touched: chat.py's EventSourceResponse sets
-# `Content-Encoding: identity`, and Starlette's GZipMiddleware skips any
-# response that already carries a Content-Encoding header (gzip.py:55-57),
-# so live token streaming is never buffered/compressed.
+# SSE bodies are not compressed: chat.py's EventSourceResponse sets
+# `Content-Encoding: identity`. Starlette's responder still retains the
+# response start until the first body frame, so every SSE generator must emit
+# an immediate handshake event; see chat._subscribe_multiplex.
 app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=6)
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -377,6 +377,7 @@ function portal() {
     _chatMuxPendingEvents: new Map(),
     _chatMuxAttachPromises: new Map(),
     _chatMuxStartPromise: null,
+    _chatMuxCoordinatorPromise: null,
     _chatMuxReconnectTimer: null,
     _chatMuxReconnectAttempts: 0,
     _chatMuxSupported: null,
@@ -10505,13 +10506,26 @@ function portal() {
     },
     async _startChatMuxCoordinator() {
       if (this._chatMuxSupported === false) return false;
-      // Establish the one authoritative live transport before any background
-      // transcript warmup. A turn can start while history is loading; mux-first
-      // startup guarantees its accepted/session_state events already have a sink.
-      const connected = await this._ensureChatMux();
-      if (!connected) return false;
-      await this._bootstrapChatMuxHistory();
-      return true;
+      if (this._chatMuxCoordinatorPromise) {
+        return await this._chatMuxCoordinatorPromise;
+      }
+      const coordinator = (async () => {
+        // Establish the one authoritative live transport before any background
+        // transcript warmup. A turn can start while history is loading; mux-first
+        // startup guarantees its accepted/session_state events already have a sink.
+        const connected = await this._ensureChatMux();
+        if (!connected) return false;
+        await this._bootstrapChatMuxHistory();
+        return true;
+      })();
+      this._chatMuxCoordinatorPromise = coordinator;
+      try {
+        return await coordinator;
+      } finally {
+        if (this._chatMuxCoordinatorPromise === coordinator) {
+          this._chatMuxCoordinatorPromise = null;
+        }
+      }
     },
 
     async initSessions(options = {}) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2237,6 +2237,11 @@ function portal() {
       // critical request queued behind non-visible startup work.
       const contextReady = Promise.resolve(this.fetchContextInfo());
       void contextReady.catch(() => false);
+      // The model list is composer-critical. Queue it before always-on SSE
+      // transports: on HTTP/1.1, several same-origin pages can otherwise fill
+      // the browser's connection budget with live streams and leave a deferred
+      // /api/chat/providers request waiting forever.
+      void Promise.resolve(this._fetchModels()).catch(() => false);
       // Attach the rejection handler immediately: the rest of boot awaits
       // context/session work before it observes this promise, and a fast tree
       // failure must never surface as an unhandled rejection in that gap.

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -581,6 +581,9 @@ def test_mux_coordinator_connects_before_background_history_warmup(
     order = page.evaluate(
         """async () => {
           const app = document.querySelector('#app')._x_dataStack[0];
+          if (app._chatMuxCoordinatorPromise) {
+            try { await app._chatMuxCoordinatorPromise; } catch (_) {}
+          }
           if (app._chatMuxStartPromise) {
             try { await app._chatMuxStartPromise; } catch (_) {}
           }

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import urllib.parse
 
 import pytest
 from fastapi import HTTPException
@@ -31,6 +32,13 @@ def _active_state(broadcast, *, attachable=True, background=False):
         "user_images": [],
         "user_docs": [],
     }
+
+
+async def _open_mux(chat_mod, checkpoints, *, mobile=False):
+    stream = chat_mod._subscribe_multiplex(checkpoints, mobile=mobile)
+    handshake = await asyncio.wait_for(anext(stream), timeout=0.2)
+    assert handshake == {"event": "ping", "data": ""}
+    return stream
 
 
 def test_turn_start_admits_accepts_and_launches(
@@ -180,6 +188,72 @@ def test_mux_ticket_validation_dedupes_and_is_single_use(
     assert exc_info.value.status_code == 401
 
 
+def test_idle_mux_flushes_headers_through_gzip(
+        chat_mod, app_module):
+    ticket = chat_mod.mux_stream_start(
+        chat_mod.MuxStreamStartReq(checkpoints=[], mobile=False),
+    )["ticket"]
+
+    async def exercise():
+        query = urllib.parse.urlencode({"ticket": ticket}).encode("ascii")
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/api/chat/stream/mux",
+            "raw_path": b"/api/chat/stream/mux",
+            "query_string": query,
+            "root_path": "",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"accept-encoding", b"gzip"),
+            ],
+            "client": ("testclient", 123),
+            "server": ("testserver", 80),
+            "state": {},
+        }
+        disconnected = asyncio.Event()
+        request_received = False
+
+        async def receive():
+            nonlocal request_received
+            if not request_received:
+                request_received = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        messages: asyncio.Queue = asyncio.Queue()
+
+        async def send(message):
+            await messages.put(message)
+
+        request_task = asyncio.create_task(
+            app_module.app(scope, receive, send),
+        )
+        try:
+            response_start = await asyncio.wait_for(messages.get(), timeout=2)
+            assert response_start["type"] == "http.response.start"
+            assert response_start["status"] == 200
+            headers = {
+                key.lower(): value
+                for key, value in response_start["headers"]
+            }
+            assert headers[b"content-type"].startswith(b"text/event-stream")
+            assert headers[b"content-encoding"] == b"identity"
+
+            first_body = await asyncio.wait_for(messages.get(), timeout=2)
+            assert first_body["type"] == "http.response.body"
+            assert b"event: ping" in first_body.get("body", b"")
+        finally:
+            disconnected.set()
+            await asyncio.wait_for(request_task, timeout=2)
+
+    asyncio.run(exercise())
+
+
 def test_mux_auto_discovers_wraps_events_and_disconnect_only_unsubscribes(
         chat_mod, monkeypatch):
     monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
@@ -195,7 +269,7 @@ def test_mux_auto_discovers_wraps_events_and_disconnect_only_unsubscribes(
     async def exercise():
         owner = asyncio.create_task(asyncio.sleep(10))
         broadcast.startup_owner_task = owner
-        stream = chat_mod._subscribe_multiplex({}, mobile=False)
+        stream = await _open_mux(chat_mod, {}, mobile=False)
         first = await anext(stream)
         second = await anext(stream)
 
@@ -236,7 +310,7 @@ def test_mux_watcher_state_can_become_attachable_dynamically(
     monkeypatch.setattr(chat_mod, "session_active_status", state)
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex({}, mobile=False)
+        stream = await _open_mux(chat_mod, {}, mobile=False)
         watcher_state = await anext(stream)
         watcher_payload = json.loads(watcher_state["data"])
         assert watcher_state["event"] == "session_state"
@@ -277,7 +351,7 @@ def test_mux_emits_inactive_state_with_finished_turn_identity(
     monkeypatch.setattr(chat_mod, "session_active_status", state)
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex({})
+        stream = await _open_mux(chat_mod, {})
         active = await asyncio.wait_for(anext(stream), timeout=0.2)
         assert json.loads(active["data"])["active"] is True
         broadcast.publish({
@@ -319,7 +393,7 @@ def test_mux_exact_recent_checkpoint_replays_without_cold_recent_discovery(
     )
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex({
+        stream = await _open_mux(chat_mod, {
             exact.session_id: {
                 "session_id": exact.session_id,
                 "turn_id": exact.turn_id,
@@ -350,7 +424,7 @@ def test_mux_turn_mismatch_resyncs_and_still_attaches_current_turn(
     )
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex({
+        stream = await _open_mux(chat_mod, {
             broadcast.session_id: {
                 "session_id": broadcast.session_id,
                 "turn_id": "stale-turn",
@@ -403,7 +477,7 @@ def test_mux_consumes_checkpoint_before_discovering_later_turn(
     }
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex(checkpoints)
+        stream = await _open_mux(chat_mod, checkpoints)
         initial = [
             await asyncio.wait_for(anext(stream), timeout=0.2)
             for _ in range(2)
@@ -454,7 +528,7 @@ def test_mux_inactive_checkpoint_resyncs_once_and_stops_polling(
     }
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex(checkpoints)
+        stream = await _open_mux(chat_mod, checkpoints)
         resync = await asyncio.wait_for(anext(stream), timeout=0.2)
         inactive = await asyncio.wait_for(anext(stream), timeout=0.2)
         assert resync["event"] == "resync"
@@ -492,7 +566,7 @@ def test_mux_child_resync_does_not_close_other_sessions(
     )
 
     async def exercise():
-        stream = chat_mod._subscribe_multiplex({
+        stream = await _open_mux(chat_mod, {
             gap.session_id: {
                 "session_id": gap.session_id,
                 "turn_id": gap.turn_id,


### PR DESCRIPTION
## 问题

空 checkpoints 且没有 active turn 时，mux 生成器不会立即产出 body。Starlette GZipMiddleware 因而一直缓存 SSE 响应头，直到 15 秒心跳；前端 5 秒建连超时会先触发，导致发送失败。

立即建立 mux 后，多页面 + HTTP/1.1 还会暴露两个启动时序：多个常驻 SSE 可能先占满浏览器连接槽，使延后加载的模型列表被饿死；启动中的 mux coordinator 也可能与后续历史预热重叠。

## 修复

- mux 建连后立即发送现有协议中的空 ping 事件，及时冲出响应头
- 在常驻 SSE 启动前优先排队模型列表请求
- 串行化并去重 mux coordinator 启动，避免握手加速后与历史预热重叠
- 修正 GZip/SSE 行为注释
- 增加经过真实 FastAPI + GZipMiddleware 的空闲 mux 回归测试
- 现有 mux 测试显式校验握手事件

## 验证

- mux 回归测试：12 passed
- 完整多标签 E2E：25 passed
- mux coordinator 与同源多标签关键用例组合：2 passed
- 原 CI 失败用例 A/B：未修改 origin/main 通过；仅握手改动失败；加入请求优先级修复后通过
- SSE 启动、前端 mux、静态 GZip 相关测试：4 passed
- 前端 lint：170 passed
- 全量 Ruff、前端语法检查和项目 lint 通过