### PR TITLE
feat(chat): 支持忙时尽快调整当前任务并升级 Claude 基线

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,9 @@ MUSELAB_TERMINAL_ENABLED=1
 # Default model / permission for fresh installs (settings UI overrides).
 # MUSELAB_DEFAULT_MODEL=claude-sonnet-4-6
 # MUSELAB_DEFAULT_PERMISSION=bypassPermissions
+# When a session is busy: adjust the current task at the next safe tool boundary,
+# or wait until the current task finishes and drain through the durable queue.
+# MUSELAB_BUSY_SEND_MODE=adjust
 
 # Days to keep soft-deleted files in <ROOT>/.muselab-dustbin/ before
 # auto-purge (runs on startup). Default 30, matching macOS Finder /

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,10 @@ RUN apt-get update && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     # claude-code pin — keep in lockstep with CLAUDE_CLI_VERSION in
-    # scripts/versions.env (the native installers read it from there).
+    # scripts/versions.env and the CLI bundled by claude-agent-sdk (the native
+    # installers read the pin from versions.env).
     npm install -g \
-        @anthropic-ai/claude-code@2.1.211 && \
+        @anthropic-ai/claude-code@2.1.251 && \
     apt-get purge -y --auto-remove gnupg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*

--- a/backend/api_settings.py
+++ b/backend/api_settings.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from claude_agent_sdk.types import PermissionMode
@@ -72,6 +72,7 @@ _CUSTOM_ENV_RE = re.compile(r"^MUSELAB_PROVIDER_[A-Z0-9_]+_API_KEY$")
 DEFAULT_KEYS = [
     "MUSELAB_DEFAULT_MODEL",
     "MUSELAB_DEFAULT_PERMISSION",
+    "MUSELAB_BUSY_SEND_MODE",
 ]
 
 
@@ -105,6 +106,7 @@ class SettingsIn(BaseModel):
     # Defaults
     default_model: str | None = None
     default_permission: PermissionMode | None = None
+    busy_send_mode: Literal["adjust", "queue"] | None = None
     # (Removed 2026-05-28) notify_scheduled / notify_normal —
     # The 4-toggle notification panel collapsed to a single client-side
     # "notify me" switch. Subscription state IS the on/off; no per-class
@@ -202,6 +204,7 @@ _SETTING_DEFAULTS: dict[str, str] = {
     "MUSELAB_MODEL":                "claude-sonnet-4-6",
     "MUSELAB_DEFAULT_MODEL":        "claude-sonnet-4-6",
     "MUSELAB_DEFAULT_PERMISSION":   "bypassPermissions",
+    "MUSELAB_BUSY_SEND_MODE":       "adjust",
 }
 
 
@@ -276,6 +279,7 @@ def get_settings() -> dict:
                 "MUSELAB_DEFAULT_MODEL",
                 os.environ.get("MUSELAB_MODEL", _SETTING_DEFAULTS["MUSELAB_MODEL"])),
             "permission": _current("MUSELAB_DEFAULT_PERMISSION"),
+            "busy_send_mode": _current("MUSELAB_BUSY_SEND_MODE"),
         },
         # `params` retained as an empty dict for FE backwards-compat — old
         # builds spread `d.params` into draftParams and would TypeError on
@@ -370,6 +374,9 @@ def put_settings(req: SettingsIn) -> dict:
     if req.default_permission is not None and _changed(
             "MUSELAB_DEFAULT_PERMISSION", req.default_permission):
         updates["MUSELAB_DEFAULT_PERMISSION"] = req.default_permission
+    if req.busy_send_mode is not None and _changed(
+            "MUSELAB_BUSY_SEND_MODE", req.busy_send_mode):
+        updates["MUSELAB_BUSY_SEND_MODE"] = req.busy_send_mode
     if req.provider_disabled is not None:
         raw = os.environ.get("MUSELAB_DISABLED_PROVIDERS", "").strip()
         disabled_models = set(raw.split(",")) if raw else set()

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -99,7 +99,11 @@ from .attachment_queue_store import (
     DurableAttachmentError,
     DurableAttachmentStore,
 )
-from .sdk_compat import UnsignedThinkingCompatibleClient
+from .sdk_compat import (
+    CommandLifecycleMessage,
+    MuseLabSDKClient,
+    UnsignedThinkingCompatibleClient,
+)
 
 # Compatibility export: tests and local tooling construct durable interrupted
 # snapshots through the historical chat-module schema constant.
@@ -988,6 +992,22 @@ class TurnBroadcast:
         # Queue ownership is durable. A claimed item stays in the queue sidecar
         # until this exact turn finishes and acknowledges it.
         self.queue_item_id: str = ""
+        # Mid-turn steering is also backed by the durable queue. The browser
+        # first commits an item there, then the enqueue response schedules a
+        # UUID-stamped ``priority=next`` write to this exact SDK runtime. The
+        # item is removed only after the CLI emits command_lifecycle=completed.
+        # Keeping the exact client/turn here closes the session-id ABA race.
+        self.runtime_client: "MuseLabSDKClient | None" = None
+        self.query_committed = False
+        self.result_forwarded = False
+        self.permission = ""
+        self.active_tool_use_ids: set[str] = set()
+        # Synchronously closed before any terminal cleanup await. This prevents
+        # a late enqueue from registering a new native command after the error
+        # finalizer has already snapshotted the old command map.
+        self.steering_closed = False
+        self.steering_commands: dict[str, dict[str, str]] = {}
+        self.steering_write_events: dict[str, asyncio.Event] = {}
         # Headless background-task continuations are separate turns, linked to
         # the user turn that launched the task for observability and recovery.
         self.parent_turn_id: str = ""
@@ -2265,7 +2285,8 @@ def _parse_codex_gateway_catalog(body: Any) -> dict[str, dict]:
 
 
 # Read-only compatibility when the live catalog is temporarily unavailable.
-# This mirrors CLIProxyAPI 7.2.111; the dynamic catalog always wins so a
+# This mirrors the tested CLIProxyAPI 7.2.145 baseline; the dynamic catalog
+# always wins so a
 # Gateway upgrade changes the UI without a MuseLab release.
 _CODEX_CONTROL_FALLBACKS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "gpt-5.6-sol": (("low", "medium", "high", "xhigh", "max", "ultra"),
@@ -3068,7 +3089,7 @@ async def _build_and_connect_client(
         max_buffer_size=max_buf,
         stderr=_cli_stderr,
         # Block harness-only tools the SDK exposes by default. AskUserQuestion
-        # is intentionally kept: SDK 0.2.144 / CLI 2.1.239 correctly turns the
+        # is intentionally kept: SDK 0.2.148 / CLI 2.1.251 correctly turns the
         # browser-injected answers into a native tool_result in every supported
         # permission mode; permission_request.py owns that UI bridge.
         #
@@ -3088,10 +3109,10 @@ async def _build_and_connect_client(
             "CronCreate", "CronDelete", "CronList",
             "EnterWorktree", "ExitWorktree",
             "Monitor", "PushNotification",
-            # Claude CLI 2.1.211 additions whose protocol is owned by a
+            # Claude CLI host features whose protocol is owned by a
             # Claude Code / claude.ai host. muselab has no matching design,
             # review-findings, remote-trigger, or teammate-message surface.
-            "DesignSync", "ListAgents", "RemoteTrigger", "ReportFindings",
+            "DesignSync", "RemoteTrigger", "ReportFindings",
             "SendMessage",
         ],
         # Load CLAUDE.md from user (~/.claude/CLAUDE.md), project
@@ -3440,7 +3461,7 @@ async def _build_and_connect_client(
     client_cls = (
         UnsignedThinkingCompatibleClient
         if endpoints.is_third_party(model)
-        else ClaudeSDKClient
+        else MuseLabSDKClient
     )
     try:
         client = client_cls(options=ClaudeAgentOptions(**opts_kwargs))
@@ -7164,6 +7185,12 @@ class QueueEnqueueReq(BaseModel):
     # Plan Mode additionally snapshots the mode ExitPlanMode should return to.
     # Legacy/malformed values are normalized to fail-closed `default`.
     plan_return_permission: str | None = None
+    # Busy-send policy. Old clients omit this and retain the historical
+    # turn-boundary queue behavior. The current frontend sends ``adjust`` when
+    # Settings asks MuseLab to fold text into the exact active foreground turn
+    # at the CLI's next post-tool boundary.
+    delivery: str = "queue"
+    active_turn_id: str = ""
 
 
 class QueuePauseReq(BaseModel):
@@ -7256,6 +7283,411 @@ async def _schedule_queue_drain_after_response(session_id: str) -> None:
     _schedule_queue_drain(session_id)
 
 
+def _eligible_steering_turn(
+    session_id: str,
+    turn_id: str,
+    *,
+    permission: str = "",
+) -> TurnBroadcast | None:
+    """Return the exact foreground turn that can accept native steering.
+
+    A session id is not sufficient: an old enqueue response can arrive after
+    turn A ended and turn B reused the same pooled client.  The immutable turn
+    id, query commit point and final-result flag together close that ABA window.
+    Queue-owned/background turns are deliberately left to ordinary FIFO drain.
+    """
+    bc = _active_turns.get(session_id)
+    if (
+        bc is None
+        or bc.done
+        or bc.cancelled
+        or not turn_id
+        or bc.turn_id != turn_id
+        or bc.is_continuation
+        or bool(bc.queue_item_id)
+        or not bc.query_committed
+        or bc.result_forwarded
+        or bc.steering_closed
+        or not isinstance(bc.runtime_client, MuseLabSDKClient)
+        or _sessions_with_inflight_tasks.get(session_id)
+        or _session_has_live_watcher(session_id)
+    ):
+        return None
+    requested_permission = (permission or "").strip()
+    if requested_permission and requested_permission != bc.permission:
+        return None
+    return bc
+
+
+def _publish_queue_steering(
+    bc: TurnBroadcast | None,
+    *,
+    item_id: str,
+    command_uuid: str,
+    state: str,
+    effective_delivery: str,
+) -> None:
+    """Publish one privacy-bounded queue state transition when possible."""
+    if bc is None or bc.done:
+        return
+    try:
+        bc.publish({
+            "event": "queue_steering",
+            "data": json.dumps({
+                "item_id": item_id,
+                "command_uuid": command_uuid,
+                "state": state,
+                "effective_delivery": effective_delivery,
+            }),
+        })
+    except Exception:
+        # The durable queue remains authoritative; GET /queue repairs any
+        # missed browser transition after a reconnect.
+        pass
+
+
+async def _fallback_steering_item(
+    session_id: str,
+    *,
+    item_id: str,
+    command_uuid: str,
+    bc: TurnBroadcast | None,
+) -> dict | None:
+    item = await obs.to_thread_io(
+        "chat.queue_steering_fallback",
+        session_id,
+        sess.fallback_queue_steering,
+        session_id,
+        item_id=item_id,
+        command_uuid=command_uuid,
+        owned=True,
+    )
+    if item is not None:
+        _publish_queue_steering(
+            bc,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            state="fallback",
+            effective_delivery="queue",
+        )
+        _schedule_queue_drain(session_id)
+    return item
+
+
+async def _deliver_steering_command(
+    session_id: str,
+    *,
+    turn_id: str,
+    item_id: str,
+    command_uuid: str,
+    text: str,
+    permission: str,
+) -> tuple[str, str, dict | None]:
+    """Write one durable queue item to the exact active CLI command queue.
+
+    The write is registered on the broadcast before the first await.  If a
+    Result frame races this HTTP request, the sole stream reader waits for this
+    write outcome before deciding whether that Result is the final boundary.
+    """
+    bc: TurnBroadcast | None = None
+    write_event: asyncio.Event | None = None
+    async with _lock:
+        bc = _eligible_steering_turn(
+            session_id, turn_id, permission=permission)
+        if bc is not None:
+            write_event = asyncio.Event()
+            bc.steering_commands[command_uuid] = {
+                "item_id": item_id,
+                "state": "pending",
+            }
+            bc.steering_write_events[command_uuid] = write_event
+
+    if bc is None or write_event is None:
+        fallback = await _fallback_steering_item(
+            session_id,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            bc=bc,
+        )
+        return "queue", "queued", fallback
+
+    try:
+        await bc.runtime_client.query_steering(
+            text,
+            session_id=session_id,
+            command_uuid=command_uuid,
+        )
+    except BaseException:
+        current = bc.steering_commands.get(command_uuid)
+        if current is not None and current.get("item_id") == item_id:
+            bc.steering_commands.pop(command_uuid, None)
+        write_event.set()
+        bc.steering_write_events.pop(command_uuid, None)
+        fallback = await _fallback_steering_item(
+            session_id,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            bc=bc,
+        )
+        if fallback is not None:
+            return "queue", "queued", fallback
+        # A terminal lifecycle may have won the race and removed the item.
+        return "adjust", "completed", None
+
+    current = bc.steering_commands.get(command_uuid)
+    updated: dict | None = None
+    if current is not None and current.get("state") == "pending":
+        updated = await obs.to_thread_io(
+            "chat.queue_steering_wait",
+            session_id,
+            sess.update_queue_steering_state,
+            session_id,
+            "waiting_tool",
+            item_id=item_id,
+            command_uuid=command_uuid,
+            owned=True,
+        )
+        # A lifecycle event can advance the same dict while the durable write
+        # runs. Never move queued/started back to waiting_tool in memory.
+        current = bc.steering_commands.get(command_uuid)
+        if current is not None and current.get("state") == "pending":
+            current["state"] = "waiting_tool"
+    write_event.set()
+    bc.steering_write_events.pop(command_uuid, None)
+
+    current = bc.steering_commands.get(command_uuid)
+    if current is None:
+        return "adjust", "completed", updated
+    state = str(current.get("state") or "waiting_tool")
+    _publish_queue_steering(
+        bc,
+        item_id=item_id,
+        command_uuid=command_uuid,
+        state=state,
+        effective_delivery="adjust",
+    )
+    return "adjust", state, updated
+
+
+async def _settle_steering_lifecycle(
+    bc: TurnBroadcast,
+    message: CommandLifecycleMessage,
+) -> bool:
+    """Persist one CLI delivery ACK; return True for a terminal state."""
+    command_uuid = message.command_uuid
+    info = bc.steering_commands.get(command_uuid)
+    if info is None:
+        # A late ACK for a command already cancelled/fallen back must never
+        # mutate a normal FIFO item. Fallback clears the durable command UUID.
+        return message.state in {
+            "completed", "cancelled", "discarded", "refused",
+        }
+    item_id = str(info.get("item_id") or "")
+    state = message.state
+    if state in {"queued", "started"}:
+        info["state"] = state
+        try:
+            await obs.to_thread_io(
+                "chat.queue_steering_lifecycle",
+                bc.session_id,
+                sess.update_queue_steering_state,
+                bc.session_id,
+                state,
+                item_id=item_id,
+                command_uuid=command_uuid,
+                owned=True,
+            )
+        except Exception as exc:
+            # The live CLI still owns the command. Retaining the in-memory map
+            # keeps Result suppression correct; restart recovery pauses the
+            # older durable state rather than risking duplicate execution.
+            sys.stderr.write(
+                f"[chat] steering state persist failed "
+                f"sid={obs.short_id(bc.session_id)} "
+                f"state={state} exc={type(exc).__name__}\n"
+            )
+        _publish_queue_steering(
+            bc,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            state=state,
+            effective_delivery="adjust",
+        )
+        return False
+
+    if state == "completed":
+        try:
+            removed = await obs.to_thread_io(
+                "chat.queue_steering_complete",
+                bc.session_id,
+                sess.update_queue_steering_state,
+                bc.session_id,
+                "completed",
+                item_id=item_id,
+                command_uuid=command_uuid,
+                owned=True,
+            )
+            if removed is not None and str(removed.get("image_ids") or ""):
+                await obs.to_thread_io(
+                    "chat.queue_attachment_finish",
+                    bc.session_id,
+                    _durable_attachment_store.finish_queue_item,
+                    bc.session_id,
+                    item_id,
+                    consume=True,
+                    owned=True,
+                )
+        except Exception as exc:
+            # The CLI says the command ran. Never convert an ACK-persistence
+            # failure into an automatic resend: the still-adjust queue row
+            # remains non-claimable and startup recovery pauses it for review.
+            sys.stderr.write(
+                f"[chat] steering completion persist failed "
+                f"sid={obs.short_id(bc.session_id)} "
+                f"exc={type(exc).__name__}\n"
+            )
+        bc.steering_commands.pop(command_uuid, None)
+        event = bc.steering_write_events.pop(command_uuid, None)
+        if event is not None:
+            event.set()
+        _publish_queue_steering(
+            bc,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            state="completed",
+            effective_delivery="adjust",
+        )
+        return True
+
+    bc.steering_commands.pop(command_uuid, None)
+    event = bc.steering_write_events.pop(command_uuid, None)
+    if event is not None:
+        event.set()
+    if state in {"discarded", "refused"}:
+        await _fallback_steering_item(
+            bc.session_id,
+            item_id=item_id,
+            command_uuid=command_uuid,
+            bc=bc,
+        )
+    else:  # cancelled
+        try:
+            await obs.to_thread_io(
+                "chat.queue_steering_cancelled",
+                bc.session_id,
+                sess.update_queue_steering_state,
+                bc.session_id,
+                "cancelled",
+                item_id=item_id,
+                command_uuid=command_uuid,
+                pause=True,
+                owned=True,
+            )
+        except Exception as exc:
+            sys.stderr.write(
+                f"[chat] steering cancellation persist failed "
+                f"sid={obs.short_id(bc.session_id)} "
+                f"exc={type(exc).__name__}\n"
+            )
+        finally:
+            _publish_queue_steering(
+                bc,
+                item_id=item_id,
+                command_uuid=command_uuid,
+                state="cancelled",
+                effective_delivery="adjust",
+            )
+    return True
+
+
+async def _cancel_outstanding_steering_commands(
+    bc: TurnBroadcast,
+) -> None:
+    """Fail closed any native commands left when their turn loses its reader.
+
+    A transport/model failure is allowed to arrive after the CLI reported a
+    command as started but before its terminal lifecycle frame. Once this
+    broadcast ends no exact live owner can cancel or settle that row. Retain it
+    as cancelled+paused so the user can explicitly resume, delete, or clear it.
+    """
+    # Close admission before the first await and before snapshotting the map.
+    # Error finalization otherwise has a window where a new enqueue can attach
+    # after this snapshot and lose its owner when the broadcast is popped.
+    bc.steering_closed = True
+    steering = list(bc.steering_commands.items())
+    bc.steering_commands.clear()
+    for command_uuid, info in steering:
+        event = bc.steering_write_events.pop(command_uuid, None)
+        if event is not None:
+            event.set()
+        item_id = str(info.get("item_id") or "")
+        persisted: dict | None = None
+        try:
+            persisted = await obs.to_thread_io(
+                "chat.queue_steering_cancelled",
+                bc.session_id,
+                sess.update_queue_steering_state,
+                bc.session_id,
+                "cancelled",
+                item_id=item_id,
+                command_uuid=command_uuid,
+                pause=True,
+                owned=True,
+            )
+        except Exception as exc:
+            sys.stderr.write(
+                f"[chat] steering terminal pause failed "
+                f"sid={obs.short_id(bc.session_id)} "
+                f"exc={type(exc).__name__}\n"
+            )
+        if persisted is not None:
+            _publish_queue_steering(
+                bc,
+                item_id=item_id,
+                command_uuid=command_uuid,
+                state="cancelled",
+                effective_delivery="adjust",
+            )
+
+
+async def _await_steering_write_stability(
+    bc: TurnBroadcast,
+    *,
+    timeout_s: float = 10.0,
+) -> bool:
+    """Wait until every writer registered before the stable check has settled.
+
+    Writers can register while Result is awaiting an older writer, so one
+    snapshot is insufficient. Returning ``False`` means at least one write is
+    still delivery-ambiguous at the bounded deadline.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, timeout_s)
+    while True:
+        pending_writes = tuple(
+            event
+            for event in bc.steering_write_events.values()
+            if not event.is_set()
+        )
+        if not pending_writes:
+            return True
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(
+                    event.wait() for event in pending_writes
+                )),
+                timeout=remaining,
+            )
+        except asyncio.TimeoutError:
+            return False
+        # A second enqueue can register while Result waits for the first write.
+        # Re-snapshot until there are no unfinished writers. The caller checks
+        # the command map immediately afterward without another await.
+
+
 @router.post("/sessions/{sid}/queue", dependencies=[Depends(require_token)])
 async def enqueue_api(
     sid: str,
@@ -7264,6 +7696,10 @@ async def enqueue_api(
 ) -> dict:
     text = (req.text or "").strip()
     attachment_ids = _attachment_ids(req.image_ids or "")
+    requested_delivery = (req.delivery or "queue").strip().lower()
+    if requested_delivery not in {"adjust", "queue"}:
+        raise HTTPException(400, "invalid queue delivery")
+    requested_turn_id = (req.active_turn_id or "").strip()
     if any(not _valid_staged_attachment_id(aid) for aid in attachment_ids):
         raise HTTPException(400, "bad attachment id")
     if not text and not attachment_ids:
@@ -7277,6 +7713,19 @@ async def enqueue_api(
         if selection_quotes
         else (req.display_text or text)
     )
+
+    # Native steering is text-only. Attachment ownership spans staged uploads,
+    # the queue sidecar and the eventual canonical user UUID; replaying that
+    # transaction inside a mid-turn CLI fold would make crash recovery
+    # ambiguous, so attachment messages retain ordinary turn-boundary FIFO.
+    steering_turn = (
+        _eligible_steering_turn(
+            sid, requested_turn_id, permission=req.permission or "")
+        if requested_delivery == "adjust" and not attachment_ids
+        else None
+    )
+    effective_delivery = "adjust" if steering_turn is not None else "queue"
+    command_uuid = str(uuid.uuid4()) if steering_turn is not None else ""
 
     # Bind blobs before the queue JSON commit. A crash may leave an orphan ref
     # (startup reconciliation releases it), but can never leave an accepted
@@ -7324,6 +7773,12 @@ async def enqueue_api(
             selection_quotes=selection_quotes,
             plan_return_permission=req.plan_return_permission,
             item_id=queue_item_id,
+            delivery=effective_delivery,
+            target_turn_id=(requested_turn_id
+                            if effective_delivery == "adjust" else ""),
+            command_uuid=command_uuid,
+            steering_state=("pending"
+                            if effective_delivery == "adjust" else ""),
         )
     )
     try:
@@ -7336,6 +7791,19 @@ async def enqueue_api(
                 continue
         res = enqueue_task.result()
         if res.get("ok"):
+            if effective_delivery == "adjust":
+                fallback_task = asyncio.create_task(_fallback_steering_item(
+                    sid,
+                    item_id=queue_item_id,
+                    command_uuid=command_uuid,
+                    bc=steering_turn,
+                ))
+                while not fallback_task.done():
+                    try:
+                        await asyncio.shield(fallback_task)
+                    except asyncio.CancelledError:
+                        continue
+                fallback_task.result()
             _schedule_queue_drain(sid)
         elif attachment_ids:
             await asyncio.to_thread(
@@ -7368,6 +7836,19 @@ async def enqueue_api(
             # complete queue reconciliation instead of risking data loss.
             queue_committed = True
         if queue_committed:
+            if effective_delivery == "adjust":
+                try:
+                    await asyncio.shield(_fallback_steering_item(
+                        sid,
+                        item_id=queue_item_id,
+                        command_uuid=command_uuid,
+                        bc=steering_turn,
+                    ))
+                except Exception:
+                    # Unknown ownership remains fail-closed in the queue. Its
+                    # active steering state blocks ordinary duplicate drain;
+                    # startup recovery pauses it for review.
+                    pass
             _schedule_queue_drain(sid)
         elif attachment_ids:
             await asyncio.to_thread(
@@ -7388,28 +7869,149 @@ async def enqueue_api(
         if res.get("error") == "session_not_found":
             raise HTTPException(404, "session not found")
         raise HTTPException(409, res.get("error", "enqueue failed"))
-    background_tasks.add_task(_schedule_queue_drain_after_response, sid)
+    if effective_delivery == "adjust":
+        delivery_task = asyncio.create_task(_deliver_steering_command(
+            sid,
+            turn_id=requested_turn_id,
+            item_id=queue_item_id,
+            command_uuid=command_uuid,
+            text=text,
+            permission=req.permission or "",
+        ))
+        try:
+            delivered_as, delivery_status, updated_item = await asyncio.shield(
+                delivery_task)
+        except asyncio.CancelledError:
+            # The durable item and CLI command must reach one known ownership
+            # state even when the browser drops the enqueue response.
+            while not delivery_task.done():
+                try:
+                    await asyncio.shield(delivery_task)
+                except asyncio.CancelledError:
+                    continue
+            delivered_as, delivery_status, updated_item = delivery_task.result()
+            if delivered_as == "queue":
+                _schedule_queue_drain(sid)
+            raise
+        effective_delivery = delivered_as
+        if updated_item is not None:
+            res["item"] = updated_item
+        # Lifecycle can beat the HTTP response. Return the authoritative small
+        # queue snapshot so the frontend never re-adds an already-completed
+        # optimistic row after its completed SSE event was delivered.
+        res["queue"] = await asyncio.to_thread(sess.get_queue, sid)
+    else:
+        delivery_status = "queued"
+        background_tasks.add_task(_schedule_queue_drain_after_response, sid)
+    res["effective_delivery"] = effective_delivery
+    res["delivery_status"] = delivery_status
     return res
 
 
-@router.delete("/sessions/{sid}/queue/{item_id}", dependencies=[Depends(require_token)])
-def remove_queue_item_api(sid: str, item_id: str) -> dict:
+async def _cancel_waiting_steering_item(
+    sid: str, item: dict,
+) -> bool:
+    """Cancel one still-queued native command before its durable row is removed."""
+    command_uuid = str(item.get("command_uuid") or "")
+    target_turn_id = str(item.get("target_turn_id") or "")
+    bc = _active_turns.get(sid)
+    if (
+        not command_uuid
+        or bc is None
+        or bc.done
+        or bc.turn_id != target_turn_id
+        or not isinstance(bc.runtime_client, MuseLabSDKClient)
+        or str((bc.steering_commands.get(command_uuid) or {}).get(
+            "item_id") or "") != str(item.get("id") or "")
+    ):
+        return False
     try:
-        updated, removed_ids = sess.remove_queue_item_with_removed(
-            sid, item_id)
+        cancelled = await bc.runtime_client.cancel_async_message(command_uuid)
+    except Exception:
+        return False
+    if not cancelled:
+        return False
+    bc.steering_commands.pop(command_uuid, None)
+    event = bc.steering_write_events.pop(command_uuid, None)
+    if event is not None:
+        event.set()
+    return True
+
+
+@router.delete("/sessions/{sid}/queue/{item_id}", dependencies=[Depends(require_token)])
+async def remove_queue_item_api(sid: str, item_id: str) -> dict:
+    snapshot = await asyncio.to_thread(sess.get_queue, sid)
+    item = next(
+        (row for row in snapshot.get("items") or []
+         if str(row.get("id") or "") == item_id),
+        None,
+    )
+    if (
+        item is not None
+        and item.get("delivery") == "adjust"
+        and item.get("steering_state") in {
+            "pending", "waiting_tool", "queued", "started",
+        }
+        and not await _cancel_waiting_steering_item(sid, item)
+    ):
+        raise HTTPException(
+            409,
+            "message is already being adjusted and cannot be withdrawn safely",
+        )
+    try:
+        updated, removed_ids = await asyncio.to_thread(
+            sess.remove_queue_item_with_removed, sid, item_id)
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     for removed_id in removed_ids:
-        _durable_attachment_store.finish_queue_item(
+        await asyncio.to_thread(
+            _durable_attachment_store.finish_queue_item,
             sid, removed_id, consume=False)
     return updated
 
 
 @router.delete("/sessions/{sid}/queue", dependencies=[Depends(require_token)])
-def clear_queue_api(sid: str) -> dict:
-    updated, item_ids = sess.clear_queue_with_removed(sid)
+async def clear_queue_api(sid: str) -> dict:
+    snapshot = await asyncio.to_thread(sess.get_queue, sid)
+    snapshot_item_ids = tuple(
+        str(item.get("id") or "")
+        for item in snapshot.get("items") or []
+        if item.get("id")
+    )
+    active_adjustments = [
+        item for item in snapshot.get("items") or []
+        if item.get("delivery") == "adjust"
+        and item.get("steering_state") in {
+            "pending", "waiting_tool", "queued", "started",
+        }
+    ]
+    cancelled: list[dict] = []
+    for item in active_adjustments:
+        if await _cancel_waiting_steering_item(sid, item):
+            cancelled.append(item)
+            continue
+        for prior in cancelled:
+            await asyncio.to_thread(
+                sess.update_queue_steering_state,
+                sid,
+                "cancelled",
+                item_id=str(prior.get("id") or ""),
+                command_uuid=str(prior.get("command_uuid") or ""),
+                pause=True,
+            )
+        raise HTTPException(
+            409,
+            "one or more adjusted messages cannot be cleared safely",
+        )
+    # Remove exactly the rows represented by the snapshot above. A concurrent
+    # enqueue may already have crossed the native CLI write boundary by now;
+    # an unconditional clear would erase its durable owner without cancelling
+    # the accepted command.
+    updated, item_ids = await asyncio.to_thread(
+        sess.remove_queue_items_with_removed, sid, snapshot_item_ids)
     for item_id in item_ids:
-        _durable_attachment_store.finish_queue_item(
+        await asyncio.to_thread(
+            _durable_attachment_store.finish_queue_item,
             sid, item_id, consume=False)
     return {"ok": True, **updated}
 
@@ -9939,15 +10541,67 @@ async def interrupt(
     # Stop means "do not continue autonomously". Pause queued work only after
     # the immutable owner check, before the SDK interrupt can race cleanup and
     # dequeue the next item.
-    await obs.to_thread_io(
-        "chat.queue_pause_nonempty",
-        session_id,
-        sess.pause_queue_if_nonempty,
-        session_id,
-        owned=True,
-    )
+    stale_after_pause = False
     async with _lock:
-        targets = [(k, c) for k, c in _clients.items() if k[0] == session_id]
+        current = _active_turns.get(session_id)
+        owner_matches = (
+            current is bc
+            and (
+                bc is None
+                or (
+                    not bc.done
+                    and (
+                        not requested_turn_id
+                        or bc.turn_id == requested_turn_id
+                    )
+                )
+            )
+        )
+        if not owner_matches:
+            stale_after_pause = True
+            targets = []
+        else:
+            # Keep admission serialized with both exact-owner checks. Turn
+            # cleanup can still pop its own broadcast outside this lock, so a
+            # second check after the disk await is required before snapshotting
+            # any pooled client.
+            await obs.to_thread_io(
+                "chat.queue_pause_nonempty",
+                session_id,
+                sess.pause_queue_if_nonempty,
+                session_id,
+                owned=True,
+            )
+            current = _active_turns.get(session_id)
+            owner_matches = (
+                current is bc
+                and (
+                    bc is None
+                    or (
+                        not bc.done
+                        and (
+                            not requested_turn_id
+                            or bc.turn_id == requested_turn_id
+                        )
+                    )
+                )
+            )
+            if not owner_matches:
+                stale_after_pause = True
+                targets = []
+            else:
+                targets = [
+                    (k, c) for k, c in _clients.items()
+                    if k[0] == session_id
+                ]
+    if stale_after_pause:
+        return _interrupt_response(
+            session_id,
+            bc,
+            requested_turn_id=requested_turn_id,
+            interrupted=[],
+            stale=True,
+        )
     # Mark the active turn user-cancelled up front (BEFORE calling SDK's
     # interrupt — the ResultMessage handler races with us, and we'd rather flag
     # too early than too late). This also lets the force-stop watchdog and the
@@ -10006,8 +10660,14 @@ async def interrupt(
 
     async def _interrupt_one(k, c) -> str | None:
         try:
+            interrupt_call = (
+                c.interrupt(cancel_queued=bool(
+                    bc is not None and bc.steering_commands))
+                if isinstance(c, MuseLabSDKClient)
+                else c.interrupt()
+            )
             await asyncio.wait_for(
-                c.interrupt(), timeout=_INTERRUPT_ACK_TIMEOUT_S)
+                interrupt_call, timeout=_INTERRUPT_ACK_TIMEOUT_S)
             return f"{k[0]}@{k[1]}"
         except asyncio.TimeoutError:
             sys.stderr.write(
@@ -10023,6 +10683,12 @@ async def interrupt(
     results = await asyncio.gather(
         *(_interrupt_one(k, c) for k, c in targets))
     interrupted = [result for result in results if result is not None]
+    if bc is not None and bc.steering_commands:
+        # Stop is an explicit request not to continue autonomously. Even when
+        # an older CLI omits its cancel_queued receipt, retain each durable
+        # adjustment as cancelled+paused for review; never blindly resend a
+        # command that may already have crossed the dequeue boundary.
+        await _cancel_outstanding_steering_commands(bc)
     # The watchdog was armed before these control requests, so a slow/broken
     # acknowledgement cannot postpone the hard-stop deadline.
     return _interrupt_response(
@@ -14233,6 +14899,7 @@ async def _start_turn(
     )
     broadcast.activity_hidden = bool(s.get("activity_hidden", False))
     broadcast.model = model_to_use
+    broadcast.permission = permission
 
     # Reasoning effort and Fast service are per-session launch controls.
     # Legacy empty effort is normalized to canonical `auto` before it reaches
@@ -14386,6 +15053,13 @@ async def _start_turn(
     # list. Do not send the prompt after the user has already cancelled.
     if broadcast.cancelled:
         return await _finish_cancelled_startup(session_id, broadcast)
+
+    # Publish the exact connected runtime only after the immutable active-turn
+    # owner has survived startup cancellation. The busy-send endpoint never
+    # looks clients up by session id alone; it rechecks this broadcast, turn id,
+    # query commit and an in-flight tool before scheduling a steering write.
+    if isinstance(client, MuseLabSDKClient):
+        broadcast.runtime_client = client
 
     # Lease staged uploads without consuming them. The payload remains retryable
     # through CPU/disk preparation and native compact preflight; only a
@@ -15116,6 +15790,7 @@ async def _start_turn(
                         # let the next turn adopt it as its own response.
                         _pending_runtime_rebuilds.add(session_id)
                         raise
+                    broadcast.query_committed = True
                     broadcast.emit_startup_perf("ready")
                     if persisted_imgs:
                         try:
@@ -15132,14 +15807,58 @@ async def _start_turn(
                             sys.stderr.flush()
 
                 replay_dropped = 0
+                deferred_result: ResultMessage | None = None
 
                 async def _dispatch(msg) -> str:
                     """Classify one message and forward it to the turn."""
-                    nonlocal replay_dropped
+                    nonlocal replay_dropped, deferred_result
+                    if isinstance(msg, CommandLifecycleMessage):
+                        terminal = await _settle_steering_lifecycle(
+                            broadcast, msg)
+                        if (
+                            terminal
+                            and not broadcast.steering_commands
+                            and deferred_result is not None
+                        ):
+                            final_result = deferred_result
+                            deferred_result = None
+                            broadcast.result_forwarded = True
+                            broadcast.active_tool_use_ids.clear()
+                            await merge_q.put(("claude", final_result))
+                            return "current_result"
+                        return "forward"
                     decision = boundary.classify(msg)
                     if decision in ("drop", "stale_result"):
                         replay_dropped += 1
                         return decision
+
+                    # Keep an exact, live view of tool execution. The native
+                    # priority=next queue consumes at PostToolBatch; these IDs
+                    # are also useful to explain why a command is still
+                    # waiting, but eligibility does not require one — a command
+                    # sent before the next tool is chosen can still fold there.
+                    if isinstance(msg, (AssistantMessage, UserMessage)):
+                        for block in (getattr(msg, "content", None) or []):
+                            if isinstance(block, ToolUseBlock) and block.id:
+                                broadcast.active_tool_use_ids.add(block.id)
+                            elif isinstance(block, ToolResultBlock):
+                                tool_id = str(
+                                    getattr(block, "tool_use_id", "") or "")
+                                if tool_id:
+                                    broadcast.active_tool_use_ids.discard(tool_id)
+
+                    if decision == "current_result":
+                        # A Result can race the enqueue HTTP request while its
+                        # one-frame write is in progress. Wait briefly for that
+                        # known write outcome; a failed write removes the map
+                        # and lets this Result close normally, while an accepted
+                        # command keeps the sole stream reader attached.
+                        await _await_steering_write_stability(broadcast)
+                        if broadcast.steering_commands:
+                            deferred_result = msg
+                            return "steering_pending_result"
+                        broadcast.result_forwarded = True
+                        broadcast.active_tool_use_ids.clear()
                     if (broadcast.perf_query_started
                             and broadcast.perf_first_event_ms < 0):
                         broadcast.perf_first_event_ms = obs.elapsed_ms(
@@ -16824,8 +17543,15 @@ async def _start_turn(
             # Activity/queue/sidecar settlement again reintroduces the race the
             # watchdog was meant to close.
             if broadcast._startup_terminal_cleanup_task is not None:
+                await _cancel_outstanding_steering_commands(broadcast)
                 await _finish_cancelled_startup(session_id, broadcast)
                 return
+
+            if turn_errored or broadcast.cancelled:
+                # Call even when the map is empty: the helper closes admission
+                # synchronously before its first possible await, preventing a
+                # late enqueue during the rest of terminal bookkeeping.
+                await _cancel_outstanding_steering_commands(broadcast)
 
             if broadcast.cancelled:
                 broadcast.perf_status = "cancelled"
@@ -17882,10 +18608,15 @@ async def providers_list() -> dict:
         # A stale hand-edited env value must not leak invalid state into the
         # selector or the SDK launch contract.
         default_permission = "bypassPermissions"
+    busy_send_mode = os.environ.get(
+        "MUSELAB_BUSY_SEND_MODE", "adjust").strip().lower()
+    if busy_send_mode not in {"adjust", "queue"}:
+        busy_send_mode = "adjust"
     return {
         "models": flat,
         "default_model": _resolve_default_model(""),
         "default_permission": default_permission,
+        "busy_send_mode": busy_send_mode,
     }
 
 def recover_durable_queue_attachments_at_startup(

--- a/backend/sdk_compat.py
+++ b/backend/sdk_compat.py
@@ -1,4 +1,11 @@
-"""Narrow compatibility shims for Anthropic-compatible vendor endpoints.
+"""Narrow compatibility shims around the pinned Claude Agent SDK.
+
+The bundled CLI already understands UUID-stamped asynchronous user messages
+and emits ``command_lifecycle`` frames for them, but the Python SDK currently
+drops those frames as unknown.  It also discards the useful receipt returned
+by ``interrupt`` and does not expose ``cancel_async_message``.  The base
+:class:`MuseLabSDKClient` fills only those small protocol gaps while the SDK is
+pinned to a version whose wire contract we have tested.
 
 The Claude Agent SDK treats ``signature`` as a required field on every
 assistant ``thinking`` block.  Some third-party endpoints emit the thinking
@@ -6,7 +13,7 @@ text but omit that field entirely, which makes the SDK raise
 ``MessageParseError`` before callers can receive the remaining assistant and
 result messages.
 
-Muselab only uses :class:`UnsignedThinkingCompatibleClient` for third-party
+MuseLab only uses :class:`UnsignedThinkingCompatibleClient` for third-party
 providers.  It supplies an empty in-memory signature for parsing, without
 mutating the raw SDK frame or pretending that the vendor produced a valid
 cryptographic signature.  ``backend.jsonl_cleanup`` removes the unverifiable
@@ -15,16 +22,105 @@ block from the persisted transcript after the turn completes.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import AsyncIterator
-from typing import Any
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Literal, cast
 
 from claude_agent_sdk import ClaudeSDKClient
-from claude_agent_sdk._errors import CLIConnectionError
+from claude_agent_sdk._errors import CLIConnectionError, MessageParseError
 from claude_agent_sdk.types import Message
 
 
 logger = logging.getLogger(__name__)
+
+
+CommandLifecycleState = Literal[
+    "queued",
+    "started",
+    "completed",
+    "cancelled",
+    "discarded",
+    "refused",
+]
+_COMMAND_LIFECYCLE_STATES = frozenset(
+    {"queued", "started", "completed", "cancelled", "discarded", "refused"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandLifecycleMessage:
+    """Delivery state for one UUID-stamped CLI command.
+
+    ``command_uuid`` is the UUID MuseLab supplied on the input frame.  ``uuid``
+    is the distinct UUID of this lifecycle event itself.
+    """
+
+    command_uuid: str
+    state: CommandLifecycleState
+    session_id: str
+    uuid: str
+
+
+@dataclass(frozen=True, slots=True)
+class InterruptReceipt:
+    """The queue snapshot returned synchronously by a CLI interrupt.
+
+    ``None`` means that the running CLI did not advertise/return that receipt
+    field; an empty tuple means it returned the field with no matching UUIDs.
+    Keeping that distinction prevents an older CLI from looking like a
+    confirmed empty queue.
+    """
+
+    still_queued: tuple[str, ...] | None
+    cancelled: tuple[str, ...] | None
+
+
+def parse_command_lifecycle(
+    data: dict[str, Any],
+) -> CommandLifecycleMessage | None:
+    """Parse a CLI ``command_lifecycle`` frame, or return ``None`` otherwise."""
+    if data.get("type") != "command_lifecycle":
+        return None
+
+    command_uuid = data.get("command_uuid")
+    state = data.get("state")
+    session_id = data.get("session_id")
+    event_uuid = data.get("uuid")
+    if not isinstance(command_uuid, str) or not command_uuid:
+        raise MessageParseError(
+            "Invalid command_lifecycle command_uuid", data)
+    if state not in _COMMAND_LIFECYCLE_STATES:
+        raise MessageParseError(
+            f"Invalid command_lifecycle state: {state!r}", data)
+    if not isinstance(session_id, str):
+        raise MessageParseError(
+            "Invalid command_lifecycle session_id", data)
+    if not isinstance(event_uuid, str) or not event_uuid:
+        raise MessageParseError(
+            "Invalid command_lifecycle uuid", data)
+    return CommandLifecycleMessage(
+        command_uuid=command_uuid,
+        state=cast(CommandLifecycleState, state),
+        session_id=session_id,
+        uuid=event_uuid,
+    )
+
+
+def _string_tuple_field(
+    response: dict[str, Any], field: str,
+) -> tuple[str, ...] | None:
+    value = response.get(field)
+    if value is None:
+        return None
+    if (
+        not isinstance(value, list)
+        or not all(isinstance(item, str) for item in value)
+    ):
+        raise MessageParseError(
+            f"Invalid interrupt receipt field: {field}", response)
+    return tuple(value)
 
 
 def normalize_missing_thinking_signatures(
@@ -70,30 +166,148 @@ def normalize_missing_thinking_signatures(
     return normalized_data, len(missing)
 
 
-class UnsignedThinkingCompatibleClient(ClaudeSDKClient):
-    """Claude SDK client that accepts unsigned vendor thinking blocks.
+class MuseLabSDKClient(ClaudeSDKClient):
+    """Claude SDK client with MuseLab's tested streaming-input extensions."""
 
-    This mirrors the SDK's small ``receive_messages`` adapter so normalization
-    happens before its strict private parser.  The SDK is deliberately pinned
-    below 0.3 in ``pyproject.toml``; remove this subclass once upstream makes
-    missing thinking signatures non-fatal.
-    """
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # The SDK transport serializes individual writes, but it cannot order a
+        # multi-frame async iterable against a concurrent normal query/control
+        # request.  MuseLab sends one frame today; keeping one app-level lock
+        # makes that ordering explicit and safe if the SDK implementation
+        # changes.
+        self._muselab_input_lock = asyncio.Lock()
 
-    async def receive_messages(self) -> AsyncIterator[Message]:
+    async def query(
+        self,
+        prompt: str | AsyncIterable[dict[str, Any]],
+        session_id: str = "default",
+    ) -> None:
+        """Serialize ordinary and steering writes on this client instance."""
+        async with self._muselab_input_lock:
+            await super().query(prompt, session_id=session_id)
+
+    async def query_steering(
+        self,
+        prompt: str,
+        *,
+        session_id: str,
+        command_uuid: str,
+    ) -> None:
+        """Queue a human prompt for the CLI's next mid-turn fold boundary.
+
+        ``priority=next`` lets the CLI absorb the command after the current
+        tool batch.  ``now`` would interrupt the active request, while
+        ``later`` intentionally defers the command to a subsequent turn.
+        """
+        if not isinstance(prompt, str):
+            raise TypeError("steering prompt must be a string")
+        if not isinstance(command_uuid, str) or not command_uuid:
+            raise ValueError("command_uuid must be a non-empty string")
+
+        frame = {
+            "type": "user",
+            "message": {"role": "user", "content": prompt},
+            "parent_tool_use_id": None,
+            "session_id": session_id,
+            "uuid": command_uuid,
+            "priority": "next",
+            "origin": {"kind": "human"},
+            "shouldQuery": True,
+        }
+
+        async def _one_frame() -> AsyncIterator[dict[str, Any]]:
+            yield frame
+
+        async with self._muselab_input_lock:
+            # Call the SDK implementation directly: going through our query()
+            # override would acquire the same non-reentrant lock twice.
+            await super().query(_one_frame(), session_id=session_id)
+
+    def _normalize_incoming_frame(
+        self, data: dict[str, Any],
+    ) -> dict[str, Any]:
+        return data
+
+    async def receive_messages(
+        self,
+    ) -> AsyncIterator[Message | CommandLifecycleMessage]:
+        """Yield SDK messages plus the lifecycle type upstream currently drops."""
         if not self._query:
             raise CLIConnectionError("Not connected. Call connect() first.")
 
         from claude_agent_sdk._internal.message_parser import parse_message
 
         async for data in self._query.receive_messages():
-            normalized, count = normalize_missing_thinking_signatures(data)
-            if count:
-                model = (normalized.get("message") or {}).get("model", "")
-                logger.warning(
-                    "accepted %d unsigned thinking block(s) from vendor model %s",
-                    count,
-                    model or "<unknown>",
-                )
+            normalized = self._normalize_incoming_frame(data)
+            lifecycle = parse_command_lifecycle(normalized)
+            if lifecycle is not None:
+                yield lifecycle
+                continue
             message = parse_message(normalized)
             if message is not None:
                 yield message
+
+    async def _send_muselab_control_request(
+        self, request: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not self._query:
+            raise CLIConnectionError("Not connected. Call connect() first.")
+        sender = getattr(self._query, "_send_control_request", None)
+        if not callable(sender):
+            raise CLIConnectionError(
+                "Installed Claude Agent SDK does not expose control requests")
+        async with self._muselab_input_lock:
+            response = await sender(request)
+        if not isinstance(response, dict):
+            raise MessageParseError("Invalid SDK control response", response)
+        return response
+
+    async def cancel_async_message(self, command_uuid: str) -> bool:
+        """Drop one UUID-stamped command that is still queued in the CLI."""
+        if not isinstance(command_uuid, str) or not command_uuid:
+            raise ValueError("command_uuid must be a non-empty string")
+        response = await self._send_muselab_control_request({
+            "subtype": "cancel_async_message",
+            "message_uuid": command_uuid,
+        })
+        cancelled = response.get("cancelled")
+        if not isinstance(cancelled, bool):
+            raise MessageParseError(
+                "Invalid cancel_async_message response", response)
+        return cancelled
+
+    async def interrupt(
+        self, *, cancel_queued: bool = False,
+    ) -> InterruptReceipt:
+        """Interrupt the turn and retain the CLI's synchronous queue receipt."""
+        request: dict[str, Any] = {"subtype": "interrupt"}
+        if cancel_queued:
+            request["cancel_queued"] = True
+        response = await self._send_muselab_control_request(request)
+        return InterruptReceipt(
+            still_queued=_string_tuple_field(response, "still_queued"),
+            cancelled=_string_tuple_field(response, "cancelled"),
+        )
+
+
+class UnsignedThinkingCompatibleClient(MuseLabSDKClient):
+    """Claude SDK client that accepts unsigned vendor thinking blocks.
+
+    The base class handles MuseLab's streaming-input protocol additions.  This
+    subclass only normalizes vendor thinking frames before the same parser, so
+    it cannot accidentally bypass command lifecycle handling.
+    """
+
+    def _normalize_incoming_frame(
+        self, data: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized, count = normalize_missing_thinking_signatures(data)
+        if count:
+            model = (normalized.get("message") or {}).get("model", "")
+            logger.warning(
+                "accepted %d unsigned thinking block(s) from vendor model %s",
+                count,
+                model or "<unknown>",
+            )
+        return normalized

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -2291,16 +2291,40 @@ def set_message_count(sid: str, message_count: int,
 # lock keeps the two independent.
 #
 # Shape: {"items": [{"id","text","display_text","selection_quotes",
-#                    "image_ids","permission",
-#                    "plan_return_permission","enqueued_at"}], "paused": bool}
+#                    "image_ids","permission","plan_return_permission",
+#                    "enqueued_at","delivery"?,"target_turn_id"?,
+#                    "command_uuid"?,"steering_state"?}], "paused": bool}
 #   - items: FIFO; head is sent next by the drain trigger in chat.py
 #   - paused: set True when a queued turn errors / hits ask_user_question /
 #     is user-cancelled; auto-drain stops until the user resumes
+#   - delivery="adjust": the live CLI owns delivery; the ordinary FIFO drain
+#     must not claim it until an explicit fallback changes delivery to "queue"
 #
 # Attachment ids resolve through chat.py's durable blob/SQLite registry. The
 # JSON sidecar deliberately retains only opaque ids and presentation data.
 _QUEUE_LOCK = threading.Lock()
 _QUEUE_MAX = 10   # mirror the frontend cap
+_QUEUE_DELIVERIES = frozenset({"adjust", "queue"})
+_QUEUE_STEERING_STATES = frozenset({
+    "pending",
+    "waiting_tool",
+    "queued",
+    "started",
+    "cancelled",
+    "fallback",
+})
+_QUEUE_ACTIVE_STEERING_STATES = frozenset({
+    "pending", "waiting_tool", "queued", "started",
+})
+_QUEUE_STEERING_STATE_RANK = {
+    "pending": 0,
+    "waiting_tool": 1,
+    "queued": 2,
+    "started": 3,
+}
+_QUEUE_STEERING_ITEM_FIELDS = (
+    "delivery", "target_turn_id", "command_uuid", "steering_state",
+)
 # Process-local deletion fence. It is always read/written under _QUEUE_LOCK.
 # Disk deletion alone is insufficient: a cancelled drain can retain an old
 # queue snapshot and otherwise write it back after unlink.
@@ -2319,6 +2343,40 @@ def _queue_path(sid: str) -> Path:
 
 def _empty_queue() -> dict:
     return {"revision": 0, "items": [], "inflight": None, "paused": False}
+
+
+def _normalize_queue_item(item: dict, *, strict: bool = False) -> dict:
+    """Return one canonical queue item without inventing steering metadata.
+
+    Steering fields are optional so sidecars created before native adjustment
+    support remain ordinary FIFO work. Compatibility reads normalize values in
+    memory only; the next mutation persists the canonical representation.
+    """
+    normalized = _normalize_session_permission_fields(item)
+    for field in _QUEUE_STEERING_ITEM_FIELDS:
+        if field not in normalized:
+            continue
+        value = normalized.get(field)
+        if strict and not isinstance(value, str):
+            raise ValueError(f"queue item {field} must be a string")
+        candidate = value.strip() if isinstance(value, str) else ""
+        if candidate:
+            normalized[field] = candidate
+        else:
+            normalized.pop(field, None)
+    if strict:
+        delivery = normalized.get("delivery", "")
+        if delivery and delivery not in _QUEUE_DELIVERIES:
+            raise ValueError("queue item delivery is invalid")
+        state = normalized.get("steering_state", "")
+        if state and state not in _QUEUE_STEERING_STATES:
+            raise ValueError("queue item steering_state is invalid")
+    return normalized
+
+
+def _queue_command_uuid(item: dict) -> str:
+    value = item.get("command_uuid")
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _load_queue(sid: str, *, strict: bool = False) -> dict:
@@ -2360,7 +2418,7 @@ def _load_queue(sid: str, *, strict: bool = False) -> dict:
             # Compatibility is read-only here: legacy Plan items immediately
             # behave as default-on-exit, while GET does not rewrite the file.
             d["items"] = [
-                _normalize_session_permission_fields(item)
+                _normalize_queue_item(item, strict=strict)
                 if isinstance(item, dict) else item
                 for item in d["items"]
             ]
@@ -2379,7 +2437,9 @@ def _load_queue(sid: str, *, strict: bool = False) -> dict:
                 raise ValueError("queue inflight must contain an item object")
             d["inflight"] = None
         else:
-            inflight_item = _normalize_session_permission_fields(inflight["item"])
+            inflight_item = _normalize_queue_item(
+                inflight["item"], strict=strict,
+            )
             inflight_id = str(inflight_item.get("id") or "")
             if strict and not inflight_id:
                 raise ValueError("queue inflight item must have an id")
@@ -2392,6 +2452,18 @@ def _load_queue(sid: str, *, strict: bool = False) -> dict:
                 "turn_id": str(inflight.get("turn_id") or ""),
                 "claimed_at": int(inflight.get("claimed_at") or 0),
             }
+        if strict:
+            command_uuids = [
+                _queue_command_uuid(item) for item in d["items"]
+                if _queue_command_uuid(item)
+            ]
+            inflight_command_uuid = _queue_command_uuid(
+                ((d.get("inflight") or {}).get("item") or {})
+            )
+            if inflight_command_uuid:
+                command_uuids.append(inflight_command_uuid)
+            if len(set(command_uuids)) != len(command_uuids):
+                raise ValueError("queue command_uuid values must be unique")
         if strict and not isinstance(d.get("paused"), bool):
             raise ValueError("queue paused must be a boolean")
         # ``paused`` only governs work still waiting in ``items``. The claimed
@@ -2418,14 +2490,14 @@ def _save_queue(sid: str, data: dict, *, bump: bool = True) -> bool:
     items = canonical.get("items")
     if isinstance(items, list):
         canonical["items"] = [
-            _normalize_session_permission_fields(item)
+            _normalize_queue_item(item)
             if isinstance(item, dict) else item
             for item in items
         ]
     inflight = canonical.get("inflight")
     if isinstance(inflight, dict) and isinstance(inflight.get("item"), dict):
         canonical["inflight"] = {
-            "item": _normalize_session_permission_fields(inflight["item"]),
+            "item": _normalize_queue_item(inflight["item"]),
             "turn_id": str(inflight.get("turn_id") or ""),
             "claimed_at": int(inflight.get("claimed_at") or 0),
         }
@@ -2552,6 +2624,11 @@ def _enqueue_message_locked(
     selection_quotes: list[dict] | None,
     plan_return_permission: str | None,
     item_id: str = "",
+    *,
+    delivery: str = "",
+    target_turn_id: str = "",
+    command_uuid: str = "",
+    steering_state: str = "",
 ) -> dict:
     """Append one item while the caller owns ``_QUEUE_LOCK``."""
     if sid in _DELETED_SESSION_IDS:
@@ -2575,6 +2652,29 @@ def _enqueue_message_locked(
         ),
         "enqueued_at": int(time.time() * 1000),
     }
+    optional_fields = {
+        "delivery": delivery,
+        "target_turn_id": target_turn_id,
+        "command_uuid": command_uuid,
+        "steering_state": steering_state,
+    }
+    item.update({key: value for key, value in optional_fields.items() if value})
+    item = _normalize_queue_item(item, strict=True)
+    queued_command_uuid = _queue_command_uuid(item)
+    if queued_command_uuid:
+        existing_items = list(data["items"])
+        inflight_item = ((data.get("inflight") or {}).get("item") or {})
+        if inflight_item:
+            existing_items.append(inflight_item)
+        if any(
+            _queue_command_uuid(existing) == queued_command_uuid
+            for existing in existing_items
+        ):
+            return {
+                "ok": False,
+                "error": "duplicate_command_uuid",
+                "queue": data,
+            }
     data["items"].append(item)
     _save_queue(sid, data)
     return {"ok": True, "item": item, "queue": data}
@@ -2586,7 +2686,11 @@ def enqueue_message(sid: str, text: str, image_ids: str = "",
                     selection_quotes: list[dict] | None = None,
                     plan_return_permission: str | None = None,
                     item_id: str = "",
-                    *, require_session: bool = False,
+                    *, delivery: str = "",
+                    target_turn_id: str = "",
+                    command_uuid: str = "",
+                    steering_state: str = "",
+                    require_session: bool = False,
                     existing_session: dict | None = None,
                     sdk_verified: bool = False) -> dict:
     """Append a message to the session's queue. Returns
@@ -2653,6 +2757,10 @@ def enqueue_message(sid: str, text: str, image_ids: str = "",
                     selection_quotes,
                     plan_return_permission,
                     item_id,
+                    delivery=delivery,
+                    target_turn_id=target_turn_id,
+                    command_uuid=command_uuid,
+                    steering_state=steering_state,
                 )
         return _enqueue_message_locked(
             sid,
@@ -2663,6 +2771,10 @@ def enqueue_message(sid: str, text: str, image_ids: str = "",
             selection_quotes,
             plan_return_permission,
             item_id,
+            delivery=delivery,
+            target_turn_id=target_turn_id,
+            command_uuid=command_uuid,
+            steering_state=steering_state,
         )
 
 
@@ -2675,6 +2787,11 @@ def enqueue_existing_message(
     selection_quotes: list[dict] | None = None,
     plan_return_permission: str | None = None,
     item_id: str = "",
+    *,
+    delivery: str = "",
+    target_turn_id: str = "",
+    command_uuid: str = "",
+    steering_state: str = "",
 ) -> dict:
     """Atomically resolve an existing session and append one queued message.
 
@@ -2722,6 +2839,10 @@ def enqueue_existing_message(
                     selection_quotes,
                     plan_return_permission,
                     item_id,
+                    delivery=delivery,
+                    target_turn_id=target_turn_id,
+                    command_uuid=command_uuid,
+                    steering_state=steering_state,
                 )
 
     # An SDK-only session needs a potentially slow workspace probe and a
@@ -2746,10 +2867,180 @@ def enqueue_existing_message(
             selection_quotes=selection_quotes,
             plan_return_permission=plan_return_permission,
             item_id=item_id,
+            delivery=delivery,
+            target_turn_id=target_turn_id,
+            command_uuid=command_uuid,
+            steering_state=steering_state,
             require_session=True,
             existing_session=current,
             sdk_verified=sdk_verified,
         )
+
+
+def _find_queue_item(
+    data: dict,
+    *,
+    item_id: str = "",
+    command_uuid: str = "",
+) -> tuple[str, int | None, dict] | None:
+    """Locate exactly one waiting/inflight item using stable identifiers."""
+    wanted_id = str(item_id or "").strip()
+    wanted_command_uuid = str(command_uuid or "").strip()
+    if not wanted_id and not wanted_command_uuid:
+        raise ValueError("item_id or command_uuid is required")
+
+    matches: list[tuple[str, int | None, dict]] = []
+    for index, item in enumerate(data.get("items") or []):
+        if wanted_id and str(item.get("id") or "") != wanted_id:
+            continue
+        if (
+            wanted_command_uuid
+            and _queue_command_uuid(item) != wanted_command_uuid
+        ):
+            continue
+        matches.append(("items", index, item))
+    inflight_item = ((data.get("inflight") or {}).get("item") or {})
+    if inflight_item:
+        if (
+            (not wanted_id or str(inflight_item.get("id") or "") == wanted_id)
+            and (
+                not wanted_command_uuid
+                or _queue_command_uuid(inflight_item) == wanted_command_uuid
+            )
+        ):
+            matches.append(("inflight", None, inflight_item))
+    if len(matches) > 1:
+        # Strict loads enforce both identifiers' uniqueness. Keep this guard so
+        # future schema changes cannot make a terminal update remove two items.
+        raise RuntimeError("queue item selector is ambiguous")
+    return matches[0] if matches else None
+
+
+def update_queue_steering_state(
+    sid: str,
+    steering_state: str,
+    *,
+    item_id: str = "",
+    command_uuid: str = "",
+    pause: bool = False,
+) -> dict | None:
+    """Atomically transition one native-adjustment item.
+
+    Non-terminal states stay durable, including ``started``. ``completed`` is
+    the sole terminal update that removes the exact matched item and returns
+    its full payload so chat.py can finish attachment ownership separately.
+    A cancelled command remains visible and pauses the waiting queue.
+    """
+    state = str(steering_state or "").strip()
+    if state != "completed" and state not in _QUEUE_STEERING_STATES:
+        raise ValueError("invalid queue steering_state")
+    with _QUEUE_LOCK:
+        if sid in _DELETED_SESSION_IDS:
+            return None
+        data = _load_queue(sid, strict=True)
+        found = _find_queue_item(
+            data, item_id=item_id, command_uuid=command_uuid,
+        )
+        if found is None:
+            return None
+        location, index, item = found
+        current_state = str(item.get("steering_state") or "")
+        if (
+            current_state == "cancelled"
+            and state in _QUEUE_STEERING_STATE_RANK
+        ):
+            # Cancellation is terminal from the durable queue's perspective.
+            # The HTTP writer can still finish its post-query waiting_tool
+            # update after Stop/cancel has already won; never resurrect a CLI
+            # command that the UI now correctly treats as paused for review.
+            return dict(item)
+        if (
+            state in _QUEUE_STEERING_STATE_RANK
+            and current_state in _QUEUE_STEERING_STATE_RANK
+            and _QUEUE_STEERING_STATE_RANK[current_state]
+            > _QUEUE_STEERING_STATE_RANK[state]
+        ):
+            # HTTP write completion and stdout lifecycle frames are handled by
+            # independent tasks. A fast `queued`/`started` ACK can overtake the
+            # post-write `waiting_tool` persistence; never let that race move
+            # the durable UI state backwards.
+            return dict(item)
+        updated = dict(item)
+        updated["steering_state"] = state
+
+        if state == "completed":
+            if location == "inflight":
+                data["inflight"] = None
+            else:
+                assert index is not None
+                data["items"].pop(index)
+            _save_queue(sid, data)
+            return updated
+
+        changed = updated != item
+        if state == "cancelled" and location == "inflight":
+            # A native-adjustment item should never enter the ordinary inflight
+            # slot, but preserving and pausing it is safer than leaving a
+            # cancelled item owned by a nonexistent turn after a race/upgrade.
+            data["inflight"] = None
+            data["items"].insert(0, updated)
+            location = "items"
+            changed = True
+        elif location == "inflight":
+            data["inflight"]["item"] = updated
+        else:
+            assert index is not None
+            data["items"][index] = updated
+
+        if (pause or state == "cancelled") and data["items"]:
+            if not data.get("paused"):
+                changed = True
+            data["paused"] = True
+        if changed:
+            _save_queue(sid, data)
+        return updated
+
+
+def fallback_queue_steering(
+    sid: str,
+    *,
+    item_id: str = "",
+    command_uuid: str = "",
+) -> dict | None:
+    """Atomically detach one failed native command into the ordinary FIFO.
+
+    The old target/command identifiers are removed so a late lifecycle event
+    cannot consume the fallback turn. Text, selection data and attachment ids
+    remain owned by the same queue item. A defensive inflight match is restored
+    to the FIFO head; an already-waiting item keeps its relative position.
+    """
+    with _QUEUE_LOCK:
+        if sid in _DELETED_SESSION_IDS:
+            return None
+        data = _load_queue(sid, strict=True)
+        found = _find_queue_item(
+            data, item_id=item_id, command_uuid=command_uuid,
+        )
+        if found is None:
+            return None
+        location, index, item = found
+        updated = dict(item)
+        updated["delivery"] = "queue"
+        updated["steering_state"] = "fallback"
+        updated.pop("target_turn_id", None)
+        updated.pop("command_uuid", None)
+
+        changed = updated != item
+        if location == "inflight":
+            data["inflight"] = None
+            data["items"].insert(0, updated)
+            changed = True
+        else:
+            assert index is not None
+            data["items"][index] = updated
+        if changed:
+            _save_queue(sid, data)
+        return updated
 
 
 def claim_queue_message(sid: str) -> dict | None:
@@ -2764,6 +3055,14 @@ def claim_queue_message(sid: str) -> dict | None:
             return None
         data = _load_queue(sid, strict=True)
         if data.get("inflight") or data.get("paused") or not data["items"]:
+            return None
+        head = data["items"][0]
+        if (
+            head.get("delivery") == "adjust"
+            and head.get("steering_state") in _QUEUE_ACTIVE_STEERING_STATES
+        ):
+            # The live CLI has accepted (or may already have executed) this
+            # command. Never skip over it or launch a duplicate ordinary turn.
             return None
         item = data["items"].pop(0)
         data["inflight"] = {
@@ -2842,8 +3141,10 @@ def recover_queue_inflight(sid: str) -> dict:
     A bound claim may already have performed external side effects.  An
     unbound claim is safe from duplicate execution, but the process restart
     still erased the preceding turn's in-memory terminal truth and all staged
-    attachments.  Restore either claim exactly once, then pause every surviving
-    item so only an explicit user review/resume can execute it.
+    attachments. Native-adjustment items already waiting are equally
+    uncertain: the CLI may have accepted/executed them before MuseLab persisted
+    its lifecycle ACK. Detach their dead CLI ownership, retain every payload,
+    then pause all surviving work so only explicit review/resume can execute it.
     """
     with _QUEUE_LOCK:
         if sid in _DELETED_SESSION_IDS:
@@ -2859,6 +3160,25 @@ def recover_queue_inflight(sid: str) -> dict:
                                    for row in data["items"]):
                 data["items"].insert(0, item)
             changed = True
+        for index, waiting in enumerate(data["items"]):
+            if (
+                waiting.get("delivery") == "adjust"
+                and waiting.get("steering_state")
+                in _QUEUE_ACTIVE_STEERING_STATES
+            ):
+                # Process restart destroys the CLI command queue and its
+                # lifecycle reader. Retain the user's exact payload, but detach
+                # the now-unverifiable native owner and pause it as cancelled.
+                # An explicit Resume can then run it as an ordinary turn, while
+                # Delete/Clear remain available if the user suspects it already
+                # executed before the crash.
+                recovered = dict(waiting)
+                recovered["delivery"] = "queue"
+                recovered["steering_state"] = "cancelled"
+                recovered.pop("target_turn_id", None)
+                recovered.pop("command_uuid", None)
+                data["items"][index] = recovered
+                changed = True
         should_pause = bool(data["items"])
         if bool(data.get("paused")) != should_pause:
             data["paused"] = should_pause
@@ -2880,7 +3200,7 @@ def requeue_head(sid: str, item: dict) -> dict:
         data = _load_queue(sid, strict=True)
         if not any(str(row.get("id") or "") == item_id
                    for row in data["items"]):
-            data["items"].insert(0, _normalize_session_permission_fields(item))
+            data["items"].insert(0, _normalize_queue_item(item))
             _save_queue(sid, data)
         return data
 
@@ -2932,6 +3252,38 @@ def clear_queue_with_removed(sid: str) -> tuple[dict, tuple[str, ...]]:
         current["items"] = []
         current["paused"] = False
         _save_queue(sid, current)
+        return current, removed
+
+
+def remove_queue_items_with_removed(
+    sid: str,
+    item_ids: list[str] | tuple[str, ...] | set[str],
+) -> tuple[dict, tuple[str, ...]]:
+    """Remove only the waiting ids captured by a caller's queue snapshot.
+
+    Unlike ``clear_queue_with_removed``, this is safe when a concurrent enqueue
+    commits after that snapshot: the new row is not silently deleted. An item
+    that became inflight in the meantime is likewise left under its turn's
+    ownership and omitted from the returned removal receipt.
+    """
+    wanted = {str(item_id or "") for item_id in item_ids}
+    wanted.discard("")
+    with _QUEUE_LOCK:
+        current = _load_queue(sid, strict=True)
+        removed = tuple(
+            str(item.get("id") or "")
+            for item in current["items"]
+            if str(item.get("id") or "") in wanted
+        )
+        if removed:
+            removed_set = set(removed)
+            current["items"] = [
+                item for item in current["items"]
+                if str(item.get("id") or "") not in removed_set
+            ]
+            if not current["items"]:
+                current["paused"] = False
+            _save_queue(sid, current)
         return current, removed
 
 

--- a/docs/codex-gateway.md
+++ b/docs/codex-gateway.md
@@ -10,11 +10,10 @@ request to the user's own Codex/OpenAI backend and translates the response back.
 muselab does **not** store Codex OAuth credentials and does **not** call
 OpenAI-native APIs directly.
 
-The compatibility baseline tested on 2026-08-12 is CLIProxyAPI `v7.2.111`,
-Claude Agent SDK `0.2.136`, and its bundled Claude CLI `2.1.228`. Newer
-CLIProxyAPI builds include fixes relevant to this bridge for Codex cache-token
-accounting, reasoning effort, tool-call replay, and Anthropic response
-translation.
+The compatibility baseline tested on 2026-08-30 is CLIProxyAPI `v7.2.145`,
+Claude Agent SDK `0.2.148`, and its bundled Claude CLI `2.1.251`. This baseline
+includes fixes relevant to this bridge for Codex cache-token accounting,
+reasoning effort, tool-call replay, and Anthropic response translation.
 
 ```text
 muselab → Claude Agent SDK → Anthropic Messages request

--- a/docs/codex-gateway_zh.md
+++ b/docs/codex-gateway_zh.md
@@ -6,10 +6,10 @@ muselab 通过**本地 Anthropic 兼容网关**支持 Codex 后端模型。网�
 
 muselab **不保存 Codex OAuth 凭据**，也**不直接调用 OpenAI 原生接口**。
 
-截至 2026-08-12，已验证的兼容基线是 CLIProxyAPI `v7.2.111`、Claude Agent
-SDK `0.2.136` 以及其内置 Claude CLI `2.1.228`。新版 CLIProxyAPI 对这条
-链路相关的 Codex 缓存 token 统计、reasoning effort、工具调用回放和
-Anthropic 响应转换都有修复。
+截至 2026-08-30，已验证的兼容基线是 CLIProxyAPI `v7.2.145`、Claude Agent
+SDK `0.2.148` 以及其内置 Claude CLI `2.1.251`。这套基线包含这条链路所需的
+Codex 缓存 token 统计、reasoning effort、工具调用回放和 Anthropic 响应
+转换修复。
 
 ```text
 muselab → Claude Agent SDK → Anthropic Messages 请求

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ muselab configuration has four layers. Not every setting belongs in `.env`:
 3. **Durable runtime state:** sessions, scheduler, Activity, Push, and image-generation jobs.
 4. **Browser preferences:** language, layout, open tabs, and other local UI state.
 
-Restart after editing `.env` manually. Provider keys, default model, and default permission saved in Settings are written atomically to the file selected by `MUSELAB_ENV_PATH` and to the current process, so they normally apply without restart. The UI does not expose the token, root directory, or bind address.
+Restart after editing `.env` manually. Provider keys, default model, default permission, and busy-send behavior saved in Settings are written atomically to the file selected by `MUSELAB_ENV_PATH` and to the current process, so they normally apply without restart. The UI does not expose the token, root directory, or bind address.
 
 ## Required and network settings
 
@@ -25,6 +25,7 @@ Restart after editing `.env` manually. Provider keys, default model, and default
 | `MUSELAB_MODEL` | Default model for new sessions; the built-in Claude default is effective when unset | `claude-sonnet-4-6` |
 | `MUSELAB_DEFAULT_MODEL` | Settings-managed default, synchronized with `MUSELAB_MODEL` | `claude-sonnet-4-6` |
 | `MUSELAB_DEFAULT_PERMISSION` | Default SDK permission mode | `bypassPermissions` |
+| `MUSELAB_BUSY_SEND_MODE` | Busy-session send behavior: `adjust` steers the current task at the next safe tool boundary; `queue` waits for the current turn to finish | `adjust` |
 | `MUSELAB_MEMORY_DIR` | Optional long-term-memory Registry/config directory | `$MUSELAB_ROOT/.muselab/memory` |
 
 `MUSELAB_ROOT` must exist. System-level roots such as `/`, `/etc`, `/root`, `/home`, `/var`, `/usr`, and `/boot` are rejected. A user's own home directory or a directory beneath it is allowed. Older documentation called this the archive root; the environment-variable name remains compatible, while the product concept is now the primary workspace.

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -9,7 +9,7 @@ muselab 的配置分成四层。不要把所有状态都理解为 `.env`：
 3. **持久化运行状态**：会话、调度、Activity、Push 和生图任务。
 4. **浏览器偏好**：语言、布局、打开的 Tab 等本地 UI 状态。
 
-手动修改 `.env` 后应重启服务。设置面板保存的 provider key、默认模型和默认权限会原子更新 `MUSELAB_ENV_PATH` 指向的文件与当前进程，通常无需重启。设置面板不会开放 token、根目录或监听地址。
+手动修改 `.env` 后应重启服务。设置面板保存的 provider key、默认模型、默认权限和忙时发送方式会原子更新 `MUSELAB_ENV_PATH` 指向的文件与当前进程，通常无需重启。设置面板不会开放 token、根目录或监听地址。
 
 ## 必需与网络设置
 
@@ -25,6 +25,7 @@ muselab 的配置分成四层。不要把所有状态都理解为 `.env`：
 | `MUSELAB_MODEL` | 新会话默认模型；未设置时使用内置 Claude 默认值 | `claude-sonnet-4-6` |
 | `MUSELAB_DEFAULT_MODEL` | 设置面板保存的默认模型，与 `MUSELAB_MODEL` 同步 | `claude-sonnet-4-6` |
 | `MUSELAB_DEFAULT_PERMISSION` | 新会话默认 SDK 权限模式 | `bypassPermissions` |
+| `MUSELAB_BUSY_SEND_MODE` | 会话忙碌时的发送方式：`adjust` 在下一个安全的工具边界调整当前任务；`queue` 等当前 turn 完成后再执行 | `adjust` |
 | `MUSELAB_MEMORY_DIR` | 可选的长期记忆 Registry／配置目录 | `$MUSELAB_ROOT/.muselab/memory` |
 
 `MUSELAB_ROOT` 必须存在。`/`、`/etc`、`/root`、`/home`、`/var`、`/usr`、`/boot` 等系统级根路径会被拒绝；用户自己的 home 或其子目录可以使用。旧版本文档曾称它为 archive root；环境变量名为兼容已有部署而保留，当前产品概念统一为“主工作区”。

--- a/docs/tool-catalog.txt
+++ b/docs/tool-catalog.txt
@@ -6,7 +6,6 @@ DesignSync
 Edit
 EnterWorktree
 ExitWorktree
-ListAgents
 Monitor
 NotebookEdit
 PushNotification
@@ -16,12 +15,9 @@ ScheduleWakeup
 SendMessage
 Skill
 Task
-TaskCreate
-TaskGet
-TaskList
 TaskOutput
 TaskStop
-TaskUpdate
+ToolSearch
 WebFetch
 WebSearch
 Workflow

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8387,12 +8387,35 @@ function portal() {
       }
       return "";
     },
+    _busySendDelivery(sid, activeTurnId = undefined, hasAttachments = undefined) {
+      if (this._normalizeBusySendMode(this.busySendMode) !== "adjust") {
+        return "queue";
+      }
+      const st = sid && this.tabState && this.tabState[sid];
+      const turnId = activeTurnId === undefined
+        ? String((st && st.activeTurnId) || "")
+        : String(activeTurnId || "");
+      const draft = (st && st.draft) || {};
+      const attachmentIntent = hasAttachments === undefined
+        ? !!((draft.pendingImages || []).length || (draft.pendingDocs || []).length)
+        : !!hasAttachments;
+      // Native SDK steering is bound to one immutable foreground turn and is
+      // text-only.  Every state that is already known to be ineligible should
+      // advertise ordinary FIFO immediately instead of briefly promising an
+      // adjustment that the queue endpoint must downgrade after the POST.
+      if (!st || !turnId || attachmentIntent || st.compacting
+          || st.backgroundActive || st._draining || st.parentTurnId
+          || (st.pendingQueue && st.pendingQueue.length)) {
+        return "queue";
+      }
+      return "adjust";
+    },
     sendButtonHint(sid) {
       if (this.composerClaimed(sid)) return this.t("btn.send");
       const disabled = this.composerDisabledReason(sid);
       if (disabled) return disabled;
       if (!this._isBusy(sid)) return this.t("btn.send");
-      return this._normalizeBusySendMode(this.busySendMode) === "adjust"
+      return this._busySendDelivery(sid) === "adjust"
         ? (this.lang === "zh" ? "尽快调整当前任务" : "Adjust the current task soon")
         : this.t("queue.button_hint");
     },
@@ -29245,6 +29268,11 @@ function portal() {
       // backend can reject stale steering rather than targeting a successor.
       const busyActiveTurnId = !isReconnect
         ? String(sendState.activeTurnId || "") : "";
+      const busyHasAttachments = !isReconnect
+        && !!(composerImages.length || composerDocs.length);
+      const busyDelivery = this._busySendDelivery(
+        sendSid, busyActiveTurnId, busyHasAttachments,
+      );
       // Resume only when this pane still owns the exact same immutable turn.
       // A cold reload or ABA turn change has no trustworthy checkpoint and uses
       // the full replay path (sequence zero). Mid-turn transport reconnects keep
@@ -29367,6 +29395,7 @@ function portal() {
           // admission is authoritative.
           _admissionPending: true,
           _optimisticQueue: !resumed && this._isBusy(sendSid),
+          _optimisticDelivery: busyDelivery,
           displayText: hasDetachedText ? detachedDisplayText : composerInput,
           selectionQuotes: composerQuotes.map(q => ({ ...q })),
           images: readyImages.map(im => ({
@@ -29426,6 +29455,7 @@ function portal() {
           pendingQuotes: composerQuotes,
           permission: sendPermission,
           plan_return_permission: sendPlanReturnPermission,
+          delivery: busyDelivery,
           active_turn_id: busyActiveTurnId,
         });
         if (!ok) {
@@ -29670,6 +29700,7 @@ function portal() {
                   pendingQuotes: hasDetachedText ? [] : composerQuotes,
                   permission: sendPermission,
                   plan_return_permission: sendPlanReturnPermission,
+                  delivery: busyDelivery,
                   active_turn_id: busyActiveTurnId,
                 });
                 if (queued) {
@@ -31112,7 +31143,17 @@ function portal() {
         // items never re-enqueue, which prevents duplicates.
         if (serverError && errKind === "turn_busy"
             && !isReconnect && !resumed) {
-          if (sentUserBubble) sentUserBubble._optimisticQueue = true;
+          const handoffTurnId = String(
+            errorMeta.active_turn_id || errorMeta.turn_id
+            || busyActiveTurnId || "",
+          );
+          const handoffDelivery = this._busySendDelivery(
+            streamSid, handoffTurnId, busyHasAttachments,
+          );
+          if (sentUserBubble) {
+            sentUserBubble._optimisticQueue = true;
+            sentUserBubble._optimisticDelivery = handoffDelivery;
+          }
           streamState._busyQueueHandoff = es;
           try { es.close(); } catch (_) {}
           const queued = await this._enqueueMessage(streamSid, {
@@ -31123,10 +31164,8 @@ function portal() {
             pendingQuotes: hasDetachedText ? [] : composerQuotes,
             permission: sendPermission,
             plan_return_permission: sendPlanReturnPermission,
-            active_turn_id: String(
-              errorMeta.active_turn_id || errorMeta.turn_id
-              || busyActiveTurnId || "",
-            ),
+            delivery: handoffDelivery,
+            active_turn_id: handoffTurnId,
           });
           if (queued) {
             if (sentUserBubble) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -313,6 +313,7 @@ function _pruneChatResourceTicketCache(now) {
 const CHAT_MUX_STREAM_EVENTS = [
   "startup", "text", "thinking", "tool_use", "tool_result",
   "compact_progress", "task_started", "task_progress", "task_notification",
+  "queue_steering",
   "rate_limit", "ask_user_question", "permission_request",
   "permission_request_resolved", "permission_mode_changed",
   "permission_mode_change_failed", "ping", "done", "error", "cancelled",
@@ -908,6 +909,10 @@ function portal() {
     // Configured default for NEW sessions. Kept separate from `permission`,
     // which always mirrors the currently viewed session.
     defaultPermission: "bypassPermissions",
+    // Global busy-send preference. New clients ask the backend to steer the
+    // active turn at its next safe tool boundary; the backend may downgrade an
+    // ineligible prompt (attachments, stale/missing turn id) to durable FIFO.
+    busySendMode: "adjust",
     permission: "bypassPermissions",
     // Mobile-only: collapses the per-session settings (permission / effort)
     // behind a gear in the composer toolbar so the row stays single-line on
@@ -1169,7 +1174,7 @@ function portal() {
       show: false,
       providers: [],
       draftKeys: {},
-      draftDefaults: { model: "", permission: "" },
+      draftDefaults: { model: "", permission: "", busy_send_mode: "adjust" },
       // (Removed 2026-05-28) draftParams — used to carry notify_scheduled /
       // notify_normal server-side toggles. Subscription state is now the
       // sole on/off; see `notifyEnabled` at the top of this object.
@@ -6440,6 +6445,7 @@ function portal() {
         schema: 10,         // v10 moves openTabIds to a versioned standalone key
         model: this.model, defaultModel: this.defaultModel,
         permission: this.permission, defaultPermission: this.defaultPermission,
+        busySendMode: this.busySendMode,
         currentId: this.currentId,
         previewTabs: this.tabs.map(t => this._previewTabSnapshot(t)),
         previewSelected: this.selected,
@@ -6500,6 +6506,9 @@ function portal() {
         // The server-authoritative value arrives next via fetchStats() regardless,
         // so leaving defaultPermission untouched when absent is correct & safe.
         if (p.defaultPermission) this.defaultPermission = p.defaultPermission;
+        if (p.busySendMode) {
+          this.busySendMode = this._normalizeBusySendMode(p.busySendMode);
+        }
         if (typeof p.activeWorkspace === "string") this.activeWorkspace = p.activeWorkspace;
         if (p.workspaceLastSession && typeof p.workspaceLastSession === "object"
             && !Array.isArray(p.workspaceLastSession)) {
@@ -6620,6 +6629,10 @@ function portal() {
             if (d.default_model) { this.defaultModel = d.default_model; this.savePrefs(); }
             if (d.default_permission) {
               this.defaultPermission = d.default_permission;
+              this.savePrefs();
+            }
+            if (d.busy_send_mode) {
+              this.busySendMode = this._normalizeBusySendMode(d.busy_send_mode);
               this.savePrefs();
             }
             this._ensureValidModel();
@@ -7190,6 +7203,10 @@ function portal() {
         "bypassPermissions", "acceptEdits", "default",
         "dontAsk", "auto", "plan",
       ].includes(mode) ? mode : fallback;
+    },
+    _normalizeBusySendMode(value, fallback = "adjust") {
+      const mode = String(value || "");
+      return mode === "adjust" || mode === "queue" ? mode : fallback;
     },
     _sessionPermissionMode(sid) {
       if (!sid) {
@@ -8374,7 +8391,10 @@ function portal() {
       if (this.composerClaimed(sid)) return this.t("btn.send");
       const disabled = this.composerDisabledReason(sid);
       if (disabled) return disabled;
-      return this._isBusy(sid) ? this.t("queue.button_hint") : this.t("btn.send");
+      if (!this._isBusy(sid)) return this.t("btn.send");
+      return this._normalizeBusySendMode(this.busySendMode) === "adjust"
+        ? (this.lang === "zh" ? "尽快调整当前任务" : "Adjust the current task soon")
+        : this.t("queue.button_hint");
     },
     _setComposerClaimPhase(st, token, phase) {
       if (st && st._composerSubmitToken === token) {
@@ -8518,6 +8538,47 @@ function portal() {
     // read-only mirror in st.pendingQueue + st._queuePaused for rendering and
     // refreshes it via _syncQueueFromServer on load / tab-activate / after any
     // turn or mutation. Every mutation below hits an endpoint then re-syncs.
+    queueDeliveryLabel(item) {
+      const state = String(item && item.deliveryStatus || "");
+      const delivery = this._normalizeBusySendMode(
+        item && item.delivery,
+        "queue",
+      );
+      if (delivery !== "adjust" || state === "fallback"
+          || state === "cancelled") {
+        return this.lang === "zh" ? "排队中" : "Queued";
+      }
+      if (state === "started") {
+        return this.lang === "zh" ? "已交给当前任务" : "Handed to current task";
+      }
+      return this.lang === "zh"
+        ? "等待当前工具完成" : "Waiting for current tool";
+    },
+    _applyQueueSteeringEvent(sid, payload) {
+      const st = sid && this.tabState[sid];
+      const itemId = String(payload && payload.item_id || "");
+      const state = String(payload && payload.state || "");
+      if (!st || !itemId || !state) return;
+      if (state === "completed") {
+        st.pendingQueue = (st.pendingQueue || []).filter(q => q.id !== itemId);
+        return;
+      }
+      const item = (st.pendingQueue || []).find(q => q.id === itemId);
+      if (!item) {
+        this._syncQueueFromServer(sid);
+        return;
+      }
+      item.delivery = this._normalizeBusySendMode(
+        payload.effective_delivery || item.delivery,
+        "queue",
+      );
+      item.deliveryStatus = state;
+      if (state === "fallback") item.delivery = "queue";
+      if (state === "cancelled") st._queuePaused = true;
+      // Replace the array so Alpine updates the status text immediately even
+      // when the item object originated from the POST acceptance mirror.
+      st.pendingQueue = [...st.pendingQueue];
+    },
     async _syncQueueFromServer(sid, options = {}) {
       if (!sid) return;
       const st = this._ensureTabState(sid);
@@ -8573,6 +8634,9 @@ function portal() {
           expiredCount,
           pendingImages: [],
           pendingDocs: [],
+          delivery: this._normalizeBusySendMode(it.delivery, "queue"),
+          deliveryStatus: String(it.steering_state
+            || (it.delivery === "adjust" ? "pending" : "queued")),
           enqueuedAt: it.enqueued_at || Date.now(),
         };
       });
@@ -8647,6 +8711,10 @@ function portal() {
             "",
           )
         : "";
+      const delivery = this._normalizeBusySendMode(
+        item.delivery || this.busySendMode,
+      );
+      const activeTurnId = String(item.active_turn_id || "");
       let accepted = null;
       try {
         const r = await fetch("/api/chat/sessions/" + sid + "/queue", {
@@ -8659,7 +8727,9 @@ function portal() {
                                  display_text: item.displayText || "",
                                  selection_quotes: item.pendingQuotes || [],
                                  permission,
-                                 plan_return_permission: planReturnPermission }),
+                                 plan_return_permission: planReturnPermission,
+                                 delivery,
+                                 active_turn_id: activeTurnId }),
         });
         if (r.status === 409) {
           this.toast(this.lang === "zh"
@@ -8690,10 +8760,29 @@ function portal() {
       const mirrorState = successor && successor._handoffSourceSid === sid
         ? successor : (this.tabState[sid] === enqueueState ? enqueueState : null);
       const mirrorSid = mirrorState === successor ? successorSid : sid;
+      // Steering lifecycle can complete before the HTTP continuation resumes.
+      // In that race `accepted.item` may be the earlier waiting snapshot while
+      // `accepted.queue.items` already proves it was removed (or cancelled).
+      // Prefer the authoritative queue snapshot whenever the backend supplied it
+      // so a completed adjustment never flashes back as a queued row.
+      const acceptedQueueItems = accepted && accepted.queue
+        && Array.isArray(accepted.queue.items) ? accepted.queue.items : null;
+      const acceptedQueueItem = acceptedQueueItems && accepted.item
+        ? acceptedQueueItems.find(q => q.id === accepted.item.id) : null;
+      const acceptedItem = acceptedQueueItems === null
+        ? (accepted && accepted.item) : acceptedQueueItem;
       if (mirrorState
-          && accepted && accepted.item && accepted.item.id
-          && !mirrorState.pendingQueue.some(q => q.id === accepted.item.id)) {
-        const queued = accepted.item;
+          && acceptedItem && acceptedItem.id
+          && !mirrorState.pendingQueue.some(q => q.id === acceptedItem.id)) {
+        const queued = acceptedItem;
+        const effectiveDelivery = this._normalizeBusySendMode(
+          queued.delivery || accepted.effective_delivery,
+          "queue",
+        );
+        const deliveryStatus = String(
+          queued.steering_state || accepted.delivery_status
+          || (effectiveDelivery === "adjust" ? "pending" : "queued"),
+        );
         const optimisticImages = (item.pendingImages || [])
           .filter(im => im.id && !im.error)
           .map(im => ({
@@ -8725,14 +8814,17 @@ function portal() {
             expiredCount: 0,
             pendingImages: [],
             pendingDocs: [],
+            delivery: effectiveDelivery,
+            deliveryStatus,
             enqueuedAt: queued.enqueued_at || Date.now(),
           },
         ];
-        const acceptedRevision = Number(accepted.queue && accepted.queue.revision);
-        if (Number.isFinite(acceptedRevision)) {
-          mirrorState._queueRevision = Math.max(
-            Number(mirrorState._queueRevision) || 0, acceptedRevision);
-        }
+      }
+      const acceptedRevision = Number(accepted && accepted.queue
+        && accepted.queue.revision);
+      if (mirrorState && Number.isFinite(acceptedRevision)) {
+        mirrorState._queueRevision = Math.max(
+          Number(mirrorState._queueRevision) || 0, acceptedRevision);
       }
       if (mirrorState === successor) {
         // The handoff's first attach probe may have observed the child before
@@ -17638,9 +17730,18 @@ function portal() {
         d.providers.map(p => [p.id, this._draftFromProvider(p)])
       );
       this.settings.providerNew = { show: false, base_url: "", prefix: "", models: "", api_key: "" };
-      this.settings.draftDefaults = { ...d.defaults };
+      this.settings.draftDefaults = {
+        ...d.defaults,
+        busy_send_mode: this._normalizeBusySendMode(
+          d.defaults && d.defaults.busy_send_mode,
+        ),
+      };
       if (d.defaults && d.defaults.permission) {
         this.defaultPermission = d.defaults.permission;
+        this.savePrefs();
+      }
+      if (d.defaults && d.defaults.busy_send_mode) {
+        this.busySendMode = this._normalizeBusySendMode(d.defaults.busy_send_mode);
         this.savePrefs();
       }
       // `d.params` is empty since 2026-05-28 (kept as {} for FE back-compat).
@@ -18768,6 +18869,10 @@ function portal() {
             this.defaultPermission = d.default_permission;
             this.savePrefs();
           }
+          if (d.busy_send_mode) {
+            this.busySendMode = this._normalizeBusySendMode(d.busy_send_mode);
+            this.savePrefs();
+          }
           this._ensureValidModel();
         }
       } catch (e) {
@@ -19017,6 +19122,9 @@ function portal() {
       const body = {
         default_model: this.settings.draftDefaults.model,
         default_permission: this.settings.draftDefaults.permission,
+        busy_send_mode: this._normalizeBusySendMode(
+          this.settings.draftDefaults.busy_send_mode,
+        ),
       };
       // Send every typed provider key through the generic provider_keys
       // map. Backend whitelists against PROVIDER_KEYS (derived from
@@ -19073,6 +19181,13 @@ function portal() {
         const newDefaultPerm = this.settings.draftDefaults.permission;
         if (newDefaultPerm && newDefaultPerm !== this.defaultPermission) {
           this.defaultPermission = newDefaultPerm;
+          this.savePrefs();
+        }
+        const newBusySendMode = this._normalizeBusySendMode(
+          this.settings.draftDefaults.busy_send_mode,
+        );
+        if (newBusySendMode !== this.busySendMode) {
+          this.busySendMode = newBusySendMode;
           this.savePrefs();
         }
         // 刷新可用 provider 列表
@@ -29124,6 +29239,12 @@ function portal() {
       const expectedTurnId = isReconnect
         ? (opts.turnId || sendState.activeTurnId || "")
         : "";
+      // Preserve the exact turn that was active when the user pressed Send.
+      // The direct-turn path clears activeTurnId below while it attempts fresh
+      // admission; busy delivery still needs the old immutable id so the
+      // backend can reject stale steering rather than targeting a successor.
+      const busyActiveTurnId = !isReconnect
+        ? String(sendState.activeTurnId || "") : "";
       // Resume only when this pane still owns the exact same immutable turn.
       // A cold reload or ABA turn change has no trustworthy checkpoint and uses
       // the full replay path (sequence zero). Mid-turn transport reconnects keep
@@ -29245,7 +29366,7 @@ function portal() {
           // owns a turn or a queue slot.  Keep pane-level Running hidden until
           // admission is authoritative.
           _admissionPending: true,
-          _optimisticQueue: false,
+          _optimisticQueue: !resumed && this._isBusy(sendSid),
           displayText: hasDetachedText ? detachedDisplayText : composerInput,
           selectionQuotes: composerQuotes.map(q => ({ ...q })),
           images: readyImages.map(im => ({
@@ -29305,6 +29426,7 @@ function portal() {
           pendingQuotes: composerQuotes,
           permission: sendPermission,
           plan_return_permission: sendPlanReturnPermission,
+          active_turn_id: busyActiveTurnId,
         });
         if (!ok) {
           rollbackOptimisticSubmission();
@@ -29548,6 +29670,7 @@ function portal() {
                   pendingQuotes: hasDetachedText ? [] : composerQuotes,
                   permission: sendPermission,
                   plan_return_permission: sendPlanReturnPermission,
+                  active_turn_id: busyActiveTurnId,
                 });
                 if (queued) {
                   rollbackUnstartedSend(false);
@@ -30223,6 +30346,11 @@ function portal() {
         // completion feedback is the durable Agent continuation bubble; its
         // revision adoption owns the off-screen unread dot exactly once.
         _scrollIfActive();
+      });
+      es.addEventListener("queue_steering", ev => {
+        let payload = {};
+        try { payload = JSON.parse(ev.data) || {}; } catch (_) {}
+        this._applyQueueSteeringEvent(streamSid, payload);
       });
       es.addEventListener("rate_limit", ev => {
         let d;
@@ -30995,6 +31123,10 @@ function portal() {
             pendingQuotes: hasDetachedText ? [] : composerQuotes,
             permission: sendPermission,
             plan_return_permission: sendPlanReturnPermission,
+            active_turn_id: String(
+              errorMeta.active_turn_id || errorMeta.turn_id
+              || busyActiveTurnId || "",
+            ),
           });
           if (queued) {
             if (sentUserBubble) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2098,7 +2098,7 @@
                         <span class="user-msg-text" x-show="userVisibleText(m)"
                               x-html="userTextHtml(userVisibleText(m))"></span>
                       </template>
-                      <div x-show="m._optimisticQueue"
+                      <div x-show="m._admissionPending"
                            class="optimistic-queue-status"
                            role="status"
                            aria-live="polite"
@@ -2106,7 +2106,9 @@
                         <span class="queued-icon" aria-hidden="true">
                           <svg><use href="#i-clock"/></svg>
                         </span>
-                        <span x-text="lang==='zh' ? '排队中' : 'Queueing'"></span>
+                        <span x-text="m._optimisticQueue
+                          ? (lang==='zh' ? '正在确认发送方式' : 'Confirming delivery')
+                          : (lang==='zh' ? '正在发送' : 'Sending')"></span>
                       </div>
                     </div>
                   </div>
@@ -3016,7 +3018,7 @@
                   <div class="queued-header">
                     <span class="queued-icon"><svg><use href="#i-clock"/></svg></span>
                     <span class="queued-label"
-                          x-text="(lang==='zh' ? '已排队 ' : 'Queued ') + (qi+1) + ' / '
+                          x-text="queueDeliveryLabel(q) + ' ' + (qi+1) + ' / '
                                    + activeSession.pendingQueue.length"></span>
                     <!-- "已排队 1/2" alone reads as "will send shortly", which
                          is wrong while the queue is paused — the item will
@@ -5254,6 +5256,19 @@
               <option value="plan">plan</option>
             </select>
           </div>
+          <div class="settings-row">
+            <label x-text="lang==='zh' ? '回复进行中发送' : 'Send while busy'"></label>
+            <select x-model="settings.draftDefaults.busy_send_mode" class="settings-input">
+              <option value="adjust"
+                      x-text="lang==='zh' ? '尽快调整当前任务' : 'Adjust the current task soon'"></option>
+              <option value="queue"
+                      x-text="lang==='zh' ? '当前任务完成后发送' : 'Send after the current task finishes'"></option>
+            </select>
+          </div>
+          <div class="settings-hint"
+               x-text="lang==='zh'
+                 ? '“尽快调整”会在安全的工具边界交给当前任务；含附件或任务已变化时会自动改为排队。'
+                 : 'Adjust hands the message to the current task at a safe tool boundary; attachments or a changed task automatically fall back to the queue.'"></div>
           <div class="settings-hint warn"
                x-show="settings.draftDefaults.permission === 'bypassPermissions'"
                x-text="lang==='zh'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2107,7 +2107,9 @@
                           <svg><use href="#i-clock"/></svg>
                         </span>
                         <span x-text="m._optimisticQueue
-                          ? (lang==='zh' ? '正在确认发送方式' : 'Confirming delivery')
+                          ? (m._optimisticDelivery === 'queue'
+                            ? (lang==='zh' ? '排队中' : 'Queued')
+                            : (lang==='zh' ? '正在确认发送方式' : 'Confirming delivery'))
                           : (lang==='zh' ? '正在发送' : 'Sending')"></span>
                       </div>
                     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # upgrade must refresh the tool catalog and rerun the native question matrix.
     # Path/effort drift is already auto-eliminated via
     # project_key_for_directory() + EffortLevel.
-    "claude-agent-sdk==0.2.144",
+    "claude-agent-sdk==0.2.148",
     "fastapi>=0.138.1",
     # Pin starlette above the fastapi-transitive 1.0.0, which carries
     # PYSEC-2026-161 (fixed in 1.0.1). Direct constraint so the pip-audit

--- a/scripts/versions.env
+++ b/scripts/versions.env
@@ -13,6 +13,6 @@
 # version frozen in uv.lock — pinning keeps the tested combo reproducible.
 # Bump deliberately via scripts/upgrade.sh, not implicitly on reinstall.
 
-# @anthropic-ai/claude-code — matches Dockerfile. Tested against the
+# @anthropic-ai/claude-code — matches Dockerfile and the CLI bundled by the
 # claude-agent-sdk version locked in uv.lock.
-CLAUDE_CLI_VERSION="2.1.211"
+CLAUDE_CLI_VERSION="2.1.251"

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -133,7 +133,13 @@ def _make_mixed_messages(total: int, prefix: str) -> list[dict]:
     return messages
 
 
-def _route_windowed_session(page: Page, sid: str, messages: list[dict]) -> list[dict]:
+def _route_windowed_session(
+    page: Page,
+    sid: str,
+    messages: list[dict],
+    *,
+    updated_at: float | None = None,
+) -> list[dict]:
     requests: list[dict] = []
 
     def handle(route):
@@ -173,6 +179,7 @@ def _route_windowed_session(page: Page, sid: str, messages: list[dict]) -> list[
                 "has_more": offset > 0,
                 "history_order": "full" if "full" in qs else "normal",
                 "history_generation": "gen-e2e-1",
+                **({"updated_at": updated_at} if updated_at is not None else {}),
             }),
         )
 
@@ -4387,7 +4394,9 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         "uuid": "done-full-history-assistant",
         "ts": 1_700_019_999,
     }]
-    requests = _route_windowed_session(page, sid, canonical_messages)
+    requests = _route_windowed_session(
+        page, sid, canonical_messages, updated_at=2,
+    )
     page.route(
         "**/api/chat/stream/start",
         lambda route: route.fulfill(
@@ -4402,6 +4411,10 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         """
         const sid = arg.sid;
         app.refreshSessions = async () => {};
+        // done uses the quiet list path directly now. Keep this synthetic
+        // session resident so the test observes canonical message morphing,
+        // not an unrelated real session-list pull removing its fake sid.
+        app._pullSessionList = async () => false;
         app._fetchTabUsage = async () => {};
         app._checkActiveTurn = () => {};
         app._scheduleIdlePreload = () => {};
@@ -4523,7 +4536,18 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             ...app.sessions[0], id: sid, updated_at: 2, active: false,
           }]);
           const frames = [];
-          for (let i = 0; i < 12; i++) {
+          const canonicalSyncBusy = () => {
+            const sync = st.sessionSync || {};
+            const reasons = new Set(["completed_turn", "history_revision"]);
+            return reasons.has(sync.inFlight?.reason)
+              || Object.keys(sync.pending || {}).some(reason => reasons.has(reason));
+          };
+          // Reconciliation is owned by sessionSync now. The old
+          // `_reconcilePromise` field no longer exists, so checking it made
+          // this test race the coordinator on fast runners and assert against
+          // the earlier tail-only completion probe. Observe every frame while
+          // the real coordinator drains instead.
+          for (let i = 0; i < 240; i++) {
             await new Promise(resolve => requestAnimationFrame(resolve));
             const pane = document.querySelector(
               `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
@@ -4533,9 +4557,10 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
               visible: !!pane && pane.textContent.includes(text.trim()),
               count: pane ? pane.querySelectorAll(".msg").length : 0,
             });
-            if (!st._reconcilePromise && i >= 2) break;
+            const canonicalReady = st.messages.some(
+              message => message?.uuid === "done-canonical-assistant");
+            if (canonicalReady && !canonicalSyncBusy() && i >= 2) break;
           }
-          if (st._reconcilePromise) await st._reconcilePromise;
           await new Promise(resolve => app.$nextTick(() => requestAnimationFrame(resolve)));
           const last = st.messages[st.messages.length - 1];
           const nodes = document.querySelectorAll(".msg-pane .msg.assistant");

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -438,6 +438,50 @@ def test_interrupt_rejects_stale_turn_before_touching_client_or_queue(
         current.close()
 
 
+@pytest.mark.asyncio
+async def test_interrupt_rechecks_exact_owner_after_queue_pause(
+        chat_mod, monkeypatch):
+    sid = "sid-stop-owner-race"
+    sdk_client = _seed(
+        chat_mod, (sid, "claude-sonnet-4-6", "auto", ""))
+    old = chat_mod.TurnBroadcast(sid)
+    replacement = chat_mod.TurnBroadcast(sid)
+    chat_mod._active_turns[sid] = old
+    pause_entered = threading.Event()
+    release_pause = threading.Event()
+
+    def blocked_pause(_sid):
+        pause_entered.set()
+        assert release_pause.wait(1)
+        return {"items": [], "paused": False}
+
+    monkeypatch.setattr(
+        chat_mod.sess, "pause_queue_if_nonempty", blocked_pause)
+    try:
+        stop_task = asyncio.create_task(
+            chat_mod.interrupt(sid, turn_id=old.turn_id))
+        assert await asyncio.to_thread(pause_entered.wait, 1)
+
+        # Model the old pump finishing and a successor taking the same session
+        # while the queue pause is in flight. The delayed Stop belongs only to
+        # `old`; its pooled runtime snapshot must never reach `replacement`.
+        chat_mod._active_turns[sid] = replacement
+        release_pause.set()
+        response = await asyncio.wait_for(stop_task, timeout=1)
+
+        assert response["stale"] is True
+        assert response["requested_turn_id"] == old.turn_id
+        assert response["current_turn_id"] == replacement.turn_id
+        assert sdk_client.interrupted is False
+        assert replacement.cancelled is False
+        assert (sid, old.turn_id) not in chat_mod._pending_interrupts
+    finally:
+        release_pause.set()
+        chat_mod._active_turns.pop(sid, None)
+        old.close()
+        replacement.close()
+
+
 def test_interrupt_swallows_sdk_error_but_still_marks_pending(chat_mod, client):
     """If client.interrupt() raises, the route must not 500 — it logs and
     returns ok with that client omitted from `interrupted`. Pending flag

--- a/tests/test_chat_options.py
+++ b/tests/test_chat_options.py
@@ -20,6 +20,7 @@ def _capture_build_options(chat_mod, monkeypatch):
 
     monkeypatch.setattr(chat_mod, "ClaudeAgentOptions", FakeOptions)
     monkeypatch.setattr(chat_mod, "ClaudeSDKClient", FakeClient)
+    monkeypatch.setattr(chat_mod, "MuseLabSDKClient", FakeClient)
     # Third-party models take the compatibility subclass, NOT ClaudeSDKClient
     # (see _build_and_connect_client). Patching only the latter left the real
     # SDK client in the third-party tests, and its connect() reads concrete

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -1112,6 +1112,486 @@ async def test_late_enqueue_after_empty_completion_check_kicks_idle_queue(
 
 
 @pytest.mark.asyncio
+async def test_busy_adjust_is_durable_then_uses_exact_native_command(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    writes = []
+
+    class SteeringClient:
+        async def query_steering(
+            self, prompt, *, session_id, command_uuid,
+        ):
+            writes.append((prompt, session_id, command_uuid))
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="adjust this task",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+
+        assert response["effective_delivery"] == "adjust"
+        assert response["delivery_status"] == "waiting_tool"
+        item = response["queue"]["items"][0]
+        assert item["delivery"] == "adjust"
+        assert item["target_turn_id"] == broadcast.turn_id
+        assert item["steering_state"] == "waiting_tool"
+        assert writes == [(
+            "adjust this task", sid, item["command_uuid"],
+        )]
+        assert broadcast.steering_commands[item["command_uuid"]] == {
+            "item_id": item["id"],
+            "state": "waiting_tool",
+        }
+
+        await chat._settle_steering_lifecycle(
+            broadcast,
+            chat.CommandLifecycleMessage(
+                command_uuid=item["command_uuid"],
+                state="queued",
+                session_id=sid,
+                uuid="life-queued",
+            ),
+        )
+        assert sess.get_queue(sid)["items"][0]["steering_state"] == "queued"
+
+        terminal = await chat._settle_steering_lifecycle(
+            broadcast,
+            chat.CommandLifecycleMessage(
+                command_uuid=item["command_uuid"],
+                state="completed",
+                session_id=sid,
+                uuid="life-completed",
+            ),
+        )
+        assert terminal is True
+        assert sess.get_queue(sid)["items"] == []
+        assert broadcast.steering_commands == {}
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_busy_adjust_stale_turn_falls_back_without_native_write(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+
+    class SteeringClient:
+        async def query_steering(self, *_args, **_kwargs):
+            raise AssertionError("stale turn must not receive steering")
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    successor = chat.TurnBroadcast(sid)
+    successor.query_committed = True
+    successor.runtime_client = SteeringClient()
+    chat._active_turns[sid] = successor
+    try:
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="belongs after successor",
+                delivery="adjust",
+                active_turn_id="old-turn-id",
+            ),
+            chat.BackgroundTasks(),
+        )
+        assert response["effective_delivery"] == "queue"
+        assert response["delivery_status"] == "queued"
+        item = sess.get_queue(sid)["items"][0]
+        assert item.get("delivery") == "queue"
+        assert not item.get("command_uuid")
+        assert not successor.steering_commands
+    finally:
+        chat._active_turns.pop(sid, None)
+        successor.close()
+
+
+@pytest.mark.asyncio
+async def test_busy_adjust_write_failure_becomes_claimable_fifo_once(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+
+    class FailingSteeringClient:
+        async def query_steering(self, *_args, **_kwargs):
+            raise RuntimeError("transport unavailable")
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", FailingSteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = FailingSteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="safe fallback",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        assert response["effective_delivery"] == "queue"
+        assert response["delivery_status"] == "queued"
+        item = sess.get_queue(sid)["items"][0]
+        assert item["delivery"] == "queue"
+        assert item["steering_state"] == "fallback"
+        assert not item.get("command_uuid")
+        assert broadcast.steering_commands == {}
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+        drain = chat._queue_drain_tasks.get(sid)
+        if drain is not None:
+            await drain
+
+
+@pytest.mark.asyncio
+async def test_withdraw_adjustment_requires_cli_cancel_receipt(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    cancelled = []
+
+    class SteeringClient:
+        async def query_steering(self, *_args, **_kwargs):
+            return None
+
+        async def cancel_async_message(self, command_uuid):
+            cancelled.append(command_uuid)
+            return True
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="withdraw me",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        item = response["queue"]["items"][0]
+        updated = await chat.remove_queue_item_api(sid, item["id"])
+        assert cancelled == [item["command_uuid"]]
+        assert updated["items"] == []
+        assert broadcast.steering_commands == {}
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_queue_preserves_adjustment_accepted_after_snapshot(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    cancel_started = asyncio.Event()
+    release_cancel = asyncio.Event()
+    writes = []
+
+    class SteeringClient:
+        async def query_steering(
+            self, prompt, *, session_id, command_uuid,
+        ):
+            writes.append((prompt, session_id, command_uuid))
+
+        async def cancel_async_message(self, _command_uuid):
+            cancel_started.set()
+            await release_cancel.wait()
+            return True
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        first = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="clear snapshot owner",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        first_item = first["queue"]["items"][0]
+
+        clear_task = asyncio.create_task(chat.clear_queue_api(sid))
+        await asyncio.wait_for(cancel_started.wait(), timeout=1)
+
+        second = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="accepted after clear snapshot",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        second_item = next(
+            item for item in second["queue"]["items"]
+            if item["text"] == "accepted after clear snapshot"
+        )
+        release_cancel.set()
+        cleared = await asyncio.wait_for(clear_task, timeout=1)
+
+        assert writes == [
+            ("clear snapshot owner", sid, first_item["command_uuid"]),
+            ("accepted after clear snapshot", sid, second_item["command_uuid"]),
+        ]
+        assert [item["id"] for item in cleared["items"]] == [
+            second_item["id"],
+        ]
+        assert [item["id"] for item in sess.get_queue(sid)["items"]] == [
+            second_item["id"],
+        ]
+        assert set(broadcast.steering_commands) == {
+            second_item["command_uuid"],
+        }
+    finally:
+        release_cancel.set()
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_turn_error_cancels_unsettled_adjustment_without_trapping_it(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    queued = sess.enqueue_message(
+        sid,
+        "retain after transport failure",
+        delivery="adjust",
+        target_turn_id="turn-that-failed",
+        command_uuid="command-that-lost-terminal",
+        steering_state="started",
+    )["item"]
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.steering_commands["command-that-lost-terminal"] = {
+        "item_id": queued["id"],
+        "state": "started",
+    }
+    write_finished = asyncio.Event()
+    broadcast.steering_write_events[
+        "command-that-lost-terminal"
+    ] = write_finished
+    published = []
+    monkeypatch.setattr(broadcast, "publish", published.append)
+    try:
+        await chat._cancel_outstanding_steering_commands(broadcast)
+
+        assert broadcast.steering_commands == {}
+        assert broadcast.steering_write_events == {}
+        assert write_finished.is_set()
+        recovered = sess.get_queue(sid)
+        assert recovered["paused"] is True
+        assert recovered["items"][0]["steering_state"] == "cancelled"
+        assert published and published[-1]["event"] == "queue_steering"
+
+        # The row is no longer an unclaimable active adjustment. An explicit
+        # Resume can retry it as an ordinary turn; Delete/Clear can also remove
+        # it without a nonexistent live CLI cancellation receipt.
+        sess.set_queue_paused(sid, False)
+        assert sess.claim_queue_message(sid)["id"] == queued["id"]
+    finally:
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_cleanup_closes_new_steering_admission_before_await(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    old = sess.enqueue_message(
+        sid,
+        "old accepted adjustment",
+        delivery="adjust",
+        target_turn_id="turn-terminal-cleanup",
+        command_uuid="command-terminal-cleanup",
+        steering_state="started",
+    )["item"]
+    persist_entered = threading.Event()
+    release_persist = threading.Event()
+    native_writes = []
+
+    class SteeringClient:
+        async def query_steering(self, prompt, **_kwargs):
+            native_writes.append(prompt)
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = SteeringClient()
+    broadcast.steering_commands["command-terminal-cleanup"] = {
+        "item_id": old["id"],
+        "state": "started",
+    }
+    chat._active_turns[sid] = broadcast
+    real_update = sess.update_queue_steering_state
+
+    def blocked_update(*args, **kwargs):
+        persist_entered.set()
+        assert release_persist.wait(1)
+        return real_update(*args, **kwargs)
+
+    monkeypatch.setattr(sess, "update_queue_steering_state", blocked_update)
+    cleanup = None
+    try:
+        cleanup = asyncio.create_task(
+            chat._cancel_outstanding_steering_commands(broadcast)
+        )
+        assert await asyncio.to_thread(persist_entered.wait, 1)
+        assert broadcast.steering_closed is True
+
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="arrived during terminal cleanup",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        assert response["effective_delivery"] == "queue"
+        assert native_writes == []
+        queued = next(
+            item for item in sess.get_queue(sid)["items"]
+            if item["text"] == "arrived during terminal cleanup"
+        )
+        assert queued.get("delivery") == "queue"
+        assert not queued.get("command_uuid")
+
+        release_persist.set()
+        await asyncio.wait_for(cleanup, timeout=1)
+        assert broadcast.steering_commands == {}
+    finally:
+        release_persist.set()
+        if cleanup is not None and not cleanup.done():
+            cleanup.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await cleanup
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_cleanup_closes_admission_with_empty_command_map(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    native_writes = []
+
+    class SteeringClient:
+        async def query_steering(self, prompt, **_kwargs):
+            native_writes.append(prompt)
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    monkeypatch.setattr(chat, "_schedule_queue_drain", lambda _sid: None)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.query_committed = True
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        # Terminal finalization invokes this helper unconditionally, including
+        # the zero-map case. It must close admission synchronously even though
+        # there is no durable command to settle.
+        await chat._cancel_outstanding_steering_commands(broadcast)
+        assert broadcast.steering_closed is True
+
+        response = await chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="arrived after empty-map terminal gate",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        )
+        assert response["effective_delivery"] == "queue"
+        assert native_writes == []
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_result_write_barrier_includes_writer_registered_while_waiting(
+    app_module,
+):
+    from backend import chat
+
+    broadcast = chat.TurnBroadcast("s-result-write-barrier")
+    first = asyncio.Event()
+    second = asyncio.Event()
+    broadcast.steering_write_events["first"] = first
+    try:
+        barrier = asyncio.create_task(
+            chat._await_steering_write_stability(
+                broadcast, timeout_s=1,
+            )
+        )
+        await asyncio.sleep(0)
+
+        # This is the critical interleaving: Result already awaits the first
+        # HTTP write when a second busy-send request registers its own writer.
+        broadcast.steering_write_events["second"] = second
+        first.set()
+        await asyncio.sleep(0)
+        assert barrier.done() is False
+
+        second.set()
+        assert await asyncio.wait_for(barrier, timeout=1) is True
+    finally:
+        first.set()
+        second.set()
+        broadcast.close()
+
+
+@pytest.mark.asyncio
 async def test_concurrent_drain_kicks_serialize_dequeue_and_preserve_fifo(
     app_module, monkeypatch,
 ):

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -1547,6 +1547,144 @@ def test_turn_response_boundary_accepts_lifecycle_and_uuid_less_error(stream_env
     assert boundary.classify(error_result) == "current_result"
 
 
+@pytest.mark.asyncio
+async def test_result_barrier_releases_after_two_concurrent_writes_fail(
+        stream_env, monkeypatch):
+    """Result waiting on A must include B when B registers during that wait."""
+    chat_mod = stream_env
+    from backend import sessions as sess
+
+    sid = sess.create_session(model="claude-sonnet-4-6")["id"]
+    main_written = asyncio.Event()
+    allow_result = asyncio.Event()
+    generator_resumed = asyncio.Event()
+    keep_generator_open = asyncio.Event()
+    fail_a = asyncio.Event()
+    fail_b = asyncio.Event()
+    write_lock = asyncio.Lock()
+
+    class RaceClient:
+        async def query(self, _prompt, session_id="default"):
+            main_written.set()
+
+        async def query_steering(
+            self, prompt, *, session_id, command_uuid,
+        ):
+            async with write_lock:
+                await (fail_a if prompt == "A" else fail_b).wait()
+                raise RuntimeError("synthetic steering write failure")
+
+        async def receive_response(self):
+            await allow_result.wait()
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=sid,
+                total_cost_usd=0.0,
+                usage={"input_tokens": 1, "output_tokens": 1},
+            )
+            # The old one-shot barrier deferred Result on B and then asked the
+            # iterator for another frame, where it could wait forever because
+            # B's failed write emitted no lifecycle message.
+            generator_resumed.set()
+            await keep_generator_open.wait()
+
+        async def get_context_usage(self):
+            return {"maxTokens": 200_000, "totalTokens": 10}
+
+    fake = RaceClient()
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    async def wait_until(predicate, *, timeout=1):
+        deadline = asyncio.get_running_loop().time() + timeout
+        while not predicate():
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("condition did not become true")
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(chat_mod, "MuseLabSDKClient", RaceClient)
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(chat_mod, "_schedule_queue_drain", lambda _sid: None)
+    broadcast = None
+    first_task = None
+    second_task = None
+    try:
+        broadcast = await chat_mod._start_turn(
+            sid, "main", model="claude-sonnet-4-6")
+        await asyncio.wait_for(main_written.wait(), timeout=1)
+        await wait_until(lambda: broadcast.query_committed)
+
+        first_task = asyncio.create_task(chat_mod.enqueue_api(
+            sid,
+            chat_mod.QueueEnqueueReq(
+                text="A",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat_mod.BackgroundTasks(),
+        ))
+        await wait_until(lambda: len(broadcast.steering_commands) == 1)
+        allow_result.set()
+        await asyncio.sleep(0)
+
+        second_task = asyncio.create_task(chat_mod.enqueue_api(
+            sid,
+            chat_mod.QueueEnqueueReq(
+                text="B",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat_mod.BackgroundTasks(),
+        ))
+        await wait_until(lambda: len(broadcast.steering_commands) == 2)
+
+        fail_a.set()
+        first_response = await asyncio.wait_for(first_task, timeout=1)
+        assert first_response["effective_delivery"] == "queue"
+        assert broadcast.result_forwarded is False
+        assert broadcast.task.done() is False
+
+        fail_b.set()
+        second_response = await asyncio.wait_for(second_task, timeout=1)
+        assert second_response["effective_delivery"] == "queue"
+        await asyncio.wait_for(broadcast.task, timeout=2)
+
+        assert broadcast.steering_commands == {}
+        assert broadcast.steering_write_events == {}
+        assert broadcast.result_forwarded is True
+        assert generator_resumed.is_set() is False
+        assert any(
+            event.get("event") == "done"
+            for event in broadcast.replay_events()
+        )
+    finally:
+        fail_a.set()
+        fail_b.set()
+        keep_generator_open.set()
+        pending = [
+            task for task in (first_task, second_task)
+            if task is not None and not task.done()
+        ]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        if (broadcast is not None and broadcast.task is not None
+                and not broadcast.task.done()):
+            broadcast.task.cancel()
+            await asyncio.gather(broadcast.task, return_exceptions=True)
+        chat_mod._active_turns.pop(sid, None)
+        recent = chat_mod._recent_turns.pop(sid, None)
+        if recent is not None:
+            recent.close()
+        sess.clear_queue(sid)
+
+
 def test_preflight_compact_failure_blocks_original_prompt(
         stream_env, client, monkeypatch, capsys):
     chat_mod = stream_env

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2887,7 +2887,7 @@ def test_composer_disabled_state_covers_failures_without_blocking_durable_queue(
     css = (FRONTEND / "styles.css").read_text(encoding="utf-8")
     status_start = app.index("    composerStatusReason(sid = this.currentId) {")
     disabled_start = app.index("    composerDisabledReason(sid = this.currentId) {")
-    end = app.index("\n    sendButtonHint(sid) {", disabled_start)
+    end = app.index("\n    _busySendDelivery(sid", disabled_start)
     status = app[status_start:disabled_start]
     disabled = app[disabled_start:end]
 
@@ -2909,7 +2909,7 @@ def test_composer_disabled_state_covers_failures_without_blocking_durable_queue(
     assert ".streaming" not in disabled
     assert ".compacting" not in disabled
     assert "pendingQueue" not in disabled
-    assert 'this._normalizeBusySendMode(this.busySendMode) === "adjust"' in app
+    assert 'return this._busySendDelivery(sid) === "adjust"' in app
     assert 'this.t("queue.button_hint")' in app
     assert 'this._setComposerClaimPhase(sendState, composerSubmitToken, "queue")' in app
     assert 'this._setComposerClaimPhase(sendState, composerSubmitToken, "stream_start")' in app
@@ -5548,12 +5548,25 @@ def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
     send_start = app.index("    async send(opts = {}) {")
     send_end = app.index("\n    // ====== ask_user_question", send_start)
     send = app[send_start:send_end]
+    delivery_start = app.index("    _busySendDelivery(sid")
+    delivery_end = app.index("\n    sendButtonHint(sid)", delivery_start)
+    delivery = app[delivery_start:delivery_end]
+    assert 'this.busySendMode) !== "adjust"' in delivery
+    assert "!turnId || attachmentIntent || st.compacting" in delivery
+    assert "st.backgroundActive || st._draining || st.parentTurnId" in delivery
+    assert "st.pendingQueue && st.pendingQueue.length" in delivery
     assert 'const busyActiveTurnId = !isReconnect' in send
+    assert "const busyDelivery = this._busySendDelivery(" in send
+    assert "_optimisticDelivery: busyDelivery" in send
+    assert "delivery: busyDelivery" in send
+    assert "delivery: handoffDelivery" in send
     assert 'active_turn_id: busyActiveTurnId' in send
     assert 'errorMeta.active_turn_id || errorMeta.turn_id' in send
     assert '_optimisticQueue: !resumed && this._isBusy(sendSid)' in send
     assert 'x-show="m._admissionPending"' in html
     assert "正在确认发送方式" in html
+    assert "m._optimisticDelivery === 'queue'" in html
+    assert "'排队中' : 'Queued'" in html
 
 
 def test_slash_registry_has_core_commands_aliases_and_busy_policies():

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2909,7 +2909,8 @@ def test_composer_disabled_state_covers_failures_without_blocking_durable_queue(
     assert ".streaming" not in disabled
     assert ".compacting" not in disabled
     assert "pendingQueue" not in disabled
-    assert 'this._isBusy(sid) ? this.t("queue.button_hint")' in app
+    assert 'this._normalizeBusySendMode(this.busySendMode) === "adjust"' in app
+    assert 'this.t("queue.button_hint")' in app
     assert 'this._setComposerClaimPhase(sendState, composerSubmitToken, "queue")' in app
     assert 'this._setComposerClaimPhase(sendState, composerSubmitToken, "stream_start")' in app
     assert 'sourceState._composerSubmitPhase = "rollover"' in app
@@ -5494,6 +5495,65 @@ def test_turn_busy_race_falls_back_to_durable_queue():
         "await this._enqueueMessage(streamSid"
     )
     assert "this._removePaneMessage(streamState, sentUserBubble);" in busy
+
+
+def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+
+    assert 'busySendMode: "adjust"' in app
+    assert 'busy_send_mode: "adjust"' in app
+    assert 'this._normalizeBusySendMode(d.busy_send_mode)' in app
+    assert 'busy_send_mode: this._normalizeBusySendMode(' in app
+    assert 'value="adjust"' in html
+    assert "尽快调整当前任务" in html
+    assert 'value="queue"' in html
+    assert "当前任务完成后发送" in html
+
+    enqueue_start = app.index("    async _enqueueMessage(sid, item) {")
+    enqueue_end = app.index("\n    // Post-turn / on-activate hook", enqueue_start)
+    enqueue = app[enqueue_start:enqueue_end]
+    assert 'item.delivery || this.busySendMode' in enqueue
+    assert 'activeTurnId = String(item.active_turn_id || "")' in enqueue
+    assert "delivery," in enqueue
+    assert "active_turn_id: activeTurnId" in enqueue
+    assert "accepted.queue.items" in enqueue
+    assert "acceptedQueueItems === null" in enqueue
+    assert "queued.delivery || accepted.effective_delivery" in enqueue
+    assert "queued.steering_state || accepted.delivery_status" in enqueue
+
+    sync_start = app.index("    async _syncQueueFromServer(sid, options = {})")
+    sync_end = app.index("\n    _currentQueueLen", sync_start)
+    sync = app[sync_start:sync_end]
+    assert 'delivery: this._normalizeBusySendMode(it.delivery, "queue")' in sync
+    assert "it.steering_state" in sync
+
+    steering_start = app.index("    _applyQueueSteeringEvent(sid, payload) {")
+    steering_end = app.index("\n    async _syncQueueFromServer", steering_start)
+    steering = app[steering_start:steering_end]
+    assert 'state === "completed"' in steering
+    assert 'state === "fallback"' in steering
+    assert 'state === "cancelled"' in steering
+    assert 'es.addEventListener("queue_steering"' in app
+    assert '"queue_steering",' in app
+
+    label_start = app.index("    queueDeliveryLabel(item) {")
+    label_end = app.index("\n    _applyQueueSteeringEvent", label_start)
+    labels = app[label_start:label_end]
+    assert "等待当前工具完成" in labels
+    assert "已交给当前任务" in labels
+    assert "排队中" in labels
+    assert "queueDeliveryLabel(q)" in html
+
+    send_start = app.index("    async send(opts = {}) {")
+    send_end = app.index("\n    // ====== ask_user_question", send_start)
+    send = app[send_start:send_end]
+    assert 'const busyActiveTurnId = !isReconnect' in send
+    assert 'active_turn_id: busyActiveTurnId' in send
+    assert 'errorMeta.active_turn_id || errorMeta.turn_id' in send
+    assert '_optimisticQueue: !resumed && this._isBusy(sendSid)' in send
+    assert 'x-show="m._admissionPending"' in html
+    assert "正在确认发送方式" in html
 
 
 def test_slash_registry_has_core_commands_aliases_and_busy_policies():

--- a/tests/test_main_observability.py
+++ b/tests/test_main_observability.py
@@ -182,6 +182,10 @@ def test_session_rename_client_perf_is_strict_and_title_free(
     app_module, client, monkeypatch,
 ):
     events = []
+    # This test owns the client-side event contract.  Keep an incidentally
+    # slow TestClient request from adding the independent http.request event
+    # to the same monkeypatched sink on loaded CI workers.
+    monkeypatch.setattr(app_module, "_perf_enabled", lambda: False)
     monkeypatch.setattr(
         app_module, "perf_event",
         lambda event, **fields: events.append((event, fields)),

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import asyncio
+import json
+
 import pytest
 
 from claude_agent_sdk import AssistantMessage, ThinkingBlock
+from claude_agent_sdk._errors import MessageParseError
 
 from backend.sdk_compat import (
+    CommandLifecycleMessage,
+    InterruptReceipt,
+    MuseLabSDKClient,
     UnsignedThinkingCompatibleClient,
     normalize_missing_thinking_signatures,
+    parse_command_lifecycle,
 )
 
 
@@ -72,3 +80,181 @@ async def test_compat_client_yields_assistant_with_missing_signature():
     assert isinstance(thinking, ThinkingBlock)
     assert thinking.thinking == "scratch"
     assert thinking.signature == ""
+
+
+def _lifecycle_frame(state: str = "queued") -> dict:
+    return {
+        "type": "command_lifecycle",
+        "command_uuid": "11111111-1111-4111-8111-111111111111",
+        "state": state,
+        "session_id": "session-1",
+        "uuid": "22222222-2222-4222-8222-222222222222",
+    }
+
+
+def test_parse_command_lifecycle_preserves_both_uuids():
+    message = parse_command_lifecycle(_lifecycle_frame("started"))
+
+    assert message == CommandLifecycleMessage(
+        command_uuid="11111111-1111-4111-8111-111111111111",
+        state="started",
+        session_id="session-1",
+        uuid="22222222-2222-4222-8222-222222222222",
+    )
+
+
+def test_parse_command_lifecycle_rejects_unknown_state():
+    with pytest.raises(MessageParseError, match="Invalid command_lifecycle state"):
+        parse_command_lifecycle(_lifecycle_frame("future-state"))
+
+
+@pytest.mark.asyncio
+async def test_client_yields_command_lifecycle_before_sdk_parser_drops_it():
+    raw = _lifecycle_frame("completed")
+
+    class FakeQuery:
+        async def receive_messages(self):
+            yield raw
+
+    client = MuseLabSDKClient()
+    client._query = FakeQuery()
+
+    messages = [message async for message in client.receive_messages()]
+
+    assert messages == [CommandLifecycleMessage(
+        command_uuid=raw["command_uuid"],
+        state="completed",
+        session_id="session-1",
+        uuid=raw["uuid"],
+    )]
+
+
+@pytest.mark.asyncio
+async def test_query_steering_writes_exact_priority_next_user_frame():
+    writes: list[dict] = []
+
+    class FakeTransport:
+        async def write(self, line: str):
+            writes.append(json.loads(line))
+
+    client = MuseLabSDKClient()
+    client._query = object()
+    client._transport = FakeTransport()
+
+    await client.query_steering(
+        "Please adjust the current task",
+        session_id="session-1",
+        command_uuid="11111111-1111-4111-8111-111111111111",
+    )
+
+    assert writes == [{
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": "Please adjust the current task",
+        },
+        "parent_tool_use_id": None,
+        "session_id": "session-1",
+        "uuid": "11111111-1111-4111-8111-111111111111",
+        "priority": "next",
+        "origin": {"kind": "human"},
+        "shouldQuery": True,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_query_and_steering_writes_are_serialized_per_client():
+    active = 0
+    max_active = 0
+
+    class SlowTransport:
+        async def write(self, _line: str):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+
+    client = MuseLabSDKClient()
+    client._query = object()
+    client._transport = SlowTransport()
+
+    await asyncio.gather(
+        client.query("ordinary", session_id="session-1"),
+        client.query_steering(
+            "steer",
+            session_id="session-1",
+            command_uuid="11111111-1111-4111-8111-111111111111",
+        ),
+    )
+
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_async_message_returns_cli_receipt():
+    class FakeQuery:
+        requests: list[dict] = []
+
+        async def _send_control_request(self, request: dict):
+            self.requests.append(request)
+            return {"cancelled": True}
+
+    query = FakeQuery()
+    client = MuseLabSDKClient()
+    client._query = query
+
+    cancelled = await client.cancel_async_message(
+        "11111111-1111-4111-8111-111111111111")
+
+    assert cancelled is True
+    assert query.requests == [{
+        "subtype": "cancel_async_message",
+        "message_uuid": "11111111-1111-4111-8111-111111111111",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_cancel_queued_preserves_full_receipt():
+    class FakeQuery:
+        requests: list[dict] = []
+
+        async def _send_control_request(self, request: dict):
+            self.requests.append(request)
+            return {
+                "still_queued": [],
+                "cancelled": ["11111111-1111-4111-8111-111111111111"],
+            }
+
+    query = FakeQuery()
+    client = MuseLabSDKClient()
+    client._query = query
+
+    receipt = await client.interrupt(cancel_queued=True)
+
+    assert receipt == InterruptReceipt(
+        still_queued=(),
+        cancelled=("11111111-1111-4111-8111-111111111111",),
+    )
+    assert query.requests == [{
+        "subtype": "interrupt",
+        "cancel_queued": True,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_distinguishes_missing_receipt_from_empty_queue():
+    class OldCLIQuery:
+        async def _send_control_request(self, _request: dict):
+            return {}
+
+    client = MuseLabSDKClient()
+    client._query = OldCLIQuery()
+
+    receipt = await client.interrupt()
+
+    assert receipt == InterruptReceipt(still_queued=None, cancelled=None)
+
+
+def test_unsigned_thinking_client_keeps_muselab_protocol_adapter():
+    assert issubclass(UnsignedThinkingCompatibleClient, MuseLabSDKClient)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -757,6 +757,280 @@ def test_queue_plan_return_permission_roundtrip_and_legacy_migration(app_module)
     assert requeued["items"][0]["plan_return_permission"] == "default"
 
 
+def test_native_adjustment_lifecycle_is_durable_and_not_double_claimed(
+        app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-adjustment"
+    adjusted = sess.enqueue_message(
+        sid,
+        "use this after the next tool",
+        image_ids="img-a,img-b",
+        delivery="adjust",
+        target_turn_id="turn-running",
+        command_uuid="command-1",
+        steering_state="pending",
+    )
+    ordinary = sess.enqueue_message(sid, "ordinary follow-up")
+    initial_revision = adjusted["queue"]["revision"]
+
+    assert adjusted["item"]["delivery"] == "adjust"
+    assert adjusted["item"]["target_turn_id"] == "turn-running"
+    assert adjusted["item"]["command_uuid"] == "command-1"
+    assert adjusted["item"]["steering_state"] == "pending"
+    # The native command owns the FIFO head. The ordinary drain must neither
+    # duplicate it nor jump over it to execute the later message.
+    assert sess.claim_queue_message(sid) is None
+    assert [item["id"] for item in sess.get_queue(sid)["items"]] == [
+        adjusted["item"]["id"], ordinary["item"]["id"],
+    ]
+
+    started = sess.update_queue_steering_state(
+        sid, "started", command_uuid="command-1",
+    )
+    assert started is not None
+    assert started["steering_state"] == "started"
+    started_snapshot = sess.get_queue(sid)
+    assert started_snapshot["revision"] == initial_revision + 2
+    assert started_snapshot["items"][0]["steering_state"] == "started"
+
+    # Replayed lifecycle frames are idempotent and do not manufacture a new
+    # revision. A selector mismatch must not remove anything.
+    assert sess.update_queue_steering_state(
+        sid, "started", command_uuid="command-1",
+    ) == started
+    assert sess.get_queue(sid)["revision"] == started_snapshot["revision"]
+    assert sess.update_queue_steering_state(
+        sid,
+        "completed",
+        item_id=adjusted["item"]["id"],
+        command_uuid="different-command",
+    ) is None
+
+    completed = sess.update_queue_steering_state(
+        sid, "completed", item_id=adjusted["item"]["id"],
+    )
+    assert completed is not None
+    assert completed["steering_state"] == "completed"
+    assert completed["image_ids"] == "img-a,img-b"
+    remaining = sess.get_queue(sid)
+    assert [item["id"] for item in remaining["items"]] == [
+        ordinary["item"]["id"],
+    ]
+    assert sess.update_queue_steering_state(
+        sid, "completed", item_id=adjusted["item"]["id"],
+    ) is None
+    assert sess.claim_queue_message(sid)["id"] == ordinary["item"]["id"]
+
+
+def test_native_adjustment_lifecycle_cannot_regress_after_fast_ack(app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-fast-ack"
+    item = sess.enqueue_message(
+        sid,
+        "apply this after the current tool",
+        delivery="adjust",
+        command_uuid="command-fast-ack",
+        steering_state="pending",
+    )["item"]
+
+    queued = sess.update_queue_steering_state(
+        sid, "queued", item_id=item["id"],
+    )
+    queued_revision = sess.get_queue(sid)["revision"]
+    assert queued is not None
+    assert queued["steering_state"] == "queued"
+
+    # The lifecycle reader can receive queued/started before the HTTP task
+    # persists its post-write waiting_tool state. Those late writes must be
+    # idempotent instead of moving the durable UI status backwards.
+    assert sess.update_queue_steering_state(
+        sid, "waiting_tool", item_id=item["id"],
+    )["steering_state"] == "queued"
+    assert sess.get_queue(sid)["revision"] == queued_revision
+
+    started = sess.update_queue_steering_state(
+        sid, "started", item_id=item["id"],
+    )
+    started_revision = sess.get_queue(sid)["revision"]
+    assert started is not None
+    assert started["steering_state"] == "started"
+    assert sess.update_queue_steering_state(
+        sid, "queued", item_id=item["id"],
+    )["steering_state"] == "started"
+    assert sess.update_queue_steering_state(
+        sid, "waiting_tool", item_id=item["id"],
+    )["steering_state"] == "started"
+    assert sess.get_queue(sid)["revision"] == started_revision
+
+
+def test_cancelled_native_adjustment_cannot_be_resurrected_by_late_write(
+        app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-cancel-race"
+    item = sess.enqueue_message(
+        sid,
+        "do not resurrect this",
+        delivery="adjust",
+        command_uuid="command-cancel-race",
+        steering_state="pending",
+    )["item"]
+
+    cancelled = sess.update_queue_steering_state(
+        sid, "cancelled", item_id=item["id"], pause=True,
+    )
+    cancelled_revision = sess.get_queue(sid)["revision"]
+    assert cancelled is not None
+    assert cancelled["steering_state"] == "cancelled"
+
+    late = sess.update_queue_steering_state(
+        sid,
+        "waiting_tool",
+        item_id=item["id"],
+        command_uuid="command-cancel-race",
+    )
+    assert late is not None
+    assert late["steering_state"] == "cancelled"
+    snapshot = sess.get_queue(sid)
+    assert snapshot["paused"] is True
+    assert snapshot["revision"] == cancelled_revision
+
+
+def test_native_adjustment_fallback_becomes_an_ordinary_fifo_item(app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-fallback"
+    adjusted = sess.enqueue_message(
+        sid,
+        "preserve all payload data",
+        image_ids="img-durable",
+        delivery="adjust",
+        target_turn_id="turn-old",
+        command_uuid="command-fallback",
+        steering_state="waiting_tool",
+    )["item"]
+    later = sess.enqueue_message(sid, "later ordinary message")["item"]
+
+    fallback = sess.fallback_queue_steering(
+        sid, command_uuid="command-fallback",
+    )
+    assert fallback is not None
+    assert fallback["id"] == adjusted["id"]
+    assert fallback["image_ids"] == "img-durable"
+    assert fallback["delivery"] == "queue"
+    assert fallback["steering_state"] == "fallback"
+    assert "target_turn_id" not in fallback
+    assert "command_uuid" not in fallback
+    snapshot = sess.get_queue(sid)
+    assert [item["id"] for item in snapshot["items"]] == [
+        adjusted["id"], later["id"],
+    ]
+    assert sess.claim_queue_message(sid)["id"] == adjusted["id"]
+    # A late lifecycle callback for the detached CLI command cannot consume the
+    # now-ordinary inflight item.
+    assert sess.update_queue_steering_state(
+        sid, "completed", command_uuid="command-fallback",
+    ) is None
+
+
+def test_cancelled_native_adjustment_is_retained_and_pauses_queue(app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-cancelled"
+    item = sess.enqueue_message(
+        sid,
+        "review before retry",
+        delivery="adjust",
+        command_uuid="command-cancelled",
+        steering_state="queued",
+    )["item"]
+
+    cancelled = sess.update_queue_steering_state(
+        sid, "cancelled", item_id=item["id"],
+    )
+
+    assert cancelled is not None
+    assert cancelled["steering_state"] == "cancelled"
+    snapshot = sess.get_queue(sid)
+    assert snapshot["paused"] is True
+    assert snapshot["items"][0]["id"] == item["id"]
+    assert sess.claim_queue_message(sid) is None
+
+
+def test_restart_detaches_and_pauses_uncertain_native_adjustment(app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-restart"
+    item = sess.enqueue_message(
+        sid,
+        "the CLI may already have accepted this",
+        delivery="adjust",
+        target_turn_id="turn-before-crash",
+        command_uuid="command-before-crash",
+        steering_state="started",
+    )["item"]
+    assert sess.get_queue(sid)["paused"] is False
+
+    recovered = sess.recover_queue_inflight(sid)
+
+    assert recovered["paused"] is True
+    assert recovered["items"][0]["id"] == item["id"]
+    assert recovered["items"][0]["delivery"] == "queue"
+    assert recovered["items"][0]["steering_state"] == "cancelled"
+    assert "target_turn_id" not in recovered["items"][0]
+    assert "command_uuid" not in recovered["items"][0]
+    assert sess.claim_queue_message(sid) is None
+
+    # Recovery is conservative but not a dead end: explicit Resume makes the
+    # retained payload claimable as an ordinary turn. It can also be deleted
+    # or cleared because no nonexistent CLI owner remains attached.
+    sess.set_queue_paused(sid, False)
+    assert sess.claim_queue_message(sid)["id"] == item["id"]
+
+
+def test_native_command_uuid_is_unique_across_waiting_and_inflight(app_module):
+    from backend import sessions as sess
+
+    sid = "s-native-command-dedup"
+    first = sess.enqueue_message(
+        sid,
+        "first",
+        delivery="queue",
+        command_uuid="same-command",
+        steering_state="fallback",
+    )
+    assert first["ok"] is True
+    assert sess.claim_queue_message(sid)["id"] == first["item"]["id"]
+
+    duplicate = sess.enqueue_message(
+        sid,
+        "must not become ambiguous",
+        delivery="adjust",
+        command_uuid="same-command",
+        steering_state="pending",
+    )
+    assert duplicate["ok"] is False
+    assert duplicate["error"] == "duplicate_command_uuid"
+    assert duplicate["queue"]["items"] == []
+    assert duplicate["queue"]["inflight"]["item"]["id"] == first["item"]["id"]
+
+
+def test_snapshot_batch_remove_preserves_later_enqueue(app_module):
+    from backend import sessions as sess
+
+    sid = "s-snapshot-batch-remove"
+    first = sess.enqueue_message(sid, "present in clear snapshot")["item"]
+    snapshot_ids = [first["id"]]
+    later = sess.enqueue_message(sid, "committed after snapshot")["item"]
+
+    queue, removed = sess.remove_queue_items_with_removed(sid, snapshot_ids)
+
+    assert removed == (first["id"],)
+    assert [item["id"] for item in queue["items"]] == [later["id"]]
+
+
 def _sdk_session_info(sid: str, *, title: str | None = None):
     return SimpleNamespace(
         session_id=sid,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -72,6 +72,33 @@ def test_put_settings_rejects_non_sdk_permission_mode(client, auth):
     assert r.status_code == 422
 
 
+def test_busy_send_mode_defaults_validates_and_persists(
+        client, auth, monkeypatch, tmp_path):
+    from backend import api_settings as api_s
+
+    monkeypatch.delenv("MUSELAB_BUSY_SEND_MODE", raising=False)
+    current = client.get("/api/settings", headers=auth)
+    assert current.status_code == 200
+    assert current.json()["defaults"]["busy_send_mode"] == "adjust"
+
+    fake_env = tmp_path / ".env"
+    fake_env.write_text("MUSELAB_TOKEN=existing-test-token-1234567890\n")
+    monkeypatch.setattr(api_s, "ENV_PATH", fake_env)
+    saved = client.put(
+        "/api/settings", headers=auth, json={"busy_send_mode": "queue"},
+    )
+    assert saved.status_code == 200
+    assert saved.json()["updated"] == ["MUSELAB_BUSY_SEND_MODE"]
+    assert saved.json()["updated_count"] == 1
+    assert "MUSELAB_BUSY_SEND_MODE=queue" in fake_env.read_text()
+    assert os.environ["MUSELAB_BUSY_SEND_MODE"] == "queue"
+
+    invalid = client.put(
+        "/api/settings", headers=auth, json={"busy_send_mode": "interrupt"},
+    )
+    assert invalid.status_code == 422
+
+
 def test_put_settings_skips_empty_values(client, auth, monkeypatch, tmp_path):
     """Empty / None provider key = 'don't touch'; existing value preserved."""
     from backend import api_settings as api_s

--- a/tests/test_version_baseline.py
+++ b/tests/test_version_baseline.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from claude_agent_sdk._cli_version import __cli_version__ as bundled_cli_version
+from claude_agent_sdk._version import __version__ as sdk_version
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _required_match(pattern: str, text: str, source: str) -> re.Match[str]:
+    match = re.search(pattern, text, flags=re.DOTALL | re.MULTILINE)
+    assert match is not None, f"version baseline missing from {source}"
+    return match
+
+
+def test_native_and_docker_cli_pins_match_bundled_cli():
+    versions = (ROOT / "scripts" / "versions.env").read_text(encoding="utf-8")
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    native_pin = _required_match(
+        r'^CLAUDE_CLI_VERSION="([^"]+)"$', versions, "scripts/versions.env"
+    ).group(1)
+    docker_pin = _required_match(
+        r"@anthropic-ai/claude-code@([0-9.]+)", dockerfile, "Dockerfile"
+    ).group(1)
+
+    assert native_pin == docker_pin == bundled_cli_version
+
+
+def test_gateway_docs_share_the_installed_sdk_cli_baseline():
+    english = (ROOT / "docs" / "codex-gateway.md").read_text(encoding="utf-8")
+    chinese = (ROOT / "docs" / "codex-gateway_zh.md").read_text(encoding="utf-8")
+
+    english_baseline = _required_match(
+        r"tested on ([0-9-]+) is CLIProxyAPI `v([^`]+)`,\s*"
+        r"Claude Agent SDK `([^`]+)`, and its bundled Claude CLI `([^`]+)`",
+        english,
+        "docs/codex-gateway.md",
+    ).groups()
+    chinese_baseline = _required_match(
+        r"截至 ([0-9-]+)，已验证的兼容基线是 CLIProxyAPI `v([^`]+)`、"
+        r"Claude Agent\s*SDK `([^`]+)` 以及其内置 Claude CLI `([^`]+)`",
+        chinese,
+        "docs/codex-gateway_zh.md",
+    ).groups()
+
+    assert english_baseline == chinese_baseline
+    assert english_baseline[2:] == (sdk_version, bundled_cli_version)

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.144"
+version = "0.2.148"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -319,12 +319,13 @@ dependencies = [
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/e0/00d873adf589a4ba7899bc7e6ab5306fa55c8e9f4a2313a6f5fef95a473b/claude_agent_sdk-0.2.144.tar.gz", hash = "sha256:bf3df9930024bb7cf963313321af59b9ad7b6a13ec28bea6b864f457cff9afbc", size = 344707, upload-time = "2026-08-21T20:12:01.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f4/fb7f81b31e44f69af9f53b93c32e2047f3ca15cd6311cfe72bfdf420f1f5/claude_agent_sdk-0.2.148.tar.gz", hash = "sha256:45c9972fa72dc6006745239c6838cc3cea7a9b42d6927c89f7bdb6996a1983b0", size = 344717, upload-time = "2026-08-28T18:33:51.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/c6/3623b5e32d903a359f0daca3b9bd5e3ca4a501e104fafbdd32bf80c6d624/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a69da08f88518695630cf88155ad5888e9c2f322b05ef4e96bb4e5460b815544", size = 92931035, upload-time = "2026-08-21T20:12:06.801Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/bd/ba760bd6c7bae939105e50df983eea65ec0cba86f748c4abbedb8abbd8eb/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e685e624f598249a215a2db57c3a2fbbea5a7f7078a4cc632e099dedca303a69", size = 97959616, upload-time = "2026-08-21T20:12:11.838Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5a/946d37a573b52be868dbcac349fcdd2090b43ea31273d2ff7e71cfd6fd99/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8fb664212f3eca5b0e4081f71ff8ccdf72b15e57609ff0c93e626bfea914360a", size = 102347684, upload-time = "2026-08-21T20:12:17.582Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bc/b3b859736291b73d3065a0eb69149f39fbbe61cd800087b085690f944df0/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8aa83aa3ea4f51ca6db113a5fe27c10db25e2af99ba0eed140738141d99a0837", size = 103339972, upload-time = "2026-08-21T20:12:25.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f5/f4affb9f882bcf61422ea48491effb6ee2de28bfbdafd0ec90d1b959dad2/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026e2b54bb3f3909712ff462b8469e2b1fc5471cfde796abc23f32d30b2c8ba1", size = 83882833, upload-time = "2026-08-28T18:33:56.238Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/e1b11dd9fac877c8b44f022cf895f54f23854b916e09b32360e71209904c/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:c8cca1f4e4eb4e0c9f44ccfca6f651cf35e8f3914e483632ae8867c5619818a0", size = 88314490, upload-time = "2026-08-28T18:34:01.284Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/53de4727576fa6b5a261414d420895f4eb5f0369e232d403f1096205709e/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3fbbea7cc30099d14f894e12fef68b0ee42fa9982567df94e59499b6aff55959", size = 94014630, upload-time = "2026-08-28T18:34:06.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e9/2ea469751ed4df75a911c4bf4dcad1ff5b71ccc9aa1a4aa108583a2a66b5/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:221efbc0f583c80258189ab93e4f0d6b6a61ad61335de1fdf3e2331ad423dbeb", size = 94210928, upload-time = "2026-08-28T18:34:11.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ea/86ccd7a34446c37174e53f03c389b25f168c7f4fd4f00f3e130baae9c902/claude_agent_sdk-0.2.148-py3-none-win_amd64.whl", hash = "sha256:f155252940fd77f1bcc707836924ca3a9691d19bbc464914ae2b7ccf17f0410f", size = 96875177, upload-time = "2026-08-28T18:34:16.378Z" },
 ]
 
 [[package]]
@@ -911,7 +912,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "claude-agent-sdk", specifier = "==0.2.144" },
+    { name = "claude-agent-sdk", specifier = "==0.2.148" },
     { name = "fastapi", specifier = ">=0.138.1" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "openpyxl", specifier = ">=3.1.5" },


### PR DESCRIPTION
## 变更

- 在设置的「新会话」中增加「回复进行中发送」，默认选择「尽快调整当前任务」，也可改为「当前任务完成后发送」。
- 忙时文本消息会绑定当前 turn，在下一次安全的 tool 边界通过 Claude 原生 async user frame 注入；附件、过期 turn 或不支持的运行时会可靠降级到持久队列。
- 持久化 steering 生命周期与前端状态，避免乐观发送先闪成运行中，并覆盖取消、停止、重启、并发与错误回退。
- 升级 Claude Agent SDK 到 0.2.148、Claude CLI 到 2.1.251，并将 CLIProxyAPI 兼容基线更新到 v7.2.145。
- 修正两个测试隔离问题：sessionSync 协调器迁移后的 E2E 等待条件，以及观测测试被偶发慢 HTTP 事件污染。

## 验证

- 全量单元测试：1561 passed，145 skipped。
- e2e core：8 passed；关键 canonical reconcile 用例额外串行复跑 3 次全部通过。
- ruff check backend tests。
- scripts/lint.sh。
- node --check frontend/app.js。
- pip-audit：无已知漏洞。
- uv lock --check、uv sync --frozen --dry-run、git diff --check。
- 使用真实新版 SDK/CLI 验证了 queued → started → completed 的 async user input 生命周期。