### PR TITLE
fix(chat): 修复完成态回挂与队列卡顿

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -16975,48 +16975,14 @@ async def _start_turn(
             # Body intentionally minimal: session name + "Muse 已回复". No
             # preview text — the actual reply is one tap away in chat.
             if not was_cancelled:
-                from . import presence as _presence
-                if _presence.recently_active():
-                    # User is at one of their devices and will see the reply
-                    # in-app.  This successful high-frequency gate is silent;
-                    # actual push failures remain logged below.
-                    pass
-                else:
-                    try:
-                        from . import push as _push
-                        sname = ""
-                        try:
-                            for s in sess.list_sessions():
-                                if s.get("id") == session_id:
-                                    sname = s.get("name", "")
-                                    break
-                        except Exception:
-                            pass
-                        # Body intentionally carries NO reply content. Workspace
-                        # replies can contain private source text, credentials-
-                        # adjacent details, or unpublished work; a preview would
-                        # surface it on the lock screen. The actual reply is one
-                        # tap away in-app. (This matches the "No preview text"
-                        # comment above — an earlier version put reply text here
-                        # and contradicted that privacy boundary.)
-                        _body = "Muse 已回复"
-                        # pywebpush does synchronous per-subscription HTTPS
-                        # (TTL + retries); offload to a thread so a slow/dead
-                        # push endpoint can't block this turn's done event and
-                        # every other concurrent SSE/HTTP request on the loop.
-                        await asyncio.to_thread(
-                            _push.send_to_all,
-                            title=sname or "muselab",
-                            body=_body,
-                            url=f"/?session={session_id}",
-                            tag=f"turn-{session_id}",
-                            context=f"turn-done {session_id[:8]}",
-                        )
-                    except Exception as e:
-                        sys.stderr.write(
-                            f"[chat] turn push failed "
-                            f"sid={session_id[:8]} "
-                            f"exc={type(e).__name__}\n")
+                # Notification delivery is not part of the turn transaction.
+                # A broken proxy previously kept the completed broadcast in
+                # ``_active_turns`` for 405s, so the UI stayed "running" and the
+                # next queued prompt could not claim the session.  Schedule the
+                # best-effort fan-out independently; push.py bounds each HTTP
+                # attempt as a second line of defence.
+                _notify_turn_done(
+                    session_id, session_name=str(s.get("name") or ""))
             # Strip unverifiable thinking-block signatures so this session
             # stays resumable via `claude --resume` (and the official
             # Anthropic API). Third-party vendors (DeepSeek / GLM /
@@ -17734,6 +17700,43 @@ async def _start_turn(
     return broadcast
 
 
+def _notify_turn_done(session_id: str, *, session_name: str = "") -> None:
+    """Best-effort turn notification that never owns the active-turn slot."""
+    async def _go():
+        try:
+            from . import presence as _presence
+            if _presence.recently_active():
+                return
+            from . import push as _push
+            display_name = session_name
+            try:
+                latest = await asyncio.to_thread(sess.get_session, session_id)
+                display_name = str((latest or {}).get("name") or display_name)
+            except Exception:
+                pass
+            # Never put reply content on a lock screen. The actual response is
+            # one tap away in the authenticated application.
+            await asyncio.to_thread(
+                _push.send_to_all,
+                title=display_name or "muselab",
+                body="Muse 已回复",
+                url=f"/?session={session_id}",
+                tag=f"turn-{session_id}",
+                context=f"turn-done {session_id[:8]}",
+            )
+        except Exception as e:
+            sys.stderr.write(
+                f"[chat] turn push failed sid={session_id[:8]} "
+                f"exc={type(e).__name__}\n")
+            sys.stderr.flush()
+
+    try:
+        task = asyncio.get_running_loop().create_task(_go())
+        _retain_detached_cleanup(task)
+    except RuntimeError:
+        pass  # no running loop (shouldn't happen in request context)
+
+
 def _notify_queue_paused_on_error(session_id: str) -> None:
     """Push 'Muse 暂停了队列（出错）' when the headless drain pauses the queue
     after a turn errored. Best-effort + presence-gated (don't buzz a user
@@ -17746,7 +17749,8 @@ def _notify_queue_paused_on_error(session_id: str) -> None:
             from . import push as _push
             sname = ""
             try:
-                for s in sess.list_sessions():
+                sessions = await asyncio.to_thread(sess.list_sessions)
+                for s in sessions:
                     if s.get("id") == session_id:
                         sname = s.get("name", "")
                         break
@@ -17765,7 +17769,8 @@ def _notify_queue_paused_on_error(session_id: str) -> None:
                 f"[chat] queue-paused push failed "
                 f"sid={session_id[:8]} exc={type(e).__name__}\n")
     try:
-        asyncio.create_task(_go())
+        task = asyncio.get_running_loop().create_task(_go())
+        _retain_detached_cleanup(task)
     except RuntimeError:
         pass  # no running loop (shouldn't happen in request context)
 

--- a/backend/push.py
+++ b/backend/push.py
@@ -39,6 +39,12 @@ _VAPID_FILE = (_DIR / "vapid.json") if _DIR else None
 _SUBS_FILE = (_DIR / "push_subs.json") if _DIR else None
 
 _vapid: dict[str, str] | None = None
+# ``pywebpush.webpush`` exposes ``timeout=None`` and forwards that explicit
+# value to requests.  That disables requests' own timeout entirely: a dead
+# proxy once held a completed chat turn open for almost seven minutes while
+# three subscriptions failed serially.  Keep every endpoint attempt bounded;
+# chat/scheduler callers may still run the fan-out in a worker thread.
+_PUSH_HTTP_TIMEOUT_S = 10.0
 # Parsed Vapid object cache: (private_pem, Vapid). Vapid.from_pem does an
 # ASN.1 parse + EC key load on every call; send_to_all re-parsed the same
 # unchanging PEM on every push. Cache keyed by the PEM string so a key
@@ -310,6 +316,7 @@ def send_to_all(title: str, body: str, *, url: str = "/",
                 vapid_claims={"sub": os.environ.get(
                     "MUSELAB_VAPID_SUBJECT", "mailto:noreply@muselab.dev")},
                 ttl=24 * 3600,
+                timeout=_PUSH_HTTP_TIMEOUT_S,
             )
             sent += 1
         except WebPushException as e:
@@ -331,9 +338,15 @@ def send_to_all(title: str, body: str, *, url: str = "/",
                 # removal; applied at the end under the lock.
                 dropped.append(endpoint)
             else:
-                errors.append(f"{code}: {e}")
+                # Push exception strings commonly embed the full subscription
+                # endpoint (including its opaque device token) and proxy URL.
+                # Return/log only bounded diagnostics; operators need the class
+                # and status, not private protocol payloads.
+                label = type(e).__name__
+                errors.append(
+                    f"{label} status={code}" if code is not None else label)
         except Exception as e:
-            errors.append(f"{type(e).__name__}: {e}")
+            errors.append(type(e).__name__)
     if dropped:
         with _subs_lock:
             _load_subs()
@@ -347,6 +360,7 @@ def send_to_all(title: str, body: str, *, url: str = "/",
     sys.stderr.write(
         f"[push] {context or tag}: sent={sent} dropped={len(dropped)}"
         + (f" errors={errors}" if errors else "") + "\n")
+    sys.stderr.flush()
     return result
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7838,6 +7838,10 @@ function portal() {
         // Exact backend turn currently owned by this tab. Session id is not
         // sufficient: a reconnect for turn A must never attach to newer B.
         activeTurnId: "",
+        // Immutable turn id of the most recent authenticated terminal frame.
+        // Post-result work may briefly leave /active or a mux state snapshot
+        // stale; never re-attach that already-rendered turn as "running".
+        _lastTerminalTurnId: "",
         parentTurnId: "",
         lastEventSeq: 0,
         es: null,
@@ -8017,6 +8021,7 @@ function portal() {
       if (st._virtualForceTail === undefined) st._virtualForceTail = false;
       if (!Number.isFinite(st._virtualRevision)) st._virtualRevision = 0;
       if (st.activeTurnId === undefined) st.activeTurnId = "";
+      if (st._lastTerminalTurnId === undefined) st._lastTerminalTurnId = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
       if (!Number.isFinite(st.lastEventSeq)) st.lastEventSeq = 0;
       if (st.permission === undefined) st.permission = "";
@@ -10565,6 +10570,41 @@ function portal() {
         }
         return;
       }
+      const turnId = String(payload.turn_id || "");
+      if (existingState && !payload.background && turnId
+          && turnId === String(existingState._lastTerminalTurnId || "")) {
+        // `done` is the authoritative boundary for this immutable turn. A
+        // synchronous postlude used to leave the aggregate state active long
+        // enough for mux/list reconciliation to re-attach the completed turn;
+        // its child had already consumed `done`, so the UI then ran forever.
+        const currentTurnId = String(existingState.activeTurnId || "");
+        if (currentTurnId && currentTurnId !== turnId) {
+          // A delayed frame for completed A cannot touch successor B.
+          return;
+        }
+        const backgroundPending = Math.max(
+          0,
+          Number(existingState.backgroundTaskCount) || 0,
+          Number(payload.background_tasks_pending) || 0,
+        );
+        const preserveBackground = !!existingState.backgroundActive
+          || backgroundPending > 0;
+        if (existingState.streaming || existingState.es) {
+          this._retireStaleSessionStream(sid, existingState);
+          if (preserveBackground) {
+            this._setBackgroundTaskActive(
+              sid, true, payload.started_at, backgroundPending);
+          }
+        }
+        this._setSessionActivityExpectation(sid, preserveBackground);
+        existingState._pendingExternalUpdate = true;
+        this._resumePendingCanonicalSync(sid, existingState);
+        return;
+      }
+      if (existingState && turnId
+          && turnId !== String(existingState._lastTerminalTurnId || "")) {
+        existingState._sessionActivityExpected = null;
+      }
       if (meta) {
         meta.active = true;
         meta.turn_active = !payload.background;
@@ -10580,7 +10620,6 @@ function portal() {
         }
         return;
       }
-      const turnId = String(payload.turn_id || "");
       if (!turnId) return;
       if (existingState && payload.stopping) {
         existingState._stoppingTurnId = turnId;
@@ -15833,6 +15872,37 @@ function portal() {
         if (!r.ok) return;
         const d = await r.json();
         if (this.tabState[sid] !== st) return;
+        const probedTurnId = String(d.turn_id || "");
+        if (d.active && !d.background && probedTurnId
+            && probedTurnId === String(st._lastTerminalTurnId || "")) {
+          // A terminal event wins over a stale /active snapshot for the exact
+          // same immutable turn. Keep the completed DOM in place and let the
+          // existing canonical completion sync adopt the persisted suffix.
+          const currentTurnId = String(st.activeTurnId || "");
+          if (currentTurnId && currentTurnId !== probedTurnId) return false;
+          const backgroundPending = Math.max(
+            0,
+            Number(st.backgroundTaskCount) || 0,
+            Number(d.background_tasks_pending) || 0,
+          );
+          const preserveBackground = !!st.backgroundActive
+            || backgroundPending > 0;
+          if (st.streaming || st.es) {
+            this._retireStaleSessionStream(sid, st);
+            if (preserveBackground) {
+              this._setBackgroundTaskActive(
+                sid, true, d.started_at, backgroundPending);
+            }
+          }
+          this._setSessionActivityExpectation(sid, preserveBackground);
+          st._pendingExternalUpdate = true;
+          this._resumePendingCanonicalSync(sid, st);
+          return false;
+        }
+        if (d.active && probedTurnId
+            && probedTurnId !== String(st._lastTerminalTurnId || "")) {
+          st._sessionActivityExpected = null;
+        }
         // A hard refresh reconstructs a rollover child from its own history,
         // not from the in-memory handoff path. Restore the inherited watcher
         // badge/poller from the presentation-only task overlay reported by
@@ -30654,6 +30724,9 @@ function portal() {
         streamState._streamStartController = null;
         streamState._cancelBeforeStream = false;
         const terminalTurnId = streamTurnId || String(streamState.activeTurnId || "");
+        if (authoritativeTerminal && terminalTurnId) {
+          streamState._lastTerminalTurnId = terminalTurnId;
+        }
         if (streamState._stoppingTurnId === terminalTurnId) {
           streamState._stoppingTurnId = "";
         }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3015,7 +3015,8 @@
                + dashed border distinguishes them from real user bubbles. -->
           <template x-for="(q, qi) in activeSession.pendingQueue" :key="q.id">
             <div class="msg user queued">
-              <div class="msg-row queued-row">
+              <div class="msg-row queued-row"
+                   :class="{ 'avoids-tail-nav': isAwayFromLatest() }">
                 <div class="bubble user-bubble queued-bubble">
                   <div class="queued-header">
                     <span class="queued-icon"><svg><use href="#i-clock"/></svg></span>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -7557,6 +7557,12 @@ html[data-theme="eyecare"] .bash-meta.interrupted { color: #7a5a20; background: 
    tried color-mix tints and opacity washes — both produced unreadable
    text on dark theme (user feedback 2026-05-22). */
 .msg.user.queued { align-items: flex-end; }
+.queued-row.avoids-tail-nav {
+  /* The three tail-navigation FABs occupy the rightmost 54px whenever the
+     reader is away from the latest message. Keep queued edit/remove controls
+     clickable without permanently changing normal right alignment. */
+  padding-inline-end: 54px;
+}
 .msg.user.queued .bubble {
   background: var(--c-accent);
   color: white;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -8,6 +8,7 @@ regression classes that static lint cannot see.
 from __future__ import annotations
 
 import json
+import re
 import time
 from urllib.parse import parse_qs, unquote, urlparse
 
@@ -576,6 +577,217 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
         "activeTurnId": "turn-b",
         "reloads": 1,
         "metaActive": True,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_terminal_turn_cannot_be_reattached_by_stale_active_state(
+    page: Page, backend_url, auth_token,
+):
+    """A completed immutable turn stays completed while postlude state lags."""
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    page.route(
+        "**/api/chat/stream/mux/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "mux-stale-terminal"}),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          const originals = {
+            send: app.send,
+            fetch: app._fetchWithDeadline,
+            queue: app._syncQueueFromServer,
+            resume: app._resumePendingCanonicalSync,
+            bgPoller: app._ensureBgContPoller,
+          };
+          const sends = [];
+          let resumes = 0;
+          let probePayload = {
+            active: true, attachable: true, background: false,
+            continuation: false, turn_id: 'turn-completed',
+            started_at: Math.floor(Date.now() / 1000),
+          };
+          try {
+            st._loaded = true;
+            st.messages = [{ role: 'assistant', text: 'VISIBLE_DONE_REPLY' }];
+            st.streaming = false;
+            st.es = null;
+            st.activeTurnId = '';
+            st._lastTerminalTurnId = 'turn-completed';
+            app.sessions = app.sessions.map(session => session.id === sid
+              ? {...session, active: false, turn_active: false,
+                  background_active: false}
+              : session);
+            app.send = async options => { sends.push(options); return true; };
+            app._syncQueueFromServer = () => Promise.resolve(true);
+            app._resumePendingCanonicalSync = () => { resumes += 1; };
+            app._ensureBgContPoller = () => {};
+            app._fetchWithDeadline = async () => new Response(
+              JSON.stringify(probePayload),
+              {status: 200, headers: {'Content-Type': 'application/json'}},
+            );
+
+            const probeResult = await app._probeActiveTurn(sid, st);
+            window.__emitMux('session_state', {
+              session_id: sid, active: true, attachable: true,
+              background: false, continuation: false,
+              turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const afterStale = {
+              probeResult,
+              sends: sends.length,
+              resumes,
+              streaming: st.streaming,
+              hasEs: !!st.es,
+              activeTurnId: st.activeTurnId,
+              text: st.messages[0] && st.messages[0].text,
+              metaActive: !!app.sessions.find(session => session.id === sid)?.active,
+            };
+
+            // The main Result can legitimately leave SDK background tasks
+            // attached to the same origin turn id. That background-only busy
+            // state remains visible and must not be mistaken for stale foreground.
+            probePayload = {
+              active: true, attachable: false, background: true,
+              continuation: false, turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+              background_tasks_pending: 1,
+            };
+            await app._probeActiveTurn(sid, st);
+            window.__emitMux('session_state', {
+              session_id: sid, active: true, attachable: false,
+              background: true, continuation: false,
+              turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+              background_tasks_pending: 1,
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const backgroundAccepted = {
+              sends: sends.length,
+              backgroundActive: st.backgroundActive,
+              backgroundTaskCount: st.backgroundTaskCount,
+              activeTurnId: st.activeTurnId,
+              metaActive: !!app.sessions.find(session => session.id === sid)?.active,
+            };
+
+            // The foreground broadcast can linger during its postlude while
+            // background tasks already exist. Suppress only its stale reattach;
+            // retain the legitimate background busy state and task count.
+            probePayload = {
+              active: true, attachable: true, background: false,
+              continuation: false, turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+              background_tasks_pending: 1,
+            };
+            await app._probeActiveTurn(sid, st);
+            window.__emitMux('session_state', probePayload);
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const backgroundSurvivesPostlude = {
+              sends: sends.length,
+              backgroundActive: st.backgroundActive,
+              backgroundTaskCount: st.backgroundTaskCount,
+              metaBackground: !!app.sessions.find(
+                session => session.id === sid)?.background_active,
+            };
+
+            window.__emitMux('session_state', {
+              session_id: sid, active: true, attachable: true,
+              background: false, continuation: false, turn_id: 'turn-successor',
+              started_at: Math.floor(Date.now() / 1000),
+            });
+            for (let i = 0; i < 50 && sends.length < 1; i++) {
+              await new Promise(resolve => setTimeout(resolve, 10));
+            }
+            st.streaming = true;
+            st.activeTurnId = 'turn-successor';
+            st.es = app._chatMuxChannel(sid, 'turn-successor');
+            app._activateChatMuxChannel(st.es);
+            const successorEs = st.es;
+            probePayload = {
+              active: true, attachable: true, background: false,
+              continuation: false, turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+            };
+            await app._probeActiveTurn(sid, st);
+            window.__emitMux('session_state', {
+              session_id: sid, active: true, attachable: true,
+              background: false, continuation: false,
+              turn_id: 'turn-completed',
+              started_at: Math.floor(Date.now() / 1000),
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const successorPreserved = {
+              streaming: st.streaming,
+              sameEs: st.es === successorEs,
+              activeTurnId: st.activeTurnId,
+              sends: sends.length,
+            };
+            if (st.es) st.es.close();
+            st.es = null;
+            st.streaming = false;
+            return {
+              afterStale,
+              backgroundAccepted,
+              backgroundSurvivesPostlude,
+              successorPreserved,
+              successorSends: sends.length,
+              successorTurnId: sends[0] && sends[0].turnId,
+              successorMuxAttach: !!(sends[0] && sends[0]._muxAttach),
+            };
+          } finally {
+            app.send = originals.send;
+            app._fetchWithDeadline = originals.fetch;
+            app._syncQueueFromServer = originals.queue;
+            app._resumePendingCanonicalSync = originals.resume;
+            app._ensureBgContPoller = originals.bgPoller;
+          }
+        }"""
+    )
+    assert result == {
+        "afterStale": {
+            "probeResult": False,
+            "sends": 0,
+            "resumes": 2,
+            "streaming": False,
+            "hasEs": False,
+            "activeTurnId": "",
+            "text": "VISIBLE_DONE_REPLY",
+            "metaActive": False,
+        },
+        "backgroundAccepted": {
+            "sends": 0,
+            "backgroundActive": True,
+            "backgroundTaskCount": 1,
+            "activeTurnId": "turn-completed",
+            "metaActive": True,
+        },
+        "backgroundSurvivesPostlude": {
+            "sends": 0,
+            "backgroundActive": True,
+            "backgroundTaskCount": 1,
+            "metaBackground": True,
+        },
+        "successorPreserved": {
+            "streaming": True,
+            "sameEs": True,
+            "activeTurnId": "turn-successor",
+            "sends": 1,
+        },
+        "successorSends": 1,
+        "successorTurnId": "turn-successor",
+        "successorMuxAttach": True,
     }
     _assert_no_browser_errors(page, errors)
 
@@ -3650,6 +3862,73 @@ def test_message_outline_traps_focus_and_supports_keyboard_selection(
     expect(opener).to_be_focused()
     assert page.evaluate("() => window.__outlineKeyboardSelection") == "outline-second"
     assert len(requests) == 1
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("viewport", [
+    {"width": 738, "height": 828},
+    {"width": 390, "height": 844},
+])
+def test_queued_message_avoids_visible_tail_navigation_fabs(
+    page: Page, backend_url, auth_token, viewport,
+):
+    """Queue edit/remove controls stay clear of the three tail FABs."""
+    page.set_viewport_size(viewport)
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(app.currentId);
+        st.pendingQueue.splice(0, st.pendingQueue.length, {
+          id: "q-tail-nav-overlap",
+          text: "queued message",
+          displayText: "queued message",
+          pendingQuotes: [], images: [], docs: [],
+        });
+        st.atBottom = false;
+        """,
+    )
+
+    queued = page.locator(".queued-row:visible")
+    expect(queued).to_be_visible()
+    expect(queued).to_have_class(re.compile(r"\bavoids-tail-nav\b"))
+    for selector in (
+        ".jump-bottom:visible",
+        ".chat-outline-fab:visible",
+        ".chat-prevuser-fab:visible",
+    ):
+        expect(page.locator(selector)).to_be_visible()
+
+    geometry = queued.locator(".queued-bubble").evaluate(
+        """bubble => {
+          const bubbleRect = bubble.getBoundingClientRect();
+          const selectors = ['.jump-bottom', '.chat-outline-fab', '.chat-prevuser-fab'];
+          return selectors.map(selector => {
+            const node = Array.from(document.querySelectorAll(selector))
+              .find(el => el.getClientRects().length);
+            const rect = node.getBoundingClientRect();
+            const overlaps = !(
+              bubbleRect.right <= rect.left || bubbleRect.left >= rect.right
+              || bubbleRect.bottom <= rect.top || bubbleRect.top >= rect.bottom
+            );
+            return {selector, overlaps};
+          });
+        }"""
+    )
+    assert not any(item["overlaps"] for item in geometry), geometry
+
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(app.currentId);
+        st.atBottom = true;
+        if (st.messageRange) {
+          st.messageRange.total = st.messageRange.offset + st.messages.length;
+        }
+        """,
+    )
+    expect(queued).not_to_have_class(re.compile(r"\bavoids-tail-nav\b"))
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -4972,6 +4972,66 @@ def _ok_turn(sid):
     ]
 
 
+@pytest.mark.asyncio
+async def test_turn_done_push_cannot_hold_active_slot_or_queue_rollover(
+        stream_env, client, monkeypatch):
+    """A dead Web Push endpoint must not extend the completed chat turn."""
+    chat_mod = stream_env
+    sid = _make_session(client)
+    fake = _FakeStreamClient(_ok_turn(sid))
+    push_entered = threading.Event()
+    push_release = threading.Event()
+    drain_triggered = asyncio.Event()
+
+    async def fake_get_client(*_args, **_kwargs):
+        return fake
+
+    def blocked_push(**_kwargs):
+        push_entered.set()
+        assert push_release.wait(timeout=5)
+        return {"sent": 0, "dropped": 0, "errors": ["timeout"]}
+
+    async def fake_maybe_drain_queue(drained_sid):
+        assert drained_sid == sid
+        drain_triggered.set()
+
+    from backend import presence, push
+    monkeypatch.setattr(chat_mod, "get_client", fake_get_client)
+    monkeypatch.setattr(presence, "recently_active", lambda: False)
+    monkeypatch.setattr(push, "send_to_all", blocked_push)
+    monkeypatch.setattr(chat_mod, "_maybe_drain_queue", fake_maybe_drain_queue)
+    before_tasks = set(chat_mod._maintenance_tasks)
+
+    async def wait_finished():
+        while not (
+            broadcast.done
+            and sid not in chat_mod._active_turns
+            and drain_triggered.is_set()
+        ):
+            await asyncio.sleep(0.01)
+
+    try:
+        broadcast = await chat_mod._start_turn(
+            sid, "finish independently of push",
+            model="claude-sonnet-4-6",
+        )
+        await asyncio.wait_for(
+            asyncio.to_thread(push_entered.wait, 3), timeout=4)
+        await asyncio.wait_for(wait_finished(), timeout=3)
+
+        assert sid not in chat_mod._active_turns
+        assert drain_triggered.is_set()
+        assert broadcast.canonical_terminal_published is True
+        push_tasks = set(chat_mod._maintenance_tasks) - before_tasks
+        assert push_tasks
+        assert any(not task.done() for task in push_tasks)
+    finally:
+        push_release.set()
+        push_tasks = set(chat_mod._maintenance_tasks) - before_tasks
+        if push_tasks:
+            await asyncio.gather(*push_tasks, return_exceptions=True)
+
+
 def test_turn_has_no_wall_clock_cap_by_default(stream_env, client, monkeypatch):
     """A turn must run unbounded unless an operator opts in.
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -247,7 +247,10 @@ def test_send_to_all_records_non_fatal_error(push_mod):
             super().__init__(msg)
             self.response = response
 
+    seen = {}
+
     def _fake_webpush(**kwargs):
+        seen.update(kwargs)
         raise _FakeWebPushException("server error", response=_FakeResp())
 
     class _FakeVapid:
@@ -264,6 +267,40 @@ def test_send_to_all_records_non_fatal_error(push_mod):
     assert res["dropped"] == 0
     assert len(res["errors"]) == 1
     assert "500" in res["errors"][0]
+    assert seen["timeout"] == push_mod._PUSH_HTTP_TIMEOUT_S
+    assert 0 < seen["timeout"] <= 15
     # Sub retained for the next attempt.
     assert any(s["endpoint"] == "https://flaky.example.com/x"
                for s in push_mod.list_subscriptions())
+
+
+def test_send_to_all_redacts_endpoint_and_proxy_details(
+        push_mod, capsys):
+    """Push logs/results must not expose opaque subscription device tokens."""
+    endpoint = "https://push.example.com/private-device-token"
+    push_mod.add_subscription(_sub_body(endpoint=endpoint))
+
+    import unittest.mock as mock
+
+    import py_vapid
+    import pywebpush
+
+    class _FakeVapid:
+        @staticmethod
+        def from_pem(pem):
+            return object()
+
+    def _fake_webpush(**kwargs):
+        raise ConnectionError(
+            f"proxy failed while posting {endpoint}?auth=private-auth-token")
+
+    with mock.patch.object(pywebpush, "webpush", _fake_webpush), \
+         mock.patch.object(py_vapid, "Vapid", _FakeVapid):
+        res = push_mod.send_to_all(
+            title="t", body="b", context="privacy-regression")
+
+    diagnostics = capsys.readouterr().err
+    assert res["errors"] == ["ConnectionError"]
+    assert endpoint not in diagnostics
+    assert "private-auth-token" not in diagnostics
+    assert "ConnectionError" in diagnostics


### PR DESCRIPTION
## 问题

- Web Push 在失效代理下同步阻塞 turn 收尾，实测让已完成 turn 继续占用 active slot 约 405 秒，队列无法接续。
- 前端会在完成态保护过期后重新挂载同一个 stale active turn；mux 子流已结束，界面因此再次显示运行中，只有刷新才能恢复。
- 右下角三个会话导航按钮会覆盖排队消息的编辑/删除区域。

## 修复

- 将 turn-done Push 从 turn 事务中完全解耦，并为每个 Push HTTP 请求设置 10 秒超时。
- Push 错误日志只保留异常类型/状态码，避免输出订阅 endpoint、设备 token 和代理详情。
- 前端记录最近的终结 turn id，拒绝同一 turn 的 stale `/active` 与 mux 状态重新挂载，同时保留合法后台任务和新 successor。
- 队列卡在尾部导航按钮可见时预留右侧空间。

## 验证

- `1563 passed`（完整非 E2E 套件）
- `5 passed`（完成态对账、stale active、队列布局桌面/手机关键浏览器回归）
- `git diff --check` 通过。