### PR TITLE
fix(chat): 正确渲染中途调整消息

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -7326,19 +7326,43 @@ def _publish_queue_steering(
     command_uuid: str,
     state: str,
     effective_delivery: str,
+    item: dict | None = None,
 ) -> None:
-    """Publish one privacy-bounded queue state transition when possible."""
+    """Publish one privacy-bounded queue state transition when possible.
+
+    ``started`` is also the live transcript boundary for a native steering
+    command.  Include the already-bounded durable queue fields so a browser
+    that missed the optimistic POST response can still replace the temporary
+    queue row with the exact user bubble at that boundary.
+    """
     if bc is None or bc.done:
         return
     try:
+        payload: dict[str, Any] = {
+            "item_id": item_id,
+            "command_uuid": command_uuid,
+            "state": state,
+            "effective_delivery": effective_delivery,
+            "turn_id": bc.turn_id,
+        }
+        if item is not None:
+            selection_quotes = item.get("selection_quotes")
+            payload["message"] = {
+                "id": item_id,
+                "uuid": command_uuid,
+                "text": str(item.get("text") or ""),
+                "display_text": str((
+                    item.get("display_text")
+                    if "display_text" in item else item.get("text")
+                ) or ""),
+                "selection_quotes": (
+                    selection_quotes if isinstance(selection_quotes, list) else []
+                ),
+                "enqueued_at": item.get("enqueued_at"),
+            }
         bc.publish({
             "event": "queue_steering",
-            "data": json.dumps({
-                "item_id": item_id,
-                "command_uuid": command_uuid,
-                "state": state,
-                "effective_delivery": effective_delivery,
-            }),
+            "data": json.dumps(payload),
         })
     except Exception:
         # The durable queue remains authoritative; GET /queue repairs any
@@ -7465,6 +7489,7 @@ async def _deliver_steering_command(
         command_uuid=command_uuid,
         state=state,
         effective_delivery="adjust",
+        item=updated,
     )
     return "adjust", state, updated
 
@@ -7486,8 +7511,9 @@ async def _settle_steering_lifecycle(
     state = message.state
     if state in {"queued", "started"}:
         info["state"] = state
+        updated: dict | None = None
         try:
-            await obs.to_thread_io(
+            updated = await obs.to_thread_io(
                 "chat.queue_steering_lifecycle",
                 bc.session_id,
                 sess.update_queue_steering_state,
@@ -7512,10 +7538,12 @@ async def _settle_steering_lifecycle(
             command_uuid=command_uuid,
             state=state,
             effective_delivery="adjust",
+            item=updated,
         )
         return False
 
     if state == "completed":
+        removed: dict | None = None
         try:
             removed = await obs.to_thread_io(
                 "chat.queue_steering_complete",
@@ -7556,6 +7584,7 @@ async def _settle_steering_lifecycle(
             command_uuid=command_uuid,
             state="completed",
             effective_delivery="adjust",
+            item=removed,
         )
         return True
 

--- a/backend/chat_presentation.py
+++ b/backend/chat_presentation.py
@@ -637,9 +637,12 @@ def broadcast_to_ui_messages(broadcast: Any) -> list[dict]:
             "text": broadcast.user_text,
             "images": broadcast.user_images,
             "docs": broadcast.user_docs,
+            "_turnId": broadcast.turn_id,
+            "_turnRoot": True,
         })
     current_text: dict | None = None
     current_thinking: dict | None = None
+    steering_users: set[str] = set()
 
     def close_segment() -> None:
         nonlocal current_text, current_thinking
@@ -706,6 +709,33 @@ def broadcast_to_ui_messages(broadcast: Any) -> list[dict]:
                 "is_error": data.get("is_error"),
                 "bash": data.get("bash"),
             })
+        elif kind == "queue_steering":
+            state = str(data.get("state") or "")
+            message = data.get("message")
+            command_uuid = str(data.get("command_uuid") or "")
+            identity = command_uuid or str(data.get("item_id") or "")
+            if (state in {"started", "completed"}
+                    and isinstance(message, dict)
+                    and identity not in steering_users):
+                close_segment()
+                steering_users.add(identity)
+                out.append({
+                    "role": "user",
+                    "text": str(message.get("text") or ""),
+                    "displayText": str(message.get("display_text") or ""),
+                    "selectionQuotes": (
+                        message.get("selection_quotes")
+                        if isinstance(message.get("selection_quotes"), list)
+                        else []
+                    ),
+                    "images": [],
+                    "docs": [],
+                    "uuid": command_uuid,
+                    "_turnId": str(data.get("turn_id") or broadcast.turn_id),
+                    "_turnRoot": False,
+                    "_steeringAdjustment": True,
+                    "_queueItemId": str(data.get("item_id") or ""),
+                })
         elif kind == "task_started":
             apply_task_status(
                 str(data.get("tool_use_id") or ""),

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8582,19 +8582,98 @@ function portal() {
       return this.lang === "zh"
         ? "等待当前工具完成" : "Waiting for current tool";
     },
+    _findQueueSteeringMessage(st, itemId, commandUuid) {
+      if (!st) return null;
+      const iid = String(itemId || "");
+      const uuid = String(commandUuid || "");
+      return (st.messages || []).find(message => message
+        && message.role === "user"
+        && ((uuid && String(message.uuid || "") === uuid)
+          || (iid && String(message._queueItemId || "") === iid))) || null;
+    },
+    _queueSteeringPromotionContext(sid, payload) {
+      const st = sid && this.tabState[sid];
+      const itemId = String(payload && payload.item_id || "");
+      const state = String(payload && payload.state || "");
+      if (!st || !itemId || !["started", "completed"].includes(state)) {
+        return null;
+      }
+      const queued = (st.pendingQueue || []).find(q => q.id === itemId) || null;
+      const wire = payload && payload.message
+        && typeof payload.message === "object" ? payload.message : null;
+      const commandUuid = String(payload && payload.command_uuid
+        || (queued && queued.commandUuid)
+        || (wire && (wire.uuid || wire.command_uuid)) || "");
+      return {
+        st,
+        itemId,
+        state,
+        commandUuid,
+        source: queued || wire,
+        existing: this._findQueueSteeringMessage(st, itemId, commandUuid),
+        turnId: String(payload && payload.turn_id
+          || (queued && queued.targetTurnId) || st.activeTurnId || ""),
+      };
+    },
+    _queueSteeringNeedsPromotion(sid, payload) {
+      const context = this._queueSteeringPromotionContext(sid, payload);
+      return !!(context && !context.existing && context.source);
+    },
+    _promoteQueueSteeringMessage(context) {
+      if (!context || context.existing || !context.source) return false;
+      const source = context.source;
+      const hasDisplayText = Object.prototype.hasOwnProperty.call(
+        source, "displayText")
+        || Object.prototype.hasOwnProperty.call(source, "display_text");
+      const displayText = Object.prototype.hasOwnProperty.call(source, "displayText")
+        ? source.displayText : source.display_text;
+      const selectionQuotes = Array.isArray(source.pendingQuotes)
+        ? source.pendingQuotes
+        : (Array.isArray(source.selection_quotes) ? source.selection_quotes : []);
+      this._appendLiveMessage(context.st, {
+        role: "user",
+        text: String(source.text || ""),
+        ...(hasDisplayText ? { displayText: String(displayText || "") } : {}),
+        selectionQuotes,
+        images: Array.isArray(source.images) ? source.images : [],
+        docs: Array.isArray(source.docs) ? source.docs : [],
+        uuid: context.commandUuid,
+        _turnId: context.turnId,
+        _queueItemId: context.itemId,
+        _steeringAdjustment: true,
+        _turnRoot: false,
+        // This row was already visible as a queue bubble. Re-entering it with
+        // the normal message animation makes the state transition look like a
+        // duplicate send instead of the same user command taking effect.
+        _noAnim: true,
+      });
+      return true;
+    },
     _applyQueueSteeringEvent(sid, payload) {
       const st = sid && this.tabState[sid];
       const itemId = String(payload && payload.item_id || "");
       const state = String(payload && payload.state || "");
-      if (!st || !itemId || !state) return;
-      if (state === "completed") {
+      if (!st || !itemId || !state) return false;
+      if (state === "started" || state === "completed") {
+        const context = this._queueSteeringPromotionContext(sid, payload);
+        const promoted = this._promoteQueueSteeringMessage(context);
+        if (context && context.existing && !context.existing._turnId
+            && context.turnId) {
+          context.existing._turnId = context.turnId;
+        }
         st.pendingQueue = (st.pendingQueue || []).filter(q => q.id !== itemId);
-        return;
+        // An older server may omit the message snapshot. Its durable queue and
+        // canonical transcript still repair the view; ask for both without
+        // manufacturing a text-less user bubble.
+        if (!context || (!context.existing && !context.source)) {
+          this._syncQueueFromServer(sid);
+        }
+        return promoted;
       }
       const item = (st.pendingQueue || []).find(q => q.id === itemId);
       if (!item) {
         this._syncQueueFromServer(sid);
-        return;
+        return false;
       }
       item.delivery = this._normalizeBusySendMode(
         payload.effective_delivery || item.delivery,
@@ -8606,6 +8685,7 @@ function portal() {
       // Replace the array so Alpine updates the status text immediately even
       // when the item object originated from the POST acceptance mirror.
       st.pendingQueue = [...st.pendingQueue];
+      return false;
     },
     async _syncQueueFromServer(sid, options = {}) {
       if (!sid) return;
@@ -8665,9 +8745,12 @@ function portal() {
           delivery: this._normalizeBusySendMode(it.delivery, "queue"),
           deliveryStatus: String(it.steering_state
             || (it.delivery === "adjust" ? "pending" : "queued")),
+          commandUuid: String(it.command_uuid || ""),
+          targetTurnId: String(it.target_turn_id || ""),
           enqueuedAt: it.enqueued_at || Date.now(),
         };
-      });
+      }).filter(item => !this._findQueueSteeringMessage(
+        st, item.id, item.commandUuid));
       st.pendingQueue = pendingQueue;
       Promise.all(pendingQueue.flatMap(item =>
         item.images.map(async im => {
@@ -8801,6 +8884,8 @@ function portal() {
         ? (accepted && accepted.item) : acceptedQueueItem;
       if (mirrorState
           && acceptedItem && acceptedItem.id
+          && !this._findQueueSteeringMessage(
+            mirrorState, acceptedItem.id, acceptedItem.command_uuid)
           && !mirrorState.pendingQueue.some(q => q.id === acceptedItem.id)) {
         const queued = acceptedItem;
         const effectiveDelivery = this._normalizeBusySendMode(
@@ -8844,6 +8929,8 @@ function portal() {
             pendingDocs: [],
             delivery: effectiveDelivery,
             deliveryStatus,
+            commandUuid: String(queued.command_uuid || ""),
+            targetTurnId: String(queued.target_turn_id || ""),
             enqueuedAt: queued.enqueued_at || Date.now(),
           },
         ];
@@ -9256,26 +9343,72 @@ function portal() {
       const messages = st.messages || [];
       let turnUser = turnId
         ? messages.find(message => message && message.role === "user"
-          && message._turnId === turnId)
+          && message._turnId === turnId
+          && message._steeringAdjustment !== true
+          && message._turnRoot !== false)
         : null;
       const tailUser = messages[messages.length - 1];
+      const rootSignature = this._activeTurnUserSignature(text, images, docs);
       // A canonical history load may already have installed this prompt without
-      // MuseLab's live turn id. Only the physical tail can belong to the active
-      // turn, and the complete prompt envelope must match before it is adopted.
+      // MuseLab's live turn id. The physical tail remains the safest ordinary
+      // case. Native mid-turn steering is the exception: canonical history can
+      // now contain tool output and extra user messages after the root prompt.
+      // When the loaded tail is explicitly marked running, search only inside
+      // that active suffix (after the latest terminal footer), never older turns.
       if (!turnUser && turnId && tailUser && tailUser.role === "user"
           && !tailUser._turnId
           && this._activeTurnUserSignature(
             tailUser.text, tailUser.images, tailUser.docs,
-          ) === this._activeTurnUserSignature(text, images, docs)) {
+          ) === rootSignature) {
         tailUser._turnId = turnId;
+        tailUser._turnRoot = true;
         turnUser = tailUser;
+      }
+      let runningTailIndex = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i] && messages[i].turn_status === "running") {
+          runningTailIndex = i;
+          break;
+        }
+      }
+      let activeSuffixStart = messages.length;
+      if (!turnUser && turnId && runningTailIndex >= 0) {
+        activeSuffixStart = 0;
+        for (let i = runningTailIndex - 1; i >= 0; i--) {
+          const status = String(messages[i] && messages[i].turn_status || "");
+          if (status && status !== "running") {
+            activeSuffixStart = i + 1;
+            break;
+          }
+        }
+        for (let i = runningTailIndex; i >= activeSuffixStart; i--) {
+          const candidate = messages[i];
+          if (!candidate || candidate.role !== "user" || candidate._turnId
+              || candidate._steeringAdjustment === true) continue;
+          if (this._activeTurnUserSignature(
+            candidate.text, candidate.images || [], candidate.docs || [],
+          ) !== rootSignature) continue;
+          candidate._turnId = turnId;
+          candidate._turnRoot = true;
+          turnUser = candidate;
+          break;
+        }
       }
       let appended = false;
       if (!turnUser) {
+        // A bounded history window can start inside a very long active turn and
+        // omit its root user row. Drop that replayable running suffix before
+        // adding the authoritative /active prompt; the cold SSE replay rebuilds
+        // it in order instead of duplicating it above the new root.
+        if (runningTailIndex >= 0 && activeSuffixStart < messages.length) {
+          this._truncatePaneMessagesFrom(st, messages[activeSuffixStart]);
+        }
         turnUser = this._appendLiveMessage(st, {
-          role: "user", text, images, docs, _turnId: turnId,
+          role: "user", text, images, docs, _turnId: turnId, _turnRoot: true,
         });
         appended = true;
+      } else {
+        turnUser._turnRoot = true;
       }
       return { message: turnUser, appended };
     },
@@ -29460,6 +29593,7 @@ function portal() {
         this._scheduleLiveMessageViewport(sendState);
         sentUserBubble = this._appendLiveMessage(sendState, {
           role: "user", text,
+          _turnRoot: true,
           // The bubble exists before the server decides whether this prompt
           // owns a turn or a queue slot.  Keep pane-level Running hidden until
           // admission is authoritative.
@@ -29554,10 +29688,17 @@ function portal() {
         // Cold/legacy reconnect: the backend will replay every event from the
         // start of the turn, so discard the already-rendered suffix first.
         // Incremental reconnects retain it and request only missing sequences.
+        const rootUserIdx = sendState.messages.findIndex(message => message
+          && message.role === "user"
+          && message._turnId === expectedTurnId
+          && message._turnRoot === true);
         const roles = sendState.messages.map(m => m.role);
-        const lastUserIdx = roles.lastIndexOf("user");
-        if (lastUserIdx >= 0 && lastUserIdx < sendState.messages.length - 1) {
-          this._truncatePaneMessagesFrom(sendState, sendState.messages[lastUserIdx + 1]);
+        const replayRootIdx = rootUserIdx >= 0
+          ? rootUserIdx : roles.lastIndexOf("user");
+        if (replayRootIdx >= 0
+            && replayRootIdx < sendState.messages.length - 1) {
+          this._truncatePaneMessagesFrom(sendState,
+            sendState.messages[replayRootIdx + 1]);
         }
       }
       // (isContinuation: keep the existing messages intact — the watcher's
@@ -29940,6 +30081,7 @@ function portal() {
         if (ev && streamState.streamPhase !== "running" && [
           "text", "thinking", "tool_use", "tool_result", "compact_progress",
           "task_started", "task_progress", "task_notification", "rate_limit",
+          "queue_steering",
           "ask_user_question", "permission_request", "permission_request_resolved",
           "permission_mode_changed", "permission_mode_change_failed",
         ].includes(ev.type)) {
@@ -29947,7 +30089,7 @@ function portal() {
         }
       };
       ["startup", "text", "thinking", "tool_use", "tool_result", "compact_progress", "task_started",
-       "task_progress", "task_notification", "rate_limit",
+       "task_progress", "task_notification", "rate_limit", "queue_steering",
        "ask_user_question", "permission_request", "permission_request_resolved",
        "permission_mode_changed",
        "permission_mode_change_failed", "ping",
@@ -30451,7 +30593,18 @@ function portal() {
       es.addEventListener("queue_steering", ev => {
         let payload = {};
         try { payload = JSON.parse(ev.data) || {}; } catch (_) {}
-        this._applyQueueSteeringEvent(streamSid, payload);
+        // A native steering `started` ACK is a real human-message boundary in
+        // the SDK transcript. Close the current assistant/thinking segment
+        // before promoting the queue row so all later output is appended after
+        // the user's adjustment. Duplicate lifecycle frames must not split the
+        // new assistant segment, hence the explicit needs-promotion guard.
+        if (this._queueSteeringNeedsPromotion(streamSid, payload)) {
+          closeAsst();
+          closeThinking();
+        }
+        if (this._applyQueueSteeringEvent(streamSid, payload)) {
+          _scrollIfActive();
+        }
       });
       es.addEventListener("rate_limit", ev => {
         let d;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4424,10 +4424,10 @@ def test_load_session_reconnects_active_turn_and_renders_live_assistant(
     _assert_no_browser_errors(page, errors)
 
 
-def test_active_turn_adoption_requires_physical_tail_and_full_prompt_envelope(
+def test_active_turn_adoption_uses_tail_or_bounded_running_suffix(
     page: Page, backend_url, auth_token,
 ):
-    """Repeated text and attachment-only prompts cannot claim an older row."""
+    """Older repeats stay unclaimed; steering can follow the active root."""
     _login(page, backend_url, auth_token)
     result = _app_eval(
         page,
@@ -4473,6 +4473,17 @@ def test_active_turn_adoption_requires_physical_tail_and_full_prompt_envelope(
           ], [{ name: "notes.md", kind: "text" }],
         );
 
+        const midturn = makeState("active-midturn", [
+          { role: "assistant", text: "previous reply", turn_status: "completed" },
+          { role: "user", text: "original active prompt" },
+          { role: "tool_result", text: "tool result" },
+          { role: "user", text: "mid-turn adjustment", uuid: "steering-command" },
+          { role: "assistant", text: "active reply", turn_status: "running" },
+        ]);
+        const midturnResult = app._installActiveTurnUser(
+          midturn, "turn-midturn", "original active prompt", [], [],
+        );
+
         return {
           repeated: {
             appended: repeatedResult.appended,
@@ -4490,6 +4501,13 @@ def test_active_turn_adoption_requires_physical_tail_and_full_prompt_envelope(
             appended: exactResult.appended,
             length: exactTail.messages.length,
             tailTurnId: exactTail.messages.at(-1)._turnId || "",
+          },
+          midturn: {
+            appended: midturnResult.appended,
+            length: midturn.messages.length,
+            rootTurnId: midturn.messages[1]._turnId || "",
+            rootMarked: midturn.messages[1]._turnRoot === true,
+            adjustmentTurnId: midturn.messages[3]._turnId || "",
           },
         };
         """,
@@ -4510,6 +4528,13 @@ def test_active_turn_adoption_requires_physical_tail_and_full_prompt_envelope(
         "appended": False,
         "length": 1,
         "tailTurnId": "turn-exact",
+    }
+    assert result["midturn"] == {
+        "appended": False,
+        "length": 5,
+        "rootTurnId": "turn-midturn",
+        "rootMarked": True,
+        "adjustmentTurnId": "",
     }
 
 
@@ -4653,6 +4678,230 @@ def test_session_sync_deadline_dispose_and_hidden_resume(
     assert result["resumed"] is True
     assert result["retryDelays"] == [800, 1600, 3200]
     assert result["activityDelays"] == [1000, 2000, 4000]
+    _assert_no_browser_errors(page, errors)
+
+
+def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
+    page: Page, backend_url, auth_token,
+):
+    """A native mid-turn adjustment replaces its queue row in event order."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _install_fake_event_source(page)
+    sid = "perf-midturn-steering-bubble"
+    command_uuid = "midturn-command-uuid"
+    item_id = "midturn-queue-item"
+    adjustment = "MIDTURN_ADJUSTMENT_VISIBLE"
+    history_marker = "MIDTURN_HISTORY_MARKER"
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"midturn-steering-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._ensureSessionRegistered = async () => true;
+        app._confirmSessionBusy = async () => false;
+        app.appReady = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.sessions = [{
+          id: sid, name: "Mid-turn steering bubble", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.messages.push({
+          role: "assistant", text: arg.historyMarker,
+          html: `<p>${arg.historyMarker}</p>`, uuid: "midturn-history-uuid",
+          _k: `${sid}:uuid:midturn-history-uuid`, _noAnim: true,
+        });
+        Object.assign(st.messageRange, {
+          visibleStart: 0, visibleEnd: 1, offset: 0, total: 1,
+          preTotal: 0, order: "full", generation: "midturn-e2e",
+        });
+        app.currentId = sid;
+        app._activateTabState(sid);
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.atBottom = true;
+        app.mobileTab = "chat";
+        app.input = "MIDTURN_ORIGINAL_PROMPT";
+        return true;
+        """,
+        {"sid": sid, "historyMarker": history_marker},
+    )
+
+    _app_eval(page, "app.send(); return true;")
+    page.wait_for_function(
+        "() => window.__fakeChatStreams && window.__fakeChatStreams().length === 1"
+    )
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        st.pendingQueue = [{
+          id: arg.itemId,
+          text: arg.adjustment,
+          displayText: arg.adjustment,
+          pendingQuotes: [], images: [], docs: [],
+          delivery: "adjust", deliveryStatus: "waiting_tool",
+          commandUuid: arg.commandUuid,
+          enqueuedAt: Date.now(),
+        }];
+        return true;
+        """,
+        {
+            "sid": sid,
+            "itemId": item_id,
+            "commandUuid": command_uuid,
+            "adjustment": adjustment,
+        },
+    )
+    expect(page.locator(".msg.user.queued")).to_contain_text(
+        adjustment, timeout=5000
+    )
+
+    page.evaluate(
+        """arg => {
+          const common = { turn_id: "midturn-turn", session_id: arg.sid };
+          window.__emitSse("text", {
+            ...common, event_seq: 1, text: "ASSISTANT_BEFORE_ADJUSTMENT",
+          });
+          window.__emitSse("tool_use", {
+            ...common, event_seq: 2, id: "midturn-tool-use",
+            name: "Read", summary: "inspect before adjustment", input: {},
+          });
+          window.__emitSse("tool_result", {
+            ...common, event_seq: 3, id: "midturn-tool-use",
+            tool_name: "Read", preview: "TOOL_RESULT_BEFORE_ADJUSTMENT",
+            text: "TOOL_RESULT_BEFORE_ADJUSTMENT", is_error: false,
+          });
+          const steering = {
+            ...common,
+            item_id: arg.itemId,
+            command_uuid: arg.commandUuid,
+            state: "started",
+            effective_delivery: "adjust",
+            message: {
+              id: arg.itemId, uuid: arg.commandUuid,
+              text: arg.adjustment, display_text: arg.adjustment,
+              selection_quotes: [],
+            },
+          };
+          window.__emitSse("queue_steering", steering);
+          window.__emitSse("text", {
+            ...common, event_seq: 4, text: "ASSISTANT_AFTER_PART_A ",
+          });
+          // The terminal lifecycle event is a duplicate transcript boundary,
+          // not a second user message and not a reason to split assistant text.
+          window.__emitSse("queue_steering", {...steering, state: "completed"});
+          window.__emitSse("text", {
+            ...common, event_seq: 5, text: "ASSISTANT_AFTER_PART_B",
+          });
+        }""",
+        {
+            "sid": sid,
+            "itemId": item_id,
+            "commandUuid": command_uuid,
+            "adjustment": adjustment,
+        },
+    )
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          const adjustmentIndex = st.messages.findIndex(
+            m => m.role === "user" && m.uuid === arg.commandUuid);
+          const after = adjustmentIndex >= 0 ? st.messages[adjustmentIndex + 1] : null;
+          return adjustmentIndex >= 0 && st.pendingQueue.length === 0
+            && after?.role === "assistant"
+            && after.text === "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B";
+        }""",
+        arg={"sid": sid, "commandUuid": command_uuid},
+        timeout=10000,
+    )
+
+    result = page.evaluate(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          const indexOf = predicate => st.messages.findIndex(predicate);
+          const before = indexOf(m => (m.text || "").includes(
+            "ASSISTANT_BEFORE_ADJUSTMENT"));
+          const toolUse = indexOf(m => m.id === "midturn-tool-use"
+            && m.role === "tool_use");
+          const toolResult = indexOf(m => m.id === "midturn-tool-use"
+            && m.role === "tool_result");
+          const adjustment = indexOf(m => m.role === "user"
+            && m.uuid === arg.commandUuid);
+          const after = st.messages.findIndex((m, i) => i > adjustment
+            && m.role === "assistant"
+            && (m.text || "").includes("ASSISTANT_AFTER_PART_A"));
+          const user = st.messages[adjustment];
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(arg.sid)}"]`);
+          const node = pane?.querySelector(
+            `.msg.user[data-uuid="${CSS.escape(arg.commandUuid)}"]`);
+          const canonical = app._preserveCanonicalMessageIdentity(st, [{
+            role: "user", text: arg.adjustment,
+            displayText: arg.adjustment, uuid: arg.commandUuid,
+          }])[0];
+          return {
+            before, toolUse, toolResult, adjustment, after,
+            pendingCount: st.pendingQueue.length,
+            adjustmentCount: st.messages.filter(m => m.role === "user"
+              && m.uuid === arg.commandUuid).length,
+            afterCount: st.messages.filter((m, i) => i > adjustment
+              && m.role === "assistant"
+              && (m.text || "").includes("ASSISTANT_AFTER_PART_A")).length,
+            afterText: st.messages[after]?.text || "",
+            turnId: user?._turnId || "",
+            noAnim: user?._noAnim === true,
+            normalBubble: !!node,
+            normalBubbleText: node?.textContent || "",
+            queuedBubbleCount: document.querySelectorAll(".msg.user.queued").length,
+            sameCanonicalObject: canonical === user,
+            sameCanonicalKey: canonical?._k === user?._k,
+          };
+        }""",
+        {
+            "sid": sid,
+            "commandUuid": command_uuid,
+            "adjustment": adjustment,
+        },
+    )
+    assert 0 <= result["before"] < result["toolUse"] < result["toolResult"]
+    assert result["toolResult"] < result["adjustment"] < result["after"]
+    assert result["pendingCount"] == 0
+    assert result["adjustmentCount"] == 1
+    assert result["afterCount"] == 1
+    assert result["afterText"] == "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B"
+    assert result["turnId"] == "midturn-turn"
+    assert result["noAnim"] is True
+    assert result["normalBubble"] is True
+    assert adjustment in result["normalBubbleText"]
+    assert result["queuedBubbleCount"] == 0
+    assert result["sameCanonicalObject"] is True
+    assert result["sameCanonicalKey"] is True
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import threading
 
 import pytest
@@ -1131,6 +1132,8 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
     broadcast = chat.TurnBroadcast(sid)
     broadcast.query_committed = True
     broadcast.runtime_client = SteeringClient()
+    published = []
+    monkeypatch.setattr(broadcast, "publish", published.append)
     chat._active_turns[sid] = broadcast
     try:
         response = await chat.enqueue_api(
@@ -1168,6 +1171,31 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
         )
         assert sess.get_queue(sid)["items"][0]["steering_state"] == "queued"
 
+        await chat._settle_steering_lifecycle(
+            broadcast,
+            chat.CommandLifecycleMessage(
+                command_uuid=item["command_uuid"],
+                state="started",
+                session_id=sid,
+                uuid="life-started",
+            ),
+        )
+        started_event = next(
+            json.loads(event["data"])
+            for event in reversed(published)
+            if event["event"] == "queue_steering"
+            and json.loads(event["data"])["state"] == "started"
+        )
+        assert started_event["turn_id"] == broadcast.turn_id
+        assert started_event["message"] == {
+            "id": item["id"],
+            "uuid": item["command_uuid"],
+            "text": "adjust this task",
+            "display_text": "adjust this task",
+            "selection_quotes": [],
+            "enqueued_at": item["enqueued_at"],
+        }
+
         terminal = await chat._settle_steering_lifecycle(
             broadcast,
             chat.CommandLifecycleMessage(
@@ -1180,6 +1208,9 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
         assert terminal is True
         assert sess.get_queue(sid)["items"] == []
         assert broadcast.steering_commands == {}
+        completed_event = json.loads(published[-1]["data"])
+        assert completed_event["state"] == "completed"
+        assert completed_event["message"]["uuid"] == item["command_uuid"]
     finally:
         chat._active_turns.pop(sid, None)
         broadcast.close()

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -574,6 +574,62 @@ def test_forced_interrupt_persists_refreshable_footer_and_private_snapshot(
     assert path.parent.stat().st_mode & 0o777 == 0o700
 
 
+def test_broadcast_presentation_keeps_midturn_steering_user_boundary(stream_env):
+    """Active/recovery projections preserve the same human boundary as live SSE."""
+    chat_mod = stream_env
+    bc = chat_mod.TurnBroadcast(
+        session_id="steering-presentation", model="codex:gpt-5.6-sol")
+    bc.user_text = "original prompt"
+    bc.publish({
+        "event": "text",
+        "data": json.dumps({"text": "assistant before adjustment"}),
+    })
+    steering = {
+        "item_id": "steering-item",
+        "command_uuid": "steering-command",
+        "state": "started",
+        "effective_delivery": "adjust",
+        "message": {
+            "id": "steering-item",
+            "uuid": "steering-command",
+            "text": "change direction",
+            "display_text": "change direction",
+            "selection_quotes": [],
+        },
+    }
+    bc.publish({"event": "queue_steering", "data": json.dumps(steering)})
+    bc.publish({
+        "event": "text",
+        "data": json.dumps({"text": "assistant after adjustment"}),
+    })
+    bc.publish({
+        "event": "queue_steering",
+        "data": json.dumps({**steering, "state": "completed"}),
+    })
+
+    messages = chat_mod._broadcast_to_ui_messages(bc)
+
+    assert [message["role"] for message in messages] == [
+        "user", "assistant", "user", "assistant",
+    ]
+    assert messages[0]["_turnRoot"] is True
+    assert messages[0]["_turnId"] == bc.turn_id
+    adjustment = messages[2]
+    assert adjustment == {
+        "role": "user",
+        "text": "change direction",
+        "displayText": "change direction",
+        "selectionQuotes": [],
+        "images": [],
+        "docs": [],
+        "uuid": "steering-command",
+        "_turnId": bc.turn_id,
+        "_turnRoot": False,
+        "_steeringAdjustment": True,
+        "_queueItemId": "steering-item",
+    }
+
+
 def test_failed_snapshot_survives_partial_canonical_assistant(
         stream_env, client, monkeypatch, tmp_path):
     """A partial JSONL assistant is not equivalent to the terminal error row."""

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3320,7 +3320,9 @@ def test_message_identity_checks_only_incoming_batch_and_keeps_cold_replay_fallb
         "if (isReconnect && !isContinuation && resumeEventSeq === 0) {"):
         send.index("// (isContinuation:")]
     assert "this._truncatePaneMessagesFrom(sendState" in reconnect
-    assert "sendState.messages[lastUserIdx + 1]" in reconnect
+    assert "message._turnRoot === true" in reconnect
+    assert 'roles.lastIndexOf("user")' in reconnect
+    assert "sendState.messages[replayRootIdx + 1]" in reconnect
     assert "_releasePaneMessageRenderKeys" not in reconnect
 
 
@@ -5527,15 +5529,36 @@ def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
     sync = app[sync_start:sync_end]
     assert 'delivery: this._normalizeBusySendMode(it.delivery, "queue")' in sync
     assert "it.steering_state" in sync
+    assert 'commandUuid: String(it.command_uuid || "")' in sync
+    assert 'targetTurnId: String(it.target_turn_id || "")' in sync
+    assert "_findQueueSteeringMessage(" in sync
 
     steering_start = app.index("    _applyQueueSteeringEvent(sid, payload) {")
     steering_end = app.index("\n    async _syncQueueFromServer", steering_start)
     steering = app[steering_start:steering_end]
+    assert 'state === "started"' in steering
     assert 'state === "completed"' in steering
     assert 'state === "fallback"' in steering
     assert 'state === "cancelled"' in steering
+    assert "_promoteQueueSteeringMessage(context)" in steering
+    assert "st.pendingQueue = (st.pendingQueue || []).filter" in steering
+    promotion_start = app.index("    _promoteQueueSteeringMessage(context) {")
+    promotion = app[promotion_start:steering_start]
+    assert "this._appendLiveMessage(context.st" in promotion
+    assert "uuid: context.commandUuid" in promotion
+    assert "_turnId: context.turnId" in promotion
+    assert "_queueItemId: context.itemId" in promotion
+    assert "_noAnim: true" in promotion
     assert 'es.addEventListener("queue_steering"' in app
     assert '"queue_steering",' in app
+    queue_event = app[app.index('es.addEventListener("queue_steering"'):]
+    queue_event = queue_event[:queue_event.index("});") + 3]
+    assert "_queueSteeringNeedsPromotion" in queue_event
+    assert "closeAsst();" in queue_event
+    assert "closeThinking();" in queue_event
+    bump_start = app.index("      const _bumpSse = (ev) => {")
+    bump_end = app.index('      es.addEventListener("startup"', bump_start)
+    assert '"queue_steering"' in app[bump_start:bump_end]
 
     label_start = app.index("    queueDeliveryLabel(item) {")
     label_end = app.index("\n    _applyQueueSteeringEvent", label_start)


### PR DESCRIPTION
## 变更类型\n- [x] 修复 (bugfix)\n- [ ] 新功能 (feature)\n- [ ] 重构 (refactor)\n- [ ] 文档 (docs)\n- [ ] 其他 (other)\n\n## 变更说明\n- 在原生 steering 命令进入 started 状态时，将临时排队气泡转换为普通用户气泡\n- 以 command_uuid 作为稳定消息身份，保证工具结果、用户调整、后续助手输出严格按事件顺序渲染\n- 将 queue_steering 纳入 SSE 序号和 turn-id 校验，避免重连重复或旧连接越权更新\n- 修复冷重连时将中途用户消息误认为本轮根消息的问题\n- 保持实时流、恢复投影和 canonical 历史的消息身份一致\n\n## 测试情况\n- 73 项队列测试通过\n- 177 项流式测试通过\n- 171 项前端结构测试通过\n- 2 项 Playwright 时序回归通过\n- 取消快照端点与 transcript index 定向回归通过\n- Ruff、JS 语法、Python 编译及 git diff 检查通过\n\n## 审查检查项\n- [x] 代码符合规范\n- [x] 添加/更新了测试\n- [x] 自测通过\n- [x] 未包含敏感信息