### PR TITLE
Fix busy-turn steering and completed transcript rendering

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -999,6 +999,11 @@ class TurnBroadcast:
         # Keeping the exact client/turn here closes the session-id ABA race.
         self.runtime_client: "MuseLabSDKClient | None" = None
         self.query_committed = False
+        # Native steering must target this exact turn, but the queue request can
+        # arrive after HTTP admission and before the root SDK query commits.
+        # Writers register durably against the broadcast, then wait on this
+        # one-shot gate instead of being downgraded to end-of-turn FIFO.
+        self.steering_ready = asyncio.Event()
         self.result_forwarded = False
         self.permission = ""
         self.active_tool_use_ids: set[str] = set()
@@ -1355,6 +1360,7 @@ class TurnBroadcast:
             return
         self._flush_compact_text()
         self.done = True
+        self.steering_ready.set()
         self.finished_at = time.time()
         if self.perf_status == "unknown":
             self.perf_status = "cancelled" if self.cancelled else "completed"
@@ -1409,6 +1415,7 @@ class TurnBroadcast:
         # Keep the compacted replay for late desktop reconnects during the grace TTL.
 
     def close(self) -> None:
+        self.steering_ready.set()
         for subscriber in tuple(self.subscribers):
             subscriber.close_reader()
             subscriber.close()
@@ -7283,18 +7290,20 @@ async def _schedule_queue_drain_after_response(session_id: str) -> None:
     _schedule_queue_drain(session_id)
 
 
-def _eligible_steering_turn(
+def _admitted_steering_turn(
     session_id: str,
     turn_id: str,
     *,
     permission: str = "",
 ) -> TurnBroadcast | None:
-    """Return the exact foreground turn that can accept native steering.
+    """Return the exact foreground turn reserved for native steering.
 
     A session id is not sufficient: an old enqueue response can arrive after
     turn A ended and turn B reused the same pooled client.  The immutable turn
-    id, query commit point and final-result flag together close that ABA window.
-    Queue-owned/background turns are deliberately left to ordinary FIFO drain.
+    id and final-result flag close that ABA window. Queue-owned/background turns
+    are deliberately left to ordinary FIFO drain. Runtime readiness is checked
+    separately so an exact admitted turn can retain a durable pending command
+    while its root query is still starting.
     """
     bc = _active_turns.get(session_id)
     if (
@@ -7305,16 +7314,32 @@ def _eligible_steering_turn(
         or bc.turn_id != turn_id
         or bc.is_continuation
         or bool(bc.queue_item_id)
-        or not bc.query_committed
         or bc.result_forwarded
         or bc.steering_closed
-        or not isinstance(bc.runtime_client, MuseLabSDKClient)
         or _sessions_with_inflight_tasks.get(session_id)
         or _session_has_live_watcher(session_id)
     ):
         return None
     requested_permission = (permission or "").strip()
     if requested_permission and requested_permission != bc.permission:
+        return None
+    return bc
+
+
+def _eligible_steering_turn(
+    session_id: str,
+    turn_id: str,
+    *,
+    permission: str = "",
+) -> TurnBroadcast | None:
+    """Return an exact admitted turn whose root SDK query is committed."""
+    bc = _admitted_steering_turn(
+        session_id, turn_id, permission=permission)
+    if (
+        bc is None
+        or not bc.query_committed
+        or not isinstance(bc.runtime_client, MuseLabSDKClient)
+    ):
         return None
     return bc
 
@@ -7415,9 +7440,16 @@ async def _deliver_steering_command(
     """
     bc: TurnBroadcast | None = None
     write_event: asyncio.Event | None = None
+    waiting_for_startup = False
     async with _lock:
         bc = _eligible_steering_turn(
             session_id, turn_id, permission=permission)
+        if bc is None:
+            admitted = _admitted_steering_turn(
+                session_id, turn_id, permission=permission)
+            if admitted is not None and not admitted.query_committed:
+                bc = admitted
+                waiting_for_startup = True
         if bc is not None:
             write_event = asyncio.Event()
             bc.steering_commands[command_uuid] = {
@@ -7435,6 +7467,43 @@ async def _deliver_steering_command(
         )
         return "queue", "queued", fallback
 
+    def _discard_registration() -> None:
+        current = bc.steering_commands.get(command_uuid)
+        if current is not None and current.get("item_id") == item_id:
+            bc.steering_commands.pop(command_uuid, None)
+        write_event.set()
+        bc.steering_write_events.pop(command_uuid, None)
+
+    if waiting_for_startup:
+        try:
+            await asyncio.wait_for(
+                bc.steering_ready.wait(), timeout=30.0)
+        except asyncio.TimeoutError:
+            _discard_registration()
+            fallback = await _fallback_steering_item(
+                session_id,
+                item_id=item_id,
+                command_uuid=command_uuid,
+                bc=bc,
+            )
+            return "queue", "queued", fallback
+        async with _lock:
+            ready = (
+                _eligible_steering_turn(
+                    session_id, turn_id, permission=permission) is bc
+                and str((bc.steering_commands.get(command_uuid) or {}).get(
+                    "item_id") or "") == item_id
+            )
+        if not ready:
+            _discard_registration()
+            fallback = await _fallback_steering_item(
+                session_id,
+                item_id=item_id,
+                command_uuid=command_uuid,
+                bc=bc,
+            )
+            return "queue", "queued", fallback
+
     try:
         await bc.runtime_client.query_steering(
             text,
@@ -7442,11 +7511,7 @@ async def _deliver_steering_command(
             command_uuid=command_uuid,
         )
     except BaseException:
-        current = bc.steering_commands.get(command_uuid)
-        if current is not None and current.get("item_id") == item_id:
-            bc.steering_commands.pop(command_uuid, None)
-        write_event.set()
-        bc.steering_write_events.pop(command_uuid, None)
+        _discard_registration()
         fallback = await _fallback_steering_item(
             session_id,
             item_id=item_id,
@@ -7747,12 +7812,17 @@ async def enqueue_api(
     # the queue sidecar and the eventual canonical user UUID; replaying that
     # transaction inside a mid-turn CLI fold would make crash recovery
     # ambiguous, so attachment messages retain ordinary turn-boundary FIFO.
-    steering_turn = (
-        _eligible_steering_turn(
+    steering_turn = None
+    if requested_delivery == "adjust" and not attachment_ids:
+        steering_turn = _eligible_steering_turn(
             sid, requested_turn_id, permission=req.permission or "")
-        if requested_delivery == "adjust" and not attachment_ids
-        else None
-    )
+        if steering_turn is None:
+            admitted = _admitted_steering_turn(
+                sid, requested_turn_id, permission=req.permission or "")
+            # Only bridge the startup gap. A query-committed turn that fails
+            # the runtime capability check remains ordinary FIFO immediately.
+            if admitted is not None and not admitted.query_committed:
+                steering_turn = admitted
     effective_delivery = "adjust" if steering_turn is not None else "queue"
     command_uuid = str(uuid.uuid4()) if steering_turn is not None else ""
 
@@ -14819,6 +14889,10 @@ async def _admit_accept_launch_turn(
         model=model,
         image_ids=image_ids,
     )
+    # The validated launch permission is immutable for this admitted turn.
+    # Publish it before detached runtime startup so an exact-turn steering
+    # request in the admission window can retain the same permission guard.
+    broadcast.permission = permission
     if broadcast.done or broadcast.cancelled:
         return broadcast
     try:
@@ -15820,6 +15894,7 @@ async def _start_turn(
                         _pending_runtime_rebuilds.add(session_id)
                         raise
                     broadcast.query_committed = True
+                    broadcast.steering_ready.set()
                     broadcast.emit_startup_perf("ready")
                     if persisted_imgs:
                         try:

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -510,6 +510,15 @@ def _transcript_ts_ms(entry: dict) -> int | None:
 _RawMsg = chat_history.RawMsg
 
 
+def _raw_msg_from_entry(entry: dict) -> _RawMsg | None:
+    """Compatibility facade for canonical record projection."""
+    return chat_history.raw_msg_from_entry(
+        entry,
+        raw_msg_type=_RawMsg,
+        timestamp_ms=_transcript_ts_ms,
+    )
+
+
 def _full_session_msgs(sid: str) -> list:
     """Compatibility wrapper for canonical full-file transcript reads."""
     return chat_history.full_session_msgs(
@@ -5373,6 +5382,7 @@ def _describe_transcript_record(entry: dict) -> dict:
     return chat_presentation.describe_transcript_record(
         entry,
         raw_message_factory=_RawMsg,
+        raw_entry_factory=_raw_msg_from_entry,
         render_messages=_sdk_messages_to_ui,
         is_real_user_prompt=_is_real_user_prompt,
     )
@@ -5425,7 +5435,10 @@ def _indexed_turn_context(
         if selected_i < 0 or selected_i >= len(records):
             continue
         selected = records[selected_i]
-        selected_uuid = str(selected.get("uuid") or "")
+        selected_uuid = str(
+            selected.get("presentation_uuid")
+            or selected.get("uuid")
+            or "")
         current_i = selected_i
         origin_i = selected_i
         seen: set[str] = set()
@@ -5465,19 +5478,26 @@ def _indexed_ui_records(
     index: dict,
     record_indices: list[int],
     annotations: dict[str, dict],
+    *,
+    defer_large_bodies: bool = True,
 ) -> list[dict]:
     """Seek/read and shape only selected records from a transcript index."""
     entries = transcript_idx.read_records(transcript_path, index, record_indices)
     turn_context = _indexed_turn_context(
         transcript_path, index, record_indices)
-    raw = [
-        _RawMsg(str(e.get("uuid") or ""), str(e.get("type") or ""),
-                e.get("message") or {}, _transcript_ts_ms(e))
-        for e in entries
+    projected = [
+        (entry, _raw_msg_from_entry(entry))
+        for entry in entries
     ]
-    compact = {str(e.get("uuid")) for e in entries if e.get("isCompactSummary")}
+    raw = [msg for _, msg in projected if msg is not None]
+    compact = {
+        str(msg.uuid)
+        for entry, msg in projected
+        if msg is not None and entry.get("isCompactSummary")
+    }
     bubbles = _sdk_messages_to_ui(
-        raw, annotations, compact, defer_large_bodies=True)
+        raw, annotations, compact,
+        defer_large_bodies=defer_large_bodies)
 
     # Cross-window context is stored in the index: a page may begin with a
     # tool_result whose tool_use is outside the read window, and a launching
@@ -5768,7 +5788,13 @@ def _jsonl_signature(sid: str) -> tuple[float, int] | None:
         sid, find_session_jsonl=_find_session_jsonl)
 
 
-def _shaped_ui_messages(sid: str, model: str, full: bool) -> list[dict]:
+def _shaped_ui_messages(
+    sid: str,
+    model: str,
+    full: bool,
+    *,
+    defer_large_bodies: bool = True,
+) -> list[dict]:
     """Shape SDK messages into UI bubbles with a freshness-checked cache.
 
     Falls back to live shaping whenever either signature is unavailable
@@ -5779,19 +5805,39 @@ def _shaped_ui_messages(sid: str, model: str, full: bool) -> list[dict]:
     jsig = _jsonl_signature(sid)
     ssig = sess.sidecar_signature(sid)
     key = (sid, full)
-    if jsig is not None:
+    if jsig is not None and defer_large_bodies:
         hit = _UI_MSGS_CACHE.get(key)
         if hit is not None and hit[0] == jsig and hit[1] == ssig:
             return hit[2]
-    try:
-        sdk_msgs = _cached_session_msgs(sid, model, full)
-    except Exception:
-        sdk_msgs = []
     annotations = sess.get_message_annotations(sid)
-    compact_uuids = _compact_summary_uuids(sid)
-    messages = _sdk_messages_to_ui(
-        sdk_msgs, annotations, compact_uuids, defer_large_bodies=True)
-    if jsig is not None:
+    messages: list[dict]
+    try:
+        indexed = _ensure_transcript_index(sid)
+    except Exception:
+        indexed = None
+    if indexed is not None:
+        transcript_path, index = indexed
+        order = "full" if full else "normal"
+        messages = _indexed_ui_records(
+            transcript_path,
+            index,
+            list((index.get("orders") or {}).get(order) or []),
+            annotations,
+            defer_large_bodies=defer_large_bodies,
+        )
+    else:
+        try:
+            sdk_msgs = _cached_session_msgs(sid, model, full)
+        except Exception:
+            sdk_msgs = []
+        compact_uuids = _compact_summary_uuids(sid)
+        messages = _sdk_messages_to_ui(
+            sdk_msgs,
+            annotations,
+            compact_uuids,
+            defer_large_bodies=defer_large_bodies,
+        )
+    if jsig is not None and defer_large_bodies:
         _UI_MSGS_CACHE.pop(key, None)
         _UI_MSGS_CACHE[key] = (jsig, ssig, messages)
         while len(_UI_MSGS_CACHE) > _UI_MSGS_CACHE_MAX:
@@ -6203,7 +6249,11 @@ def get_session_api(
             pre_total = 0
         if not full and total > 0 and meta.get("message_count", 0) != total:
             try:
-                turns = sum(1 for item in messages if item.get("role") == "user")
+                turns = sum(
+                    1 for item in messages
+                    if item.get("role") == "user"
+                    and item.get("_steeringAdjustment") is not True
+                )
                 sess.set_message_count(sid, total, turn_count=turns)
             except Exception:
                 pass
@@ -6258,7 +6308,10 @@ def get_session_block_api(sid: str, block_id: str) -> dict:
     transcript_path, index = indexed
     record_i = next(
         (i for i, record in enumerate(index.get("records") or [])
-         if str(record.get("uuid") or "") == record_uuid),
+         if record_uuid in {
+             str(record.get("uuid") or ""),
+             str(record.get("presentation_uuid") or ""),
+         }),
         None,
     )
     if record_i is None:
@@ -6267,14 +6320,12 @@ def get_session_block_api(sid: str, block_id: str) -> dict:
     if not entries:
         raise HTTPException(404, "block not found")
     entry = entries[0]
-    raw = _RawMsg(
-        str(entry.get("uuid") or ""),
-        str(entry.get("type") or ""),
-        entry.get("message") or {},
-        _transcript_ts_ms(entry),
-    )
-    compact = {record_uuid} if entry.get("isCompactSummary") else set()
-    messages = _sdk_messages_to_ui([raw], {}, compact)
+    raw = _raw_msg_from_entry(entry)
+    if raw is None:
+        raise HTTPException(404, "block not found")
+    compact = {raw.uuid} if entry.get("isCompactSummary") else set()
+    messages = _sdk_messages_to_ui(
+        [raw], sess.get_message_annotations(sid), compact)
     block = next(
         (message for message in messages
          if message.get("block_id") == block_id),
@@ -6631,12 +6682,8 @@ def export_session_markdown(sid: str, ticket: str = Query("")) -> Response:
         messages, _, _, _ = _interrupted_history_window(
             transcript_path, index, snapshots, annotations, "normal")
     else:
-        try:
-            sdk_msgs = _get_session_msgs(sid, model)
-        except Exception:
-            sdk_msgs = []
-        compact_uuids = _compact_summary_uuids(sid)
-        messages = _sdk_messages_to_ui(sdk_msgs, annotations, compact_uuids)
+        messages = _shaped_ui_messages(
+            sid, model, False, defer_large_bodies=False)
     # Bind any unbound pending image/doc attachments (those persisted
     # before the stream completed could write a uuid annotation) to the
     # user messages that have inline image refs but no thumb/url yet.
@@ -7430,6 +7477,8 @@ async def _deliver_steering_command(
     item_id: str,
     command_uuid: str,
     text: str,
+    display_text: str,
+    selection_quotes: list[dict],
     permission: str,
 ) -> tuple[str, str, dict | None]:
     """Write one durable queue item to the exact active CLI command queue.
@@ -7503,6 +7552,33 @@ async def _deliver_steering_command(
                 bc=bc,
             )
             return "queue", "queued", fallback
+
+    # The CLI's canonical queued_command attachment only retains the model
+    # prompt. Keep the bounded presentation metadata under the source UUID so
+    # refresh can restore the exact visible bubble and reconcile it with the
+    # live DOM identity. Commit this before the SDK write so a very fast CLI
+    # cannot publish the attachment/completion before its display metadata.
+    try:
+        await obs.to_thread_io(
+            "chat.queue_steering_annotation",
+            session_id,
+            sess.set_message_annotation,
+            session_id,
+            command_uuid,
+            steering_display_text=(
+                display_text if selection_quotes else None),
+            steering_selection_quotes=(
+                selection_quotes if selection_quotes else None),
+            steering_queue_item_id=item_id,
+            steering_turn_id=turn_id,
+            file_path=sess._sidecar_path(session_id),
+            owned=True,
+        )
+    except Exception as exc:
+        sys.stderr.write(
+            f"[chat] steering annotation failed sid={session_id[:8]} "
+            f"exc={type(exc).__name__}\n")
+        sys.stderr.flush()
 
     try:
         await bc.runtime_client.query_steering(
@@ -7975,6 +8051,8 @@ async def enqueue_api(
             item_id=queue_item_id,
             command_uuid=command_uuid,
             text=text,
+            display_text=display_text,
+            selection_quotes=selection_quotes,
             permission=req.permission or "",
         ))
         try:

--- a/backend/chat_history.py
+++ b/backend/chat_history.py
@@ -235,6 +235,58 @@ class RawMsg:
         self.mts = mts
 
 
+def raw_msg_from_entry(
+    entry: dict,
+    *,
+    raw_msg_type: type[RawMsg] = RawMsg,
+    timestamp_ms: Callable[[dict], int | None] = transcript_ts_ms,
+) -> RawMsg | None:
+    """Project one canonical JSONL record onto the SDK message facade.
+
+    Claude CLI persists a native mid-turn human adjustment as an
+    ``attachment`` record rather than a regular ``user`` record.  The
+    attachment's ``source_uuid`` is the UUID MuseLab originally supplied to
+    the SDK, so use it as the presentation identity: a live bubble and the
+    later canonical reload then reconcile as the same message.
+    """
+    record_type = str(entry.get("type") or "")
+    record_uuid = str(entry.get("uuid") or "")
+    message_uuid = record_uuid
+    message_type = record_type
+    message = entry.get("message") or {}
+
+    if record_type == "attachment":
+        attachment = entry.get("attachment")
+        if (not isinstance(attachment, dict)
+                or attachment.get("type") != "queued_command"):
+            return None
+        prompt = attachment.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return None
+        source_uuid = str(attachment.get("source_uuid") or "")
+        message_uuid = source_uuid or record_uuid
+        if not message_uuid:
+            return None
+        message_type = "user"
+        message = {
+            "role": "user",
+            "content": prompt,
+            "_muselab_steering": {
+                "record_uuid": record_uuid,
+                "source_uuid": message_uuid,
+            },
+        }
+    elif record_type not in {"user", "assistant"} or not message_uuid:
+        return None
+
+    return raw_msg_type(
+        message_uuid,
+        message_type,
+        message if isinstance(message, dict) else {},
+        timestamp_ms(entry),
+    )
+
+
 def full_session_msgs(
     sid: str,
     *,
@@ -242,7 +294,7 @@ def full_session_msgs(
     raw_msg_type: type[RawMsg] = RawMsg,
     timestamp_ms: Callable[[dict], int | None] = transcript_ts_ms,
 ) -> list[RawMsg]:
-    """Read every canonical user/assistant record in JSONL file order."""
+    """Read every canonical visible message in JSONL file order."""
     jsonl_path = find_session_jsonl(sid)
     if jsonl_path is None:
         return []
@@ -258,18 +310,15 @@ def full_session_msgs(
                     entry = json.loads(line)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if entry.get("type") not in ("user", "assistant"):
+                msg = raw_msg_from_entry(
+                    entry,
+                    raw_msg_type=raw_msg_type,
+                    timestamp_ms=timestamp_ms,
+                )
+                if msg is None or msg.uuid in seen:
                     continue
-                message_uuid = entry.get("uuid")
-                if not message_uuid or message_uuid in seen:
-                    continue
-                seen.add(message_uuid)
-                out.append(raw_msg_type(
-                    message_uuid,
-                    entry.get("type"),
-                    entry.get("message") or {},
-                    timestamp_ms(entry),
-                ))
+                seen.add(msg.uuid)
+                out.append(msg)
     except Exception:
         return []
     return out

--- a/backend/chat_history_window.py
+++ b/backend/chat_history_window.py
@@ -223,7 +223,10 @@ def history_window_around_uuid(
             record_id = int(segment.get("record_id") or 0)
             if (
                 0 <= record_id < len(records)
-                and str(records[record_id].get("uuid") or "") == uuid_value
+                and uuid_value in {
+                    str(records[record_id].get("uuid") or ""),
+                    str(records[record_id].get("presentation_uuid") or ""),
+                }
             ):
                 target_start = cursor
                 target_end = cursor + count

--- a/backend/chat_presentation.py
+++ b/backend/chat_presentation.py
@@ -310,6 +310,37 @@ def sdk_messages_to_ui(
         is_compact = sm.uuid in compact_uuids
         msg = sm.message or {}
         content = msg.get("content")
+        steering = msg.get("_muselab_steering")
+        if isinstance(steering, dict):
+            text = content if isinstance(content, str) else ""
+            if not text:
+                continue
+            entry = {
+                "role": "user",
+                "text": text,
+                "displayText": str(
+                    ann.get("steering_display_text", text) or ""),
+                "selectionQuotes": (
+                    ann.get("steering_selection_quotes")
+                    if isinstance(ann.get("steering_selection_quotes"), list)
+                    else []
+                ),
+                "uuid": sm.uuid,
+                "_turnRoot": False,
+                "_steeringAdjustment": True,
+            }
+            queue_item_id = str(
+                ann.get("steering_queue_item_id") or "")
+            if queue_item_id:
+                entry["_queueItemId"] = queue_item_id
+            turn_id = str(ann.get("steering_turn_id") or "")
+            if turn_id:
+                entry["_turnId"] = turn_id
+            for key, value in ann.items():
+                if not key.startswith("steering_"):
+                    entry[key] = value
+            out.append(entry)
+            continue
         if isinstance(content, str):
             if is_cli_interrupt_message(content):
                 continue
@@ -495,18 +526,36 @@ def describe_transcript_record(
     entry: dict,
     *,
     raw_message_factory: Callable[..., Any],
+    raw_entry_factory: Callable[[dict], Any] | None = None,
     render_messages: Callable[[list, dict, set[str]], list[dict]],
     is_real_user_prompt: Callable[[Any], bool],
 ) -> dict:
-    msg = raw_message_factory(
-        str(entry.get("uuid") or ""),
-        str(entry.get("type") or ""),
-        entry.get("message") or {},
+    msg = (
+        raw_entry_factory(entry)
+        if raw_entry_factory is not None
+        else raw_message_factory(
+            str(entry.get("uuid") or ""),
+            str(entry.get("type") or ""),
+            entry.get("message") or {},
+        )
     )
+    if msg is None:
+        return {
+            "bubble_count": 0,
+            "user_preview": "",
+            "real_user_prompt": False,
+            "has_inline_images": False,
+            "tool_uses": [],
+            "task_notifications": [],
+            "presentation_record": False,
+            "presentation_uuid": "",
+        }
     compact = {msg.uuid} if entry.get("isCompactSummary") else set()
     bubbles = render_messages([msg], {}, compact)
     tool_uses: list[dict] = []
-    content = (entry.get("message") or {}).get("content")
+    content = (msg.message or {}).get("content")
+    is_steering = isinstance(
+        (msg.message or {}).get("_muselab_steering"), dict)
     if isinstance(content, list):
         for block in content:
             if isinstance(block, dict) and block.get("type") == "tool_use":
@@ -527,10 +576,16 @@ def describe_transcript_record(
     return {
         "bubble_count": len(bubbles),
         "user_preview": outline_preview(user_text) if user_bubble is not None else "",
-        "real_user_prompt": is_real_user_prompt(msg) and not notifications,
+        "real_user_prompt": (
+            not is_steering
+            and is_real_user_prompt(msg)
+            and not notifications
+        ),
         "has_inline_images": has_inline_images,
         "tool_uses": tool_uses,
         "task_notifications": notifications,
+        "presentation_record": is_steering,
+        "presentation_uuid": msg.uuid if is_steering else "",
     }
 
 
@@ -553,10 +608,22 @@ def complete_turn_footer_metadata(
         if messages[index].get("role") == "user":
             index += 1
             continue
-        group_start = index
-        while index < len(messages) and messages[index].get("role") != "user":
+        group: list[dict] = []
+        while index < len(messages):
+            item = messages[index]
+            if item.get("role") == "user":
+                # Native steering is an inline human adjustment inside the
+                # same logical turn. It splits assistant text/tool segments for
+                # rendering, but must not close the preceding segment or grow
+                # a second completed/running footer.
+                if item.get("_steeringAdjustment") is True:
+                    index += 1
+                    continue
+                break
+            group.append(item)
             index += 1
-        group = messages[group_start:index]
+        if not group:
+            continue
         tail = group[-1]
         origin_uuid = str(tail.get("_turn_origin_uuid") or "")
         scope = ([item for item in group

--- a/backend/transcript_index.py
+++ b/backend/transcript_index.py
@@ -21,7 +21,7 @@ from .settings import atomic_write_text
 
 # Increment whenever persisted descriptor semantics (bubble expansion, preview,
 # tool/task metadata) change, not only when the JSON container shape changes.
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 _TRANSCRIPT_TYPES = {"user", "assistant", "progress", "system", "attachment"}
 _PREFIX_GUARD_BYTES = 1024 * 1024
 
@@ -200,6 +200,10 @@ def _append_complete_lines(
                 "is_meta": bool(entry.get("isMeta")),
                 "compact": bool(entry.get("isCompactSummary")),
                 "bubble_count": int(desc.get("bubble_count") or 0),
+                "presentation_record": bool(
+                    desc.get("presentation_record")),
+                "presentation_uuid": str(
+                    desc.get("presentation_uuid") or ""),
                 "user_preview": desc.get("user_preview") or "",
                 "real_user_prompt": bool(desc.get("real_user_prompt")),
                 "has_inline_images": bool(desc.get("has_inline_images")),
@@ -212,13 +216,22 @@ def _append_complete_lines(
 def _rebuild_derived(index: dict[str, Any]) -> None:
     records: list[dict[str, Any]] = index["records"]
 
+    def is_visible(record: dict[str, Any]) -> bool:
+        return (
+            record["type"] in {"user", "assistant"}
+            or bool(record.get("presentation_record"))
+        )
+
+    def visible_uuid(record: dict[str, Any]) -> str:
+        return str(record.get("presentation_uuid") or record["uuid"])
+
     # Full history preserves the old raw-reader contract: first UUID wins,
-    # user/assistant records only, chronological file order, no branch filters.
+    # visible records only, chronological file order, no branch filters.
     full: list[int] = []
     full_seen: set[str] = set()
     for i, rec in enumerate(records):
-        uid = rec["uuid"]
-        if rec["type"] in {"user", "assistant"} and uid not in full_seen:
+        uid = visible_uuid(rec)
+        if is_visible(rec) and uid not in full_seen:
             full_seen.add(uid)
             full.append(i)
 
@@ -239,7 +252,7 @@ def _rebuild_derived(index: dict[str, Any]) -> None:
             if uid in seen:
                 break
             seen.add(uid)
-            if rec["type"] in {"user", "assistant"}:
+            if is_visible(rec):
                 leaves.append(cur)
                 break
             parent = rec.get("parent")
@@ -265,13 +278,17 @@ def _rebuild_derived(index: dict[str, Any]) -> None:
             reverse_chain.append(cur)
             parent = rec.get("parent")
             cur = by_uuid.get(parent) if parent else None
+        normal_seen: set[str] = set()
         for i in reversed(reverse_chain):
             rec = records[i]
-            if (rec["type"] in {"user", "assistant"}
+            uid = visible_uuid(rec)
+            if (is_visible(rec)
+                    and uid not in normal_seen
                     and not rec["is_meta"]
                     and not rec["is_sidechain"]
                     and not rec["team_name"]):
                 normal.append(i)
+                normal_seen.add(uid)
 
     index["orders"] = {"normal": normal, "full": full}
     prefixes: dict[str, list[int]] = {}
@@ -458,8 +475,13 @@ def record_indices_around_uuid(
     order = index["orders"]["full"]
     prefix = index["bubble_prefix"]["full"]
     total = prefix[-1]
-    pos = next((i for i, rec_i in enumerate(order)
-                if index["records"][rec_i]["uuid"] == uuid_value), -1)
+    pos = next((
+        i for i, rec_i in enumerate(order)
+        if (
+            index["records"][rec_i]["uuid"] == uuid_value
+            or index["records"][rec_i].get("presentation_uuid") == uuid_value
+        )
+    ), -1)
     if pos < 0:
         return [], 0, 0, 0, total
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4306,15 +4306,20 @@ function portal() {
       }
       if (!ownerUser) return false;
 
+      // A native steering bubble divides the visible assistant/tool stream,
+      // but it is still part of this same logical turn. Pane-level live state
+      // belongs only to the newest user-delimited segment; otherwise both the
+      // pre-adjustment and post-adjustment tails render as Running.
+      for (let k = index + 1; k < pane.messages.length; k += 1) {
+        if (pane.messages[k] && pane.messages[k].role === "user") return false;
+      }
+
       const ownerTurnId = String(ownerUser._turnId || "");
       const activeTurnId = String(pane.activeTurnId || "");
       if (ownerTurnId && activeTurnId) return ownerTurnId === activeTurnId;
 
       // Before the first turn metadata event arrives, the newest user boundary
       // is the only reply run that can own the pane-level live state.
-      for (let k = index + 1; k < pane.messages.length; k += 1) {
-        if (pane.messages[k] && pane.messages[k].role === "user") return false;
-      }
       return true;
     },
     turnFooterStatus(m, pane) {
@@ -4413,7 +4418,8 @@ function portal() {
       const m = arr[i];
       if (!m || m.role === "user") return false;
       const next = arr[i + 1];
-      return !next || next.role === "user"
+      return !next || (next.role === "user"
+        && next._steeringAdjustment !== true)
         || next.display_kind === "runtime_continuation";
     },
     // Resolve a persisted message UUID for a footer mounted on the actual turn
@@ -4430,7 +4436,8 @@ function portal() {
       if (tail.display_kind === "runtime_continuation"
           || tail.forkable === false || tail.presentation_only) return "";
       const next = arr[i + 1];
-      if (next && next.role !== "user"
+      if (next && (next.role !== "user"
+          || next._steeringAdjustment === true)
           && next.display_kind !== "runtime_continuation") return "";
       for (let k = i; k >= 0; k -= 1) {
         const message = arr[k];
@@ -13580,7 +13587,8 @@ function portal() {
       const msgs = paneMsgs || [];
       const isTurnTail = m.role !== "user"
         && (i === msgs.length - 1
-            || (msgs[i + 1] && msgs[i + 1].role === "user"));
+            || (msgs[i + 1] && msgs[i + 1].role === "user"
+                && msgs[i + 1]._steeringAdjustment !== true));
       if (isTurnTail) return true;
 
       if (m._is_compact_summary) return true;
@@ -17103,7 +17111,12 @@ function portal() {
               body_ref: existing.body_ref,
             }
           : null;
-        Object.assign(existing, m, { _k: renderKey });
+        // A prior quiet reconciliation may have adopted this canonical block
+        // into an already-mounted live object. Keep that mounted key on every
+        // later canonical refresh; replacing it with renderKey here remounts
+        // the bubble on the second poll even though object identity survived.
+        const mountedKey = existing._k || renderKey;
+        Object.assign(existing, m, { _k: mountedKey });
         if (loadedBody) Object.assign(existing, loadedBody);
         return existing;
       });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -184,6 +184,12 @@ const _mcpFmtCache  = new WeakMap();   // raw msg -> { kind, value }
 const _readLinesCache = new WeakMap(); // raw msg -> { src, lines }
 const _searchHitsCache = new WeakMap();// raw msg -> { src, hits }
 const _toolMdCache = new WeakMap();    // raw msg -> { src, html }
+// Keyed by the per-tab state proxy. A structural transcript update normally
+// shifts many keyed Alpine rows at once; rebuilding this lookup once keeps each
+// row's derived index O(1) while still validating the cached coordinate before
+// use. This avoids stale x-for indices after a canonical row is inserted in the
+// middle of a live turn.
+const _paneMessageIndexCache = new WeakMap(); // tab state -> Map(message key, index)
 // Activity grouping/search runs from several Alpine expressions per render.
 // Keep its derived snapshot off reactive state so populating the cache cannot
 // itself schedule another render. Weak keys let each portal instance GC.
@@ -9856,11 +9862,13 @@ function portal() {
     },
     _reconcileCompletedTurn(
       sid, ownerState, expectedText = "", attempt = 0, expectedAssistantUuid = "",
+      completedTurnId = "",
     ) {
       if (!sid || this.tabState[sid] !== ownerState) return Promise.resolve(false);
       const options = {
         expectedText: String(expectedText || ""),
         expectedAssistantUuid: String(expectedAssistantUuid || ""),
+        completedTurnId: String(completedTurnId || ""),
         attempt: Math.max(0, Number(attempt) || 0),
       };
       ownerState._pendingCompletedTurnSync = options;
@@ -9874,13 +9882,16 @@ function portal() {
       const attempt = Math.max(0, Number(options.attempt) || 0);
       const expectedText = String(options.expectedText || "");
       const expectedAssistantUuid = String(options.expectedAssistantUuid || "");
+      const completedTurnId = String(options.completedTurnId || "");
       const stillOwned = () => this.tabState[sid] === ownerState
-        && !ownerState.streaming && !ownerState.es;
+        && !ownerState.streaming && !ownerState.es
+        && !this._hasPendingAdmission(ownerState);
       if (!stillOwned()) return false;
       const retry = () => {
         if (options.signal?.aborted) return;
         const next = {
-          expectedText, expectedAssistantUuid, attempt: attempt + 1,
+          expectedText, expectedAssistantUuid, completedTurnId,
+          attempt: attempt + 1,
         };
         ownerState._pendingCompletedTurnSync = next;
         if (attempt < 30 && stillOwned()) {
@@ -9890,19 +9901,23 @@ function portal() {
         }
       };
       try {
-        const activeResponse = await this._fetchWithDeadline(
-          "/api/chat/sessions/" + sid + "/active",
-          { headers: this.hdr(), signal: options.signal },
-        );
-        if (!stillOwned()) return false;
-        let activity = null;
-        try { activity = activeResponse.ok ? await activeResponse.json() : null; }
-        catch (_) { activity = null; }
-        if (!activity || (activity.active && !activity.background)) {
-          retry();
-          return false;
-        }
+        // The terminal SSE frame already identifies the exact assistant UUID.
+        // `/active` can remain true briefly while backend postlude/index work
+        // finishes, so treating it as a hard gate leaves the live DOM stale even
+        // when canonical history is already complete. Read history immediately
+        // and let the expected UUID below be the authoritative commit boundary.
         const reconcileTail = this._historyReconcileWindowSize();
+        // Probe identity in parallel with history. A stale active=true for the
+        // completed turn is harmless, while a different active turn means a
+        // successor has already claimed this session and its optimistic/live
+        // suffix must win over A's delayed canonical replacement.
+        const activeProbe = completedTurnId
+          ? this._fetchWithDeadline(
+              "/api/chat/sessions/" + sid + "/active",
+              { headers: this.hdr(), signal: options.signal },
+              2500,
+            ).catch(() => null)
+          : Promise.resolve(null);
         const historyResponse = await this._fetchWithDeadline(
           "/api/chat/sessions/" + sid + "?tail=" + reconcileTail,
           { headers: this.hdr(), signal: options.signal },
@@ -9910,31 +9925,69 @@ function portal() {
         if (!stillOwned()) return false;
         if (!historyResponse.ok) { retry(); return false; }
         const history = await historyResponse.json();
+        const activeResponse = await activeProbe;
+        if (!stillOwned()) return false;
+        let activity = null;
+        try { activity = activeResponse?.ok ? await activeResponse.json() : null; }
+        catch (_) { activity = null; }
+        const activeTurnId = String((activity && activity.turn_id) || "");
+        if (activity && activity.active && !activity.background
+            && activeTurnId && activeTurnId !== completedTurnId) {
+          retry();
+          return false;
+        }
         const messages = Array.isArray(history.messages) ? history.messages : [];
-        let latestUserIndex = -1;
-        for (let i = messages.length - 1; i >= 0; i -= 1) {
-          if (messages[i] && messages[i].role === "user") {
-            latestUserIndex = i;
+        let finalIndex = -1;
+        if (expectedAssistantUuid) {
+          for (let i = messages.length - 1; i >= 0; i -= 1) {
+            const message = messages[i];
+            if (message && message.role === "assistant"
+                && message.uuid === expectedAssistantUuid) {
+              finalIndex = i;
+              break;
+            }
+          }
+        } else if (expectedText) {
+          for (let i = messages.length - 1; i >= 0; i -= 1) {
+            const message = messages[i];
+            if (message && message.role === "assistant" && message.uuid
+                && (message.text || "") === expectedText) {
+              finalIndex = i;
+              break;
+            }
+          }
+        }
+        if (finalIndex < 0) { retry(); return false; }
+        const hasSuccessorRoot = messages.slice(finalIndex + 1).some(
+          message => message && message.role === "user"
+            && message._steeringAdjustment !== true
+            && message._turnRoot !== false,
+        );
+        if (hasSuccessorRoot) { retry(); return false; }
+        // Native steering messages are user-role records inside the same logical
+        // turn. Walk backward from the committed final assistant to the nearest
+        // root user instead of truncating the window at the last adjustment.
+        let rootUserIndex = -1;
+        for (let i = finalIndex - 1; i >= 0; i -= 1) {
+          const message = messages[i];
+          if (message && message.role === "user"
+              && message._steeringAdjustment !== true
+              && message._turnRoot !== false) {
+            rootUserIndex = i;
             break;
           }
         }
-        const turnStart = latestUserIndex + 1;
-        const canonicalTurn = messages.slice(turnStart);
+        const turnStart = rootUserIndex + 1;
+        const canonicalTurn = messages.slice(turnStart, finalIndex + 1);
         // Mobile's normal 20-block window can start inside a tool-heavy turn.
         // Reconcile at least through this turn's user boundary so canonical
         // installation never keeps the reply while dropping its prompt.
-        const completedTurnWindow = latestUserIndex >= 0
-          ? messages.length - latestUserIndex : reconcileTail;
+        const completedTurnWindow = rootUserIndex >= 0
+          ? messages.length - rootUserIndex : reconcileTail;
         const hasBoundary = canonicalTurn.some(
           m => m && m.role !== "user" && m.uuid,
         );
-        const hasFinal = expectedAssistantUuid
-          ? canonicalTurn.some(m => m && m.uuid === expectedAssistantUuid)
-          : !!expectedText && canonicalTurn.some(
-              m => m && m.role === "assistant" && m.uuid
-                && (m.text || "") === expectedText,
-            );
-        if (!hasBoundary || !hasFinal) { retry(); return false; }
+        if (!hasBoundary) { retry(); return false; }
         if (!stillOwned()) return false;
         const loaded = await this.loadSession(sid, {
           quiet: true, probeActive: false,
@@ -9954,9 +10007,11 @@ function portal() {
     },
     _reconcileCompletedContinuation(
       sid, ownerState, expectedText = "", attempt = 0, expectedAssistantUuid = "",
+      completedTurnId = "",
     ) {
       return this._reconcileCompletedTurn(
         sid, ownerState, expectedText, attempt, expectedAssistantUuid,
+        completedTurnId,
       );
     },
     async removePendingQueueItem(sid, idx) {
@@ -10366,6 +10421,40 @@ function portal() {
       if (!tid) return [];
       return this._visiblePaneMessages(this.tabState && this.tabState[tid]);
     },
+    paneMessageIndex(tid, message) {
+      const st = tid && this.tabState && this.tabState[tid];
+      if (!st || !message) return -1;
+      const rows = Array.isArray(st.messages) ? st.messages : [];
+      if (rows.length) this._ensureNonEmptyMessageRange(st);
+      const start = st.messageRange
+        ? Math.max(0, Math.min(st.messageRange.visibleStart, rows.length)) : 0;
+      const end = st.messageRange
+        ? Math.max(start, Math.min(st.messageRange.visibleEnd, rows.length))
+        : rows.length;
+      const key = message._k;
+      let indexes = _paneMessageIndexCache.get(st);
+      const cached = key && indexes ? indexes.get(key) : undefined;
+      if (Number.isInteger(cached) && cached >= start && cached < end
+          && rows[cached] && rows[cached]._k === key) {
+        return cached - start;
+      }
+      indexes = new Map();
+      for (let index = start; index < end; index += 1) {
+        const candidate = rows[index];
+        if (candidate && candidate._k) indexes.set(candidate._k, index);
+      }
+      _paneMessageIndexCache.set(st, indexes);
+      if (key && indexes.has(key)) return indexes.get(key) - start;
+      const absolute = rows.indexOf(message, start);
+      return absolute >= start && absolute < end ? absolute - start : -1;
+    },
+    _hasPendingAdmission(st) {
+      return !!(st && (st._composerSubmitToken || this._hasAdmissionBubble(st)));
+    },
+    _hasAdmissionBubble(st) {
+      return !!(st && Array.isArray(st.messages)
+        && st.messages.some(message => message && message._admissionPending));
+    },
     _messageVirtualHeight(st, message) {
       const key = message && message._k;
       const measured = key && Number(st._virtualHeights[key]);
@@ -10436,19 +10525,6 @@ function portal() {
       st._virtualEnd = next.end;
       st._virtualRevision++;
     },
-    paneMessageRows(tid) {
-      const st = tid && this.tabState && this.tabState[tid];
-      const messages = this._visiblePaneMessages(st);
-      if (!st || !messages.length) return [];
-      // Render the resident window directly. The custom estimated-height spacers
-      // could not keep up with fast wheel/touch movement: readers outran the
-      // mounted range into blank space, then each measured-height correction
-      // resized the scrollbar and flashed the pane. Network paging still bounds
-      // the resident range; the browser now owns layout with exact row heights.
-      return messages.map((message, index) => ({
-        key: message._k, index, message, spacer: false,
-      }));
-    },
     _measureMessageVirtualRows(tid, st) {
       const pane = this._paneElement(tid);
       if (!pane || this.tabState[tid] !== st) return false;
@@ -10465,8 +10541,8 @@ function portal() {
       return changed;
     },
     _syncMessageViewport(tid = this.currentId, forceTail = false) {
-      // Intentionally no-op: paneMessageRows renders the resident range with
-      // exact browser layout. Keeping the old velocity/estimated-height window
+      // Intentionally no-op: the flat keyed message loop renders the resident
+      // range with exact browser layout. Keeping the old velocity/estimated-height window
       // updater active would continue rewriting indexes and restoring anchors
       // on every scroll frame even though there are no virtual spacers left.
       void tid;
@@ -16318,7 +16394,7 @@ function portal() {
       // Canonical history reconciliation runs only after the stream retires.
       // Return false so full-history/outline callers know the requested load was
       // deferred instead of recursively treating it as completed.
-      if (st.streaming || st.es) return false;
+      if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
       const historyReplaceToken = this._beginHistoryReplace(st);
       const quietRangeSnapshot = quiet
         ? this._captureMessageRangeSnapshot(st) : null;
@@ -16423,7 +16499,7 @@ function portal() {
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
           return false;
         }
-        if (st.streaming || st.es) return false;
+        if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
         const loadedRuntimeUiRevision = String(s.runtime_ui_revision || "");
         const currentRuntimeUiRevision = String(st.runtimeUiRevision || "");
         // A different load for this same tab adopted another presentation
@@ -16506,12 +16582,13 @@ function portal() {
         // this state while markdown rendering yielded. Never write into a stale
         // generation or replace an active owner's message array.
         if (this.tabState[sid] !== st || st.streaming || st.es
+            || this._hasAdmissionBubble(st)
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
           return false;
         }
         // Replace the one repository in place. Quiet reconciliation preserves
         // matching message object identity; cold reveal changes only range coords.
-        if (st.streaming || st.es) return false;
+        if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
         // _virtualStart/_virtualEnd are LOCAL to the revealed slice. A quiet
         // canonical refresh can move visibleStart from a narrow recent tail to
         // an older coordinate; carrying the same numbers across that change
@@ -16567,6 +16644,7 @@ function portal() {
         }
         historyPerf.install_ms = Math.round(perfNow() - installStarted);
         if (this.tabState[sid] !== st || st.streaming || st.es
+            || this._hasAdmissionBubble(st)
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
           return false;
         }
@@ -17324,6 +17402,10 @@ function portal() {
       this._assignLiveKey(st, m);
       const tailWasVisible = st.messageRange.visibleEnd === st.messages.length;
       const followTail = tailWasVisible && st.atBottom !== false;
+      // A live/optimistic append is newer than every history response already
+      // in flight. Advance the replacement epoch before exposing the bubble so
+      // an older quiet load cannot splice it out during turn admission.
+      this._invalidateHistoryReplace(st);
       st.messages.push(m);
       st.messageRange.total = Math.max(
         st.messageRange.total + 1, st.messageRange.offset + st.messages.length);
@@ -17423,6 +17505,9 @@ function portal() {
       return null;
     },
     _beginHistoryReplace(st) {
+      return this._invalidateHistoryReplace(st);
+    },
+    _invalidateHistoryReplace(st) {
       const seq = (Number(st && st._historyRequestSeq) || 0) + 1;
       st._historyRequestSeq = seq;
       st._historyReplaceOwner = seq;
@@ -31280,12 +31365,12 @@ function portal() {
         } else if (isContinuation && !d.cancelled) {
           this._reconcileCompletedContinuation(
             streamSid, streamState, continuationFinalText, 0,
-            String(d.assistant_uuid || ""),
+            String(d.assistant_uuid || ""), completedTurnId,
           );
         } else if (!d.cancelled) {
           this._reconcileCompletedTurn(
             streamSid, streamState, d.is_error ? "" : completedFinalText, 0,
-            String(d.assistant_uuid || ""),
+            String(d.assistant_uuid || ""), completedTurnId,
           );
         }
         if (!d.cancelled) {
@@ -31836,6 +31921,13 @@ function portal() {
           // async queue/start request settles. The token is globally unique, so
           // release every surviving holder instead of guessing one successor.
           this._releaseComposerClaim(composerSubmitToken);
+          this.$nextTick(() => {
+            for (const [sid, state] of Object.entries(this.tabState || {})) {
+              if (state && state._pendingCompletedTurnSync) {
+                this._resumePendingCanonicalSync(sid, state);
+              }
+            }
+          });
         }
       }
     },

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7838,6 +7838,10 @@ function portal() {
         // Exact backend turn currently owned by this tab. Session id is not
         // sufficient: a reconnect for turn A must never attach to newer B.
         activeTurnId: "",
+        // Primitive identity for the local stream attempt that owns the active
+        // turn. A delayed /active admission probe may observe a successor turn
+        // in the same tab, so discovery must also match this local owner.
+        _streamOwnerToken: "",
         // Immutable turn id of the most recent authenticated terminal frame.
         // Post-result work may briefly leave /active or a mux state snapshot
         // stale; never re-attach that already-rendered turn as "running".
@@ -8023,6 +8027,7 @@ function portal() {
       if (st.activeTurnId === undefined) st.activeTurnId = "";
       if (st._lastTerminalTurnId === undefined) st._lastTerminalTurnId = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
+      if (st._streamOwnerToken === undefined) st._streamOwnerToken = "";
       if (!Number.isFinite(st.lastEventSeq)) st.lastEventSeq = 0;
       if (st.permission === undefined) st.permission = "";
       if (st.effort === undefined) st.effort = "auto";
@@ -8414,6 +8419,57 @@ function portal() {
         return "queue";
       }
       return "adjust";
+    },
+    async _resolveBusyAdjustmentTurnId(
+      sid, st, expectedStreamOwnerToken = "", activeTurnId = "",
+      hasAttachments = false,
+    ) {
+      const streamOwnerToken = String(expectedStreamOwnerToken || "");
+      const ownerStillCurrent = () => !!streamOwnerToken
+        && this.tabState[sid] === st
+        && st.streaming
+        && String(st._streamOwnerToken || "") === streamOwnerToken;
+      if (!ownerStillCurrent()) return "";
+      const accept = value => {
+        const turnId = String(value || "");
+        return turnId
+          && this._busySendDelivery(sid, turnId, hasAttachments) === "adjust"
+          ? turnId : "";
+      };
+      const known = accept(activeTurnId || (st && st.activeTurnId));
+      if (known) return known;
+      // A second Send can land after the first call marked the pane streaming
+      // but before /turns/start returned its immutable turn id.  Falling back
+      // to FIFO in that narrow admission window strands the message until the
+      // whole turn completes, even if many tool boundaries follow. Resolve the
+      // already-reserved server turn once, then keep the ordinary exact-id ABA
+      // checks in the queue endpoint. Every genuinely ineligible state still
+      // returns immediately without an extra request.
+      if (!st || this.tabState[sid] !== st
+          || this._normalizeBusySendMode(this.busySendMode) !== "adjust"
+          || hasAttachments || !st.streaming || st.compacting
+          || st.backgroundActive || st._draining || st.parentTurnId
+          || (st.pendingQueue && st.pendingQueue.length)) {
+        return "";
+      }
+      try {
+        const r = await this._fetchWithDeadline(
+          "/api/chat/sessions/" + sid + "/active",
+          { headers: this.hdr(), cache: "no-store" },
+          2500,
+        );
+        if (!ownerStillCurrent()) return "";
+        const local = accept(st.activeTurnId);
+        if (local) return local;
+        if (!r.ok) return "";
+        const status = await r.json();
+        if (!ownerStillCurrent() || !status.active || status.background) {
+          return "";
+        }
+        return accept(status.turn_id);
+      } catch (_) {
+        return ownerStillCurrent() ? accept(st.activeTurnId) : "";
+      }
     },
     sendButtonHint(sid) {
       if (this.composerClaimed(sid)) return this.t("btn.send");
@@ -8822,10 +8878,20 @@ function portal() {
             "",
           )
         : "";
-      const delivery = this._normalizeBusySendMode(
+      let delivery = this._normalizeBusySendMode(
         item.delivery || this.busySendMode,
       );
-      const activeTurnId = String(item.active_turn_id || "");
+      let activeTurnId = String(item.active_turn_id || "");
+      const streamOwnerToken = String(item.stream_owner_token || "");
+      if (delivery !== "adjust" && !activeTurnId && !image_ids) {
+        const resolvedTurnId = await this._resolveBusyAdjustmentTurnId(
+          sid, enqueueState, streamOwnerToken, "", false,
+        );
+        if (resolvedTurnId) {
+          activeTurnId = resolvedTurnId;
+          delivery = "adjust";
+        }
+      }
       let accepted = null;
       try {
         const r = await fetch("/api/chat/sessions/" + sid + "/queue", {
@@ -29471,6 +29537,8 @@ function portal() {
       // backend can reject stale steering rather than targeting a successor.
       const busyActiveTurnId = !isReconnect
         ? String(sendState.activeTurnId || "") : "";
+      const busyStreamOwnerToken = !isReconnect
+        ? String(sendState._streamOwnerToken || "") : "";
       const busyHasAttachments = !isReconnect
         && !!(composerImages.length || composerDocs.length);
       const busyDelivery = this._busySendDelivery(
@@ -29661,6 +29729,7 @@ function portal() {
           plan_return_permission: sendPlanReturnPermission,
           delivery: busyDelivery,
           active_turn_id: busyActiveTurnId,
+          stream_owner_token: busyStreamOwnerToken,
         });
         if (!ok) {
           rollbackOptimisticSubmission();
@@ -29763,6 +29832,7 @@ function portal() {
       // visual generation makes an older load response unable to turn the live
       // pane into either a loading or error surface when it eventually settles.
       this._releaseTranscriptLoadForLive(streamState);
+      streamState._streamOwnerToken = composerSubmitToken;
       streamState.streaming = true;
       if (!isReconnect || !streamState.streamPhase) {
         streamState.streamPhase = "connecting";
@@ -29850,6 +29920,7 @@ function portal() {
         streamState._streamStartedAt = 0;
         streamState.streamElapsed = 0;
         streamState.streaming = false;
+        streamState._streamOwnerToken = "";
         streamState.streamPhase = "";
         streamState._continuationAwaitingReaction = false;
         streamState.es = null;
@@ -29913,6 +29984,7 @@ function portal() {
                   plan_return_permission: sendPlanReturnPermission,
                   delivery: busyDelivery,
                   active_turn_id: busyActiveTurnId,
+                  stream_owner_token: busyStreamOwnerToken,
                 });
                 if (queued) {
                   rollbackUnstartedSend(false);
@@ -30862,6 +30934,7 @@ function portal() {
         // permission-mode commit never arrived.
         _finalizePendingPermissionRequests();
         streamState.streaming = false;
+        streamState._streamOwnerToken = "";
         streamState.streamPhase = "";
         streamState._continuationAwaitingReaction = false;
         streamState.es = null;
@@ -31392,6 +31465,7 @@ function portal() {
             plan_return_permission: sendPlanReturnPermission,
             delivery: handoffDelivery,
             active_turn_id: handoffTurnId,
+            stream_owner_token: busyStreamOwnerToken,
           });
           if (queued) {
             if (sentUserBubble) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2899,7 +2899,8 @@
                    x-show="(m.role !== 'user' || m.turn_status || m._interrupted || m._failed)
                      && (i === paneMsgs.length - 1
                        || (paneMsgs[i + 1] && (
-                         paneMsgs[i + 1].role === 'user'
+                         (paneMsgs[i + 1].role === 'user'
+                           && paneMsgs[i + 1]._steeringAdjustment !== true)
                          || paneMsgs[i + 1].display_kind === 'runtime_continuation'
                        )))
                      && turnFooterStatus(m, pane)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1956,14 +1956,13 @@
                x-cloak
                :aria-hidden="tid === currentId ? null : 'true'"
                :data-tid="tid"
-               x-data="{ get pane(){ return paneState(tid) }, get paneMsgs(){ return paneMessages(tid) }, get paneRows(){ return paneMessageRows(tid) } }">
-          <template x-for="row in paneRows" :key="row.key">
-            <div x-data="{ get m(){ return row.message }, get i(){ return row.index } }"
-                 :class="row.spacer ? 'msg-virtual-spacer' : ('msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i, paneMsgs) ? '' : ' is-hidden') + (m._noAnim ? ' no-anim' : ''))"
-                 :data-uuid="row.spacer ? '' : (m.uuid || '')"
-                 :data-message-key="row.spacer ? '' : m._k"
-                 :aria-hidden="row.spacer ? 'true' : null"
-                 :style="row.spacer ? ('height:' + row.height + 'px') : ('contain-intrinsic-size: auto ' + messageIntrinsicH(pane, m) + 'px')">
+               x-data="{ get pane(){ return paneState(tid) }, get paneMsgs(){ return paneMessages(tid) } }">
+          <template x-for="m in paneMsgs" :key="m._k">
+            <div x-data="{ get i(){ return paneMessageIndex(tid, m) } }"
+                 :class="'msg ' + (m._is_compact_summary ? 'compact' : m.role) + (isMsgRenderable(m, i, paneMsgs) ? '' : ' is-hidden') + (m._noAnim ? ' no-anim' : '')"
+                 :data-uuid="m.uuid || ''"
+                 :data-message-key="m._k"
+                 :style="'contain-intrinsic-size: auto ' + messageIntrinsicH(pane, m) + 'px'">
               <!-- Per-message wall-clock (`mts`, backend). Deliberately NOT on
                    by default: an agentic turn is 30+ tool cards, and stamping
                    every one of them costs more attention than it returns —

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -4322,14 +4322,6 @@ pre.text {
   flex-direction: column;
   gap: var(--sp-2);
 }
-.msg-virtual-spacer {
-  flex: 0 0 auto;
-  width: 100%;
-  min-height: 0;
-  overflow: hidden;
-  pointer-events: none;
-}
-.msg-virtual-spacer > * { display: none !important; }
 .chat-bottom-anchor {
   flex: 0 0 1px;
   width: 100%;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4934,6 +4934,10 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
     item_id = "midturn-queue-item"
     adjustment = "MIDTURN_ADJUSTMENT_VISIBLE"
     history_marker = "MIDTURN_HISTORY_MARKER"
+    canonical_messages: list[dict] = []
+    requests = _route_windowed_session(
+        page, sid, canonical_messages, updated_at=2,
+    )
     page.route(
         "**/api/chat/stream/start",
         lambda route: route.fulfill(
@@ -4970,6 +4974,7 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
         app.tabState[sid] = app._blankTabState();
         const st = app._ensureTabState(sid);
         st._loaded = true;
+        st._seenUpdated = 1;
         st.messages.push({
           role: "assistant", text: arg.historyMarker,
           html: `<p>${arg.historyMarker}</p>`, uuid: "midturn-history-uuid",
@@ -5106,6 +5111,14 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             role: "user", text: arg.adjustment,
             displayText: arg.adjustment, uuid: arg.commandUuid,
           }])[0];
+          window.__midturnLiveUser = user;
+          window.__midturnLiveKey = user?._k || "";
+          const visibleRunningFooters = [...document.querySelectorAll(
+            ".turn-footer .turn-status.running")].filter(node => {
+              const footer = node.closest(".turn-footer");
+              return footer && getComputedStyle(footer).display !== "none"
+                && getComputedStyle(node).display !== "none";
+            });
           return {
             before, toolUse, toolResult, adjustment, after,
             pendingCount: st.pendingQueue.length,
@@ -5122,6 +5135,9 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             queuedBubbleCount: document.querySelectorAll(".msg.user.queued").length,
             sameCanonicalObject: canonical === user,
             sameCanonicalKey: canonical?._k === user?._k,
+            beforeStatus: app.turnFooterStatus(st.messages[toolResult], st),
+            afterStatus: app.turnFooterStatus(st.messages[after], st),
+            visibleRunningFooterCount: visibleRunningFooters.length,
           };
         }""",
         {
@@ -5143,6 +5159,134 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
     assert result["queuedBubbleCount"] == 0
     assert result["sameCanonicalObject"] is True
     assert result["sameCanonicalKey"] is True
+    assert result["beforeStatus"] == ""
+    assert result["afterStatus"] == "running"
+    assert result["visibleRunningFooterCount"] == 1
+
+    canonical_messages.extend([
+        {
+            "role": "assistant", "text": history_marker,
+            "html": f"<p>{history_marker}</p>",
+            "uuid": "midturn-history-uuid", "ts": 1_700_030_000,
+            "turn_status": "completed",
+            "block_id": "midturn-history-uuid:0:assistant",
+            "_key": "midturn-history-uuid:0:assistant",
+        },
+        {
+            "role": "user", "text": "MIDTURN_ORIGINAL_PROMPT",
+            "uuid": "midturn-root-user", "_turnRoot": True,
+            "block_id": "midturn-root-user:0:user",
+            "_key": "midturn-root-user:0:user",
+        },
+        {
+            "role": "assistant", "text": "ASSISTANT_BEFORE_ADJUSTMENT",
+            "uuid": "midturn-before-assistant",
+            "block_id": "midturn-before-assistant:0:assistant",
+            "_key": "midturn-before-assistant:0:assistant",
+        },
+        {
+            "role": "tool_use", "id": "midturn-tool-use", "name": "Read",
+            "summary": "inspect before adjustment", "input": {},
+            "uuid": "midturn-before-assistant",
+            "block_id": "midturn-before-assistant:1:tool_use",
+            "_key": "midturn-before-assistant:1:tool_use",
+        },
+        {
+            "role": "tool_result", "id": "midturn-tool-use",
+            "tool_name": "Read", "preview": "TOOL_RESULT_BEFORE_ADJUSTMENT",
+            "text": "TOOL_RESULT_BEFORE_ADJUSTMENT", "is_error": False,
+            "uuid": "midturn-before-result",
+            "block_id": "midturn-before-result:0:tool_result",
+            "_key": "midturn-before-result:0:tool_result",
+        },
+        {
+            "role": "user", "text": adjustment, "displayText": adjustment,
+            "selectionQuotes": [], "uuid": command_uuid,
+            "_steeringAdjustment": True, "_turnRoot": False,
+            "block_id": f"{command_uuid}:0:user",
+            "_key": f"{command_uuid}:0:user",
+        },
+        {
+            "role": "assistant",
+            "text": "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B",
+            "uuid": "midturn-final-assistant", "ts": 1_700_030_010,
+            "turn_status": "completed",
+            "block_id": "midturn-final-assistant:0:assistant",
+            "_key": "midturn-final-assistant:0:assistant",
+        },
+    ])
+    page.evaluate(
+        """() => window.__emitSse("done", {
+          total_cost_usd: 0.001, turn_id: "midturn-turn", event_seq: 6,
+        })"""
+    )
+    page.wait_for_function(
+        """sid => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app._ensureTabState(sid).streaming === false;
+        }""",
+        arg=sid,
+        timeout=10000,
+    )
+    loaded = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        st._pendingExternalUpdate = true;
+        return await app.loadSession(arg.sid, {
+          quiet: true, probeActive: false, followTail: true,
+        });
+        """,
+        {"sid": sid},
+    )
+    assert loaded is True
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          return st.messages.some(m => m.uuid === "midturn-final-assistant")
+            && st.messages.some(m => m.uuid === arg.commandUuid);
+        }""",
+        arg={"sid": sid, "commandUuid": command_uuid},
+        timeout=10000,
+    )
+    completed = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        const root = st.messages.findIndex(m => m.uuid === "midturn-root-user");
+        const steering = st.messages.find(m => m.uuid === arg.commandUuid);
+        const firstTail = st.messages.find(m => m.uuid === "midturn-before-result");
+        const final = st.messages.find(m => m.uuid === "midturn-final-assistant");
+        const statuses = st.messages.slice(root + 1)
+          .map(m => app.turnFooterStatus(m, st)).filter(Boolean);
+        return {
+          steeringCount: st.messages.filter(
+            m => m.uuid === arg.commandUuid).length,
+          sameSteeringObject: steering === window.__midturnLiveUser,
+          sameSteeringKey: steering?._k === window.__midturnLiveKey,
+          liveSteeringKey: window.__midturnLiveKey,
+          canonicalSteeringKey: steering?._k || "",
+          firstStatus: app.turnFooterStatus(firstTail, st),
+          finalStatus: app.turnFooterStatus(final, st),
+          currentTurnStatuses: statuses,
+          hasPostResult: st.messages.some(m => m.uuid === "midturn-final-assistant"
+            && m.text === "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B"),
+          steeringFlag: steering?._steeringAdjustment === true,
+        };
+        """,
+        {"sid": sid, "commandUuid": command_uuid},
+    )
+    assert requests, "done reconciliation did not request canonical history"
+    assert completed["steeringCount"] == 1
+    assert completed["sameSteeringObject"] is True
+    assert completed["sameSteeringKey"] is True, (
+        completed["liveSteeringKey"], completed["canonicalSteeringKey"])
+    assert completed["firstStatus"] == ""
+    assert completed["finalStatus"] == "completed"
+    assert completed["currentTurnStatuses"] == ["completed"]
+    assert completed["hasPostResult"] is True
+    assert completed["steeringFlag"] is True
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4933,7 +4933,11 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
     command_uuid = "midturn-command-uuid"
     item_id = "midturn-queue-item"
     adjustment = "MIDTURN_ADJUSTMENT_VISIBLE"
+    second_command_uuid = "midturn-second-command-uuid"
+    second_item_id = "midturn-second-queue-item"
+    second_adjustment = "MIDTURN_SECOND_ADJUSTMENT_VISIBLE"
     history_marker = "MIDTURN_HISTORY_MARKER"
+    canonical_thinking_uuid = "midturn-canonical-thinking"
     canonical_messages: list[dict] = []
     requests = _route_windowed_session(
         page, sid, canonical_messages, updated_at=2,
@@ -4944,6 +4948,21 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             status=200,
             content_type="application/json",
             body='{"ticket":"midturn-steering-ticket"}',
+        ),
+    )
+    page.route(
+        f"**/api/chat/sessions/{sid}/active",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            # A terminal frame may beat the backend's inactive snapshot. The
+            # exact assistant UUID in canonical history must still settle the
+            # live transcript without waiting for this endpoint to catch up.
+            body=json.dumps({
+                "active": True,
+                "background": False,
+                "turn_id": "midturn-turn",
+            }),
         ),
     )
     _login(page, backend_url, auth_token)
@@ -5055,13 +5074,49 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
           };
           window.__emitSse("queue_steering", steering);
           window.__emitSse("text", {
-            ...common, event_seq: 4, text: "ASSISTANT_AFTER_PART_A ",
+            ...common, event_seq: 4, text: "ASSISTANT_AFTER_PART_A",
           });
           // The terminal lifecycle event is a duplicate transcript boundary,
           // not a second user message and not a reason to split assistant text.
           window.__emitSse("queue_steering", {...steering, state: "completed"});
+          window.__emitSse("tool_use", {
+            ...common, event_seq: 5, id: "midturn-tool-use-2",
+            name: "Read", summary: "inspect after first adjustment", input: {},
+          });
+          window.__emitSse("tool_result", {
+            ...common, event_seq: 6, id: "midturn-tool-use-2",
+            tool_name: "Read", preview: "TOOL_RESULT_AFTER_ADJUSTMENT",
+            text: "TOOL_RESULT_AFTER_ADJUSTMENT", is_error: false,
+          });
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          st.pendingQueue.push({
+            id: arg.secondItemId,
+            text: arg.secondAdjustment,
+            displayText: arg.secondAdjustment,
+            pendingQuotes: [], images: [], docs: [],
+            delivery: "adjust", deliveryStatus: "waiting_tool",
+            commandUuid: arg.secondCommandUuid,
+            enqueuedAt: Date.now(),
+          });
+          const secondSteering = {
+            ...common,
+            item_id: arg.secondItemId,
+            command_uuid: arg.secondCommandUuid,
+            state: "started",
+            effective_delivery: "adjust",
+            message: {
+              id: arg.secondItemId, uuid: arg.secondCommandUuid,
+              text: arg.secondAdjustment, display_text: arg.secondAdjustment,
+              selection_quotes: [],
+            },
+          };
+          window.__emitSse("queue_steering", secondSteering);
           window.__emitSse("text", {
-            ...common, event_seq: 5, text: "ASSISTANT_AFTER_PART_B",
+            ...common, event_seq: 7, text: "ASSISTANT_AFTER_PART_B",
+          });
+          window.__emitSse("queue_steering", {
+            ...secondSteering, state: "completed",
           });
         }""",
         {
@@ -5069,6 +5124,9 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             "itemId": item_id,
             "commandUuid": command_uuid,
             "adjustment": adjustment,
+            "secondItemId": second_item_id,
+            "secondCommandUuid": second_command_uuid,
+            "secondAdjustment": second_adjustment,
         },
     )
     page.wait_for_function(
@@ -5077,12 +5135,19 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
           const st = app._ensureTabState(arg.sid);
           const adjustmentIndex = st.messages.findIndex(
             m => m.role === "user" && m.uuid === arg.commandUuid);
-          const after = adjustmentIndex >= 0 ? st.messages[adjustmentIndex + 1] : null;
-          return adjustmentIndex >= 0 && st.pendingQueue.length === 0
+          const secondIndex = st.messages.findIndex(
+            m => m.role === "user" && m.uuid === arg.secondCommandUuid);
+          const after = secondIndex >= 0 ? st.messages[secondIndex + 1] : null;
+          return adjustmentIndex >= 0 && secondIndex > adjustmentIndex
+            && st.pendingQueue.length === 0
             && after?.role === "assistant"
-            && after.text === "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B";
+            && after.text === "ASSISTANT_AFTER_PART_B";
         }""",
-        arg={"sid": sid, "commandUuid": command_uuid},
+        arg={
+            "sid": sid,
+            "commandUuid": command_uuid,
+            "secondCommandUuid": second_command_uuid,
+        },
         timeout=10000,
     )
 
@@ -5099,20 +5164,38 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             && m.role === "tool_result");
           const adjustment = indexOf(m => m.role === "user"
             && m.uuid === arg.commandUuid);
-          const after = st.messages.findIndex((m, i) => i > adjustment
+          const afterFirst = st.messages.findIndex((m, i) => i > adjustment
             && m.role === "assistant"
             && (m.text || "").includes("ASSISTANT_AFTER_PART_A"));
+          const toolUse2 = indexOf(m => m.id === "midturn-tool-use-2"
+            && m.role === "tool_use");
+          const toolResult2 = indexOf(m => m.id === "midturn-tool-use-2"
+            && m.role === "tool_result");
+          const secondAdjustment = indexOf(m => m.role === "user"
+            && m.uuid === arg.secondCommandUuid);
+          const afterSecond = st.messages.findIndex((m, i) => i > secondAdjustment
+            && m.role === "assistant"
+            && (m.text || "").includes("ASSISTANT_AFTER_PART_B"));
           const user = st.messages[adjustment];
+          const secondUser = st.messages[secondAdjustment];
           const pane = document.querySelector(
             `.msg-pane[data-tid="${CSS.escape(arg.sid)}"]`);
           const node = pane?.querySelector(
             `.msg.user[data-uuid="${CSS.escape(arg.commandUuid)}"]`);
+          const secondNode = pane?.querySelector(
+            `.msg.user[data-uuid="${CSS.escape(arg.secondCommandUuid)}"]`);
           const canonical = app._preserveCanonicalMessageIdentity(st, [{
             role: "user", text: arg.adjustment,
             displayText: arg.adjustment, uuid: arg.commandUuid,
           }])[0];
+          const secondCanonical = app._preserveCanonicalMessageIdentity(st, [{
+            role: "user", text: arg.secondAdjustment,
+            displayText: arg.secondAdjustment, uuid: arg.secondCommandUuid,
+          }])[0];
           window.__midturnLiveUser = user;
           window.__midturnLiveKey = user?._k || "";
+          window.__midturnSecondLiveUser = secondUser;
+          window.__midturnSecondLiveKey = secondUser?._k || "";
           const visibleRunningFooters = [...document.querySelectorAll(
             ".turn-footer .turn-status.running")].filter(node => {
               const footer = node.closest(".turn-footer");
@@ -5120,23 +5203,31 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
                 && getComputedStyle(node).display !== "none";
             });
           return {
-            before, toolUse, toolResult, adjustment, after,
+            before, toolUse, toolResult, adjustment, afterFirst,
+            toolUse2, toolResult2, secondAdjustment, afterSecond,
             pendingCount: st.pendingQueue.length,
             adjustmentCount: st.messages.filter(m => m.role === "user"
               && m.uuid === arg.commandUuid).length,
+            secondAdjustmentCount: st.messages.filter(m => m.role === "user"
+              && m.uuid === arg.secondCommandUuid).length,
             afterCount: st.messages.filter((m, i) => i > adjustment
               && m.role === "assistant"
               && (m.text || "").includes("ASSISTANT_AFTER_PART_A")).length,
-            afterText: st.messages[after]?.text || "",
+            afterText: st.messages[afterFirst]?.text || "",
+            afterSecondText: st.messages[afterSecond]?.text || "",
             turnId: user?._turnId || "",
             noAnim: user?._noAnim === true,
             normalBubble: !!node,
             normalBubbleText: node?.textContent || "",
+            secondNormalBubble: !!secondNode,
+            secondNormalBubbleText: secondNode?.textContent || "",
             queuedBubbleCount: document.querySelectorAll(".msg.user.queued").length,
             sameCanonicalObject: canonical === user,
             sameCanonicalKey: canonical?._k === user?._k,
+            sameSecondCanonicalObject: secondCanonical === secondUser,
+            sameSecondCanonicalKey: secondCanonical?._k === secondUser?._k,
             beforeStatus: app.turnFooterStatus(st.messages[toolResult], st),
-            afterStatus: app.turnFooterStatus(st.messages[after], st),
+            afterStatus: app.turnFooterStatus(st.messages[afterSecond], st),
             visibleRunningFooterCount: visibleRunningFooters.length,
           };
         }""",
@@ -5144,21 +5235,31 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             "sid": sid,
             "commandUuid": command_uuid,
             "adjustment": adjustment,
+            "secondCommandUuid": second_command_uuid,
+            "secondAdjustment": second_adjustment,
         },
     )
     assert 0 <= result["before"] < result["toolUse"] < result["toolResult"]
-    assert result["toolResult"] < result["adjustment"] < result["after"]
+    assert result["toolResult"] < result["adjustment"] < result["afterFirst"]
+    assert result["afterFirst"] < result["toolUse2"] < result["toolResult2"]
+    assert result["toolResult2"] < result["secondAdjustment"] < result["afterSecond"]
     assert result["pendingCount"] == 0
     assert result["adjustmentCount"] == 1
+    assert result["secondAdjustmentCount"] == 1
     assert result["afterCount"] == 1
-    assert result["afterText"] == "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B"
+    assert result["afterText"] == "ASSISTANT_AFTER_PART_A"
+    assert result["afterSecondText"] == "ASSISTANT_AFTER_PART_B"
     assert result["turnId"] == "midturn-turn"
     assert result["noAnim"] is True
     assert result["normalBubble"] is True
     assert adjustment in result["normalBubbleText"]
+    assert result["secondNormalBubble"] is True
+    assert second_adjustment in result["secondNormalBubbleText"]
     assert result["queuedBubbleCount"] == 0
     assert result["sameCanonicalObject"] is True
     assert result["sameCanonicalKey"] is True
+    assert result["sameSecondCanonicalObject"] is True
+    assert result["sameSecondCanonicalKey"] is True
     assert result["beforeStatus"] == ""
     assert result["afterStatus"] == "running"
     assert result["visibleRunningFooterCount"] == 1
@@ -5207,8 +5308,43 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
             "_key": f"{command_uuid}:0:user",
         },
         {
+            "role": "thinking", "text": "[encrypted thinking]",
+            "uuid": canonical_thinking_uuid,
+            "block_id": f"{canonical_thinking_uuid}:0:thinking",
+            "_key": f"{canonical_thinking_uuid}:0:thinking",
+        },
+        {
+            "role": "assistant", "text": "ASSISTANT_AFTER_PART_A",
+            "uuid": "midturn-after-first-assistant",
+            "block_id": "midturn-after-first-assistant:0:assistant",
+            "_key": "midturn-after-first-assistant:0:assistant",
+        },
+        {
+            "role": "tool_use", "id": "midturn-tool-use-2", "name": "Read",
+            "summary": "inspect after first adjustment", "input": {},
+            "uuid": "midturn-after-first-assistant",
+            "block_id": "midturn-after-first-assistant:1:tool_use",
+            "_key": "midturn-after-first-assistant:1:tool_use",
+        },
+        {
+            "role": "tool_result", "id": "midturn-tool-use-2",
+            "tool_name": "Read", "preview": "TOOL_RESULT_AFTER_ADJUSTMENT",
+            "text": "TOOL_RESULT_AFTER_ADJUSTMENT", "is_error": False,
+            "uuid": "midturn-after-first-result",
+            "block_id": "midturn-after-first-result:0:tool_result",
+            "_key": "midturn-after-first-result:0:tool_result",
+        },
+        {
+            "role": "user", "text": second_adjustment,
+            "displayText": second_adjustment, "selectionQuotes": [],
+            "uuid": second_command_uuid,
+            "_steeringAdjustment": True, "_turnRoot": False,
+            "block_id": f"{second_command_uuid}:0:user",
+            "_key": f"{second_command_uuid}:0:user",
+        },
+        {
             "role": "assistant",
-            "text": "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B",
+            "text": "ASSISTANT_AFTER_PART_B",
             "uuid": "midturn-final-assistant", "ts": 1_700_030_010,
             "turn_status": "completed",
             "block_id": "midturn-final-assistant:0:assistant",
@@ -5217,7 +5353,8 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
     ])
     page.evaluate(
         """() => window.__emitSse("done", {
-          total_cost_usd: 0.001, turn_id: "midturn-turn", event_seq: 6,
+          total_cost_usd: 0.001, turn_id: "midturn-turn", event_seq: 8,
+          assistant_uuid: "midturn-final-assistant",
         })"""
     )
     page.wait_for_function(
@@ -5228,65 +5365,113 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
         arg=sid,
         timeout=10000,
     )
-    loaded = _app_eval(
-        page,
-        """
-        const st = app._ensureTabState(arg.sid);
-        st._pendingExternalUpdate = true;
-        return await app.loadSession(arg.sid, {
-          quiet: true, probeActive: false, followTail: true,
-        });
-        """,
-        {"sid": sid},
-    )
-    assert loaded is True
     page.wait_for_function(
         """arg => {
           const app = document.querySelector('#app')._x_dataStack[0];
           const st = app._ensureTabState(arg.sid);
           return st.messages.some(m => m.uuid === "midturn-final-assistant")
-            && st.messages.some(m => m.uuid === arg.commandUuid);
+            && st.messages.some(m => m.uuid === arg.commandUuid)
+            && st.messages.some(m => m.uuid === arg.secondCommandUuid)
+            && st.messages.some(m => m.uuid === arg.thinkingUuid);
         }""",
-        arg={"sid": sid, "commandUuid": command_uuid},
+        arg={
+            "sid": sid,
+            "commandUuid": command_uuid,
+            "secondCommandUuid": second_command_uuid,
+            "thinkingUuid": canonical_thinking_uuid,
+        },
         timeout=10000,
     )
+    thinking_row = page.locator(
+        f'.msg-pane[data-tid="{sid}"] '
+        f'.msg.thinking[data-uuid="{canonical_thinking_uuid}"]'
+    )
+    expect(thinking_row).to_be_visible(timeout=10000)
+    completed_footer = page.locator(
+        f'.msg-pane[data-tid="{sid}"] '
+        '.msg[data-uuid="midturn-final-assistant"] '
+        '.turn-footer .turn-status.completed'
+    )
+    expect(completed_footer).to_be_visible(timeout=10000)
+    expect(
+        page.locator(
+            f'.msg-pane[data-tid="{sid}"] '
+            '.turn-footer .turn-status.running:visible'
+        )
+    ).to_have_count(0)
     completed = _app_eval(
         page,
         """
         const st = app._ensureTabState(arg.sid);
         const root = st.messages.findIndex(m => m.uuid === "midturn-root-user");
         const steering = st.messages.find(m => m.uuid === arg.commandUuid);
+        const secondSteering = st.messages.find(
+          m => m.uuid === arg.secondCommandUuid);
         const firstTail = st.messages.find(m => m.uuid === "midturn-before-result");
+        const secondToolTail = st.messages.find(
+          m => m.uuid === "midturn-after-first-result");
         const final = st.messages.find(m => m.uuid === "midturn-final-assistant");
+        const indexOfUuid = uuid => st.messages.findIndex(m => m.uuid === uuid);
         const statuses = st.messages.slice(root + 1)
           .map(m => app.turnFooterStatus(m, st)).filter(Boolean);
         return {
           steeringCount: st.messages.filter(
             m => m.uuid === arg.commandUuid).length,
+          secondSteeringCount: st.messages.filter(
+            m => m.uuid === arg.secondCommandUuid).length,
           sameSteeringObject: steering === window.__midturnLiveUser,
           sameSteeringKey: steering?._k === window.__midturnLiveKey,
           liveSteeringKey: window.__midturnLiveKey,
           canonicalSteeringKey: steering?._k || "",
+          sameSecondSteeringObject:
+            secondSteering === window.__midturnSecondLiveUser,
+          sameSecondSteeringKey:
+            secondSteering?._k === window.__midturnSecondLiveKey,
           firstStatus: app.turnFooterStatus(firstTail, st),
+          secondToolStatus: app.turnFooterStatus(secondToolTail, st),
           finalStatus: app.turnFooterStatus(final, st),
           currentTurnStatuses: statuses,
           hasPostResult: st.messages.some(m => m.uuid === "midturn-final-assistant"
-            && m.text === "ASSISTANT_AFTER_PART_A ASSISTANT_AFTER_PART_B"),
+            && m.text === "ASSISTANT_AFTER_PART_B"),
+          hasCanonicalThinking: st.messages.some(
+            m => m.uuid === arg.thinkingUuid && m.role === "thinking"),
           steeringFlag: steering?._steeringAdjustment === true,
+          secondSteeringFlag: secondSteering?._steeringAdjustment === true,
+          canonicalOrder: [
+            indexOfUuid(arg.commandUuid),
+            indexOfUuid(arg.thinkingUuid),
+            indexOfUuid("midturn-after-first-assistant"),
+            indexOfUuid("midturn-after-first-result"),
+            indexOfUuid(arg.secondCommandUuid),
+            indexOfUuid("midturn-final-assistant"),
+          ],
         };
         """,
-        {"sid": sid, "commandUuid": command_uuid},
+        {
+            "sid": sid,
+            "commandUuid": command_uuid,
+            "secondCommandUuid": second_command_uuid,
+            "thinkingUuid": canonical_thinking_uuid,
+        },
     )
     assert requests, "done reconciliation did not request canonical history"
     assert completed["steeringCount"] == 1
+    assert completed["secondSteeringCount"] == 1
     assert completed["sameSteeringObject"] is True
     assert completed["sameSteeringKey"] is True, (
         completed["liveSteeringKey"], completed["canonicalSteeringKey"])
+    assert completed["sameSecondSteeringObject"] is True
+    assert completed["sameSecondSteeringKey"] is True
     assert completed["firstStatus"] == ""
+    assert completed["secondToolStatus"] == ""
     assert completed["finalStatus"] == "completed"
     assert completed["currentTurnStatuses"] == ["completed"]
     assert completed["hasPostResult"] is True
+    assert completed["hasCanonicalThinking"] is True
     assert completed["steeringFlag"] is True
+    assert completed["secondSteeringFlag"] is True
+    assert completed["canonicalOrder"] == sorted(completed["canonicalOrder"])
+    assert all(index >= 0 for index in completed["canonicalOrder"])
     _assert_no_browser_errors(page, errors)
 
 
@@ -6004,7 +6189,7 @@ def test_fast_completed_queued_turn_reconciles_footer_without_refresh(
 def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     page: Page, backend_url, auth_token,
 ):
-    """Early done metadata completes the visual tail without touching identity."""
+    """Done completes the live tail while canonical history is still retrying."""
     errors = _capture_browser_errors(page)
     page.set_viewport_size({"width": 1440, "height": 900})
     _install_fake_event_source(page)
@@ -6012,7 +6197,6 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     assistant_uuid = "tool-tail-assistant-boundary"
     completed_at_ms = int(time.time() * 1000)
     duration_ms = 125_000
-    active_requests: list[str] = []
     history_requests: list[str] = []
 
     page.route(
@@ -6042,14 +6226,13 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     )
 
     def active_stays_true(route):
-        active_requests.append(route.request.url)
         route.fulfill(
             status=200,
             content_type="application/json",
             body='{"active":true}',
         )
 
-    def unexpected_history(route):
+    def incomplete_history(route):
         history_requests.append(route.request.url)
         route.fulfill(
             status=200,
@@ -6069,7 +6252,7 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
         )
 
     page.route(f"**/api/chat/sessions/{sid}/active", active_stays_true)
-    page.route(f"**/api/chat/sessions/{sid}?*", unexpected_history)
+    page.route(f"**/api/chat/sessions/{sid}?*", incomplete_history)
     _login(page, backend_url, auth_token)
     _app_eval(
         page,
@@ -6183,40 +6366,34 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
         "assistantUuid": "",
     }
 
-    with page.expect_request(
-        lambda request: request.url.endswith(
-            f"/api/chat/sessions/{sid}/active"
-        ),
-        timeout=5000,
-    ):
-        page.evaluate(
-            """arg => window.__emitSse('done', {
-              assistant_uuid: arg.assistantUuid,
-              completed_at_ms: arg.completedAtMs,
-              duration_ms: arg.durationMs,
-              total_cost_usd: 0.001,
-              model: 'e2e-model',
-              memory_recall: {
-                id: 'tool-tail-memory-trace', count: 1,
-                latency_ms: 8, status: 'ok', items: [{
-                  id: 'tool-tail-memory-item', kind: 'preference',
-                  content: 'A deliberately long memory detail '.repeat(36),
-                }],
-              },
-              session_usage: {
-                context_used_pct: 5,
-                context_used: 500,
-                context_limit: 100000,
-              },
-              turn_id: 'tool-tail-turn',
-              event_seq: 4,
-            })""",
-            {
-                "assistantUuid": assistant_uuid,
-                "completedAtMs": completed_at_ms,
-                "durationMs": duration_ms,
-            },
-        )
+    page.evaluate(
+        """arg => window.__emitSse('done', {
+          assistant_uuid: arg.assistantUuid,
+          completed_at_ms: arg.completedAtMs,
+          duration_ms: arg.durationMs,
+          total_cost_usd: 0.001,
+          model: 'e2e-model',
+          memory_recall: {
+            id: 'tool-tail-memory-trace', count: 1,
+            latency_ms: 8, status: 'ok', items: [{
+              id: 'tool-tail-memory-item', kind: 'preference',
+              content: 'A deliberately long memory detail '.repeat(36),
+            }],
+          },
+          session_usage: {
+            context_used_pct: 5,
+            context_used: 500,
+            context_limit: 100000,
+          },
+          turn_id: 'tool-tail-turn',
+          event_seq: 4,
+        })""",
+        {
+            "assistantUuid": assistant_uuid,
+            "completedAtMs": completed_at_ms,
+            "durationMs": duration_ms,
+        },
+    )
 
     page.wait_for_function(
         """arg => {
@@ -6339,10 +6516,8 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
         "streaming": False,
     }
     assert ":live:" in live_key
-    assert active_requests, "canonical barrier never checked /active"
-    assert history_requests == [], (
-        "canonical history loaded even though /active still reported true"
-    )
+    assert history_requests, "done did not probe canonical history immediately"
+    assert all("tail=800" in url for url in history_requests)
     _assert_no_browser_errors(page, errors)
 
 
@@ -6612,6 +6787,287 @@ def test_stale_older_response_cannot_overwrite_new_canonical_tail(
         "last": "fresh-59",
         "atBottom": True,
         "hasLater": False,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_completed_history_defers_to_optimistic_and_remote_successors(
+    page: Page, backend_url, auth_token,
+):
+    """A's late canonical sync never removes a newly admitted B prompt."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = 'completed-history-successor-race';
+          app.refreshSessions = async () => {};
+          app._fetchTabUsage = async () => {};
+          app._scheduleIdlePreload = () => {};
+          app.sessions = [{id: sid, name: 'Successor race', message_count: 2}];
+          app.openTabIds = [sid];
+          app.tabState = {};
+          app.currentId = sid;
+          const st = app._ensureTabState(sid);
+          st._loaded = true;
+          st.atBottom = true;
+          st.messages.push(
+            {role: 'user', text: 'TURN_A_PROMPT', uuid: 'turn-a-user',
+             _turnRoot: true, _k: `${sid}:uuid:turn-a-user`},
+            {role: 'assistant', text: 'TURN_A_REPLY', uuid: 'turn-a-final',
+             turn_status: 'completed', _k: `${sid}:uuid:turn-a-final`},
+          );
+          Object.assign(st.messageRange, {
+            visibleStart: 0, visibleEnd: 2, offset: 0, total: 2,
+            preTotal: 0, order: 'normal', generation: 'race-g1',
+          });
+          app._activateTabState(sid);
+
+          const originalFetch = window.fetch;
+          const originalDeadline = app._fetchWithDeadline;
+          const originalLoad = app.loadSession;
+          let releaseHistory = null;
+          let guardedFetches = 0;
+          try {
+            window.fetch = async input => {
+              const url = String(input);
+              if (!url.includes(`/api/chat/sessions/${sid}?tail=`)) {
+                return originalFetch(input);
+              }
+              return await new Promise(resolve => {
+                releaseHistory = () => resolve(new Response(JSON.stringify({
+                  id: sid, name: 'Successor race', model: 'e2e-model',
+                  permission: 'bypassPermissions', thinking: true,
+                  messages: [
+                    {role: 'user', text: 'TURN_A_PROMPT', uuid: 'turn-a-user',
+                     _turnRoot: true},
+                    {role: 'assistant', text: 'TURN_A_REPLY', uuid: 'turn-a-final',
+                     turn_status: 'completed'},
+                  ],
+                  offset: 0, total: 2, message_count: 2,
+                  pre_total: 0, history_order: 'normal',
+                  history_generation: 'race-g2', updated_at: 2,
+                }), {status: 200, headers: {'content-type': 'application/json'}}));
+              });
+            };
+            const pendingLoad = app.loadSession(sid, {
+              quiet: true, probeActive: false, followTail: true,
+            });
+            while (!releaseHistory) await new Promise(resolve => setTimeout(resolve, 0));
+
+            st._composerSubmitToken = 'turn-b-composer-claim';
+            const optimistic = app._appendLiveMessage(st, {
+              role: 'user', text: 'TURN_B_OPTIMISTIC',
+              _turnRoot: true, _admissionPending: true,
+            });
+            releaseHistory();
+            const staleLoadResult = await pendingLoad;
+            await new Promise(resolve => app.$nextTick(resolve));
+            const pane = document.querySelector(
+              `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+
+            // A completion retry that starts after the claim is visible must
+            // not even issue a canonical read.
+            app._fetchWithDeadline = async () => {
+              guardedFetches += 1;
+              throw new Error('guarded completion fetched unexpectedly');
+            };
+            st._pendingCompletedTurnSync = {
+              expectedAssistantUuid: 'turn-a-final',
+              completedTurnId: 'turn-a', attempt: 30,
+            };
+            const guardedCompletion = await app._runCompletedTurnSync(sid, st, {
+              expectedAssistantUuid: 'turn-a-final',
+              completedTurnId: 'turn-a', attempt: 30,
+            });
+
+            // A remote successor can win before its mux channel reaches this
+            // browser. Identity-aware /active must defer A's replacement too.
+            const remoteSid = 'completed-history-remote-successor';
+            const remote = app._ensureTabState(remoteSid);
+            remote._loaded = true;
+            let remoteLoads = 0;
+            app._fetchWithDeadline = async url => new Response(JSON.stringify(
+              String(url).endsWith('/active')
+                ? {active: true, background: false, turn_id: 'turn-b'}
+                : {messages: [
+                    {role: 'user', text: 'A', uuid: 'remote-a-user',
+                     _turnRoot: true},
+                    {role: 'assistant', text: 'A done', uuid: 'remote-a-final'},
+                  ]},
+            ), {status: 200, headers: {'content-type': 'application/json'}});
+            app.loadSession = async () => { remoteLoads += 1; return true; };
+            const remoteCompletion = await app._runCompletedTurnSync(
+              remoteSid, remote, {
+                expectedAssistantUuid: 'remote-a-final',
+                completedTurnId: 'turn-a', attempt: 30,
+              },
+            );
+
+            // Non-zero visible windows use absolute coordinates without
+            // allocating a fresh slice for every Alpine binding.
+            const indexSid = 'pane-index-window';
+            const indexState = app._ensureTabState(indexSid);
+            indexState.messages = Array.from({length: 800}, (_, index) => ({
+              role: 'assistant', text: String(index),
+              _k: `${indexSid}:${index}`,
+            }));
+            Object.assign(indexState.messageRange, {
+              visibleStart: 700, visibleEnd: 800, offset: 0, total: 800,
+              preTotal: 0, order: 'normal', generation: 'index-g1',
+            });
+            const indexedMessage = indexState.messages[750];
+            const firstIndex = app.paneMessageIndex(indexSid, indexedMessage);
+            indexState.messages.splice(720, 0, {
+              role: 'thinking', text: 'inserted', _k: `${indexSid}:inserted`,
+            });
+            indexState.messageRange.visibleEnd = 801;
+            const shiftedIndex = app.paneMessageIndex(indexSid, indexedMessage);
+            indexState.messageRange.visibleStart = 710;
+            const movedWindowIndex = app.paneMessageIndex(indexSid, indexedMessage);
+
+            const optimisticKey = optimistic._k;
+            return {
+              staleLoadResult,
+              optimisticRetained: st.messages.includes(optimistic),
+              optimisticKey,
+              optimisticVisible: !!pane?.querySelector(
+                `.msg[data-message-key="${CSS.escape(optimisticKey)}"]`),
+              guardedCompletion,
+              guardedFetches,
+              pendingCompletionRetained: !!st._pendingCompletedTurnSync,
+              remoteCompletion,
+              remoteLoads,
+              firstIndex,
+              shiftedIndex,
+              movedWindowIndex,
+            };
+          } finally {
+            window.fetch = originalFetch;
+            app._fetchWithDeadline = originalDeadline;
+            app.loadSession = originalLoad;
+            st._composerSubmitToken = null;
+          }
+        }"""
+    )
+
+    assert result == {
+        "staleLoadResult": False,
+        "optimisticRetained": True,
+        "optimisticKey": "completed-history-successor-race:live:1",
+        "optimisticVisible": True,
+        "guardedCompletion": False,
+        "guardedFetches": 0,
+        "pendingCompletionRetained": True,
+        "remoteCompletion": False,
+        "remoteLoads": 0,
+        "firstIndex": 50,
+        "shiftedIndex": 51,
+        "movedWindowIndex": 41,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_send_from_older_window_returns_to_latest_with_composer_claim(
+    page: Page, backend_url, auth_token,
+):
+    """Send's own composer claim must not block its return-to-tail load."""
+    errors = _capture_browser_errors(page)
+    _install_fake_event_source(page)
+    sid = "send-from-older-window"
+    prompt = "SEND_FROM_OLDER_WINDOW"
+    canonical_messages = [
+        {
+            "role": "user", "text": "OLDER_PROMPT", "uuid": "older-user",
+            "_turnRoot": True,
+        },
+        {
+            "role": "assistant", "text": "OLDER_REPLY", "uuid": "older-reply",
+            "turn_status": "completed",
+        },
+        {
+            "role": "user", "text": "LATEST_PROMPT", "uuid": "latest-user",
+            "_turnRoot": True,
+        },
+        {
+            "role": "assistant", "text": "LATEST_REPLY", "uuid": "latest-reply",
+            "turn_status": "completed",
+        },
+    ]
+    requests = _route_windowed_session(page, sid, canonical_messages)
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"older-window-send-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    _bootstrap_session_for_real_load(page, sid, "Send from older window")
+    _app_eval(
+        page,
+        """
+        app._ensureSessionRegistered = async () => true;
+        app._awaitRuntimeSettingPatches = async () => true;
+        app._confirmSessionBusy = async () => false;
+        const st = app._ensureTabState(arg.sid);
+        st.messages.splice(0, st.messages.length, ...app._historyEnvelopes(arg.sid, [
+          {role: "user", text: "OLDER_PROMPT", uuid: "older-user", _turnRoot: true},
+          {role: "assistant", text: "OLDER_REPLY", uuid: "older-reply",
+           turn_status: "completed"},
+        ]));
+        Object.assign(st.messageRange, {
+          visibleStart: 0, visibleEnd: 2, offset: 0, total: 4,
+          preTotal: 0, order: "normal", generation: "older-window-g1",
+        });
+        st._loaded = true;
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.atBottom = false;
+        st.draft.input = arg.prompt;
+        app._activateTabState(arg.sid);
+        return app.hasLaterMessages(arg.sid);
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+
+    send_result = _app_eval(
+        page,
+        """
+        const result = await app.send();
+        await new Promise(resolve => app.$nextTick(resolve));
+        const st = app._ensureTabState(arg.sid);
+        return {
+          didNotFail: result !== false,
+          streaming: st.streaming,
+          composerClaim: st._composerSubmitToken,
+          draft: st.draft.input,
+          hasLater: app.hasLaterMessages(arg.sid),
+          latestPresent: st.messages.some(m => m.uuid === "latest-reply"),
+          promptCount: st.messages.filter(m => m.role === "user"
+            && m.text === arg.prompt).length,
+          promptVisible: !!document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(arg.sid)}"] .msg.user`
+          ) && document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(arg.sid)}"]`
+          ).textContent.includes(arg.prompt),
+        };
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+
+    assert requests, "send did not load the canonical latest tail"
+    assert send_result == {
+        "didNotFail": True,
+        "streaming": True,
+        "composerClaim": None,
+        "draft": "",
+        "hasLater": False,
+        "latestPresent": True,
+        "promptCount": 1,
+        "promptVisible": True,
     }
     _assert_no_browser_errors(page, errors)
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4681,6 +4681,247 @@ def test_session_sync_deadline_dispose_and_hidden_resume(
     _assert_no_browser_errors(page, errors)
 
 
+def test_admission_gap_resolves_exact_turn_before_busy_adjust_enqueue(
+    page: Page, backend_url, auth_token,
+):
+    """A second send during first-turn admission must not freeze as FIFO."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    sid = "perf-busy-admission-gap"
+    turn_id = "admitted-root-turn"
+    item_id = "admission-gap-item"
+    command_uuid = "admission-gap-command"
+    active_calls: list[str] = []
+    queue_payloads: list[dict] = []
+
+    def active_route(route):
+        active_calls.append(route.request.method)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "active": True,
+                "background": False,
+                "turn_id": turn_id,
+            }),
+        )
+
+    def queue_route(route):
+        payload = route.request.post_data_json
+        queue_payloads.append(payload)
+        item = {
+            "id": item_id,
+            "text": payload["text"],
+            "display_text": payload["display_text"],
+            "selection_quotes": [],
+            "image_ids": "",
+            "delivery": "adjust",
+            "steering_state": "waiting_tool",
+            "command_uuid": command_uuid,
+            "target_turn_id": turn_id,
+            "enqueued_at": int(time.time() * 1000),
+        }
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "ok": True,
+                "item": item,
+                "effective_delivery": "adjust",
+                "delivery_status": "waiting_tool",
+                "queue": {"items": [item], "revision": 1},
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}/active", active_route)
+    page.route(f"**/api/chat/sessions/{sid}/queue", queue_route)
+    result = _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.busySendMode = "adjust";
+        app.sessions = [{
+          id: sid, name: "Admission gap", model: "e2e-model",
+          permission: "bypassPermissions", updated_at: 1,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.streaming = true;
+        st._streamOwnerToken = "admitting-root-owner";
+        st.streamPhase = "connecting";
+        st.activeTurnId = "";
+        st.pendingQueue = [];
+        app.currentId = sid;
+        app._activateTabState(sid);
+        app._syncQueueFromServer = async () => {};
+        const queued = await app._enqueueMessage(sid, {
+          text: "ADJUST_DURING_ADMISSION",
+          displayText: "ADJUST_DURING_ADMISSION",
+          pendingImages: [], pendingDocs: [], pendingQuotes: [],
+          permission: "bypassPermissions",
+          delivery: "queue",
+          active_turn_id: "",
+          stream_owner_token: "admitting-root-owner",
+        });
+        return {
+          queued,
+          pending: st.pendingQueue.map(item => ({
+            id: item.id,
+            delivery: item.delivery,
+            deliveryStatus: item.deliveryStatus,
+            targetTurnId: item.targetTurnId,
+          })),
+        };
+        """,
+        {"sid": sid},
+    )
+
+    assert active_calls == ["GET"]
+    assert len(queue_payloads) == 1
+    assert queue_payloads[0]["delivery"] == "adjust"
+    assert queue_payloads[0]["active_turn_id"] == turn_id
+    assert result == {
+        "queued": True,
+        "pending": [{
+            "id": item_id,
+            "delivery": "adjust",
+            "deliveryStatus": "waiting_tool",
+            "targetTurnId": turn_id,
+        }],
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_admission_gap_probe_cannot_steer_successor_turn(
+    page: Page, backend_url, auth_token,
+):
+    """A delayed admission probe is bound to its original local stream."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    sid = "perf-busy-admission-successor"
+    result = _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.busySendMode = "adjust";
+        app.sessions = [{
+          id: sid, name: "Admission successor", model: "e2e-model",
+          permission: "bypassPermissions", updated_at: 1,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.streaming = true;
+        st._streamOwnerToken = "root-a-owner";
+        st.streamPhase = "connecting";
+        st.activeTurnId = "";
+        st.pendingQueue = [];
+        app.currentId = sid;
+        app._activateTabState(sid);
+        app._syncQueueFromServer = async () => {};
+
+        const originalFetch = window.fetch;
+        let activeCalls = 0;
+        const queuePayloads = [];
+        window.fetch = async (url, options = {}) => {
+          const path = String(url);
+          if (path.endsWith("/active")) {
+            activeCalls += 1;
+            await new Promise(resolve => setTimeout(resolve, 40));
+            return new Response(JSON.stringify({
+              active: true,
+              background: false,
+              turn_id: "successor-turn-b",
+            }), { status: 200, headers: { "Content-Type": "application/json" } });
+          }
+          if (path.endsWith("/queue")) {
+            const queuePayload = JSON.parse(options.body || "{}");
+            queuePayloads.push(queuePayload);
+            const item = {
+              id: `successor-safe-queue-item-${queuePayloads.length}`,
+              text: queuePayload.text,
+              display_text: queuePayload.display_text,
+              selection_quotes: [],
+              image_ids: "",
+              delivery: "queue",
+              steering_state: "",
+              command_uuid: "",
+              target_turn_id: "",
+              enqueued_at: Date.now(),
+            };
+            return new Response(JSON.stringify({
+              ok: true,
+              item,
+              effective_delivery: "queue",
+              delivery_status: "queued",
+              queue: { items: [item], revision: 1 },
+            }), { status: 200, headers: { "Content-Type": "application/json" } });
+          }
+          return originalFetch(url, options);
+        };
+        try {
+          const enqueue = app._enqueueMessage(sid, {
+            text: "MUST_NOT_STEER_SUCCESSOR",
+            displayText: "MUST_NOT_STEER_SUCCESSOR",
+            pendingImages: [], pendingDocs: [], pendingQuotes: [],
+            permission: "bypassPermissions",
+            delivery: "queue",
+            active_turn_id: "",
+            stream_owner_token: "root-a-owner",
+          });
+          await new Promise(resolve => setTimeout(resolve, 10));
+          st.streaming = false;
+          st._streamOwnerToken = "";
+          st.activeTurnId = "";
+          st.streaming = true;
+          st._streamOwnerToken = "root-b-owner";
+          st.activeTurnId = "successor-turn-b";
+          const firstQueued = await enqueue;
+          const activeCallsAfterFirst = activeCalls;
+
+          // Also cover the earlier race: A can become B while send() awaits
+          // its busy probe, before _enqueueMessage even enters the resolver.
+          st.pendingQueue = [];
+          const secondQueued = await app._enqueueMessage(sid, {
+            text: "SNAPSHOT_FROM_ROOT_A",
+            displayText: "SNAPSHOT_FROM_ROOT_A",
+            pendingImages: [], pendingDocs: [], pendingQuotes: [],
+            permission: "bypassPermissions",
+            delivery: "queue",
+            active_turn_id: "",
+            stream_owner_token: "root-a-owner",
+          });
+          return {
+            firstQueued,
+            secondQueued,
+            queuePayloads,
+            activeCalls,
+            activeCallsAfterFirst,
+          };
+        } finally {
+          window.fetch = originalFetch;
+        }
+        """,
+        {"sid": sid},
+    )
+
+    assert result["firstQueued"] is True
+    assert result["secondQueued"] is True
+    assert result["activeCallsAfterFirst"] == 1
+    assert result["activeCalls"] == 1
+    assert len(result["queuePayloads"]) == 2
+    assert all(payload["delivery"] == "queue"
+               for payload in result["queuePayloads"])
+    assert all(payload["active_turn_id"] == ""
+               for payload in result["queuePayloads"])
+    _assert_no_browser_errors(page, errors)
+
+
 def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -1217,6 +1217,124 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
 
 
 @pytest.mark.asyncio
+async def test_busy_adjust_during_admission_waits_for_root_query_commit(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    writes = []
+
+    class SteeringClient:
+        async def query_steering(
+            self, prompt, *, session_id, command_uuid,
+        ):
+            writes.append((prompt, session_id, command_uuid))
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        enqueue = asyncio.create_task(chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="adjust the starting task",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        ))
+        for _ in range(100):
+            if broadcast.steering_commands:
+                break
+            await asyncio.sleep(0.01)
+
+        assert not enqueue.done()
+        pending = sess.get_queue(sid)["items"][0]
+        assert pending["delivery"] == "adjust"
+        assert pending["target_turn_id"] == broadcast.turn_id
+        assert pending["steering_state"] == "pending"
+        command_uuid = pending["command_uuid"]
+        assert broadcast.steering_commands[command_uuid] == {
+            "item_id": pending["id"],
+            "state": "pending",
+        }
+        assert writes == []
+
+        broadcast.query_committed = True
+        broadcast.steering_ready.set()
+        response = await asyncio.wait_for(enqueue, timeout=1)
+
+        assert response["effective_delivery"] == "adjust"
+        assert response["delivery_status"] == "waiting_tool"
+        assert writes == [(
+            "adjust the starting task", sid, command_uuid,
+        )]
+        assert sess.get_queue(sid)["items"][0][
+            "steering_state"] == "waiting_tool"
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_busy_adjust_during_admission_falls_back_when_turn_finishes(
+    app_module, monkeypatch,
+):
+    from backend import chat
+
+    sess = _sess(app_module)
+    sid = sess.create_session()["id"]
+    writes = []
+
+    class SteeringClient:
+        async def query_steering(self, *_args, **_kwargs):
+            writes.append(True)
+
+    monkeypatch.setattr(chat, "MuseLabSDKClient", SteeringClient)
+    monkeypatch.setattr(chat, "_schedule_queue_drain", lambda _sid: None)
+    broadcast = chat.TurnBroadcast(sid)
+    broadcast.runtime_client = SteeringClient()
+    chat._active_turns[sid] = broadcast
+    try:
+        enqueue = asyncio.create_task(chat.enqueue_api(
+            sid,
+            chat.QueueEnqueueReq(
+                text="keep this after failed startup",
+                delivery="adjust",
+                active_turn_id=broadcast.turn_id,
+            ),
+            chat.BackgroundTasks(),
+        ))
+        for _ in range(100):
+            if broadcast.steering_commands:
+                break
+            await asyncio.sleep(0.01)
+
+        assert not enqueue.done()
+        pending = sess.get_queue(sid)["items"][0]
+        assert pending["delivery"] == "adjust"
+        assert pending["steering_state"] == "pending"
+
+        broadcast.finish()
+        response = await asyncio.wait_for(enqueue, timeout=1)
+
+        assert response["effective_delivery"] == "queue"
+        assert response["delivery_status"] == "queued"
+        fallback = sess.get_queue(sid)["items"][0]
+        assert fallback["delivery"] == "queue"
+        assert fallback["steering_state"] == "fallback"
+        assert not fallback.get("command_uuid")
+        assert broadcast.steering_commands == {}
+        assert writes == []
+    finally:
+        chat._active_turns.pop(sid, None)
+        broadcast.close()
+
+
+@pytest.mark.asyncio
 async def test_busy_adjust_stale_turn_falls_back_without_native_write(
     app_module, monkeypatch,
 ):

--- a/tests/test_chat_queue.py
+++ b/tests/test_chat_queue.py
@@ -1135,11 +1135,18 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
     published = []
     monkeypatch.setattr(broadcast, "publish", published.append)
     chat._active_turns[sid] = broadcast
+    selection_quotes = [{
+        "id": "quote-1", "source": "chat", "role": "assistant",
+        "sessionId": sid, "messageId": "a1", "path": "",
+        "text": "selected context", "truncated": False,
+    }]
     try:
         response = await chat.enqueue_api(
             sid,
             chat.QueueEnqueueReq(
-                text="adjust this task",
+                text="model prompt with quote context",
+                display_text="adjust this task",
+                selection_quotes=selection_quotes,
                 delivery="adjust",
                 active_turn_id=broadcast.turn_id,
             ),
@@ -1153,7 +1160,7 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
         assert item["target_turn_id"] == broadcast.turn_id
         assert item["steering_state"] == "waiting_tool"
         assert writes == [(
-            "adjust this task", sid, item["command_uuid"],
+            "model prompt with quote context", sid, item["command_uuid"],
         )]
         assert broadcast.steering_commands[item["command_uuid"]] == {
             "item_id": item["id"],
@@ -1190,10 +1197,17 @@ async def test_busy_adjust_is_durable_then_uses_exact_native_command(
         assert started_event["message"] == {
             "id": item["id"],
             "uuid": item["command_uuid"],
-            "text": "adjust this task",
+            "text": "model prompt with quote context",
             "display_text": "adjust this task",
-            "selection_quotes": [],
+            "selection_quotes": selection_quotes,
             "enqueued_at": item["enqueued_at"],
+        }
+        annotation = sess.get_message_annotations(sid)[item["command_uuid"]]
+        assert annotation == {
+            "steering_display_text": "adjust this task",
+            "steering_selection_quotes": selection_quotes,
+            "steering_queue_item_id": item["id"],
+            "steering_turn_id": broadcast.turn_id,
         }
 
         terminal = await chat._settle_steering_lifecycle(

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -2845,7 +2845,11 @@ def test_around_uuid_uses_virtual_snapshot_coordinates(stream_env, monkeypatch):
     index = {
         "records": [
             {"uuid": "u1", "bubble_count": 1},
-            {"uuid": "u2", "bubble_count": 1},
+            {
+                "uuid": "attachment-u2",
+                "presentation_uuid": "command-u2",
+                "bubble_count": 1,
+            },
         ],
         "orders": {"full": [0, 1], "normal": [0, 1]},
         "bubble_prefix": {"full": [0, 1, 2], "normal": [0, 1, 2]},
@@ -2867,7 +2871,13 @@ def test_around_uuid_uses_virtual_snapshot_coordinates(stream_env, monkeypatch):
 
     def shaped(_path, shaped_index, record_ids, _annotations):
         return [
-            {"role": "assistant", "uuid": shaped_index["records"][i]["uuid"]}
+            {
+                "role": "assistant",
+                "uuid": (
+                    shaped_index["records"][i].get("presentation_uuid")
+                    or shaped_index["records"][i]["uuid"]
+                ),
+            }
             for i in record_ids
         ]
 
@@ -2877,14 +2887,14 @@ def test_around_uuid_uses_virtual_snapshot_coordinates(stream_env, monkeypatch):
         index,
         [snapshot],
         {},
-        "u2",
+        "command-u2",
         before=1,
         after=0,
     )
     assert result is not None
     window, total, offset, has_later = result
     assert [item.get("text") or item.get("uuid") for item in window] == [
-        "后台 Agent 气泡", "u2"]
+        "后台 Agent 气泡", "command-u2"]
     assert (total, offset, has_later) == (3, 1, False)
 
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -5517,6 +5517,8 @@ def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
     enqueue = app[enqueue_start:enqueue_end]
     assert 'item.delivery || this.busySendMode' in enqueue
     assert 'activeTurnId = String(item.active_turn_id || "")' in enqueue
+    assert "await this._resolveBusyAdjustmentTurnId(" in enqueue
+    assert 'delivery = "adjust"' in enqueue
     assert "delivery," in enqueue
     assert "active_turn_id: activeTurnId" in enqueue
     assert "accepted.queue.items" in enqueue
@@ -5578,12 +5580,26 @@ def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
     assert "!turnId || attachmentIntent || st.compacting" in delivery
     assert "st.backgroundActive || st._draining || st.parentTurnId" in delivery
     assert "st.pendingQueue && st.pendingQueue.length" in delivery
+    resolve_start = app.index("    async _resolveBusyAdjustmentTurnId(")
+    resolve_end = app.index("\n    sendButtonHint(sid)", resolve_start)
+    resolve = app[resolve_start:resolve_end]
+    assert '"/api/chat/sessions/" + sid + "/active"' in resolve
+    assert "status.active" in resolve
+    assert "status.background" in resolve
+    assert "this._busySendDelivery(sid, turnId, hasAttachments)" in resolve
+    assert "this.tabState[sid] !== st" in resolve
+    assert "const streamOwnerToken = String(expectedStreamOwnerToken || \"\")" in resolve
+    assert "ownerStillCurrent()" in resolve
+    assert "String(st._streamOwnerToken || \"\") === streamOwnerToken" in resolve
     assert 'const busyActiveTurnId = !isReconnect' in send
+    assert 'const busyStreamOwnerToken = !isReconnect' in send
+    assert "streamState._streamOwnerToken = composerSubmitToken" in send
     assert "const busyDelivery = this._busySendDelivery(" in send
     assert "_optimisticDelivery: busyDelivery" in send
     assert "delivery: busyDelivery" in send
     assert "delivery: handoffDelivery" in send
     assert 'active_turn_id: busyActiveTurnId' in send
+    assert 'stream_owner_token: busyStreamOwnerToken' in send
     assert 'errorMeta.active_turn_id || errorMeta.turn_id' in send
     assert '_optimisticQueue: !resumed && this._isBusy(sendSid)' in send
     assert 'x-show="m._admissionPending"' in html

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3211,6 +3211,8 @@ def test_history_store_normalizes_canonical_blocks_without_count_eviction():
     assert "this._messagesById.get(storeKey)" in store
     assert "this._messagesById.set(storeKey, created)" in store
     assert "Object.assign(existing, m" in store
+    assert "const mountedKey = existing._k || renderKey" in store
+    assert "Object.assign(existing, m, { _k: mountedKey })" in store
     assert 'existing.body_state === "loaded"' in store
     assert 'm.body_state === "unloaded"' in store
     assert "this._sessionWindows.set(sid, retained)" in store
@@ -4997,10 +4999,22 @@ def test_running_turn_footer_is_owned_by_active_user_boundary():
     assert "ownerUser._turnId" in helper
     assert "pane.activeTurnId" in helper
     assert "ownerTurnId === activeTurnId" in helper
+    assert helper.index("for (let k = index + 1") < helper.index(
+        "if (ownerTurnId && activeTurnId)")
     assert "this._turnMessageBelongsToActiveTurn(m, pane)" in status
     assert "pane && pane.streaming && m && !m.ts" not in status
     assert "this._turnMessageBelongsToActiveTurn(m, pane)" in model
     assert "|| (pane && pane.streamingModel)" not in model
+
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    footer = html[html.index('<div class="turn-footer"'):]
+    footer = footer[:footer.index('<button class="turn-fork-btn"')]
+    assert "paneMsgs[i + 1]._steeringAdjustment !== true" in footer
+
+    turn_tail_start = app.index("isTurnTail(i) {")
+    turn_tail_end = app.index("\n    turnForkMessageId", turn_tail_start)
+    assert "next._steeringAdjustment !== true" in app[
+        turn_tail_start:turn_tail_end]
 
 
 def test_turn_footer_is_a_separator_and_hosts_the_only_running_dots():

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2843,6 +2843,7 @@ def test_composer_send_has_one_claim_owner_without_exposing_internal_phases():
     assert "if (sendState._optimisticInterrupt" not in send
     assert "if (sendState.es) sendState.es.close()" not in send
     assert "this._releaseComposerClaim(composerSubmitToken);" in send
+    assert "this._resumePendingCanonicalSync(sid, state);" in send
     assert send.index('sendState._composerSubmitPhase = "submitting";') < send.index(
         "await this._awaitRuntimeSettingPatches(sendSid, sendState)"
     )
@@ -3091,7 +3092,8 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     send_start = app.index("async send(opts = {})")
     send = app[send_start:app.index("async stop()", send_start)]
 
-    assert "if (st.streaming || st.es) return false" in load
+    assert "if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false" in load
+    assert "st._composerSubmitToken || this._hasAdmissionBubble(st)" in app
     assert "this.tabState[sid] !== st || st.streaming || st.es" in load
     reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true)")
     reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
@@ -3156,9 +3158,10 @@ def test_fork_banner_and_message_template_are_null_and_key_safe():
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
 
     assert "currentForkSource()?.name || ''" in html
-    assert 'x-for="row in paneRows" :key="row.key"' in html
-    assert 'get m(){ return row.message }' in html
-    assert ':data-message-key="row.spacer ? \'\' : m._k"' in html
+    assert 'x-for="m in paneMsgs" :key="m._k"' in html
+    assert "paneMessageIndex(tid, m)" in html
+    assert 'get i(){ return paneMessageIndex(tid, m) }' in html
+    assert ':data-message-key="m._k"' in html
 
 
 def test_history_keys_prefer_backend_block_identity_without_local_dup_suffixes():
@@ -3390,6 +3393,9 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     assert 'hasOwnProperty.call(m, "elapsed")' in append
     assert "return st.messages[st.messages.length - 1]" in append
     assert "return m;" not in append
+    assert append.index("this._invalidateHistoryReplace(st)") < append.index(
+        "st.messages.push(m)"
+    )
 
     mark_start = app.index("const _markDone = (")
     mark_end = app.index("\n      const markUserFailed", mark_start)
@@ -3428,15 +3434,21 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     reconcile = app[reconcile_start:reconcile_end]
     assert '"/api/chat/sessions/" + sid + "/active"' in reconcile
     assert "activity.active && !activity.background" in reconcile
+    assert "activeTurnId !== completedTurnId" in reconcile
+    assert "const activeProbe = completedTurnId" in reconcile
+    assert "!this._hasPendingAdmission(ownerState)" in reconcile
     assert "const reconcileTail = this._historyReconcileWindowSize();" in reconcile
     assert '"/api/chat/sessions/" + sid + "?tail=" + reconcileTail' in reconcile
-    assert "const completedTurnWindow = latestUserIndex >= 0" in reconcile
+    assert "const completedTurnWindow = rootUserIndex >= 0" in reconcile
     assert "minimumTail: completedTurnWindow" in reconcile
     assert "m && m.role !== \"user\" && m.uuid" in reconcile
-    assert "m.role === \"assistant\" && m.uuid" in reconcile
-    assert "m && m.uuid === expectedAssistantUuid" in reconcile
-    assert ": !!expectedText && canonicalTurn.some(" in reconcile
-    assert "!expectedText || canonicalTurn.some(" not in reconcile
+    assert 'message.role === "assistant"' in reconcile
+    assert "message.uuid === expectedAssistantUuid" in reconcile
+    assert "message._steeringAdjustment !== true" in reconcile
+    assert "message._turnRoot !== false" in reconcile
+    assert "messages.slice(turnStart, finalIndex + 1)" in reconcile
+    assert "if (finalIndex < 0) { retry(); return false; }" in reconcile
+    assert "const hasSuccessorRoot = messages.slice(finalIndex + 1).some(" in reconcile
     assert "const loaded = await this.loadSession(sid, {" in reconcile
     assert "quiet: true, probeActive: false" in reconcile
     assert "attempt < 30" in reconcile
@@ -3890,7 +3902,7 @@ def test_quiet_canonical_reload_rebases_virtual_window_before_alpine_paints():
     assert "_historyPageStillOwns" in range_helper
 
     helper_start = app.index("    _captureMessageVirtualWindow(st) {")
-    helper_end = app.index("    paneMessageRows(tid) {", helper_start)
+    helper_end = app.index("    _measureMessageVirtualRows(tid, st) {", helper_start)
     helper = app[helper_start:helper_end]
     assert "startKey:" in helper and "endKey:" in helper
     assert "messages.findIndex(m => m && m._k === snapshot.startKey)" in helper
@@ -3962,13 +3974,18 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     virtual_start = app.index("_messageVirtualHeight(st, message)")
     virtual_end = app.index("async initSessions(options = {})", virtual_start)
     virtual = app[virtual_start:virtual_end]
-    assert "paneMessageRows(tid)" in virtual
+    assert "paneMessageRows(tid)" not in virtual
     assert "_syncMessageViewport(tid = this.currentId" in virtual
-    assert "return messages.map((message, index) =>" in virtual
-    assert "spacer: false" in virtual
     assert "Intentionally no-op" in virtual
     assert 'querySelectorAll(".msg[data-message-key]")' in virtual
     assert "st._virtualHeights[key] = height" in virtual
+    index_start = app.index("    paneMessageIndex(tid, message) {")
+    index_end = app.index("    _hasPendingAdmission(st) {", index_start)
+    pane_index = app[index_start:index_end]
+    assert "_visiblePaneMessages" not in pane_index
+    assert "st.messageRange.visibleStart" in pane_index
+    assert "st.messageRange.visibleEnd" in pane_index
+    assert "return cached - start" in pane_index
     # Streaming and completed states share one exact-height browser layout. The
     # removed estimated spacers could expose blank regions during fast touch scroll.
     assert "messages.length - 3" not in virtual
@@ -4022,10 +4039,11 @@ def test_long_chat_state_keeps_complete_normalized_history_and_generation_safety
     assert terminal.index("const completedText") < terminal.rindex("curBubble = null;")
     assert "return { bubble: completedBubble, text: completedText };" in terminal
     assert ':data-tid="tid"' in pane
-    assert 'x-for="row in paneRows" :key="row.key"' in pane
-    assert "paneMessageRows(tid)" in pane
-    assert "msg-virtual-spacer" in pane
-    assert ".msg-virtual-spacer > * { display: none !important; }" in css
+    assert 'x-for="m in paneMsgs" :key="m._k"' in pane
+    assert "paneMessageIndex(tid, m)" in pane
+    assert "paneMessageRows(tid)" not in pane
+    assert "msg-virtual-spacer" not in pane
+    assert ".msg-virtual-spacer" not in css
     assert "pane.streaming" in pane
     # The single shared footer reads through the active-session façade rather
     # than duplicating elapsed timers inside every warm transcript pane.
@@ -5814,7 +5832,7 @@ def test_canonical_history_load_never_reports_stream_takeover_as_success():
     end = app.index("\n    // Warm OPEN-but-inactive tabs", start)
     load = app[start:end]
 
-    assert "if (st.streaming || st.es) return false;" in load
+    assert "if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;" in load
     assert "if (st.streaming || st.es) return true;" not in load
     assert "if (this.tabState[sid] !== st || st.streaming || st.es) return true;" not in load
     assert "st._installedCanonicalCount = Math.max(" in load

--- a/tests/test_transcript_index.py
+++ b/tests/test_transcript_index.py
@@ -20,6 +20,29 @@ def _entry(uid: str, typ: str, content, parent: str | None = None, **extra):
     }
 
 
+def _queued_command_entry(
+    uid: str,
+    source_uuid: str,
+    prompt: str,
+    parent: str | None = None,
+    **extra,
+):
+    return {
+        "uuid": uid,
+        "parentUuid": parent,
+        "type": "attachment",
+        "sessionId": "00000000-0000-4000-8000-000000000001",
+        "attachment": {
+            "type": "queued_command",
+            "prompt": prompt,
+            "source_uuid": source_uuid,
+            "commandMode": "prompt",
+            "origin": {"kind": "human"},
+        },
+        **extra,
+    }
+
+
 def _append(path: Path, *entries: dict, final_newline: bool = True) -> None:
     text = "\n".join(json.dumps(e, ensure_ascii=False) for e in entries)
     if final_newline:
@@ -377,6 +400,136 @@ def test_window_endpoint_matches_full_oracle_and_adds_stable_keys(
         m["block_id"] for m in body["messages"]
     ]
     assert len({m["block_id"] for m in body["messages"]}) == len(body["messages"])
+
+
+def test_queued_command_survives_terminal_leaf_reload_and_later_output(
+    client, auth, app_module, tmp_path,
+):
+    """A native steering attachment is one durable inline user boundary."""
+    from backend import chat as chat_mod
+
+    command_uuid = "00000000-0000-4000-8000-000000000077"
+    entries = [
+        _entry(
+            "u1", "user", "run tools",
+            timestamp="2026-08-31T03:15:34.000Z"),
+        _entry("a1", "assistant", [{
+            "type": "tool_use", "id": "toolu_1", "name": "Bash",
+            "input": {"command": "ls"},
+        }], "u1", timestamp="2026-08-31T03:15:34.500Z"),
+        _entry("tr1", "user", [{
+            "type": "tool_result", "tool_use_id": "toolu_1",
+            "content": "first result",
+        }], "a1", timestamp="2026-08-31T03:15:34.800Z"),
+        _queued_command_entry(
+            "attachment-1", command_uuid, "quoted prompt for the model", "tr1",
+            timestamp="2026-08-31T03:15:35.000Z"),
+    ]
+    sid, transcript = _make_endpoint_session(
+        client, auth, chat_mod, tmp_path, entries)
+    quotes = [{
+        "id": "quote-1", "source": "chat", "role": "assistant",
+        "sessionId": sid, "messageId": "a1", "path": "",
+        "text": "selected context", "truncated": False,
+    }]
+    chat_mod.sess.set_message_annotation(
+        sid,
+        command_uuid,
+        steering_display_text="visible adjustment",
+        steering_selection_quotes=quotes,
+        steering_queue_item_id="q-steer",
+        steering_turn_id="turn-1",
+    )
+
+    # queued_command can briefly be the terminal transcript leaf. It must
+    # already be visible instead of waiting for a later assistant record.
+    terminal = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+    assert terminal.status_code == 200, terminal.text
+    terminal_messages = terminal.json()["messages"]
+    assert terminal_messages[-1]["uuid"] == command_uuid
+    assert terminal_messages[-1]["role"] == "user"
+
+    _append(
+        transcript,
+        _entry("a2", "assistant", [{
+            "type": "tool_use", "id": "toolu_2", "name": "Bash",
+            "input": {"command": "pwd"},
+        }], "attachment-1", timestamp="2026-08-31T03:15:35.500Z"),
+        _entry("tr2", "user", [{
+            "type": "tool_result", "tool_use_id": "toolu_2",
+            "content": "second result",
+        }], "a2", timestamp="2026-08-31T03:15:36.000Z"),
+        _entry(
+            "a3", "assistant", "all done", "tr2",
+            timestamp="2026-08-31T03:15:37.000Z"),
+    )
+
+    expected = [
+        ("u1", "user"),
+        ("a1", "tool_use"),
+        ("tr1", "tool_result"),
+        (command_uuid, "user"),
+        ("a2", "tool_use"),
+        ("tr2", "tool_result"),
+        ("a3", "assistant"),
+    ]
+    tail = client.get(
+        f"/api/chat/sessions/{sid}", headers=auth, params={"tail": 50})
+    assert tail.status_code == 200, tail.text
+    body = tail.json()
+    assert [(item["uuid"], item["role"]) for item in body["messages"]] == expected
+    steering = body["messages"][3]
+    assert steering["text"] == "quoted prompt for the model"
+    assert steering["displayText"] == "visible adjustment"
+    assert steering["selectionQuotes"] == quotes
+    assert steering["_steeringAdjustment"] is True
+    assert steering["_turnRoot"] is False
+    assert steering["_queueItemId"] == "q-steer"
+    assert steering["_turnId"] == "turn-1"
+    assert steering["_turn_origin_uuid"] == "u1"
+    assert steering["block_id"].startswith(f"{command_uuid}:")
+    assert body["turn_count"] == 1
+    assert body["total"] == len(expected)
+    assert [
+        item["uuid"] for item in body["messages"]
+        if item.get("turn_status")
+    ] == ["a3"]
+
+    # Both compatibility paths and UUID navigation use the same canonical
+    # presentation identity instead of the raw attachment node UUID.
+    for params in ({}, {"full": 1}):
+        response = client.get(
+            f"/api/chat/sessions/{sid}", headers=auth, params=params)
+        assert response.status_code == 200, response.text
+        assert [(item["uuid"], item["role"])
+                for item in response.json()["messages"]] == expected
+    around = client.get(
+        f"/api/chat/sessions/{sid}",
+        headers=auth,
+        params={"around_uuid": command_uuid, "limit": 3},
+    )
+    assert around.status_code == 200, around.text
+    assert any(item["uuid"] == command_uuid
+               for item in around.json()["messages"])
+
+    outline = client.get(
+        f"/api/chat/sessions/{sid}/outline", headers=auth)
+    assert outline.status_code == 200, outline.text
+    assert [item["uuid"] for item in outline.json()["outline"]] == ["u1"]
+    ticket = client.post(
+        "/api/chat/resource-ticket",
+        headers=auth,
+        json={"resource": "export", "session_id": sid},
+    )
+    assert ticket.status_code == 200, ticket.text
+    exported = client.get(ticket.json()["url"])
+    assert exported.status_code == 200, exported.text
+    assert "quoted prompt for the model" in exported.text
+    assert "all done" in exported.text
+    assert [msg.uuid for msg in chat_mod._full_session_msgs(sid)] == [
+        "u1", "a1", "tr1", command_uuid, "a2", "tr2", "a3",
+    ]
 
 
 def test_window_endpoint_interleaves_cancelled_snapshot_at_original_anchor(


### PR DESCRIPTION
## Summary

- steer busy sends into the exact active turn, including the short admission window before the SDK query is committed
- persist repeated mid-turn adjustments as canonical user bubbles at the correct tool boundaries
- reconcile the exact completed assistant and canonical-only rows immediately after done, without requiring a page refresh
- keep Alpine keyed rows aligned when canonical history inserts a row in the middle of a live turn
- prevent a completed-turn refresh from removing an optimistic successor while preserving send-from-old-history behavior
- fall back durably to FIFO if startup fails or the exact turn becomes ineligible

## Verification

- `uv run pytest tests/test_transcript_index.py tests/test_chat_queue.py tests/test_chat_stream.py tests/test_chat_lifecycle_contracts.py tests/test_chat_endpoints.py -q` — 368 passed
- `.venv/bin/pytest -q tests/test_frontend_lint.py` — 171 passed
- targeted Playwright regression suite covering stale terminal state, mobile fork, admission/successor races, repeated steering, canonical-only thinking, completed footer, bounded long history, old-window send, and mobile footer — 11 passed
- `node --check frontend/app.js`
- `git diff --check`