### PR TITLE
fix(chat): 修复队列投递与实时渲染收敛

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -249,6 +249,7 @@ const _EMPTY_ACTIVE_SESSION_PANE = Object.freeze({
   _streamStartedAt: 0,
   sessionUsage: _EMPTY_SESSION_USAGE,
   pendingQueue: Object.freeze([]),
+  _queueAdmission: null,
   _queuePaused: false,
   backgroundActive: false,
   compacting: false,
@@ -7943,6 +7944,11 @@ function portal() {
         // compact-finally / activateTab. Items are {id, text,
         // pendingImages, pendingDocs, enqueuedAt}.
         pendingQueue: [],
+        // One locally submitted FIFO item whose durable queue POST has not
+        // acknowledged yet. It renders after the authoritative queue mirror,
+        // never inside transcript messages, so the first optimistic frame is
+        // already the correct queue tail.
+        _queueAdmission: null,
         // Set to true when a turn errors out while the queue is non-empty.
         // Stops auto-drain so the user explicitly chooses to resume vs
         // discard (auto-draining post-failure would burn tokens on a
@@ -8105,6 +8111,7 @@ function portal() {
       if (!st._queueMutating || typeof st._queueMutating !== "object") {
         st._queueMutating = {};
       }
+      if (st._queueAdmission === undefined) st._queueAdmission = null;
       return st;
     },
     _sessionSyncNeedsVisibility(reason) {
@@ -8659,6 +8666,12 @@ function portal() {
       return this.lang === "zh"
         ? "等待当前工具完成" : "Waiting for current tool";
     },
+    queueDisplayItems(st = this.activeSessionPane()) {
+      const durable = Array.isArray(st && st.pendingQueue)
+        ? st.pendingQueue : [];
+      const admission = st && st._queueAdmission;
+      return admission ? [...durable, admission] : durable;
+    },
     _findQueueSteeringMessage(st, itemId, commandUuid) {
       if (!st) return null;
       const iid = String(itemId || "");
@@ -8958,6 +8971,14 @@ function portal() {
       const mirrorState = successor && successor._handoffSourceSid === sid
         ? successor : (this.tabState[sid] === enqueueState ? enqueueState : null);
       const mirrorSid = mirrorState === successor ? successorSid : sid;
+      const admissionToken = String(item._submitToken || "");
+      if (mirrorState && admissionToken
+          && mirrorState._queueAdmission?._submitToken === admissionToken) {
+        // Swap the local tail projection for the durable row in the same
+        // synchronous acceptance step. Keeping both until send() resumes would
+        // give Alpine one frame with a duplicate fourth card / wrong fractions.
+        mirrorState._queueAdmission = null;
+      }
       // Steering lifecycle can complete before the HTTP continuation resumes.
       // In that race `accepted.item` may be the earlier waiting snapshot while
       // `accepted.queue.items` already proves it was removed (or cancelled).
@@ -9092,6 +9113,8 @@ function portal() {
         0, Number(sourceState._installedCanonicalCount) || 0);
       child._seenUpdated = sourceState._seenUpdated;
       child.pendingQueue = this._cloneRolloverValue(sourceState.pendingQueue || []);
+      child._queueAdmission = this._cloneRolloverValue(
+        sourceState._queueAdmission || null);
       child._queuePaused = !!sourceState._queuePaused;
       child._draining = !!sourceState._draining || child.pendingQueue.length > 0;
       child._handoffSourceSid = sourceSid;
@@ -9594,6 +9617,16 @@ function portal() {
             });
             return true;
           }
+          // A failed canonical install must remain an explicit obligation.
+          // The queue-attach retry budget tracks transport timing, not whether
+          // the visible transcript actually converged. Schedule one owner-free
+          // history retry so an Alpine keyed-DOM repair cannot strand the UI in
+          // the stale pre-refresh state after the last fast queued successor.
+          st._pendingExternalUpdate = true;
+          this._requestSessionSync(sid, "history_revision", {
+            targetUpdated: Number(st._reconcileTargetUpdated) || 0,
+            delayMs: 80,
+          });
           if (tries <= 1) {
             st._draining = false;
             this._syncQueueFromServer(sid);
@@ -9971,7 +10004,14 @@ function portal() {
             && message._steeringAdjustment !== true
             && message._turnRoot !== false,
         );
-        if (hasSuccessorRoot) { retry(); return false; }
+        // A later root is unsafe only while its ownership is unknown or it is
+        // still active. An explicit inactive probe means those fast successors
+        // have already completed headlessly, so the latest canonical snapshot
+        // is exactly what this pane must install rather than defer until reload.
+        if (hasSuccessorRoot && (!activity || activity.active)) {
+          retry();
+          return false;
+        }
         // Native steering messages are user-role records inside the same logical
         // turn. Walk backward from the committed final assistant to the nearest
         // root user instead of truncating the window at the last adjustment.
@@ -10529,7 +10569,8 @@ function portal() {
       return absolute >= start && absolute < end ? absolute - start : -1;
     },
     _hasPendingAdmission(st) {
-      return !!(st && (st._composerSubmitToken || this._hasAdmissionBubble(st)));
+      return !!(st && (st._composerSubmitToken || st._queueAdmission
+        || this._hasAdmissionBubble(st)));
     },
     _hasAdmissionBubble(st) {
       return !!(st && Array.isArray(st.messages)
@@ -17325,10 +17366,18 @@ function portal() {
     _messageContinuitySignatures(m) {
       if (!m) return [];
       const role = String(m.role || "");
+      // A native steering command is a user-role record inside its parent
+      // turn, while an ordinary user row opens a successor turn. Identical
+      // text is common across that boundary (for example repeated `test`),
+      // but the two rows are never interchangeable DOM identities.
+      const identityRole = role === "user"
+        ? role + (m._steeringAdjustment === true || m._turnRoot === false
+          ? ":steering" : ":root")
+        : role;
       const out = [];
-      const push = (kind, value) => {
+      const push = (kind, value, signatureRole = identityRole) => {
         if (value === undefined || value === null || value === "") return;
-        out.push(role + ":" + kind + ":" + this._stableHash(String(value)));
+        out.push(signatureRole + ":" + kind + ":" + this._stableHash(String(value)));
       };
       // Presentation-only runtime replies may legitimately have identical
       // prose (for example two "后台任务已完成" continuations). Their durable
@@ -17348,7 +17397,10 @@ function portal() {
       const continuityIds = [m.uuid, m.id, m.tool_use_id, m.task_id];
       if (role === "assistant") continuityIds.push(m.forkUuid);
       for (const value of continuityIds) {
-        push("id", value);
+        // Exact durable ids trump the steering/root presentation distinction.
+        // That semantic split exists only to stop identical prose from moving
+        // a mid-turn command onto a later ordinary user turn.
+        push("id", value, role);
       }
       push("text", m.text);
       // Some non-text tool/status rows expose only a preview or summary.
@@ -17378,22 +17430,29 @@ function portal() {
       }
       const used = new Set();
       const result = incoming.slice();
-      // Tail windows can omit older duplicate prompts. Match newest-first so a
-      // repeated role+text pair inherits the live/current-tail key rather than
-      // an older cached bubble with the same text.
-      for (let i = result.length - 1; i >= 0; i--) {
-        const canonical = result[i];
-        let matched = null;
-        for (const signature of this._messageContinuitySignatures(canonical)) {
-          const queue = candidates.get(signature);
-          while (queue && queue.length && used.has(queue[queue.length - 1])) queue.pop();
-          if (queue && queue.length) {
-            matched = queue.pop();
-            break;
-          }
+      const canonicalRows = incoming.slice();
+      const adopted = new Set();
+      const adoptionKind = new Map();
+      const adoptedMessage = new Map();
+      const signatures = result.map(message =>
+        this._messageContinuitySignatures(message));
+      const isStrong = signature => signature.includes(":id:")
+        || signature.includes(":runtime-event:");
+      const candidateFor = signature => {
+        const queue = candidates.get(signature) || [];
+        for (let i = queue.length - 1; i >= 0; i -= 1) {
+          if (!used.has(queue[i])) return queue[i];
         }
-        if (!matched || !matched._k) continue;
+        return null;
+      };
+      const adopt = (index, matched, kind) => {
+        if (!matched || !matched._k || used.has(matched)
+            || adopted.has(index)) return false;
+        const canonical = result[index];
         used.add(matched);
+        adopted.add(index);
+        adoptionKind.set(index, kind);
+        adoptedMessage.set(index, matched);
         const mountedKey = matched._k;
         // Canonical history can become readable one request before its
         // completion annotation sidecar. Keep the already-visible live footer
@@ -17420,14 +17479,98 @@ function portal() {
         }
         matched._k = mountedKey;
         matched._noAnim = true;
-        result[i] = matched;
+        result[index] = matched;
+        return true;
+      };
+
+      // Reserve every durable identity before considering prose continuity.
+      // Otherwise canonical turn B can weak-match turn A's identical text and
+      // consume the object that turn A would have matched by UUID/forkUuid.
+      for (let i = result.length - 1; i >= 0; i -= 1) {
+        for (const signature of signatures[i]) {
+          if (!isStrong(signature)) continue;
+          if (adopt(i, candidateFor(signature), "strong")) break;
+        }
       }
-      // If the canonical shaper split/combined the final tool block
-      // differently, signature matching may not reuse the exact live tail.
-      // The footer still belongs to the canonical tail, so carry its immediate
-      // done-time stamp across without overwriting authoritative fields.
+
+      // Text/preview/summary are continuity hints, not identities. Reuse them
+      // only when the unmatched row is unique on BOTH sides. Repeated prompts
+      // or replies deliberately get fresh canonical keys instead of moving an
+      // older live key onto a later turn and corrupting Alpine's keyed mover.
+      const weakExisting = new Map();
+      for (const message of existing) {
+        if (used.has(message)) continue;
+        for (const signature of this._messageContinuitySignatures(message)) {
+          if (isStrong(signature)) continue;
+          if (!weakExisting.has(signature)) weakExisting.set(signature, []);
+          weakExisting.get(signature).push(message);
+        }
+      }
+      const weakIncoming = new Map();
+      for (let i = 0; i < result.length; i += 1) {
+        if (adopted.has(i)) continue;
+        for (const signature of signatures[i]) {
+          if (isStrong(signature)) continue;
+          if (!weakIncoming.has(signature)) weakIncoming.set(signature, []);
+          weakIncoming.get(signature).push(i);
+        }
+      }
+      for (const [signature, indexes] of weakIncoming) {
+        const matches = weakExisting.get(signature) || [];
+        if (indexes.length !== 1 || matches.length !== 1) continue;
+        adopt(indexes[0], matches[0], "weak");
+      }
+
+      // Reused keys must keep the same relative order they had in the mounted
+      // repository. Alpine's keyed mover cannot safely consume a mapping that
+      // crosses two old nodes (and may throw from its internal `.after()` call).
+      // Prefer durable identities over weak prose matches; if even two strong
+      // identities cross, keep the earlier canonical row and give the later row
+      // its fresh canonical key. Object reuse is an optimisation, never worth a
+      // corrupt DOM.
+      const oldIndexes = new Map(existing.map((message, index) => [message, index]));
+      const retained = [];
+      const revertAdoption = index => {
+        const matched = adoptedMessage.get(index);
+        if (matched) used.delete(matched);
+        adopted.delete(index);
+        adoptionKind.delete(index);
+        adoptedMessage.delete(index);
+        result[index] = canonicalRows[index];
+      };
+      for (let index = 0; index < result.length; index += 1) {
+        if (!adopted.has(index)) continue;
+        const oldIndex = oldIndexes.get(adoptedMessage.get(index));
+        if (!Number.isInteger(oldIndex)) {
+          revertAdoption(index);
+          continue;
+        }
+        let previous = retained[retained.length - 1];
+        if (previous && oldIndex <= previous.oldIndex
+            && adoptionKind.get(index) === "strong") {
+          while (previous && previous.kind === "weak"
+              && oldIndex <= previous.oldIndex) {
+            revertAdoption(previous.index);
+            retained.pop();
+            previous = retained[retained.length - 1];
+          }
+        }
+        if (previous && oldIndex <= previous.oldIndex) {
+          revertAdoption(index);
+          continue;
+        }
+        retained.push({
+          index, oldIndex, kind: adoptionKind.get(index),
+        });
+      }
+      // Carry a live footer only when canonical reconciliation proved that the
+      // canonical tail is the SAME mounted logical row. A fast successor can
+      // already be present in canonical history while the browser still ends
+      // at the previous queued reply; blindly copying the old footer onto the
+      // new canonical tail makes the successor inherit the wrong time/status.
       const canonicalTail = result[result.length - 1];
-      if (liveFooter && canonicalTail && canonicalTail.role !== "user"
+      if (liveFooter && canonicalTail === existingTail
+          && canonicalTail.role !== "user"
           && canonicalTail.display_kind !== "runtime_continuation") {
         if (!canonicalTail.ts && liveFooter.ts) canonicalTail.ts = liveFooter.ts;
         if (!canonicalTail.elapsed && liveFooter.elapsed) {
@@ -29564,6 +29707,8 @@ function portal() {
         const child = childSid && this.tabState[childSid];
         return child && child._handoffSourceSid === sendSid ? child : null;
       };
+      let clearOwnedQueueAdmission = () => {};
+      let queueAdmissionAsyncHandoff = false;
       try {
       // Stop is an acknowledged control handshake, not an idle gap.  Sending
       // while it is still settling used to enqueue a fresh message between the
@@ -29609,6 +29754,21 @@ function portal() {
         && state._composerSubmitToken === composerSubmitToken
         && state.draft && state.draft.input === composerInput);
       let sentUserBubble = null;
+      let queueAdmission = null;
+      const clearQueueAdmission = () => {
+        const owners = new Set([
+          sendState, successorState(), ...Object.values(this.tabState || {}),
+        ]);
+        for (const state of owners) {
+          const pending = state && state._queueAdmission;
+          if (pending && pending._submitToken === composerSubmitToken) {
+            state._queueAdmission = null;
+          }
+        }
+        queueAdmission = null;
+        queueAdmissionAsyncHandoff = false;
+      };
+      clearOwnedQueueAdmission = clearQueueAdmission;
       const clearSubmittedComposer = ({ preserveForHandshake = false } = {}) => {
         if (hasDetachedText) return;
         // A proactive background rollover can replace sourceState while this
@@ -29680,6 +29840,7 @@ function portal() {
           this._removePaneMessage(sendState, sentUserBubble);
           sentUserBubble = null;
         }
+        clearQueueAdmission();
         restoreSubmittedComposer(true);
       };
       // Snapshot model/permission alongside sendSid — the attachment-upload
@@ -29836,6 +29997,70 @@ function portal() {
         readyDocs = ownedDocs.slice();
       }
 
+      const optimisticDisplayText = hasDetachedText
+        ? detachedDisplayText : composerInput;
+      const optimisticImages = readyImages.map(im => ({
+        id: im.id || "",
+        preview: im.preview,
+        src: im.preview || im.src || "",
+        url: (im.id && im.attach_ext && sendSid)
+          ? `/api/chat/attachments/${sendSid}/${im.id}.${im.attach_ext}`
+          : undefined,
+        mime: im.mime || "",
+      }));
+      const optimisticDocs = readyDocs.map(doc => ({
+        id: doc.id || "",
+        name: doc.name || "file",
+        kind: doc.kind || "text",
+      }));
+      const stageQueueAdmission = () => {
+        const owner = successorState()
+          || (this.tabState[sendSid] === sendState ? sendState : null);
+        if (!owner) return false;
+        if (owner._queueAdmission
+            && owner._queueAdmission._submitToken === composerSubmitToken) {
+          queueAdmission = owner._queueAdmission;
+          return true;
+        }
+        queueAdmission = {
+          id: `admission:${composerSubmitToken}`,
+          text,
+          displayText: String(optimisticDisplayText || ""),
+          pendingQuotes: composerQuotes.map(quote => ({ ...quote })),
+          image_ids: optimisticImages.map(image => image.id).filter(Boolean).join(","),
+          hasAttach: !!(optimisticImages.length || optimisticDocs.length),
+          images: optimisticImages,
+          docs: optimisticDocs,
+          expiredCount: 0,
+          pendingImages: [],
+          pendingDocs: [],
+          delivery: "queue",
+          deliveryStatus: "queued",
+          enqueuedAt: Date.now(),
+          _admissionPending: true,
+          _submitToken: composerSubmitToken,
+        };
+        owner._queueAdmission = queueAdmission;
+        return true;
+      };
+      const appendOptimisticUserBubble = () => this._appendLiveMessage(
+        sendState,
+        {
+          role: "user", text,
+          _turnRoot: true,
+          // The bubble exists before the server decides whether this prompt
+          // owns a turn or a queue slot. Keep pane-level Running hidden until
+          // admission is authoritative.
+          _admissionPending: true,
+          _optimisticQueue: !resumed && this._isBusy(sendSid),
+          _optimisticDelivery: busyDelivery,
+          displayText: optimisticDisplayText,
+          selectionQuotes: composerQuotes.map(q => ({ ...q })),
+          images: optimisticImages,
+          docs: optimisticDocs,
+        },
+      );
+
       // Commit the interaction to the screen before any network preflight. The
       // payload snapshot above is immutable, so later registration/settings/busy
       // checks can safely run after the textarea clears and the user bubble paints.
@@ -29854,26 +30079,10 @@ function portal() {
         // before appending so the optimistic user bubble enters the bounded range.
         sendState.atBottom = true;
         this._scheduleLiveMessageViewport(sendState);
-        sentUserBubble = this._appendLiveMessage(sendState, {
-          role: "user", text,
-          _turnRoot: true,
-          // The bubble exists before the server decides whether this prompt
-          // owns a turn or a queue slot.  Keep pane-level Running hidden until
-          // admission is authoritative.
-          _admissionPending: true,
-          _optimisticQueue: !resumed && this._isBusy(sendSid),
-          _optimisticDelivery: busyDelivery,
-          displayText: hasDetachedText ? detachedDisplayText : composerInput,
-          selectionQuotes: composerQuotes.map(q => ({ ...q })),
-          images: readyImages.map(im => ({
-            preview: im.preview,
-            url: (im.id && im.attach_ext && sendSid)
-              ? `/api/chat/attachments/${sendSid}/${im.id}.${im.attach_ext}`
-              : undefined,
-            mime: im.mime,
-          })),
-          docs: readyDocs.map(d => ({ name: d.name, kind: d.kind })),
-        });
+        const knownFifo = !resumed && busyDelivery === "queue"
+          && this._isBusy(sendSid);
+        if (knownFifo) stageQueueAdmission();
+        else sentUserBubble = appendOptimisticUserBubble();
         if (this.currentId === sendSid) {
           sendState.atBottom = true;
           this.scrollToBottom(true);
@@ -29908,7 +30117,15 @@ function portal() {
         ? await this._confirmSessionBusy(sendSid, sendState)
         : false;
       if (confirmedBusy) {
-        if (sentUserBubble) sentUserBubble._optimisticQueue = true;
+        if (busyDelivery === "queue") {
+          if (sentUserBubble) {
+            this._removePaneMessage(sendState, sentUserBubble);
+            sentUserBubble = null;
+          }
+          stageQueueAdmission();
+        } else if (sentUserBubble) {
+          sentUserBubble._optimisticQueue = true;
+        }
         this._setComposerClaimPhase(sendState, composerSubmitToken, "queue");
         const shouldHandoffBackground = !sendState.streaming
           && !sendState.compacting
@@ -29925,11 +30142,13 @@ function portal() {
           delivery: busyDelivery,
           active_turn_id: busyActiveTurnId,
           stream_owner_token: busyStreamOwnerToken,
+          _submitToken: composerSubmitToken,
         });
         if (!ok) {
           rollbackOptimisticSubmission();
           return false;
         }
+        clearQueueAdmission();
         if (sentUserBubble) {
           this._removePaneMessage(sendState, sentUserBubble);
           sentUserBubble = null;
@@ -29945,6 +30164,13 @@ function portal() {
           this.scrollToBottom(true);
         }
         return true;
+      }
+      // The locally-known queue can finish while registration/settings probes
+      // are in flight. If the authoritative busy check now says idle, promote
+      // the temporary queue-tail card into the ordinary direct-turn bubble.
+      if (queueAdmission) {
+        clearQueueAdmission();
+        sentUserBubble = appendOptimisticUserBubble();
       }
       // Reconnect mode has no optimistic user bubble: the backend already owns
       // the prompt and its canonical replay replaces any stale rendered suffix.
@@ -30168,7 +30394,15 @@ function portal() {
               useMux = false;
             } else {
               if (tr.status === 409 && !resumed) {
-                if (sentUserBubble) sentUserBubble._optimisticQueue = true;
+                if (busyDelivery === "queue") {
+                  if (sentUserBubble) {
+                    this._removePaneMessage(streamState, sentUserBubble);
+                    sentUserBubble = null;
+                  }
+                  stageQueueAdmission();
+                } else if (sentUserBubble) {
+                  sentUserBubble._optimisticQueue = true;
+                }
                 const queued = await this._enqueueMessage(streamSid, {
                   text,
                   displayText: hasDetachedText ? detachedDisplayText : composerInput,
@@ -30180,8 +30414,10 @@ function portal() {
                   delivery: busyDelivery,
                   active_turn_id: busyActiveTurnId,
                   stream_owner_token: busyStreamOwnerToken,
+                  _submitToken: composerSubmitToken,
                 });
                 if (queued) {
+                  clearQueueAdmission();
                   rollbackUnstartedSend(false);
                   if (isComposerSubmission) {
                     this._commitChatRecoveryDraft(sendSid, composerInput);
@@ -30191,6 +30427,10 @@ function portal() {
                     : "The current task is still finishing; message queued",
                   "info", 2800);
                   return true;
+                }
+                if (queueAdmission) {
+                  clearQueueAdmission();
+                  sentUserBubble = appendOptimisticUserBubble();
                 }
               }
               if (!tr.ok) tr = await startTurn();
@@ -31644,7 +31884,18 @@ function portal() {
           const handoffDelivery = this._busySendDelivery(
             streamSid, handoffTurnId, busyHasAttachments,
           );
-          if (sentUserBubble) {
+          if (handoffDelivery === "queue") {
+            if (sentUserBubble) {
+              this._removePaneMessage(streamState, sentUserBubble);
+              sentUserBubble = null;
+            }
+            // Cached mux events are dispatched synchronously while send() is
+            // still activating the channel. The handler then yields on this
+            // POST and send() reaches its outer finally; mark the admission as
+            // independently owned so that finally cannot erase the queue card
+            // while durable acceptance is still pending.
+            queueAdmissionAsyncHandoff = stageQueueAdmission();
+          } else if (sentUserBubble) {
             sentUserBubble._optimisticQueue = true;
             sentUserBubble._optimisticDelivery = handoffDelivery;
           }
@@ -31661,8 +31912,10 @@ function portal() {
             delivery: handoffDelivery,
             active_turn_id: handoffTurnId,
             stream_owner_token: busyStreamOwnerToken,
+            _submitToken: composerSubmitToken,
           });
           if (queued) {
+            clearQueueAdmission();
             if (sentUserBubble) {
               this._removePaneMessage(streamState, sentUserBubble);
               sentUserBubble = null;
@@ -31680,6 +31933,10 @@ function portal() {
               "info", 2800,
             );
             return;
+          }
+          if (queueAdmission) {
+            clearQueueAdmission();
+            sentUserBubble = appendOptimisticUserBubble();
           }
           if (streamState._busyQueueHandoff === es) {
             streamState._busyQueueHandoff = null;
@@ -32013,6 +32270,7 @@ function portal() {
       // turn to "done" (input re-enabled, footer stamped, unread dot) ~800ms
       // before the reconnect restored streaming. Removing it stops that flicker.
       } finally {
+        if (!queueAdmissionAsyncHandoff) clearOwnedQueueAdmission();
         if (isComposerSubmission) {
           // Runtime rollover may replace the source more than once while an
           // async queue/start request settles. The token is globally unique, so

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7740,8 +7740,9 @@ function portal() {
     },
 
     // ===== sessions =====
-    // A fresh per-tab state slot. Object refs (messages, sessionUsage) live
-    // forever — we mutate in place so Alpine's reactivity stays bound.
+    // A fresh per-tab state slot. The slot itself lives forever; live streams
+    // mutate its current message objects, while owner-free canonical installs
+    // may atomically publish a replacement array through the same reactive slot.
     _blankTabState() {
       return {
         // One chronological normalized repository. messageRange owns the
@@ -7774,6 +7775,10 @@ function portal() {
         _virtualSyncFrame: 0,
         _virtualForceTail: false,
         _virtualRevision: 0,
+        // Bumped only when a quiet canonical install proves that Alpine's
+        // keyed message DOM diverged from the accepted state. The outer pane
+        // key then remounts this one transcript without disturbing other tabs.
+        _transcriptRenderEpoch: 0,
         // Attachments/controllers stay memory-only; text is restored from the
         // browser-local per-session draft store by _ensureTabState().
         draft: {
@@ -8037,6 +8042,9 @@ function portal() {
       if (!Number.isFinite(st._virtualSyncFrame)) st._virtualSyncFrame = 0;
       if (st._virtualForceTail === undefined) st._virtualForceTail = false;
       if (!Number.isFinite(st._virtualRevision)) st._virtualRevision = 0;
+      if (!Number.isInteger(st._transcriptRenderEpoch)) {
+        st._transcriptRenderEpoch = 0;
+      }
       if (st.activeTurnId === undefined) st.activeTurnId = "";
       if (st._lastTerminalTurnId === undefined) st._lastTerminalTurnId = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
@@ -10254,6 +10262,11 @@ function portal() {
       }
       return warm;
     },
+    transcriptPaneKey(tid) {
+      const st = tid && this.tabState && this.tabState[tid];
+      return String(tid || "") + ":" + Math.max(
+        0, Number(st && st._transcriptRenderEpoch) || 0);
+    },
     _chatBodyElement() {
       // chatBody lives below a nested x-data scope (`activeSession` façade).
       // Alpine does not expose descendant component refs through the root
@@ -10274,6 +10287,73 @@ function portal() {
       const pane = this._paneElement(tid);
       if (!pane || !key) return null;
       return pane.querySelector(`.msg[data-message-key="${CSS.escape(key)}"]`);
+    },
+    _transcriptDomMatchesState(tid, st) {
+      if (!tid || !st || this.tabState[tid] !== st) return false;
+      const pane = this._paneElement(tid);
+      // An evicted/never-mounted background pane will build from state when it
+      // next becomes warm; there is no resident DOM to reconcile now.
+      if (!pane) return true;
+      const expected = this._visiblePaneMessages(st);
+      const nodes = Array.from(
+        pane.querySelectorAll(":scope > .msg[data-message-key]"));
+      if (nodes.length !== expected.length) return false;
+      const unique = new Set();
+      for (let index = 0; index < expected.length; index += 1) {
+        const message = expected[index];
+        const key = String(message && message._k || "");
+        if (!key || unique.has(key)) return false;
+        unique.add(key);
+        const node = nodes[index];
+        if (node.dataset.messageKey !== key
+            || String(node.dataset.uuid || "")
+              !== String(message && message.uuid || "")) return false;
+      }
+      return true;
+    },
+    async _ensureTranscriptDomConverged(tid, st, options = {}) {
+      if (!tid || !st || this.tabState[tid] !== st) return false;
+      if (typeof document === "undefined" || tid !== this.currentId) return true;
+      // loadSession already awaited the keyed-list update once. One additional
+      // Alpine tick lets dependent bindings (uuid/footer/index getters) settle
+      // before treating a mismatch as structural rather than merely scheduled.
+      await new Promise(resolve => this.$nextTick(resolve));
+      if (this.tabState[tid] !== st) return false;
+      // The canonical state remains valid if the user switches tabs during the
+      // tick. Its pane is hidden/evicted state now and will mount from that
+      // canonical array on activation; DOM convergence must not abort the
+      // metadata/watermark half of this successful history transaction.
+      if (tid !== this.currentId) return true;
+      if (this._transcriptDomMatchesState(tid, st)) return true;
+
+      // A successor can claim the pane while Alpine is settling the canonical
+      // array. Never remount a pane after live ownership has started; let the
+      // caller's takeover path retain the stream and retry canonical sync once
+      // that owner settles.
+      if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
+
+      // Alpine 3.14's keyed x-for mover can leave its lookup and physical nodes
+      // out of sync after a large live→canonical replacement. Re-key only this
+      // pane, and only after proving divergence; normal reconciles retain every
+      // mounted message node and its selection/observer state.
+      st._transcriptRenderEpoch += 1;
+      await new Promise(resolve => this.$nextTick(resolve));
+      if (this.tabState[tid] !== st) return false;
+      if (tid !== this.currentId) return true;
+      if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
+      const scrollEl = options.scrollEl || this._chatBodyElement();
+      if (options.followTail) {
+        st.atBottom = true;
+        this._scrollChatTailNow(tid, st);
+      } else if (scrollEl && options.anchor) {
+        if (!this._restoreMessageAnchor(scrollEl, options.anchor)
+            && Number.isFinite(options.scrollTop)) {
+          scrollEl.scrollTop = options.scrollTop;
+        }
+      } else if (scrollEl && Number.isFinite(options.scrollTop)) {
+        scrollEl.scrollTop = options.scrollTop;
+      }
+      return this._transcriptDomMatchesState(tid, st);
     },
     paneState(tid) {
       if (!tid) return null;
@@ -16368,8 +16448,8 @@ function portal() {
       // at the compact summary and can't reach it). Records st._fullLoaded
       // so the jump retry doesn't loop re-requesting full mode.
       const full = !!opts.full;
-      // quiet:true → in-place message refresh with NO skeleton + a scroll-
-      // preserving morph swap. Used by the open-session auto-resync
+      // quiet:true → identity-preserving message refresh with NO skeleton + a
+      // scroll-preserving keyed swap. Used by the open-session auto-resync
       // (_reconcileOpenSession) so a background poll that pulls newly-finished
       // messages never blanks the conversation or jumps the scroll. Cold opens
       // and tab switches keep the normal skeleton + chunked-reveal path.
@@ -16586,8 +16666,11 @@ function portal() {
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
           return false;
         }
-        // Replace the one repository in place. Quiet reconciliation preserves
-        // matching message object identity; cold reveal changes only range coords.
+        // Publish the canonical repository atomically. A 100-row in-place
+        // splice schedules a long sequence of reactive index mutations and can
+        // make Alpine's keyed mover observe an inconsistent intermediate
+        // lookup. The matched message objects and their `_k` values are still
+        // reused, so stable bubbles keep their DOM identity on the normal path.
         if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
         // _virtualStart/_virtualEnd are LOCAL to the revealed slice. A quiet
         // canonical refresh can move visibleStart from a narrow recent tail to
@@ -16625,7 +16708,8 @@ function portal() {
         const quietEnd = quietRangeResolved ? quietRangeResolved.end : startIdx;
         st.messageRange.visibleStart = quiet ? quietStart : startIdx;
         st.messageRange.visibleEnd = quiet ? quietEnd : startIdx;
-        st.messages.splice(0, st.messages.length, ...all);
+        st.messages = all;
+        _paneMessageIndexCache.delete(st);
         Object.assign(st.messageRange, {
           visibleStart: quiet ? quietStart : startIdx,
           visibleEnd: quiet ? quietEnd : startIdx,
@@ -16662,6 +16746,19 @@ function portal() {
         // response coordinates. Canonical envelopes remain untouched.
         this._scheduleHistoryViewport(st, "newer");
         this._syncSessionMessageStore(st);
+        if (quiet && sid === this.currentId) {
+          const domConverged = await this._ensureTranscriptDomConverged(sid, st, {
+            scrollEl: quietScrollEl,
+            scrollTop: quietScrollTop,
+            anchor: quietAnchor,
+            followTail: followTailAtInstall,
+          });
+          if (!domConverged || this.tabState[sid] !== st
+              || st.streaming || st.es || this._hasAdmissionBubble(st)
+              || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
+            return false;
+          }
+        }
         st._hasMoreHistory = st.messageRange.visibleStart > 0
           || st.messageRange.offset > 0 || this._preCompactReachable(st);
         // Remember whether this load pulled the full raw-JSONL history, so

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8443,7 +8443,7 @@ function portal() {
       // adjustment that the queue endpoint must downgrade after the POST.
       if (!st || !turnId || attachmentIntent || st.compacting
           || st.backgroundActive || st._draining || st.parentTurnId
-          || (st.pendingQueue && st.pendingQueue.length)) {
+          || !this._pendingQueueAllowsAdjustment(st, turnId)) {
         return "queue";
       }
       return "adjust";
@@ -8477,7 +8477,7 @@ function portal() {
           || this._normalizeBusySendMode(this.busySendMode) !== "adjust"
           || hasAttachments || !st.streaming || st.compacting
           || st.backgroundActive || st._draining || st.parentTurnId
-          || (st.pendingQueue && st.pendingQueue.length)) {
+          || !this._pendingQueueAllowsAdjustment(st)) {
         return "";
       }
       try {
@@ -8498,6 +8498,28 @@ function portal() {
       } catch (_) {
         return ownerStillCurrent() ? accept(st.activeTurnId) : "";
       }
+    },
+    _pendingQueueAllowsAdjustment(st, activeTurnId = "") {
+      if (!st || st._queueAdmission) return false;
+      const pending = Array.isArray(st.pendingQueue) ? st.pendingQueue : [];
+      if (!pending.length) return true;
+      const turnId = String(activeTurnId || "");
+      // Multiple native `priority=next` commands may target the same immutable
+      // foreground turn.  They must not be confused with ordinary FIFO rows:
+      // a fallback, attachment send, or item from another turn still owns its
+      // original queue position and blocks a later message from overtaking it.
+      return pending.every(item => {
+        const delivery = this._normalizeBusySendMode(
+          item && item.delivery, "queue",
+        );
+        const state = String(item && item.deliveryStatus || "pending");
+        const targetTurnId = String(item && item.targetTurnId || "");
+        const active = [
+          "pending", "waiting_tool", "queued", "started",
+        ].includes(state);
+        return delivery === "adjust" && active && !!targetTurnId
+          && (!turnId || targetTurnId === turnId);
+      });
     },
     sendButtonHint(sid) {
       if (this.composerClaimed(sid)) return this.t("btn.send");
@@ -10968,8 +10990,19 @@ function portal() {
             sid, existingState, { minimumWaitMs: 0 });
           return;
         }
-        if (existingState && !existingState.streaming) {
-          this._setBackgroundTaskActive(sid, false, payload.started_at, 0);
+        if (existingState) {
+          if (!existingState.streaming) {
+            this._setBackgroundTaskActive(sid, false, payload.started_at, 0);
+          }
+          // A short server-drained turn can start and finish between browser
+          // attach probes, so this tab never acquires its immutable turn id.
+          // Its inactive mux frame is still an authoritative canonical-history
+          // boundary. Keep one replay obligation alive across any later queued
+          // successors; the replay worker waits for the backend to become idle
+          // and then installs the complete suffix without a manual refresh.
+          existingState._pendingExternalUpdate = true;
+          this._scheduleCanonicalStreamReload(
+            sid, existingState, { minimumWaitMs: 0 });
         }
         return;
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2985,6 +2985,7 @@
                                        || activeSession.messages[activeSession.messages.length-1].role === 'user')
                        && (!activeSession.messages.length
                          || !activeSession.messages[activeSession.messages.length-1]._admissionPending)
+                       && !activeSession._queueAdmission
                        && !activeSession.compacting
                        && !activeSession._continuationAwaitingReaction"
                class="turn-footer turn-pending-footer"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1950,7 +1950,7 @@
           <!-- Keep a bounded set of recent transcript panes mounted as an LRU DOM
                cache. Each pane exposes only its messageRange window; hidden panes
                retain keyed state but remain out of layout. -->
-          <template x-for="tid in warmTranscriptTabIds()" :key="tid">
+          <template x-for="tid in warmTranscriptTabIds()" :key="transcriptPaneKey(tid)">
           <div class="msg-pane"
                x-show="tid === currentId"
                x-cloak

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3013,7 +3013,7 @@
                replying (or while a compact was running). They auto-drain on
                the next done event / compact-finally / activateTab. Faded
                + dashed border distinguishes them from real user bubbles. -->
-          <template x-for="(q, qi) in activeSession.pendingQueue" :key="q.id">
+          <template x-for="(q, qi) in queueDisplayItems(activeSession)" :key="q.id">
             <div class="msg user queued">
               <div class="msg-row queued-row"
                    :class="{ 'avoids-tail-nav': isAwayFromLatest() }">
@@ -3022,7 +3022,7 @@
                     <span class="queued-icon"><svg><use href="#i-clock"/></svg></span>
                     <span class="queued-label"
                           x-text="queueDeliveryLabel(q) + ' ' + (qi+1) + ' / '
-                                   + activeSession.pendingQueue.length"></span>
+                                   + queueDisplayItems(activeSession).length"></span>
                     <!-- "已排队 1/2" alone reads as "will send shortly", which
                          is wrong while the queue is paused — the item will
                          NEVER send until Resume. State the difference on the
@@ -3035,14 +3035,14 @@
                           x-text="lang==='zh' ? '已暂停' : 'paused'"></span>
                     <span style="flex:1"></span>
                     <button class="queued-act icon-btn sm"
-                            @click="editPendingQueueItem(currentId, qi)"
-                            :disabled="queueActionBusy(currentId, 'edit:' + q.id)"
+                            @click="!q._admissionPending && editPendingQueueItem(currentId, qi)"
+                            :disabled="q._admissionPending || queueActionBusy(currentId, 'edit:' + q.id)"
                             :title="lang==='zh' ? '编辑' : 'Edit'">
                       <svg><use href="#i-edit"/></svg>
                     </button>
                     <button class="queued-act icon-btn sm"
-                            @click="removePendingQueueItem(currentId, qi)"
-                            :disabled="queueActionBusy(currentId, 'remove:' + q.id)"
+                            @click="!q._admissionPending && removePendingQueueItem(currentId, qi)"
+                            :disabled="q._admissionPending || queueActionBusy(currentId, 'remove:' + q.id)"
                             :title="lang==='zh' ? '移除' : 'Remove'">
                       <svg><use href="#i-x"/></svg>
                     </button>

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -6689,6 +6689,169 @@ def test_live_turn_keeps_resident_messages_but_bounds_mounted_rows(
     _assert_no_browser_errors(page, errors)
 
 
+def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
+    page: Page, backend_url, auth_token,
+):
+    """Successive quiet installs must converge the keyed DOM without reload."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const sid = "canonical-dom-fast-turns";
+          app.refreshSessions = async () => {};
+          app._fetchTabUsage = async () => {};
+          app._scheduleIdlePreload = () => {};
+          app.sessions = [{id: sid, name: "Canonical DOM", model: "e2e-model"}];
+          app.openTabIds = [sid];
+          app.tabState = {};
+          app.currentId = sid;
+          const st = app._ensureTabState(sid);
+          st._loaded = true;
+          st.messagesReady = true;
+          st.messagesLoading = false;
+          st.atBottom = true;
+          const canonical = [];
+          const addCanonical = message => {
+            canonical.push({...message, block_id: `${message.uuid}:0:${message.role}`});
+          };
+          const settle = async () => {
+            let next = app._historyEnvelopes(
+              sid, canonical.map(message => ({...message, _noAnim: true})));
+            next = app._preserveCanonicalMessageIdentity(st, next);
+            st.messageRange.visibleStart = Math.max(0, next.length - 100);
+            st.messageRange.visibleEnd = next.length;
+            st.messageRange.total = next.length;
+            st.messages = next;
+            app._syncSessionMessageStore(st);
+            await new Promise(resolve => app.$nextTick(
+              () => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+          };
+          const live = message => app._appendLiveMessage(st, message);
+
+          for (let i = 0; i < 70; i++) {
+            addCanonical({role: "assistant", text: `OLDER ${i}`,
+                          uuid: `older-${i}`});
+          }
+          addCanonical({role: "user", text: "RUN TEN LS",
+                        uuid: "prior-turn-user", _turnRoot: true});
+          for (let i = 0; i < 10; i++) {
+            const id = `prior-tool-${i}`;
+            addCanonical({role: "tool_use", name: "Bash", text: "ls", id,
+                          uuid: `prior-tool-use-${i}`});
+            addCanonical({role: "tool_result", tool_name: "Bash",
+                          text: "same output", preview: "same output", id,
+                          tool_use_id: id, uuid: `prior-tool-result-${i}`});
+          }
+          addCanonical({role: "assistant", text: "TEN LS DONE",
+                        uuid: "prior-turn-final", turn_status: "completed"});
+          await settle();
+
+          live({role: "user", text: "RUN TEN LS", _turnRoot: true});
+          addCanonical({role: "user", text: "RUN TEN LS", uuid: "turn-a-user",
+                        _turnRoot: true});
+          for (let i = 0; i < 10; i++) {
+            const id = `tool-${i}`;
+            live({role: "tool_use", name: "Bash", text: "ls", id});
+            addCanonical({role: "tool_use", name: "Bash", text: "ls", id,
+                          uuid: `turn-a-tool-use-${i}`});
+            live({role: "tool_result", tool_name: "Bash", text: "same output",
+                  preview: "same output", id, tool_use_id: id});
+            addCanonical({role: "tool_result", tool_name: "Bash",
+                          text: "same output", preview: "same output", id,
+                          tool_use_id: id, uuid: `turn-a-tool-result-${i}`});
+            if (i === 0) {
+              live({role: "user", text: "test", uuid: "midturn-user",
+                    _steeringAdjustment: true, _turnRoot: false});
+              addCanonical({role: "user", text: "test",
+                            uuid: "midturn-user", _steeringAdjustment: true,
+                            _turnRoot: false});
+            }
+          }
+          live({role: "assistant", text: "TEN LS DONE", forkUuid: "turn-a-final"});
+          addCanonical({role: "assistant", text: "TEN LS DONE",
+                        uuid: "turn-a-final", turn_status: "completed"});
+
+          for (const [index, prompt, reply] of [
+            [1, "test", "TEST REPLY"],
+            [2, "test3", "TEST3 REPLY"],
+            [3, "stop", "STOP REPLY"],
+          ]) {
+            live({role: "user", text: prompt, _turnRoot: true,
+                  _turnId: `turn-${index}`});
+            live({role: "assistant", text: reply,
+                  forkUuid: `turn-${index}-assistant`});
+            addCanonical({role: "user", text: prompt,
+                          uuid: `turn-${index}-user`, _turnRoot: true});
+            addCanonical({role: "assistant", text: reply,
+                          uuid: `turn-${index}-assistant`,
+                          turn_status: "completed"});
+          }
+          await settle();
+
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          const visible = st.messages.slice(
+            st.messageRange.visibleStart, st.messageRange.visibleEnd);
+          const stateKeys = visible.map(message => message._k);
+          const stateRows = visible.map(message =>
+            `${message.role}:${message.text || message.preview || ""}`);
+          const dom = Array.from(pane.querySelectorAll(":scope > .msg"));
+          const initial = {
+            stateKeys,
+            stateRows,
+            domKeys: dom.map(node => node.dataset.messageKey),
+            domRows: dom.map(node => {
+              const message = (node._x_dataStack || [])
+                .map(scope => scope && scope.m).find(Boolean);
+                return `${message?.role || ""}:${message?.text || message?.preview || ""}`;
+              }),
+          };
+          const epochBeforeRepair = st._transcriptRenderEpoch;
+          dom[Math.floor(dom.length / 2)].remove();
+          const repaired = await app._ensureTranscriptDomConverged(
+            sid, st, {followTail: true});
+          await new Promise(resolve => app.$nextTick(
+            () => requestAnimationFrame(resolve)));
+          const epochBeforeSwitch = st._transcriptRenderEpoch;
+          const switchedCheck = app._ensureTranscriptDomConverged(sid, st);
+          app.currentId = "another-open-tab";
+          const switchedAwayAccepted = await switchedCheck;
+          app.currentId = sid;
+          app._activateTabState(sid);
+          await new Promise(resolve => app.$nextTick(resolve));
+          const repairedPane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          return {
+            initial,
+            repaired,
+            epochBeforeRepair,
+            epochAfterRepair: st._transcriptRenderEpoch,
+            repairedDomKeys: Array.from(repairedPane.querySelectorAll(
+              ":scope > .msg[data-message-key]"
+            )).map(node => node.dataset.messageKey),
+            switchedAwayAccepted,
+            epochBeforeSwitch,
+            epochAfterSwitch: st._transcriptRenderEpoch,
+          };
+        }"""
+    )
+
+    initial = result["initial"]
+    assert len(initial["stateKeys"]) == len(set(initial["stateKeys"])), result
+    assert len(initial["domKeys"]) == len(set(initial["domKeys"])), result
+    assert initial["domKeys"] == initial["stateKeys"], result
+    assert initial["domRows"] == initial["stateRows"], result
+    assert result["repaired"] is True, result
+    assert result["epochAfterRepair"] == result["epochBeforeRepair"] + 1, result
+    assert result["repairedDomKeys"] == initial["stateKeys"], result
+    assert result["switchedAwayAccepted"] is True, result
+    assert result["epochAfterSwitch"] == result["epochBeforeSwitch"], result
+    _assert_no_browser_errors(page, errors)
+
+
 def test_stale_older_response_cannot_overwrite_new_canonical_tail(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -492,6 +492,28 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
           try {
             st._loaded = true;
             st.messages = [{ role: 'assistant', text: 'VISIBLE_COMPLETED_REPLY' }];
+            st.streaming = false;
+            st.streamPhase = '';
+            st.activeTurnId = '';
+            st.es = null;
+            if (meta) meta.active = true;
+
+            // A fast server-drained queue turn can start and finish before this
+            // browser ever owns its mux channel. Its inactive aggregate frame is
+            // then the only live hint that canonical history has a missing suffix.
+            window.__emitMux('session_state', {
+              session_id: sid, turn_id: 'turn-headless-queued', active: false,
+              stopping: false, attachable: false, activity_source: 'queued',
+            });
+            await new Promise(resolve => setTimeout(resolve, 30));
+            const headless = {
+              streaming: st.streaming,
+              activeTurnId: st.activeTurnId,
+              reloads,
+              text: st.messages[0] && st.messages[0].text,
+              metaActive: meta && meta.active,
+            };
+
             st.streaming = true;
             st.streamPhase = 'runtime';
             st.activeTurnId = 'turn-a';
@@ -551,12 +573,19 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
             clearInterval(st._streamTimer);
             clearInterval(st._stallWatch);
             if (st.es) st.es.close();
-            return { matching, successor };
+            return { headless, matching, successor };
           } finally {
             app._scheduleCanonicalStreamReload = originalReload;
           }
         }"""
     )
+    assert result["headless"] == {
+        "streaming": False,
+        "activeTurnId": "",
+        "reloads": 1,
+        "text": "VISIBLE_COMPLETED_REPLY",
+        "metaActive": False,
+    }
     assert result["matching"] == {
         "streaming": False,
         "phase": "",
@@ -565,7 +594,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
         "stall": None,
         "stoppingTurn": "",
         "elapsed": 0,
-        "reloads": 1,
+        "reloads": 2,
         "text": "VISIBLE_COMPLETED_REPLY",
         "metaActive": False,
     }
@@ -575,7 +604,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
         "sameEs": True,
         "sameTimer": True,
         "activeTurnId": "turn-b",
-        "reloads": 1,
+        "reloads": 2,
         "metaActive": True,
     }
     _assert_no_browser_errors(page, errors)
@@ -4879,6 +4908,175 @@ def test_existing_fifo_queue_renders_pending_send_as_disabled_tail_card(
     ]
     assert queued.locator(".queued-label").all_text_contents() == [
         "排队中 1 / 3", "排队中 2 / 3", "排队中 3 / 3",
+    ]
+    _assert_no_browser_errors(page, errors)
+
+
+def test_existing_same_turn_adjust_keeps_next_real_send_as_adjust(
+    page: Page, backend_url, auth_token,
+):
+    """A waiting adjustment must not downgrade the next same-turn send to FIFO."""
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    sid = "perf-repeated-midturn-adjust"
+    turn_id = "repeated-midturn-active-turn"
+    first_prompt = "FIRST_ADJUSTMENT_WAITING_FOR_TOOL"
+    second_prompt = "SECOND_ADJUSTMENT_MUST_STAY_NATIVE"
+    first = {
+        "id": "repeated-adjust-first",
+        "text": first_prompt,
+        "display_text": first_prompt,
+        "selection_quotes": [],
+        "image_ids": "",
+        "attachments": [],
+        "delivery": "adjust",
+        "steering_state": "waiting_tool",
+        "command_uuid": "repeated-adjust-first-command",
+        "target_turn_id": turn_id,
+        "enqueued_at": 1,
+    }
+    accepted = {
+        "id": "repeated-adjust-second",
+        "text": second_prompt,
+        "display_text": second_prompt,
+        "selection_quotes": [],
+        "image_ids": "",
+        "attachments": [],
+        "delivery": "adjust",
+        "steering_state": "waiting_tool",
+        "command_uuid": "repeated-adjust-second-command",
+        "target_turn_id": turn_id,
+        "enqueued_at": 2,
+    }
+    post_payloads: list[dict] = []
+
+    def queue_route(route):
+        if route.request.method == "POST":
+            post_payloads.append(route.request.post_data_json)
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({
+                    "ok": True,
+                    "item": accepted,
+                    "effective_delivery": "adjust",
+                    "delivery_status": "waiting_tool",
+                    "queue": {
+                        "items": [first, accepted],
+                        "paused": False,
+                        "revision": 2,
+                    },
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "items": [first, accepted], "paused": False, "revision": 2,
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}/queue", queue_route)
+    result = _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        const turnId = arg.turnId;
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._syncQueueFromServer = async () => {};
+        app.appReady = true;
+        app._modelsLoaded = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.permission = "bypassPermissions";
+        app.busySendMode = "adjust";
+        app.sessions = [{
+          id: sid, name: "Repeated mid-turn adjust", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+          active: true, turn_active: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.streaming = true;
+        st.activeTurnId = turnId;
+        st._streamOwnerToken = "repeated-midturn-owner";
+        st.pendingQueue = [{
+          id: arg.first.id,
+          text: arg.first.text,
+          displayText: arg.first.display_text,
+          pendingQuotes: [], image_ids: "", hasAttach: false,
+          images: [], docs: [], expiredCount: 0,
+          pendingImages: [], pendingDocs: [],
+          delivery: "adjust", deliveryStatus: "waiting_tool",
+          commandUuid: arg.first.command_uuid,
+          targetTurnId: turnId,
+          enqueuedAt: arg.first.enqueued_at,
+        }];
+        app.currentId = sid;
+        app.mobileTab = "chat";
+        app._activateTabState(sid);
+        st.atBottom = true;
+
+        // A native adjustment from another immutable turn is still an ordering
+        // barrier; only the exact current-turn row may admit another adjustment.
+        st.pendingQueue[0].targetTurnId = "different-active-turn";
+        const differentTurnDelivery = app._busySendDelivery(sid, turnId, false);
+        st.pendingQueue[0].targetTurnId = turnId;
+
+        app.input = arg.secondPrompt;
+        const sent = await app.send();
+        return {
+          sent,
+          differentTurnDelivery,
+          pending: st.pendingQueue.map(item => ({
+            id: item.id,
+            delivery: item.delivery,
+            deliveryStatus: item.deliveryStatus,
+            targetTurnId: item.targetTurnId,
+          })),
+        };
+        """,
+        {
+            "sid": sid,
+            "turnId": turn_id,
+            "first": first,
+            "secondPrompt": second_prompt,
+        },
+    )
+
+    assert result["sent"] is True
+    assert result["differentTurnDelivery"] == "queue"
+    assert len(post_payloads) == 1
+    assert post_payloads[0]["text"] == second_prompt
+    assert post_payloads[0]["delivery"] == "adjust"
+    assert post_payloads[0]["active_turn_id"] == turn_id
+    assert result["pending"] == [
+        {
+            "id": first["id"],
+            "delivery": "adjust",
+            "deliveryStatus": "waiting_tool",
+            "targetTurnId": turn_id,
+        },
+        {
+            "id": accepted["id"],
+            "delivery": "adjust",
+            "deliveryStatus": "waiting_tool",
+            "targetTurnId": turn_id,
+        },
     ]
     _assert_no_browser_errors(page, errors)
 

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -4681,6 +4681,424 @@ def test_session_sync_deadline_dispose_and_hidden_resume(
     _assert_no_browser_errors(page, errors)
 
 
+def test_existing_fifo_queue_renders_pending_send_as_disabled_tail_card(
+    page: Page, backend_url, auth_token,
+):
+    """A known FIFO send stays at the visual queue tail while POST is pending."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    sid = "perf-optimistic-queue-tail"
+    prompt = "THIRD_QUEUE_ITEM_PENDING_POST"
+
+    def queue_item(item_id: str, text: str, enqueued_at: int) -> dict:
+        return {
+            "id": item_id,
+            "text": text,
+            "display_text": text,
+            "selection_quotes": [],
+            "image_ids": "",
+            "attachments": [],
+            "delivery": "queue",
+            "steering_state": "queued",
+            "command_uuid": f"{item_id}-command",
+            "target_turn_id": "existing-running-turn",
+            "enqueued_at": enqueued_at,
+        }
+
+    first = queue_item("queue-tail-first", "FIRST_QUEUE_ITEM", 1)
+    second = queue_item("queue-tail-second", "SECOND_QUEUE_ITEM", 2)
+    accepted = queue_item("queue-tail-third", prompt, 3)
+    authoritative = [first, second, accepted]
+    held_post: dict[str, object] = {}
+    post_payloads: list[dict] = []
+
+    def queue_route(route):
+        if route.request.method == "POST":
+            post_payloads.append(route.request.post_data_json)
+            held_post["route"] = route
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"items": authoritative, "paused": False, "revision": 3}),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}/queue", queue_route)
+    _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        const queueView = item => ({
+          id: item.id,
+          text: item.text,
+          displayText: item.display_text,
+          pendingQuotes: [], image_ids: "", hasAttach: false,
+          images: [], docs: [], expiredCount: 0,
+          pendingImages: [], pendingDocs: [],
+          delivery: "queue", deliveryStatus: "queued",
+          commandUuid: item.command_uuid,
+          targetTurnId: item.target_turn_id,
+          enqueuedAt: item.enqueued_at,
+        });
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._syncQueueFromServer = async () => {};
+        app.appReady = true;
+        app._modelsLoaded = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.lang = "zh";
+        app.busySendMode = "adjust";
+        app.sessions = [{
+          id: sid, name: "Optimistic queue tail", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+          active: true, turn_active: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.messages = [{
+          role: "assistant", text: "RUNNING_ASSISTANT_BEFORE_QUEUE",
+          html: "<p>RUNNING_ASSISTANT_BEFORE_QUEUE</p>",
+          uuid: "queue-tail-running-assistant",
+          _k: `${sid}:uuid:queue-tail-running-assistant`, _noAnim: true,
+        }];
+        Object.assign(st.messageRange, {
+          visibleStart: 0, visibleEnd: 1, offset: 0, total: 1,
+          preTotal: 0, order: "full", generation: "queue-tail-e2e",
+        });
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.streaming = true;
+        st.activeTurnId = "existing-running-turn";
+        st._streamOwnerToken = "existing-running-owner";
+        st.pendingQueue = arg.initial.map(queueView);
+        app.currentId = sid;
+        app.mobileTab = "chat";
+        app._activateTabState(sid);
+        st.atBottom = true;
+        app.input = arg.prompt;
+        window.__optimisticQueueTailSend = app.send();
+        return true;
+        """,
+        {"sid": sid, "prompt": prompt, "initial": [first, second]},
+    )
+
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          return st._queueAdmission?.displayText === arg.prompt
+            && document.querySelectorAll(".msg.user.queued").length === 3;
+        }""",
+        arg={"sid": sid, "prompt": prompt},
+        timeout=10000,
+    )
+    assert "route" in held_post, "send() did not reach the delayed queue POST"
+    assert len(post_payloads) == 1
+    assert post_payloads[0]["text"] == prompt
+    assert post_payloads[0]["delivery"] == "queue"
+
+    queued = page.locator(".msg.user.queued")
+    expect(queued).to_have_count(3)
+    assert queued.locator(".queued-text").all_text_contents() == [
+        "FIRST_QUEUE_ITEM", "SECOND_QUEUE_ITEM", prompt,
+    ]
+    assert queued.locator(".queued-label").all_text_contents() == [
+        "排队中 1 / 3", "排队中 2 / 3", "排队中 3 / 3",
+    ]
+    expect(
+        page.locator(f'.msg-pane[data-tid="{sid}"] .msg.user').filter(
+            has_text=prompt
+        )
+    ).to_have_count(0)
+    pending_actions = queued.nth(2).locator("button.queued-act")
+    expect(pending_actions).to_have_count(2)
+    expect(pending_actions.nth(0)).to_be_disabled()
+    expect(pending_actions.nth(1)).to_be_disabled()
+
+    held_post["route"].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "ok": True,
+            "item": accepted,
+            "effective_delivery": "queue",
+            "delivery_status": "queued",
+            "queue": {"items": authoritative, "revision": 3},
+        }),
+    )
+    send_result = _app_eval(
+        page, "return await window.__optimisticQueueTailSend;"
+    )
+    assert send_result is True
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          return st._queueAdmission === null
+            && st.pendingQueue.length === 3
+            && document.querySelectorAll(".msg.user.queued").length === 3;
+        }""",
+        arg={"sid": sid},
+        timeout=10000,
+    )
+    settled = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        return {
+          admission: st._queueAdmission,
+          ids: st.pendingQueue.map(item => item.id),
+          texts: st.pendingQueue.map(item => item.displayText),
+          transcriptPromptCount: st.messages.filter(
+            item => item.role === "user" && item.displayText === arg.prompt).length,
+        };
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+    assert settled == {
+        "admission": None,
+        "ids": [first["id"], second["id"], accepted["id"]],
+        "texts": [first["display_text"], second["display_text"], prompt],
+        "transcriptPromptCount": 0,
+    }
+    expect(queued).to_have_count(3)
+    assert queued.locator(".queued-text").all_text_contents() == [
+        "FIRST_QUEUE_ITEM", "SECOND_QUEUE_ITEM", prompt,
+    ]
+    assert queued.locator(".queued-label").all_text_contents() == [
+        "排队中 1 / 3", "排队中 2 / 3", "排队中 3 / 3",
+    ]
+    _assert_no_browser_errors(page, errors)
+
+
+def test_mux_pending_turn_busy_keeps_queue_admission_until_post_ack(
+    page: Page, backend_url, auth_token,
+):
+    """A synchronously replayed mux busy frame must not lose its pending card."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _login(page, backend_url, auth_token)
+    sid = "mux-pending-turn-busy-admission"
+    prompt = "MUX_BUSY_QUEUE_POST_PENDING"
+    attempted_turn_id = "mux-attempted-turn"
+    busy_turn_id = "mux-existing-busy-turn"
+    accepted = {
+        "id": "mux-busy-queued-item",
+        "text": prompt,
+        "display_text": prompt,
+        "selection_quotes": [],
+        "image_ids": "",
+        "attachments": [],
+        "delivery": "queue",
+        "steering_state": "queued",
+        "command_uuid": "mux-busy-command",
+        "target_turn_id": busy_turn_id,
+        "enqueued_at": 1,
+    }
+    held_post: dict[str, object] = {}
+    post_payloads: list[dict] = []
+    start_payloads: list[dict] = []
+
+    def start_route(route):
+        start_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "accepted": True,
+                "turn_id": attempted_turn_id,
+                "started_at": 1,
+            }),
+        )
+
+    def queue_route(route):
+        if route.request.method == "POST":
+            post_payloads.append(route.request.post_data_json)
+            held_post["route"] = route
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"items": [accepted], "paused": False, "revision": 1}),
+        )
+
+    page.route("**/api/chat/turns/start", start_route)
+    page.route(f"**/api/chat/sessions/{sid}/queue", queue_route)
+    _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._syncQueueFromServer = async () => {};
+        app._awaitRuntimeSettingPatches = async () => true;
+        app._confirmSessionBusy = async () => false;
+        app._ensureChatMux = async () => {
+          app._chatMuxConnected = true;
+          return true;
+        };
+        app.appReady = true;
+        app._modelsLoaded = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.permission = "bypassPermissions";
+        app.lang = "zh";
+        app.busySendMode = "queue";
+        app.sessions = [{
+          id: sid, name: "Mux pending busy", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+          active: false, turn_active: false,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.pendingQueue = [];
+        st.atBottom = true;
+        app.currentId = sid;
+        app._touchTranscriptPane(sid);
+        app._activateTabState(sid);
+        app.input = arg.prompt;
+
+        // The aggregate mux received this terminal admission race before the
+        // per-turn adapter installed its listeners. Activation replays it via
+        // dispatchEvent synchronously; its async handler then waits on the
+        // deliberately-held queue POST while send() reaches outer finally.
+        app._queueChatMuxEvent(sid, "error", JSON.stringify({
+          session_id: sid,
+          turn_id: arg.attemptedTurnId,
+          active_turn_id: arg.busyTurnId,
+          error: "session already has an active turn",
+          kind: "turn_busy",
+          retryable: true,
+          cta: "retry",
+        }));
+        window.__muxPendingBusySendSettled = false;
+        window.__muxPendingBusySendResult = "pending";
+        window.__muxPendingBusySend = app.send().then(result => {
+          window.__muxPendingBusySendSettled = true;
+          window.__muxPendingBusySendResult = result;
+          return result;
+        });
+        return true;
+        """,
+        {
+            "sid": sid,
+            "prompt": prompt,
+            "attemptedTurnId": attempted_turn_id,
+            "busyTurnId": busy_turn_id,
+        },
+    )
+
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          return window.__muxPendingBusySendSettled === true
+            && st._composerSubmitToken === null
+            && st._queueAdmission?.displayText === arg.prompt
+            && st.pendingQueue.length === 0
+            && document.querySelectorAll(".msg.user.queued").length === 1;
+        }""",
+        arg={"sid": sid, "prompt": prompt},
+        timeout=10000,
+    )
+    assert len(start_payloads) == 1
+    assert "route" in held_post, "turn_busy handoff did not reach the delayed queue POST"
+    assert len(post_payloads) == 1
+    assert post_payloads[0]["text"] == prompt
+    assert post_payloads[0]["delivery"] == "queue"
+    assert post_payloads[0]["active_turn_id"] == busy_turn_id
+
+    queued = page.locator(".msg.user.queued")
+    expect(queued).to_have_count(1)
+    expect(queued.locator(".queued-text")).to_have_text(prompt)
+    expect(queued.locator(".queued-label")).to_have_text("排队中 1 / 1")
+    expect(queued.locator("button.queued-act").nth(0)).to_be_disabled()
+    expect(queued.locator("button.queued-act").nth(1)).to_be_disabled()
+    expect(
+        page.locator(f'.msg-pane[data-tid="{sid}"] .msg.user').filter(
+            has_text=prompt
+        )
+    ).to_have_count(0)
+
+    held_post["route"].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "ok": True,
+            "item": accepted,
+            "effective_delivery": "queue",
+            "delivery_status": "queued",
+            "queue": {"items": [accepted], "revision": 1},
+        }),
+    )
+    page.wait_for_function(
+        """arg => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(arg.sid);
+          return st._queueAdmission === null
+            && st.pendingQueue.length === 1
+            && st.pendingQueue[0].id === arg.itemId
+            && st.streaming === false
+            && !st._busyQueueHandoff
+            && document.querySelectorAll(".msg.user.queued").length === 1;
+        }""",
+        arg={"sid": sid, "itemId": accepted["id"]},
+        timeout=10000,
+    )
+    settled = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        return {
+          admission: st._queueAdmission,
+          claim: st._composerSubmitToken,
+          ids: st.pendingQueue.map(item => item.id),
+          texts: st.pendingQueue.map(item => item.displayText),
+          displayIds: app.queueDisplayItems(st).map(item => item.id),
+          transcriptPromptCount: st.messages.filter(
+            item => item.role === "user" && item.displayText === arg.prompt).length,
+        };
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+    assert settled == {
+        "admission": None,
+        "claim": None,
+        "ids": [accepted["id"]],
+        "texts": [prompt],
+        "displayIds": [accepted["id"]],
+        "transcriptPromptCount": 0,
+    }
+    expect(queued).to_have_count(1)
+    expect(queued.locator(".queued-text")).to_have_text(prompt)
+    expect(queued.locator(".queued-label")).to_have_text("排队中 1 / 1")
+    _assert_no_browser_errors(page, errors)
+
+
 def test_admission_gap_resolves_exact_turn_before_busy_adjust_enqueue(
     page: Page, backend_url, auth_token,
 ):
@@ -6737,6 +7155,7 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
           }
           addCanonical({role: "user", text: "RUN TEN LS",
                         uuid: "prior-turn-user", _turnRoot: true});
+          let midturnSteering = null;
           for (let i = 0; i < 10; i++) {
             const id = `prior-tool-${i}`;
             addCanonical({role: "tool_use", name: "Bash", text: "ls", id,
@@ -6763,8 +7182,10 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
                           text: "same output", preview: "same output", id,
                           tool_use_id: id, uuid: `turn-a-tool-result-${i}`});
             if (i === 0) {
-              live({role: "user", text: "test", uuid: "midturn-user",
-                    _steeringAdjustment: true, _turnRoot: false});
+              midturnSteering = live({
+                role: "user", text: "test", uuid: "midturn-user",
+                _steeringAdjustment: true, _turnRoot: false,
+              });
               addCanonical({role: "user", text: "test",
                             uuid: "midturn-user", _steeringAdjustment: true,
                             _turnRoot: false});
@@ -6774,15 +7195,30 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
           addCanonical({role: "assistant", text: "TEN LS DONE",
                         uuid: "turn-a-final", turn_status: "completed"});
 
+          let firstQueuedLiveUser = null;
+          let firstQueuedLiveAssistant = null;
           for (const [index, prompt, reply] of [
             [1, "test", "TEST REPLY"],
-            [2, "test3", "TEST3 REPLY"],
+            [2, "test", "TEST REPLY"],
             [3, "stop", "STOP REPLY"],
           ]) {
-            live({role: "user", text: prompt, _turnRoot: true,
-                  _turnId: `turn-${index}`});
-            live({role: "assistant", text: reply,
-                  forkUuid: `turn-${index}-assistant`});
+            // The browser attached only to the first short queued turn. The
+            // second identical turn and the final stop both completed between
+            // /active probes and therefore exist only in canonical history.
+            // This is the real refresh-only failure: weak newest-first text
+            // matching must not move the first live `test` node onto turn 2.
+            if (index === 1) {
+              firstQueuedLiveUser = live({
+                role: "user", text: prompt, _turnRoot: true,
+                _turnId: `turn-${index}`,
+              });
+              firstQueuedLiveAssistant = live({
+                role: "assistant", text: reply,
+                forkUuid: `turn-${index}-assistant`,
+                ts: "13:49", elapsed: 7, model: "first-live-model",
+                turn_status: "completed",
+              });
+            }
             addCanonical({role: "user", text: prompt,
                           uuid: `turn-${index}-user`, _turnRoot: true});
             addCanonical({role: "assistant", text: reply,
@@ -6790,6 +7226,15 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
                           turn_status: "completed"});
           }
           await settle();
+
+          const firstCanonicalUser = st.messages.find(
+            message => message.uuid === "turn-1-user");
+          const secondCanonicalUser = st.messages.find(
+            message => message.uuid === "turn-2-user");
+          const firstCanonicalAssistant = st.messages.find(
+            message => message.uuid === "turn-1-assistant");
+          const finalCanonicalAssistant = st.messages.find(
+            message => message.uuid === "turn-3-assistant");
 
           const pane = document.querySelector(
             `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
@@ -6815,23 +7260,45 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
             sid, st, {followTail: true});
           await new Promise(resolve => app.$nextTick(
             () => requestAnimationFrame(resolve)));
+          const repairedPane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          const repairedDomKeys = Array.from(repairedPane.querySelectorAll(
+            ":scope > .msg[data-message-key]"
+          )).map(node => node.dataset.messageKey);
           const epochBeforeSwitch = st._transcriptRenderEpoch;
           const switchedCheck = app._ensureTranscriptDomConverged(sid, st);
           app.currentId = "another-open-tab";
           const switchedAwayAccepted = await switchedCheck;
           app.currentId = sid;
           app._activateTabState(sid);
-          await new Promise(resolve => app.$nextTick(resolve));
-          const repairedPane = document.querySelector(
-            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
           return {
             initial,
+            identity: {
+              firstUserPreserved: firstCanonicalUser === firstQueuedLiveUser,
+              firstAssistantPreserved:
+                firstCanonicalAssistant === firstQueuedLiveAssistant,
+              firstLiveUserOwnerUuid: st.messages.find(
+                message => message === firstQueuedLiveUser)?.uuid || "",
+              steeringOwnerUuid: st.messages.find(
+                message => message === midturnSteering)?.uuid || "",
+              firstLiveUserKey: firstQueuedLiveUser?._k || "",
+              firstUserKey: firstCanonicalUser?._k || "",
+              secondUserKey: secondCanonicalUser?._k || "",
+              firstAssistantFooter: {
+                ts: firstCanonicalAssistant?.ts || "",
+                elapsed: firstCanonicalAssistant?.elapsed || 0,
+                model: firstCanonicalAssistant?.model || "",
+              },
+              finalAssistantFooter: {
+                ts: finalCanonicalAssistant?.ts || "",
+                elapsed: finalCanonicalAssistant?.elapsed || 0,
+                model: finalCanonicalAssistant?.model || "",
+              },
+            },
             repaired,
             epochBeforeRepair,
             epochAfterRepair: st._transcriptRenderEpoch,
-            repairedDomKeys: Array.from(repairedPane.querySelectorAll(
-              ":scope > .msg[data-message-key]"
-            )).map(node => node.dataset.messageKey),
+            repairedDomKeys,
             switchedAwayAccepted,
             epochBeforeSwitch,
             epochAfterSwitch: st._transcriptRenderEpoch,
@@ -6844,11 +7311,367 @@ def test_repeated_tool_turn_then_fast_canonical_turns_keep_exact_dom_order(
     assert len(initial["domKeys"]) == len(set(initial["domKeys"])), result
     assert initial["domKeys"] == initial["stateKeys"], result
     assert initial["domRows"] == initial["stateRows"], result
+    assert result["identity"]["firstAssistantPreserved"] is True, result
+    assert result["identity"]["firstLiveUserOwnerUuid"] != "turn-2-user", result
+    assert result["identity"]["steeringOwnerUuid"] == "midturn-user", result
+    assert result["identity"]["secondUserKey"] != result["identity"]["firstLiveUserKey"], result
+    assert result["identity"]["firstUserKey"] != result["identity"]["secondUserKey"], result
+    assert result["identity"]["firstAssistantFooter"] == {
+        "ts": "13:49", "elapsed": 7, "model": "first-live-model",
+    }, result
+    assert result["identity"]["finalAssistantFooter"] == {
+        "ts": "", "elapsed": 0, "model": "",
+    }, result
     assert result["repaired"] is True, result
     assert result["epochAfterRepair"] == result["epochBeforeRepair"] + 1, result
     assert result["repairedDomKeys"] == initial["stateKeys"], result
     assert result["switchedAwayAccepted"] is True, result
     assert result["epochAfterSwitch"] == result["epochBeforeSwitch"], result
+    _assert_no_browser_errors(page, errors)
+
+
+def test_queue_attach_final_canonical_load_converges_duplicate_fast_successors(
+    page: Page, backend_url, auth_token,
+):
+    """The real queue-attach fallback must install every fast successor once."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    sid = "queue-attach-duplicate-successors"
+
+    canonical_messages: list[dict] = []
+
+    def add_message(role: str, text: str, uuid: str, **extra) -> None:
+        canonical_messages.append({
+            "role": role,
+            "text": text,
+            "uuid": uuid,
+            "block_id": f"{uuid}:0:{role}",
+            **extra,
+        })
+
+    # 99 durable rows precede the first queued turn. Together with the three
+    # queued prompt/reply pairs below, the final canonical snapshot has 105
+    # blocks, matching the long tool-heavy transcript that exposed the bug.
+    for index in range(77):
+        add_message("assistant", f"OLDER {index}", f"older-{index}")
+    add_message(
+        "user", "RUN TEN LS", "direct-turn-user", _turnRoot=True,
+    )
+    for index in range(10):
+        tool_id = f"direct-tool-{index}"
+        add_message(
+            "tool_use", "ls", f"direct-tool-use-{index}",
+            id=tool_id, name="Bash",
+        )
+        add_message(
+            "tool_result", "same output", f"direct-tool-result-{index}",
+            id=tool_id, tool_use_id=tool_id, tool_name="Bash",
+            preview="same output",
+        )
+    add_message(
+        "assistant", "TEN LS DONE", "direct-turn-final",
+        turn_status="completed", model="e2e-model", ts=69_000, elapsed=9,
+    )
+    assert len(canonical_messages) == 99
+
+    add_message("user", "test", "turn-1-user", _turnRoot=True)
+    add_message(
+        "assistant", "TEST REPLY", "turn-1-assistant",
+        turn_status="completed", model="e2e-model", ts=70_000, elapsed=1,
+    )
+    live_canonical_count = len(canonical_messages)
+    add_message("user", "test", "turn-2-user", _turnRoot=True)
+    add_message(
+        "assistant", "TEST REPLY", "turn-2-assistant",
+        turn_status="completed", model="e2e-model", ts=71_000, elapsed=1,
+    )
+    add_message("user", "stop", "turn-3-user", _turnRoot=True)
+    add_message(
+        "assistant", "STOP REPLY", "turn-3-assistant",
+        turn_status="completed", model="e2e-model", ts=72_000, elapsed=1,
+    )
+    assert len(canonical_messages) == 105
+
+    queue_requests: list[str] = []
+    active_requests: list[str] = []
+    history_requests: list[str] = []
+
+    def empty_queue(route):
+        queue_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"items": [], "paused": False, "revision": 72}),
+        )
+
+    def inactive_queued(route):
+        active_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "active": False,
+                "activity_source": "queued",
+                "background_tasks_pending": 0,
+            }),
+        )
+
+    def final_canonical_history(route):
+        history_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "id": sid,
+                "name": "Queue attach duplicate successors",
+                "model": "e2e-model",
+                "permission": "bypassPermissions",
+                "thinking": True,
+                "updated_at": 72,
+                "messages": canonical_messages,
+                "offset": 0,
+                "total": len(canonical_messages),
+                "message_count": len(canonical_messages),
+                "pre_total": 0,
+                "history_order": "normal",
+                "history_generation": "queue-generation-72",
+                "runtime_ui_revision": "queue-ui-revision-72",
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}/queue", empty_queue)
+    page.route(f"**/api/chat/sessions/{sid}/active", inactive_queued)
+    page.route(
+        re.compile(
+            rf".*/api/chat/sessions/{re.escape(sid)}\?tail=\d+(?:&.*)?$"
+        ),
+        final_canonical_history,
+    )
+    _login(page, backend_url, auth_token)
+
+    result = _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        if (app._sessionsSyncTimer) clearInterval(app._sessionsSyncTimer);
+        app._sessionsSyncTimer = null;
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._syncSessionListQuiet = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app.appReady = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.sessions = [{
+          id: sid, name: "Queue attach duplicate successors", updated_at: 70,
+          message_count: arg.baseMessages.length,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st.messages = app._historyEnvelopes(
+          sid, arg.baseMessages.map(message => ({...message, _noAnim: true})));
+        Object.assign(st.messageRange, {
+          visibleStart: 0,
+          visibleEnd: st.messages.length,
+          offset: 0,
+          total: st.messages.length,
+          preTotal: 0,
+          order: "normal",
+          generation: "queue-generation-70",
+        });
+        app._syncSessionMessageStore(st);
+        st._loaded = true;
+        st._installedCanonicalCount = st.messages.length;
+        st._seenUpdated = 70;
+        st.runtimeUiRevision = "queue-ui-revision-70";
+        st._queueRevision = 71;
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.atBottom = true;
+
+        // Only queue turn 1 reached the browser live. Turn 2 has identical
+        // prompt/reply prose, so a weak newest-first matcher used to steal
+        // turn 1's mounted key and make Alpine's keyed mover throw `.after`.
+        const firstLiveUser = app._appendLiveMessage(st, {
+          role: "user", text: "test", _turnRoot: true, _turnId: "turn-1",
+        });
+        const firstLiveAssistant = app._appendLiveMessage(st, {
+          role: "assistant", text: "TEST REPLY",
+          forkUuid: "turn-1-assistant", turn_status: "completed",
+          model: "e2e-model", ts: 70_000, elapsed: 1,
+        });
+        st.pendingQueue = arg.pending.map(item => ({
+          id: item.id,
+          text: item.text,
+          displayText: item.text,
+          pendingQuotes: [],
+          image_ids: "",
+          hasAttach: false,
+          images: [], docs: [], expiredCount: 0,
+          pendingImages: [], pendingDocs: [],
+          delivery: "queue",
+          deliveryStatus: "queued",
+          commandUuid: `${item.id}-command`,
+          targetTurnId: "turn-1",
+          enqueuedAt: item.enqueuedAt,
+        }));
+        st._queuePaused = false;
+        app.currentId = sid;
+        app.mobileTab = "chat";
+        app._activateTabState(sid);
+
+        const reports = [];
+        const originalReport = app._reportHistoryLoadPerf;
+        app._reportHistoryLoadPerf = fields => reports.push({...fields});
+        try {
+          await new Promise(resolve => app.$nextTick(
+            () => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+          const before = {
+            messageCount: st.messages.length,
+            tail: st.messages.slice(-2).map(message => ({
+              role: message.role,
+              text: message.text,
+              uuid: message.uuid || "",
+            })),
+            pending: st.pendingQueue.map(item => item.text),
+            queueCards: document.querySelectorAll(".msg.user.queued").length,
+          };
+
+          const loaded = await app._runQueueAttach(sid, st, {tries: 2});
+          for (let index = 0; index < 100; index++) {
+            const sync = st.sessionSync;
+            if (!st._draining && !sync.inFlight && !sync.timer
+                && !Object.keys(sync.pending || {}).length) break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          await new Promise(resolve => app.$nextTick(
+            () => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          const rendered = app.paneMessages(sid);
+          const nodes = Array.from(pane.querySelectorAll(
+            ":scope > .msg[data-message-key]"));
+          const firstCanonicalAssistant = st.messages.find(
+            message => message.uuid === "turn-1-assistant");
+          const secondCanonicalAssistant = st.messages.find(
+            message => message.uuid === "turn-2-assistant");
+          return {
+            before,
+            loaded,
+            reports,
+            watermarks: {
+              seenUpdated: st._seenUpdated,
+              installedCanonicalCount: st._installedCanonicalCount,
+              runtimeUiRevision: st.runtimeUiRevision,
+              queueRevision: st._queueRevision,
+              total: st.messageRange.total,
+              generation: st.messageRange.generation,
+            },
+            canonicalUuids: st.messages.map(message => message.uuid || ""),
+            stateKeys: rendered.map(message => message._k),
+            stateUuids: rendered.map(message => message.uuid || ""),
+            domKeys: nodes.map(node => node.dataset.messageKey),
+            domUuids: nodes.map(node => node.dataset.uuid || ""),
+            identity: {
+              firstAssistantPreserved:
+                firstCanonicalAssistant === firstLiveAssistant,
+              firstAssistantKey: firstCanonicalAssistant?._k || "",
+              firstLiveAssistantKey: firstLiveAssistant?._k || "",
+              secondAssistantKey: secondCanonicalAssistant?._k || "",
+              firstLiveUserOwnerUuid: st.messages.find(
+                message => message === firstLiveUser)?.uuid || "",
+            },
+            queue: {
+              pendingCount: st.pendingQueue.length,
+              displayCount: app.queueDisplayItems(st).length,
+              cardCount: document.querySelectorAll(".msg.user.queued").length,
+              paused: st._queuePaused,
+            },
+            settled: {
+              draining: st._draining,
+              syncInFlight: !!st.sessionSync.inFlight,
+              syncTimer: !!st.sessionSync.timer,
+              syncPending: Object.keys(st.sessionSync.pending || {}).length,
+              ready: st.messagesReady,
+              loading: st.messagesLoading,
+            },
+          };
+        } finally {
+          app._reportHistoryLoadPerf = originalReport;
+          app._disposeSessionSync(st);
+        }
+        """,
+        {
+            "sid": sid,
+            "baseMessages": canonical_messages[:99],
+            "pending": [
+                {"id": "queued-turn-2", "text": "test", "enqueuedAt": 71},
+                {"id": "queued-turn-3", "text": "stop", "enqueuedAt": 72},
+            ],
+        },
+    )
+
+    assert result["before"] == {
+        "messageCount": live_canonical_count,
+        "tail": [
+            {"role": "user", "text": "test", "uuid": ""},
+            {"role": "assistant", "text": "TEST REPLY", "uuid": ""},
+        ],
+        "pending": ["test", "stop"],
+        "queueCards": 2,
+    }, result
+    assert result["loaded"] is True, result
+    assert len(history_requests) == 1, history_requests
+    assert len(queue_requests) >= 2, queue_requests
+    assert len(active_requests) >= 2, active_requests
+    assert result["watermarks"] == {
+        "seenUpdated": 72,
+        "installedCanonicalCount": 105,
+        "runtimeUiRevision": "queue-ui-revision-72",
+        "queueRevision": 72,
+        "total": 105,
+        "generation": "queue-generation-72",
+    }, result
+    assert result["canonicalUuids"] == [
+        message["uuid"] for message in canonical_messages
+    ], result
+    assert len(result["stateKeys"]) == len(set(result["stateKeys"])), result
+    assert len(result["domKeys"]) == len(set(result["domKeys"])), result
+    assert result["domKeys"] == result["stateKeys"], result
+    assert result["domUuids"] == result["stateUuids"], result
+    assert result["identity"]["firstAssistantPreserved"] is True, result
+    assert (
+        result["identity"]["firstAssistantKey"]
+        == result["identity"]["firstLiveAssistantKey"]
+    ), result
+    assert (
+        result["identity"]["secondAssistantKey"]
+        != result["identity"]["firstLiveAssistantKey"]
+    ), result
+    assert result["identity"]["firstLiveUserOwnerUuid"] != "turn-2-user", result
+    assert result["queue"] == {
+        "pendingCount": 0,
+        "displayCount": 0,
+        "cardCount": 0,
+        "paused": False,
+    }, result
+    assert result["settled"] == {
+        "draining": False,
+        "syncInFlight": False,
+        "syncTimer": False,
+        "syncPending": 0,
+        "ready": True,
+        "loading": False,
+    }, result
+    assert result["reports"] and result["reports"][0]["status"] == "ok", result
     _assert_no_browser_errors(page, errors)
 
 

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -922,8 +922,19 @@ def test_server_busy_admission_never_borrows_running_footer(
         }"""
     )
     page.wait_for_function("() => window.__queueCalls === 1")
-    expect(page.locator(".optimistic-queue-status")).to_be_visible()
-    expect(page.locator(".optimistic-queue-status")).to_contain_text("排队中")
+    # Admission now occupies the same queue-tail slot as the durable row so
+    # accepting the POST cannot move or duplicate the bubble.  Assert the
+    # visible contract and the temporary ownership state independently.
+    expect(page.locator(".msg.user.queued")).to_be_visible()
+    expect(page.locator(".msg.user.queued .queued-label")).to_contain_text("排队中")
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app.tabState[app.currentId];
+          return st._queueAdmission?.displayText === 'QUEUE_ON_409'
+            && st.pendingQueue.length === 0;
+        }"""
+    )
     expect(page.locator(".turn-pending-footer")).to_be_hidden()
     assert page.evaluate("() => window.__turnStartCalls") == 1
 
@@ -935,7 +946,12 @@ def test_server_busy_admission_never_borrows_running_footer(
           return app.tabState[app.currentId].pendingQueue.length === 1;
         }"""
     )
-    expect(page.locator(".optimistic-queue-status")).to_have_count(0)
+    page.wait_for_function(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return app.tabState[app.currentId]._queueAdmission === null;
+        }"""
+    )
     expect(page.locator(".msg.user.queued")).to_have_count(1)
     assert page.evaluate("() => window.__queueCalls") == 1
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1333,7 +1333,8 @@ def test_session_sync_transitions_preserve_canonical_and_view_ownership():
 
     # Synchronization changes only the canonical per-tab repository. Keep the
     # ordered messages + range model and composer ownership established earlier.
-    assert "st.messages.splice(0, st.messages.length, ...all)" in app
+    assert "st.messages = all" in app
+    assert "_paneMessageIndexCache.delete(st)" in app
     assert "Object.assign(st.messageRange" in app
     assert "child.messages = cloneMessages(sourceState.messages)" in app
     assert "child.messageRange = { ...sourceState.messageRange }" in app
@@ -2736,7 +2737,7 @@ def test_runtime_ui_revision_rejects_out_of_order_session_response():
     assert response in load
     assert current in load
     assert stale_guard in load
-    assert load.index(stale_guard) < load.index("st.messages.splice(")
+    assert load.index(stale_guard) < load.index("st.messages = all")
     assert load.index(stale_guard) < load.index(
         "st.runtimeUiRevision = loadedRuntimeUiRevision")
 
@@ -3158,6 +3159,7 @@ def test_fork_banner_and_message_template_are_null_and_key_safe():
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")
 
     assert "currentForkSource()?.name || ''" in html
+    assert ':key="transcriptPaneKey(tid)"' in html
     assert 'x-for="m in paneMsgs" :key="m._k"' in html
     assert "paneMessageIndex(tid, m)" in html
     assert 'get i(){ return paneMessageIndex(tid, m) }' in html
@@ -3882,12 +3884,26 @@ def test_quiet_canonical_reload_rebases_virtual_window_before_alpine_paints():
     load_end = app.index("// Warm OPEN-but-inactive tabs", load_start)
     load = app[load_start:load_end]
     capture = "const virtualWindowBeforeInstall = quiet"
-    splice = "st.messages.splice(0, st.messages.length, ...all)"
+    publish = "st.messages = all"
     assign = "Object.assign(st.messageRange"
     rebase = "this._rebaseMessageVirtualWindow("
     assert capture in load
     assert rebase in load
-    assert load.index(capture) < load.index(splice) < load.index(assign) < load.index(rebase)
+    assert load.index(capture) < load.index(publish) < load.index(assign) < load.index(rebase)
+    assert load.index(publish) < load.index("_paneMessageIndexCache.delete(st)")
+    assert "await this._ensureTranscriptDomConverged(sid, st" in load
+    assert "st._transcriptRenderEpoch += 1" in app
+    assert "this._transcriptDomMatchesState(tid, st)" in app
+    assert "if (this.tabState[tid] !== st) return false;" in app
+    assert "if (tid !== this.currentId) return true;" in app
+    converge_start = app.index("    async _ensureTranscriptDomConverged(tid, st")
+    converge_end = app.index("\n    paneState(tid)", converge_start)
+    converge = app[converge_start:converge_end]
+    mismatch = "if (this._transcriptDomMatchesState(tid, st)) return true;"
+    takeover = "if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;"
+    remount = "st._transcriptRenderEpoch += 1"
+    assert converge.index(mismatch) < converge.index(takeover) < converge.index(remount)
+    assert converge.count(takeover) == 2
     assert "opts.followTail === true" in load
     assert "this._resolveMessageRangeSnapshot(all, quietRangeSnapshot)" in load
     assert "if (quiet && !quietRangeResolved)" in load
@@ -5836,7 +5852,7 @@ def test_canonical_history_load_never_reports_stream_takeover_as_success():
     assert "if (st.streaming || st.es) return true;" not in load
     assert "if (this.tabState[sid] !== st || st.streaming || st.es) return true;" not in load
     assert "st._installedCanonicalCount = Math.max(" in load
-    assert load.index("st.messages.splice(0, st.messages.length, ...all)") < load.index(
+    assert load.index("st.messages = all") < load.index(
         "st._installedCanonicalCount = Math.max("
     )
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -5661,7 +5661,9 @@ def test_busy_send_mode_uses_authoritative_delivery_and_steering_state():
     assert 'this.busySendMode) !== "adjust"' in delivery
     assert "!turnId || attachmentIntent || st.compacting" in delivery
     assert "st.backgroundActive || st._draining || st.parentTurnId" in delivery
-    assert "st.pendingQueue && st.pendingQueue.length" in delivery
+    assert "!this._pendingQueueAllowsAdjustment(st, turnId)" in delivery
+    assert "!this._pendingQueueAllowsAdjustment(st)" in delivery
+    assert 'delivery === "adjust" && active && !!targetTurnId' in delivery
     resolve_start = app.index("    async _resolveBusyAdjustmentTurnId(")
     resolve_end = app.index("\n    sendButtonHint(sid)", resolve_start)
     resolve = app[resolve_start:resolve_end]

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1358,7 +1358,7 @@ def test_optimistic_session_paints_immediately_but_registers_before_ticket():
     assert "async _ensureSessionRegistered(id)" in helpers
     assert helpers.count("this._registerOptimisticSession(meta)") >= 2
     ensure_at = send.index("await this._ensureSessionRegistered(sendSid)")
-    push_at = send.index("this._appendLiveMessage(sendState")
+    push_at = send.index("if (knownFifo) stageQueueAdmission();")
     ticket_at = send.index('fetch("/api/chat/stream/start"')
     clear_at = send.index("clearSubmittedComposer({ preserveForHandshake: true })")
     assert clear_at < push_at < ensure_at < ticket_at
@@ -1587,7 +1587,7 @@ def test_runtime_setting_writes_gate_send_and_restore_per_session():
     send_start = app.index("async send(opts = {})")
     send = app[send_start:]
     assert send.count("await this._awaitRuntimeSettingPatches(sendSid, sendState)") == 1
-    assert send.index("sentUserBubble = this._appendLiveMessage") < send.index(
+    assert send.index("if (knownFifo) stageQueueAdmission();") < send.index(
         "await this._awaitRuntimeSettingPatches(sendSid, sendState)"
     )
     assert "runtimeSettingsPending()" in html
@@ -2765,11 +2765,17 @@ def test_runtime_continuation_history_identity_footer_and_fork_guards():
     runtime_guard = runtime_guard[:runtime_guard.index("const continuityIds")]
     assert 'push("runtime-event", m.runtime_event_id)' in runtime_guard
     assert 'push("text", m.text)' not in runtime_guard
+    assert "m._steeringAdjustment === true || m._turnRoot === false" in continuity
 
     preserve_start = app.index(
         "    _preserveCanonicalMessageIdentity(st, incoming) {")
     preserve_end = app.index("\n    _assignLiveKey", preserve_start)
     preserve = app[preserve_start:preserve_end]
+    assert preserve.index("Reserve every durable identity") < preserve.index(
+        "Text/preview/summary are continuity hints")
+    assert "indexes.length !== 1 || matches.length !== 1" in preserve
+    assert "oldIndex <= previous.oldIndex" in preserve
+    assert "canonicalTail === existingTail" in preserve
     assert 'canonicalTail.display_kind !== "runtime_continuation"' in preserve
 
     fork_start = app.index("    turnForkMessageId(paneMsgs, i) {")
@@ -2787,6 +2793,25 @@ def test_runtime_continuation_history_identity_footer_and_fork_guards():
     )
     assert css.count(avatar_boundary) == 2
 
+
+def test_fifo_admission_projects_after_durable_queue_without_transcript_flash():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+    html = (FRONTEND / "index.html").read_text(encoding="utf-8")
+    send_start = app.index("    async send(opts = {}) {")
+    send_end = app.index("\n    // ====== ask_user_question", send_start)
+    send = app[send_start:send_end]
+
+    assert "_queueAdmission: null" in app
+    assert "return admission ? [...durable, admission] : durable;" in app
+    assert "const knownFifo = !resumed && busyDelivery === \"queue\"" in send
+    assert "if (knownFifo) stageQueueAdmission();" in send
+    assert "owner._queueAdmission = queueAdmission;" in send
+    assert "_submitToken: composerSubmitToken" in send
+    assert "queueAdmissionAsyncHandoff = stageQueueAdmission();" in send
+    assert "if (!queueAdmissionAsyncHandoff) clearOwnedQueueAdmission();" in send
+    assert "mirrorState._queueAdmission = null;" in app
+    assert 'x-for="(q, qi) in queueDisplayItems(activeSession)"' in html
+    assert ":disabled=\"q._admissionPending || queueActionBusy" in html
 
 def test_detached_rollover_preserves_migrated_queue_fifo():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
@@ -2849,13 +2874,13 @@ def test_composer_send_has_one_claim_owner_without_exposing_internal_phases():
         "await this._awaitRuntimeSettingPatches(sendSid, sendState)"
     )
     assert send.count("await this._awaitRuntimeSettingPatches(sendSid, sendState)") == 1
-    assert send.index("sentUserBubble = this._appendLiveMessage") < send.index(
+    assert send.index("if (knownFifo) stageQueueAdmission();") < send.index(
         "await this._ensureSessionRegistered(sendSid)"
     )
     assert send.index("clearSubmittedComposer({ preserveForHandshake: true })") < send.index(
         "await this._ensureSessionRegistered(sendSid)"
     )
-    assert send.index("sentUserBubble = this._appendLiveMessage") < send.index(
+    assert send.index("if (knownFifo) stageQueueAdmission();") < send.index(
         "await this._confirmSessionBusy(sendSid, sendState)"
     )
     assert "rollbackOptimisticSubmission();" in send
@@ -3094,7 +3119,8 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     send = app[send_start:app.index("async stop()", send_start)]
 
     assert "if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false" in load
-    assert "st._composerSubmitToken || this._hasAdmissionBubble(st)" in app
+    assert "st._composerSubmitToken || st._queueAdmission" in app
+    assert "|| this._hasAdmissionBubble(st)" in app
     assert "this.tabState[sid] !== st || st.streaming || st.es" in load
     reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true)")
     reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
@@ -3451,10 +3477,18 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     assert "messages.slice(turnStart, finalIndex + 1)" in reconcile
     assert "if (finalIndex < 0) { retry(); return false; }" in reconcile
     assert "const hasSuccessorRoot = messages.slice(finalIndex + 1).some(" in reconcile
+    assert "hasSuccessorRoot && (!activity || activity.active)" in reconcile
     assert "const loaded = await this.loadSession(sid, {" in reconcile
     assert "quiet: true, probeActive: false" in reconcile
     assert "attempt < 30" in reconcile
     assert "Math.min(2000, 250 + options.attempt * 100)" in reconcile
+
+    queue_start = app.index("    async _runQueueAttach(")
+    queue_end = app.index(
+        "\n    // ===== background-task continuation poller", queue_start)
+    queue_attach = app[queue_start:queue_end]
+    assert "st._pendingExternalUpdate = true;" in queue_attach
+    assert 'this._requestSessionSync(sid, "history_revision"' in queue_attach
 
     load_start = app.index("    async loadSession(sid, opts = {}) {")
     load_end = app.index("\n    async renameSession()", load_start)
@@ -3859,7 +3893,7 @@ def test_live_turn_bounds_dom_and_indexes_task_status_without_linear_scans():
     assert "this._normalizeTaskStatusPreview" in send[apply_start:apply_end]
     assert "if (_scrollCoalesceHandle !== null) return" in send
     assert send.index("sendState.atBottom = true") < send.index(
-        "sentUserBubble = this._appendLiveMessage")
+        "if (knownFifo) stageQueueAdmission();")
 
     assert '@click="returnToLatest()"' in html
     assert html.count('x-show="isAwayFromLatest()"') >= 3


### PR DESCRIPTION
## 变更类型
- [x] 修复 (bugfix)

## 变更说明
- 统一实时消息与规范历史的消息身份和 DOM key，避免完成后错位、重复或必须刷新才显示正确内容
- 修复队列乐观渲染顺序、快速后继任务接管和最终历史收敛
- 允许同一活动 turn 的多条“尽快调整”保持原生 adjustment 交付，同时继续保护普通 FIFO、附件和不同 turn 的排队顺序
- mux 收到浏览器未接管的短任务 inactive 状态后，自动等待队列链结束并同步完整规范历史

## 测试情况
- `tests/test_frontend_lint.py`: 172 passed
- 5 个关键 Playwright E2E：5 passed
- `node --check frontend/app.js`
- Python compile check
- `git diff --check`
- 已在 WSL 8780 实例部署验证；本地与公网健康检查均为 200

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过
- [x] 无敏感信息
