### PR TITLE
fix(chat): 修复规范正文未实时渲染

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -13397,7 +13397,14 @@ function portal() {
           const candidate = this._historyRichRenderQueue.shift();
           const m = candidate && candidate.message;
           if (m) delete m._richRenderQueued;
-          if (!m || m.html || !m.text) continue;
+          if (!m || !m.text) continue;
+          if (m.html) {
+            if (m._canonicalPlainUntilRich) {
+              m._streamPlain = false;
+              delete m._canonicalPlainUntilRich;
+            }
+            continue;
+          }
           if (candidate.el && !candidate.el.isConnected) continue;
           const st = this.tabState[candidate.sid];
           if (!st || !st.messages.includes(m)) continue;
@@ -13406,6 +13413,10 @@ function portal() {
         if (!pending) return;
         const m = pending.message;
         m.html = this._renderHistoryMessage(m);
+        if (m._canonicalPlainUntilRich) {
+          m._streamPlain = false;
+          delete m._canonicalPlainUntilRich;
+        }
         if (pending.el && pending.el.isConnected) {
           this.$nextTick(() => this._afterPaint(() => {
             if (pending.el.isConnected) {
@@ -17482,6 +17493,12 @@ function portal() {
         if (!matched || !matched._k || used.has(matched)
             || adopted.has(index)) return false;
         const canonical = result[index];
+        const canonicalText = String(canonical && canonical.text || "");
+        const staleAssistantPresentation = canonical?.role === "assistant" && (
+          String(matched.text || "") !== canonicalText
+          || (matched._streamPlain === true
+            && String(matched._streamText || "") !== canonicalText)
+        );
         used.add(matched);
         adopted.add(index);
         adoptionKind.set(index, kind);
@@ -17512,6 +17529,25 @@ function portal() {
         }
         matched._k = mountedKey;
         matched._noAnim = true;
+        // `html` / `_streamText` are derived only from the live text snapshot
+        // and are not part of canonical history. Object.assign cannot remove
+        // those absent fields, so a replay gap could leave `text` canonical
+        // while the mounted bubble kept rendering the shorter live HTML until
+        // a hard refresh rebuilt the object. Invalidate only presentations
+        // whose canonical body actually changed: the plain fallback exposes
+        // the complete text immediately and rich Markdown is rebuilt lazily.
+        if (staleAssistantPresentation) {
+          matched.html = "";
+          matched._streamText = canonicalText;
+          // Keep the complete canonical text visibly mounted while the idle
+          // Markdown renderer rebuilds the rich body; this avoids even one
+          // blank frame between invalidating stale HTML and installing new HTML.
+          matched._streamPlain = true;
+          matched._deferredRichReady = false;
+          matched._canonicalPlainUntilRich = true;
+          delete matched._richRenderQueued;
+          this._queueHistoryRichRender(matched, st._sid);
+        }
         result[index] = matched;
         return true;
       };

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -6094,14 +6094,20 @@ def test_started_queue_steering_becomes_user_bubble_at_stream_boundary(
 def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     page: Page, backend_url, auth_token,
 ):
-    """SSE done → quiet canonical reload keeps the rendered reply node mounted."""
+    """Done keeps its node while canonical history replaces stale live HTML."""
     errors = _capture_browser_errors(page)
     page.set_viewport_size({"width": 1440, "height": 900})
     _install_fake_event_source(page)
     sid = "perf-done-canonical-identity"
     prompt = "DOM_IDENTITY_USER_PROMPT"
     history_marker = "FULL_ORDER_HISTORY_SURVIVES_LRU_REMOUNT"
-    final_text = "DOM_IDENTITY_FINAL_REPLY " + ("stable canonical text " * 40)
+    live_text = "DOM_IDENTITY_PARTIAL_REPLY"
+    canonical_marker = "CANONICAL_ONLY_SUFFIX_VISIBLE"
+    final_text = (
+        live_text + " "
+        + ("stable canonical text " * 40)
+        + canonical_marker
+    )
     canonical_messages: list[dict] = [{
         "role": "assistant",
         "text": history_marker,
@@ -6181,7 +6187,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
         """text => window.__emitSse("text", {
           text, turn_id: "done-reconcile-turn", event_seq: 1,
         })""",
-        final_text,
+        live_text,
     )
     page.wait_for_function(
         """text => {
@@ -6193,7 +6199,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
           return st.streaming && last?.role === "assistant" && last.text === text
             && pane?.querySelector(".msg.assistant");
         }""",
-        arg=final_text,
+        arg=live_text,
         timeout=10000,
     )
     live = page.evaluate(
@@ -6229,7 +6235,8 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
           total_cost_usd: 0.001,
           memory_recall: { count: 2, query: "private-query" },
           session_usage: { context_used_pct: 5, context_used: 500, context_limit: 100000 },
-          turn_id: "done-reconcile-turn", event_seq: 2,
+          turn_id: "done-reconcile-turn",
+          assistant_uuid: "done-canonical-assistant", event_seq: 2,
         })"""
     )
     page.wait_for_function(
@@ -6242,7 +6249,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     )
 
     result = page.evaluate(
-        """async ({ sid, text }) => {
+        """async ({ sid, marker, liveText }) => {
           const app = document.querySelector("#app")._x_dataStack[0];
           const st = app._ensureTabState(sid);
           st._pendingExternalUpdate = true;
@@ -6265,14 +6272,16 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             await new Promise(resolve => requestAnimationFrame(resolve));
             const pane = document.querySelector(
               `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+            const canonicalReady = st.messages.some(
+              message => message?.uuid === "done-canonical-assistant");
             frames.push({
               ready: st.messagesReady,
               loading: st.messagesLoading,
-              visible: !!pane && pane.textContent.includes(text.trim()),
+              canonicalReady,
+              liveVisible: !!pane && pane.innerText.includes(liveText),
+              visible: !!pane && pane.innerText.includes(marker),
               count: pane ? pane.querySelectorAll(".msg").length : 0,
             });
-            const canonicalReady = st.messages.some(
-              message => message?.uuid === "done-canonical-assistant");
             if (canonicalReady && !canonicalSyncBusy() && i >= 2) break;
           }
           await new Promise(resolve => app.$nextTick(() => requestAnimationFrame(resolve)));
@@ -6289,9 +6298,11 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
             cost: last.cost || "",
             memoryCount: Number(last.memoryRecall?.count) || 0,
             historyOrder: st.messageRange.order,
+            visible: !!canonicalNode
+              && canonicalNode.innerText.includes(marker),
           };
         }""",
-        {"sid": sid, "text": final_text},
+        {"sid": sid, "marker": canonical_marker, "liveText": live_text},
     )
 
     assert requests, "canonical reconciliation did not request session history"
@@ -6305,7 +6316,12 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     assert result["historyOrder"] == "full"
     assert result["frames"]
     assert all(frame["ready"] and not frame["loading"] for frame in result["frames"]), result
-    assert all(frame["visible"] and frame["count"] > 0 for frame in result["frames"]), result
+    assert all(frame["count"] > 0 for frame in result["frames"]), result
+    assert result["frames"][0]["liveVisible"] is True, result
+    assert any(
+        frame["canonicalReady"] and frame["visible"] for frame in result["frames"]
+    ), result
+    assert result["visible"] is True, result
 
     remount = _app_eval(
         page,

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -6249,7 +6249,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     )
 
     result = page.evaluate(
-        """async ({ sid, marker, liveText }) => {
+        """async ({ sid, marker }) => {
           const app = document.querySelector("#app")._x_dataStack[0];
           const st = app._ensureTabState(sid);
           st._pendingExternalUpdate = true;
@@ -6278,7 +6278,6 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
               ready: st.messagesReady,
               loading: st.messagesLoading,
               canonicalReady,
-              liveVisible: !!pane && pane.innerText.includes(liveText),
               visible: !!pane && pane.innerText.includes(marker),
               count: pane ? pane.querySelectorAll(".msg").length : 0,
             });
@@ -6302,7 +6301,7 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
               && canonicalNode.innerText.includes(marker),
           };
         }""",
-        {"sid": sid, "marker": canonical_marker, "liveText": live_text},
+        {"sid": sid, "marker": canonical_marker},
     )
 
     assert requests, "canonical reconciliation did not request session history"
@@ -6317,7 +6316,6 @@ def test_desktop_done_reconcile_preserves_live_message_dom_identity(
     assert result["frames"]
     assert all(frame["ready"] and not frame["loading"] for frame in result["frames"]), result
     assert all(frame["count"] > 0 for frame in result["frames"]), result
-    assert result["frames"][0]["liveVisible"] is True, result
     assert any(
         frame["canonicalReady"] and frame["visible"] for frame in result["frames"]
     ), result


### PR DESCRIPTION
## 变更说明
- 规范历史正文比实时气泡更完整时，失效旧的 html 与流式文本缓存
- 完整规范正文先以纯文本立即显示，再在空闲阶段重建 Markdown
- 保留原消息对象、DOM key、气泡位置和滚动状态

## 回归覆盖
- 模拟实时 SSE 只收到部分正文、后端规范历史已经完整的真实竞态
- 断言不刷新页面即可看到规范正文后缀，且原气泡 DOM 节点保持不变

## 测试
- 前端约束：172 passed
- 相关 Playwright 场景：5 passed
- git diff --check：通过