### PR TITLE
fix(chat): 修复完成回答需刷新才完整

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4709,12 +4709,17 @@ function portal() {
     _renderHistoryMessage(m) {
       if (!m || m.role !== "assistant" || !m.text) return "";
       const key = m._k || "";
-      if (!key) return this.mdRender(m.text);
+      if (!key) {
+        const html = this.mdRender(m.text);
+        m._htmlSourceText = m.text;
+        return html;
+      }
       const cache = this._historyHtmlByKey;
       const hit = cache.get(key);
       if (hit && hit.text === m.text) {
         cache.delete(key);
         cache.set(key, hit);
+        m._htmlSourceText = m.text;
         return hit.html;
       }
       if (hit) {
@@ -4732,6 +4737,7 @@ function portal() {
           0, this._historyHtmlBytes - (oldest ? oldest.bytes : 0));
         cache.delete(oldestKey);
       }
+      m._htmlSourceText = m.text;
       return html;
     },
 
@@ -10370,6 +10376,17 @@ function portal() {
         if (node.dataset.messageKey !== key
             || String(node.dataset.uuid || "")
               !== String(message && message.uuid || "")) return false;
+        // Matching attributes are necessary but not sufficient. Alpine's keyed
+        // mover can leave a node bound to the previous object when a canonical
+        // array reuses the same key/uuid. In that state the repository is new
+        // while every x-text/x-html expression still reads the old scope, so a
+        // refresh appears to "fix" the answer. Verify the actual x-for owner;
+        // the existing epoch remount below repairs only the affected pane.
+        const boundMessage = (node._x_dataStack || [])
+          .map(scope => scope && scope.m).find(Boolean);
+        const raw = (typeof Alpine !== "undefined" && Alpine.raw)
+          ? Alpine.raw : value => value;
+        if (!boundMessage || raw(boundMessage) !== raw(message)) return false;
       }
       return true;
     },
@@ -17323,6 +17340,31 @@ function portal() {
         summary_truncated: declaredTruncated || summaryLength > previewPoints.length,
       };
     },
+    _assistantPresentationDiffers(message, canonicalText) {
+      if (!message || message.role !== "assistant") return false;
+      const text = String(canonicalText || "");
+      return String(message.text || "") !== text
+        || (message._streamPlain === true
+          && String(message._streamText || "") !== text)
+        || (!!message.html
+          && String(message._htmlSourceText || "") !== text);
+    },
+    _invalidateAssistantPresentation(message, canonicalText, sid = this.currentId) {
+      if (!message || message.role !== "assistant") return false;
+      const text = String(canonicalText || "");
+      message.html = "";
+      delete message._htmlSourceText;
+      message._streamText = text;
+      // Keep canonical text visible while the idle Markdown renderer rebuilds
+      // the derived HTML. This path is shared by both block-cache refreshes and
+      // live-object adoption so neither can retain an older presentation.
+      message._streamPlain = true;
+      message._deferredRichReady = false;
+      message._canonicalPlainUntilRich = true;
+      delete message._richRenderQueued;
+      this._queueHistoryRichRender(message, sid);
+      return true;
+    },
     _historyEnvelopes(sid, list) {
       const source = list || [];
       const renderKeys = source.map(m => this._historyMessageKey(sid, m));
@@ -17371,6 +17413,14 @@ function portal() {
               body_ref: existing.body_ref,
             }
           : null;
+        // Capture presentation staleness BEFORE Object.assign below. A second
+        // quiet history response reuses this same block_id object; assigning
+        // canonical text first would erase the only evidence that cached HTML
+        // and stream text were derived from an older, shorter body.
+        const nextText = String(
+          (loadedBody ? loadedBody.text : (m && m.text)) || "");
+        const staleAssistantPresentation =
+          this._assistantPresentationDiffers(existing, nextText);
         // A prior quiet reconciliation may have adopted this canonical block
         // into an already-mounted live object. Keep that mounted key on every
         // later canonical refresh; replacing it with renderKey here remounts
@@ -17378,6 +17428,9 @@ function portal() {
         const mountedKey = existing._k || renderKey;
         Object.assign(existing, m, { _k: mountedKey });
         if (loadedBody) Object.assign(existing, loadedBody);
+        if (staleAssistantPresentation) {
+          this._invalidateAssistantPresentation(existing, nextText, sid);
+        }
         return existing;
       });
     },
@@ -17494,11 +17547,8 @@ function portal() {
             || adopted.has(index)) return false;
         const canonical = result[index];
         const canonicalText = String(canonical && canonical.text || "");
-        const staleAssistantPresentation = canonical?.role === "assistant" && (
-          String(matched.text || "") !== canonicalText
-          || (matched._streamPlain === true
-            && String(matched._streamText || "") !== canonicalText)
-        );
+        const staleAssistantPresentation =
+          this._assistantPresentationDiffers(matched, canonicalText);
         used.add(matched);
         adopted.add(index);
         adoptionKind.set(index, kind);
@@ -17537,16 +17587,8 @@ function portal() {
         // whose canonical body actually changed: the plain fallback exposes
         // the complete text immediately and rich Markdown is rebuilt lazily.
         if (staleAssistantPresentation) {
-          matched.html = "";
-          matched._streamText = canonicalText;
-          // Keep the complete canonical text visibly mounted while the idle
-          // Markdown renderer rebuilds the rich body; this avoids even one
-          // blank frame between invalidating stale HTML and installing new HTML.
-          matched._streamPlain = true;
-          matched._deferredRichReady = false;
-          matched._canonicalPlainUntilRich = true;
-          delete matched._richRenderQueued;
-          this._queueHistoryRichRender(matched, st._sid);
+          this._invalidateAssistantPresentation(
+            matched, canonicalText, st._sid);
         }
         result[index] = matched;
         return true;

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -7172,11 +7172,10 @@ def test_stable_message_identity_needs_no_repair_telemetry(
           st._loaded = true;
           const payload = [
             {role: "user", text: "question", block_id: "record-1:0:user"},
-            {role: "assistant", text: "answer", block_id: "record-2:0:assistant"},
+            {role: "assistant", text: "partial answer", block_id: "record-2:0:assistant"},
             {role: "tool_result", text: "tool", block_id: "record-2:1:tool_result"},
           ];
           const first = app._historyEnvelopes(sid, payload);
-          const second = app._historyEnvelopes(sid, payload.map(message => ({...message})));
           st.messages.push(...first);
           st.messageRange.visibleEnd = st.messages.length;
           st.messageRange.total = st.messages.length;
@@ -7185,9 +7184,29 @@ def test_stable_message_identity_needs_no_repair_telemetry(
           app._ensureTabState(app.currentId).messagesReady = true;
           app._ensureTabState(app.currentId).messagesLoading = false;
           await new Promise(resolve => app.$nextTick(() => requestAnimationFrame(resolve)));
+          for (let i = 0; i < 120 && !first[1].html; i++) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          const initialHtml = first[1].html || "";
+          const second = app._historyEnvelopes(
+            sid, payload.map(message => ({...message})));
+          const completeMarker = "CANONICAL_BLOCK_REVISION_VISIBLE";
+          const revisedPayload = payload.map(message => message.role === "assistant"
+            ? {...message, text: message.text + " " + completeMarker}
+            : {...message});
+          const revised = app._historyEnvelopes(sid, revisedPayload);
+          for (let i = 0; i < 120; i++) {
+            const pane = document.querySelector(`.msg-pane[data-tid="${sid}"]`);
+            if ((first[1].html || "").includes(completeMarker)
+                && pane?.innerText.includes(completeMarker)) break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          await new Promise(resolve => app.$nextTick(
+            () => requestAnimationFrame(() => requestAnimationFrame(resolve))));
           const pane = document.querySelector(`.msg-pane[data-tid="${sid}"]`);
           const domKeys = pane ? Array.from(pane.querySelectorAll(".msg"))
             .map(el => el.dataset.messageKey) : [];
+          const assistantNode = pane?.querySelector(".msg.assistant .bubble");
           const live = Array.from({length: 25}, (_, i) => app._appendLiveMessage(st, {
             role: "thinking", text: `live ${i}`,
           }));
@@ -7198,7 +7217,15 @@ def test_stable_message_identity_needs_no_repair_telemetry(
           return {
             keys: first.map(message => message._k),
             sameObjects: first.every((message, i) => Alpine.raw(second[i]) === Alpine.raw(message)),
+            sameRevisedObject: Alpine.raw(revised[1]) === Alpine.raw(first[1]),
             domKeys,
+            initialHtml,
+            revisedText: first[1].text || "",
+            revisedHtml: first[1].html || "",
+            revisedStreamText: first[1]._streamText || "",
+            revisedStreamPlain: first[1]._streamPlain === true,
+            revisedVisible: !!assistantNode
+              && assistantNode.innerText.includes(completeMarker),
             liveKeys: live.map(message => message._k),
             followedEnd,
             hiddenEnd,
@@ -7217,7 +7244,18 @@ def test_stable_message_identity_needs_no_repair_telemetry(
         "stable-render-identity:block:record-2:1:tool_result",
     ]
     assert result["sameObjects"] is True
+    assert result["sameRevisedObject"] is True
     assert result["domKeys"] == result["keys"]
+    assert "CANONICAL_BLOCK_REVISION_VISIBLE" not in result["initialHtml"]
+    assert "CANONICAL_BLOCK_REVISION_VISIBLE" in result["revisedText"]
+    assert (
+        "CANONICAL_BLOCK_REVISION_VISIBLE" in result["revisedHtml"]
+        or (
+            result["revisedStreamPlain"] is True
+            and "CANONICAL_BLOCK_REVISION_VISIBLE" in result["revisedStreamText"]
+        )
+    )
+    assert result["revisedVisible"] is True
     assert len(result["liveKeys"]) == len(set(result["liveKeys"])) == 25
     assert all(":live:" in key for key in result["liveKeys"])
     assert result["followedEnd"] == 28


### PR DESCRIPTION
## 变更说明

- 在同 block_id 的 canonical 缓存对象被覆盖前检测正文变化，失效旧 HTML 和流式文本
- 记录 HTML 对应的源正文，避免 text 已更新但派生 HTML 仍旧时漏判
- 校验 Alpine keyed DOM 节点实际绑定的消息对象，发现错绑时沿用现有单 pane 重挂载恢复
- 扩展真实浏览器回归，覆盖两阶段 quiet canonical 更新且无需刷新即可显示完整后缀

## 验证

- node --check frontend/app.js
- tests/test_frontend_lint.py：172 passed
- 相关 Playwright 回归：4 passed
- 新回归在修复前稳定失败，修复后通过