### PR TITLE
fix(chat): 修复完成回复需刷新才可见

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9931,14 +9931,22 @@ function portal() {
     },
     _reconcileCompletedTurn(
       sid, ownerState, expectedText = "", attempt = 0, expectedAssistantUuid = "",
-      completedTurnId = "",
+      completedTurnId = "", completionViewport = null,
     ) {
       if (!sid || this.tabState[sid] !== ownerState) return Promise.resolve(false);
+      const viewport = completionViewport || {};
       const options = {
         expectedText: String(expectedText || ""),
         expectedAssistantUuid: String(expectedAssistantUuid || ""),
         completedTurnId: String(completedTurnId || ""),
         attempt: Math.max(0, Number(attempt) || 0),
+        // A layout-induced scroll can flip the live pane's geometry between
+        // `done` and the delayed canonical read. Preserve the terminal-frame
+        // ownership decision, but only while no later real user gesture has
+        // claimed the viewport.
+        followTail: viewport.followTail === true,
+        followTailUserScrollAt: Math.max(
+          0, Number(viewport.userScrollAt) || 0),
       };
       ownerState._pendingCompletedTurnSync = options;
       return this._requestSessionSync(sid, "completed_turn", {
@@ -9952,6 +9960,9 @@ function portal() {
       const expectedText = String(options.expectedText || "");
       const expectedAssistantUuid = String(options.expectedAssistantUuid || "");
       const completedTurnId = String(options.completedTurnId || "");
+      const followTail = options.followTail === true;
+      const followTailUserScrollAt = Math.max(
+        0, Number(options.followTailUserScrollAt) || 0);
       const stillOwned = () => this.tabState[sid] === ownerState
         && !ownerState.streaming && !ownerState.es
         && !this._hasPendingAdmission(ownerState);
@@ -9960,6 +9971,7 @@ function portal() {
         if (options.signal?.aborted) return;
         const next = {
           expectedText, expectedAssistantUuid, completedTurnId,
+          followTail, followTailUserScrollAt,
           attempt: attempt + 1,
         };
         ownerState._pendingCompletedTurnSync = next;
@@ -10065,9 +10077,13 @@ function portal() {
         );
         if (!hasBoundary) { retry(); return false; }
         if (!stillOwned()) return false;
+        const followTailStillOwned = followTail
+          && Math.max(0, Number(ownerState._userScrollAt) || 0)
+            === followTailUserScrollAt;
         const loaded = await this.loadSession(sid, {
           quiet: true, probeActive: false,
           minimumTail: completedTurnWindow,
+          followTail: followTailStillOwned,
           signal: options.signal,
         });
         if (!loaded) retry();
@@ -10083,11 +10099,11 @@ function portal() {
     },
     _reconcileCompletedContinuation(
       sid, ownerState, expectedText = "", attempt = 0, expectedAssistantUuid = "",
-      completedTurnId = "",
+      completedTurnId = "", completionViewport = null,
     ) {
       return this._reconcileCompletedTurn(
         sid, ownerState, expectedText, attempt, expectedAssistantUuid,
-        completedTurnId,
+        completedTurnId, completionViewport,
       );
     },
     async removePendingQueueItem(sid, idx) {
@@ -31678,6 +31694,11 @@ function portal() {
             ta.focus();
           });
         }
+        return {
+          followTail: followedTail,
+          userScrollAt: Math.max(
+            0, Number(streamState._userScrollAt) || 0),
+        };
       };
       const markUserFailed = (errorText, kind, cta, retryable) => {
         const allMessages = streamState.messages;
@@ -31781,7 +31802,7 @@ function portal() {
           d.turn_id || streamState.activeTurnId || expectedTurnId || "",
         );
         es.close();
-        _markDone(!!d.cancelled, backgroundPending, true, {
+        const completionViewport = _markDone(!!d.cancelled, backgroundPending, true, {
           turnId: completedTurnId,
           assistantUuid: d.assistant_uuid,
           completedAtMs: d.completed_at_ms,
@@ -31814,11 +31835,13 @@ function portal() {
           this._reconcileCompletedContinuation(
             streamSid, streamState, continuationFinalText, 0,
             String(d.assistant_uuid || ""), completedTurnId,
+            completionViewport,
           );
         } else if (!d.cancelled) {
           this._reconcileCompletedTurn(
             streamSid, streamState, d.is_error ? "" : completedFinalText, 0,
             String(d.assistant_uuid || ""), completedTurnId,
+            completionViewport,
           );
         }
         if (!d.cancelled) {

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -7151,6 +7151,196 @@ def test_tool_result_tail_done_metadata_renders_footer_before_canonical_reload(
     _assert_no_browser_errors(page, errors)
 
 
+def test_completed_tool_turn_reveals_canonical_final_without_refresh(
+    page: Page, backend_url, auth_token,
+):
+    """A terminal tail latch reveals a final block missing from live SSE."""
+    errors = _capture_browser_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _install_fake_event_source(page)
+    sid = "perf-done-canonical-tail-latch"
+    prompt = "CANONICAL_TAIL_LATCH_PROMPT"
+    final_marker = "CANONICAL_FINAL_VISIBLE_WITHOUT_REFRESH"
+    final_text = final_marker + " " + ("complete answer " * 30)
+    canonical_messages: list[dict] = []
+    requests = _route_windowed_session(
+        page, sid, canonical_messages, updated_at=2,
+    )
+    page.route(
+        f"**/api/chat/sessions/{sid}/active*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"active": False, "turn_id": "tail-latch-turn"}),
+        ),
+    )
+    page.route(
+        "**/api/chat/stream/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ticket":"done-tail-latch-ticket"}',
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    _app_eval(
+        page,
+        """
+        const sid = arg.sid;
+        app.refreshSessions = async () => {};
+        app._pullSessionList = async () => false;
+        app._fetchTabUsage = async () => {};
+        app._checkActiveTurn = () => {};
+        app._scheduleIdlePreload = () => {};
+        app._ensureSessionRegistered = async () => true;
+        app._confirmSessionBusy = async () => false;
+        app.appReady = true;
+        app.availableModels = [{
+          model: "e2e-model", label: "E2E model", group: "e2e",
+          supports_thinking: true,
+        }];
+        app.model = "e2e-model";
+        app.defaultModel = "e2e-model";
+        app.sessions = [{
+          id: sid, name: "Done canonical tail latch", updated_at: 1,
+          model: "e2e-model", permission: "bypassPermissions", thinking: true,
+        }];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.tabState[sid] = app._blankTabState();
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st._seenUpdated = 1;
+        app.currentId = sid;
+        app._activateTabState(sid);
+        st.messagesReady = true;
+        st.messagesLoading = false;
+        st.atBottom = true;
+        app.mobileTab = "chat";
+        app.input = arg.prompt;
+        return true;
+        """,
+        {"sid": sid, "prompt": prompt},
+    )
+
+    _app_eval(page, "app.send(); return true;")
+    page.wait_for_function(
+        "() => window.__fakeChatStreams && window.__fakeChatStreams().length === 1"
+    )
+    page.evaluate(
+        """() => {
+          window.__emitSse("thinking", {
+            text: "inspect canonical state", turn_id: "tail-latch-turn",
+            event_seq: 1,
+          });
+          window.__emitSse("tool_use", {
+            id: "toolu_tail_latch", name: "Skill", summary: "load helper",
+            input: {skill: "fixture"}, turn_id: "tail-latch-turn", event_seq: 2,
+          });
+          window.__emitSse("tool_result", {
+            id: "toolu_tail_latch", tool_use_id: "toolu_tail_latch",
+            tool_name: "Skill", preview: "loaded", text: "loaded",
+            truncated: false, text_truncated: false, is_error: false,
+            turn_id: "tail-latch-turn", event_seq: 3,
+          });
+        }"""
+    )
+    page.wait_for_function(
+        """sid => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(sid);
+          return st.streaming && st.messages.at(-1)?.role === "tool_result"
+            && st.atBottom !== false
+            && st.messageRange.visibleEnd === st.messages.length;
+        }""",
+        arg=sid,
+        timeout=10000,
+    )
+
+    canonical_messages.extend([
+        {
+            "role": "user", "text": prompt, "uuid": "tail-latch-user",
+            "block_id": "tail-latch-user:0:user", "_turnRoot": True,
+        },
+        {
+            "role": "thinking", "text": "inspect canonical state",
+            "uuid": "tail-latch-thinking",
+            "block_id": "tail-latch-thinking:0:thinking",
+        },
+        {
+            "role": "tool_use", "id": "toolu_tail_latch", "name": "Skill",
+            "summary": "load helper", "input": {"skill": "fixture"},
+            "uuid": "tail-latch-tool-use",
+            "block_id": "tail-latch-tool-use:0:tool_use",
+        },
+        {
+            "role": "tool_result", "id": "toolu_tail_latch",
+            "tool_use_id": "toolu_tail_latch", "tool_name": "Skill",
+            "preview": "loaded", "text": "loaded", "is_error": False,
+            "uuid": "tail-latch-tool-result",
+            "block_id": "tail-latch-tool-result:0:tool_result",
+        },
+        {
+            "role": "assistant", "text": final_text,
+            "uuid": "tail-latch-final",
+            "block_id": "tail-latch-final:0:assistant",
+        },
+    ])
+    page.evaluate(
+        """() => {
+          window.__emitSse("done", {
+            turn_id: "tail-latch-turn", assistant_uuid: "tail-latch-final",
+            completed_at_ms: Date.now(), duration_ms: 1200,
+            model: "e2e-model", total_cost_usd: 0.001,
+            session_usage: {context_used_pct: 1}, event_seq: 4,
+          });
+          // Model the production race: a post-done layout scroll changes the
+          // geometry-derived bit before the delayed canonical read, but no
+          // wheel/touch/scrollbar gesture has claimed the viewport.
+          const app = document.querySelector("#app")._x_dataStack[0];
+          app._ensureTabState(app.currentId).atBottom = false;
+        }"""
+    )
+    page.wait_for_function(
+        """({sid, marker}) => {
+          const app = document.querySelector("#app")._x_dataStack[0];
+          const st = app._ensureTabState(sid);
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          const pending = st.sessionSync?.pending?.completed_turn;
+          const inFlight = st.sessionSync?.inFlight?.reason === "completed_turn";
+          return !pending && !inFlight
+            && st.messages.some(message => message?.uuid === "tail-latch-final")
+            && pane?.innerText.includes(marker);
+        }""",
+        arg={"sid": sid, "marker": final_marker},
+        timeout=15000,
+    )
+    result = _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        const pane = document.querySelector(
+          `.msg-pane[data-tid="${CSS.escape(arg.sid)}"]`);
+        return {
+          atBottom: st.atBottom,
+          visibleEnd: st.messageRange.visibleEnd,
+          messageCount: st.messages.length,
+          paneText: pane?.innerText || "",
+          visibleUuids: app.paneMessages(arg.sid).map(message => message.uuid || ""),
+        };
+        """,
+        {"sid": sid},
+    )
+
+    assert requests, "done reconciliation did not request canonical history"
+    assert result["atBottom"] is True, result
+    assert result["visibleEnd"] == result["messageCount"] == 5, result
+    assert "tail-latch-final" in result["visibleUuids"], result
+    assert final_marker in result["paneText"], result
+    _assert_no_browser_errors(page, errors)
+
+
 def test_stable_message_identity_needs_no_repair_telemetry(
     page: Page, backend_url, auth_token,
 ):


### PR DESCRIPTION
## 变更类型
- [x] 修复 (bugfix)

## 变更说明
- 在终止 SSE 帧记录会话当时的尾部跟随状态
- 规范历史稍后补齐最终 assistant 块时恢复尾部可见区
- 若完成后发生真实用户滚动，不强制拉回底部
- 增加 Tool Use 结束后规范答案无需刷新即可出现的 Playwright 回归

## 测试情况
- `RUN_E2E=1 uv run pytest -q`：相关 Playwright 场景 3 个通过
- `uv run pytest -q tests/test_frontend_lint.py`：172 个通过
- `node --check frontend/app.js`
- 已部署到 8780 实测候选版本

## 审查检查项
- [x] 代码符合规范
- [x] 添加/更新了测试
- [x] 自测通过