### PR TITLE
fix(chat): 消除 reconcile JSON 热循环并恢复 successor 会话状态

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -8808,6 +8808,15 @@ class SessionPatchReq(BaseModel):
 
 @router.patch("/sessions/{sid}", dependencies=[Depends(require_token)])
 async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
+    requested_sid = sid
+    redirects = await obs.to_thread_io(
+        "chat.session_redirect",
+        sid,
+        sess.runtime_successor_redirects,
+        (sid,),
+        file_path=sess.INDEX,
+    )
+    sid = redirects.get(sid, sid)
     # Model, effort, and service tier form one runtime contract. Validate the
     # complete *target* tuple before mutating any field in this request; this
     # makes a rejected cross-model combination side-effect free.
@@ -9037,7 +9046,11 @@ async def patch_session_api(sid: str, req: SessionPatchReq) -> dict:
         ok = True
     if not ok:
         raise HTTPException(404, "session not found or no changes")
-    return {"ok": True}
+    return {
+        "ok": True,
+        "session_id": sid,
+        "redirected_from": requested_sid if sid != requested_sid else "",
+    }
 
 
 # ====== usage / reset ======

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -5099,6 +5099,10 @@ def list_sessions_api(
     #               that fell outside the recent window.
     # limit=0 (the default) preserves the old "return everything" behaviour for
     # any caller that doesn't opt in.
+    requested_ids = tuple(dict.fromkeys(
+        sid for raw_sid in (ids or "").split(",")
+        if (sid := raw_sid.strip())
+    ))
     full, list_revision = sess.list_sessions_snapshot()
     # A workspace switch only needs that workspace's recent sessions.  Filter
     # before applying q/limit/ids so an open-tab id owned by another workspace
@@ -5110,6 +5114,16 @@ def list_sessions_api(
             s for s in full
             if str(s.get("cwd") or ROOT) == workspace_path
         ]
+    public_ids = {
+        str(row.get("id") or "") for row in full if row.get("id")
+    }
+    session_redirects = {
+        source_sid: target_sid
+        for source_sid, target_sid in sess.runtime_successor_redirects(
+            requested_ids
+        ).items()
+        if target_sid in public_ids
+    }
     total = len(full)
     q_norm = (q or "").strip().lower()
     if q_norm:
@@ -5121,7 +5135,7 @@ def list_sessions_api(
     elif limit and limit < total:
         subset = list(full[:limit])
         have = {s.get("id") for s in subset}
-        keep = {x for x in (ids or "").split(",") if x}
+        keep = set(requested_ids) | set(session_redirects.values())
         if keep:
             for s in full:
                 sid = s.get("id")
@@ -5187,7 +5201,12 @@ def list_sessions_api(
     # We hash the same payload we're about to send (including live `active`
     # flags), so any user-visible change flips the tag. default=str guards
     # stray datetime/Path values in session dicts.
-    body = {"sessions": sessions, "total": total, "returned": len(sessions)}
+    body = {
+        "sessions": sessions,
+        "total": total,
+        "returned": len(sessions),
+        "session_redirects": session_redirects,
+    }
     # ETag digest cache: hashing ~150KB of JSON on every poll adds up. The
     # body is fully determined by (list-cache generation, request params,
     # active turn set), so key on those and skip the dumps+md5 when nothing
@@ -5203,6 +5222,7 @@ def list_sessions_api(
         frozenset(turn_active_sids),
         frozenset(background_active_sids),
         tuple(sorted(scheduled_counts.items())),
+        tuple(sorted(session_redirects.items())),
     )
     _hit = _LIST_ETAG_CACHE.get("v")
     if _hit is not None and _hit[0] == _etag_key:

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -19390,6 +19390,19 @@ def _mux_session_state_fingerprint(state: dict) -> str:
     return json.dumps(stable, sort_keys=True, ensure_ascii=False)
 
 
+def _runtime_reconcile_projections(
+    session_ids: Iterable[str],
+) -> tuple[dict[str, list[str]], dict[str, frozenset[str]]]:
+    """Load durable status projections together on a worker thread."""
+    ordered_ids = tuple(dict.fromkeys(
+        sid for raw_sid in session_ids if (sid := str(raw_sid or ""))
+    ))
+    return (
+        sess.runtime_lineages(ordered_ids),
+        sess.running_runtime_task_ids(ordered_ids),
+    )
+
+
 async def _subscribe_multiplex(
     checkpoints: dict[str, dict],
     *,
@@ -19505,20 +19518,25 @@ async def _subscribe_multiplex(
         )
         candidate_ids.update(pending_checkpoints)
 
-        # Parse the durable session index once for the whole reconcile pass.
-        # This loop runs every 200 ms per multiplex connection; resolving each
-        # candidate independently used to read + json.loads the complete index
-        # N times on the event-loop thread. The batch read runs off-loop and
-        # returns private lineage lists that status projection cannot mutate.
-        runtime_lineages = (
-            await asyncio.to_thread(sess.runtime_lineages, candidate_ids)
-            if candidate_ids else {}
+        # Load durable projections once for the whole reconcile pass. This loop
+        # runs every 200 ms per multiplex connection; neither the full session
+        # index nor a large sidecar may be read/decoded on the event-loop thread.
+        # Runtime-task summaries retain only immutable task ids, so warm passes
+        # are O(stat) even when full sidecars churn out of their small cache.
+        runtime_lineages, durable_runtime_task_ids = (
+            await asyncio.to_thread(
+                _runtime_reconcile_projections, candidate_ids,
+            )
+            if candidate_ids else ({}, {})
         )
         active_ids: set[str] = set()
         for session_id in sorted(candidate_ids):
             state = _session_active_status(
                 session_id,
                 runtime_lineage=runtime_lineages.get(session_id, []),
+                durable_runtime_task_ids=durable_runtime_task_ids.get(
+                    session_id, frozenset(),
+                ),
             )
             checkpoint = pending_checkpoints.get(session_id)
             checkpoint_recent = None
@@ -19707,17 +19725,22 @@ async def _subscribe_broadcast(
 
 
 def _session_active_status(
-    sid: str, *, runtime_lineage: list[str] | None = None,
+    sid: str,
+    *,
+    runtime_lineage: list[str] | None = None,
+    durable_runtime_task_ids: Iterable[str] | None = None,
 ) -> dict:
     """Tell the frontend whether `sid` has an in-progress background
     turn. Used on session load to decide between "render JSONL history"
     and "open a reconnect SSE stream to follow the live tail."""
     runtime_task_ids = set(_sessions_with_inflight_tasks.get(sid, ()))
-    runtime_task_ids.update(
-        task_id
-        for task_id, overlay in sess.get_runtime_task_overlays(sid).items()
-        if overlay.get("state") == "running"
-    )
+    if durable_runtime_task_ids is None:
+        durable_runtime_task_ids = (
+            task_id
+            for task_id, overlay in sess.get_runtime_task_overlays(sid).items()
+            if overlay.get("state") == "running"
+        )
+    runtime_task_ids.update(durable_runtime_task_ids)
     runtime_background_pending = len(runtime_task_ids)
     runtime_continuation_pending, runtime_ui_revision = (
         _runtime_continuation_projection_state(

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -245,7 +245,31 @@ def _sidecar_path(sid: str) -> Path:
     return SESS_DIR / f"{sid}.sidecar.json"
 
 
+# The session index grows with every session (hundreds of rows, ~0.5MB), yet
+# is re-read + re-parsed on every _load_index() call.  The 0.2s reconcile hot
+# loop reaches it through runtime_lineages(), so an uncached json.loads there
+# saturates the event loop with redundant parse work.  Cache the last parse
+# keyed by (mtime_ns, size); drop on save so cache state stays derived purely
+# from disk (mirrors _SIDECAR_CACHE's "drop rather than refresh" policy).
+# Callers get a shallow copy so structural mutations (idx.append) never touch
+# the cached list; single-field dict writes are GIL-atomic and the cache is
+# dropped on every save, so a concurrent lock-free reader (get_session_meta)
+# only ever observes a pre- or post-mutation field value.
+_INDEX_CACHE: dict[str, Any] = {}
+_INDEX_CACHE_LOCK = threading.Lock()
+
+
 def _load_index() -> list[dict]:
+    try:
+        st = INDEX.stat()
+    except FileNotFoundError:
+        with _INDEX_CACHE_LOCK:
+            _INDEX_CACHE.clear()
+        return []
+    sig = (st.st_mtime_ns, st.st_size)
+    with _INDEX_CACHE_LOCK:
+        if _INDEX_CACHE.get("sig") == sig:
+            return list(_INDEX_CACHE["data"])
     try:
         raw = INDEX.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -260,7 +284,10 @@ def _load_index() -> list[dict]:
         raise RuntimeError(f"cannot parse session index: {INDEX}") from exc
     if not isinstance(data, list):
         raise RuntimeError(f"session index must contain a list: {INDEX}")
-    return data
+    with _INDEX_CACHE_LOCK:
+        _INDEX_CACHE["sig"] = sig
+        _INDEX_CACHE["data"] = data
+    return list(data)
 
 
 def _save_index(items: list[dict]) -> None:
@@ -274,6 +301,10 @@ def _save_index(items: list[dict]) -> None:
     ]
     atomic_write_text(
         INDEX, json.dumps(canonical, ensure_ascii=False, indent=2), mode=0o600)
+    # Drop the parsed-index cache so the next _load_index re-stats and
+    # re-caches the just-written file (mirrors _save_sidecar's drop policy).
+    with _INDEX_CACHE_LOCK:
+        _INDEX_CACHE.clear()
     # Keep the cheap metadata layer live in-place.  A one-session rename/count
     # update must not discard the independently cached transcript metadata and
     # force the next /sessions poll to enumerate every workspace JSONL again.

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1458,6 +1458,46 @@ def runtime_lineage(sid: str) -> list[str]:
     return runtime_lineages((canonical_sid,)).get(canonical_sid, [])
 
 
+def runtime_successor_redirects(sids: Iterable[str]) -> dict[str, str]:
+    """Resolve hidden runtime ids to their final public successor.
+
+    A browser can persist the predecessor id immediately before a detached
+    runtime handoff commits, then miss the response because it reloads or the
+    service restarts.  Public session lists intentionally hide that predecessor,
+    so callers need this small durable redirect projection to repair the tab id
+    instead of dropping it.  Only complete chains ending at a public row are
+    returned; broken/cyclic/in-progress links remain untouched.
+    """
+    ordered_sids = tuple(dict.fromkeys(
+        sid for raw_sid in sids if (sid := str(raw_sid or ""))
+    ))
+    if not ordered_sids:
+        return {}
+    with _INDEX_LOCK:
+        by_id = _runtime_rows_snapshot()
+
+    redirects: dict[str, str] = {}
+    for source_sid in ordered_sids:
+        source = by_id.get(source_sid)
+        if source is None or not source.get("runtime_shadow"):
+            continue
+        current_sid = source_sid
+        seen = {source_sid}
+        for _step in range(_RUNTIME_LINEAGE_MAX - 1):
+            successor_sid = str(
+                by_id.get(current_sid, {}).get("runtime_successor") or ""
+            )
+            if (not successor_sid or successor_sid in seen
+                    or successor_sid not in by_id):
+                break
+            seen.add(successor_sid)
+            current_sid = successor_sid
+            if not by_id[current_sid].get("runtime_shadow"):
+                redirects[source_sid] = current_sid
+                break
+    return redirects
+
+
 def update_model(sid: str, model: str) -> None:
     with _INDEX_LOCK:
         idx = _load_index()

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -402,15 +402,82 @@ def invalidate_sessions_cache() -> None:
     _META_CACHE.clear()
 
 
-# Parsed-sidecar cache keyed by sid → (mtime, size, dict). Sidecars are
+# Parsed-sidecar cache keyed by sid → (file signature, dict). Sidecars are
 # re-read + json.loads'd on EVERY GET /sessions/{sid} (annotations), every
 # ctx-window read, etc., and can reach MBs when they hold base64 thumbs.
-# (mtime, size) keying means an external edit (or our own _save_sidecar)
-# is picked up on the next read. Cached dicts are returned as-is: callers
+# Device + inode make atomic replacements visible even if an external writer
+# preserves mtime and size; nanosecond mtime catches rapid in-place edits.
+# Cached dicts are returned as-is: callers
 # that mutate them do so under _SIDECAR_LOCK and immediately _save_sidecar
 # (which drops the cache entry), so mutation never leaks a stale snapshot.
-_SIDECAR_CACHE: dict[str, tuple[float, int, dict]] = {}
+_SidecarSignature = tuple[int, int, int, int]
+_SIDECAR_CACHE: dict[str, tuple[_SidecarSignature, dict]] = {}
 _SIDECAR_CACHE_MAX = 64
+
+# Multiplex reconciliation needs only the ids of durable runtime tasks whose
+# overlay is still running. Keeping that tiny immutable projection separately
+# prevents the 64-entry full-sidecar cache from forcing repeated reads of MB-
+# sized annotation/image payloads. The larger bound is cheap (sets of ids only)
+# and covers archives with thousands of sessions without retaining sidecars.
+_RUNNING_RUNTIME_TASK_IDS_CACHE: dict[
+    str, tuple[_SidecarSignature, frozenset[str]]
+] = {}
+_RUNNING_RUNTIME_TASK_IDS_CACHE_LOCK = threading.Lock()
+_RUNNING_RUNTIME_TASK_IDS_CACHE_MAX = 4096
+
+
+def _sidecar_file_signature(path: Path) -> _SidecarSignature | None:
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return None
+    return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _running_runtime_task_ids_from_data(data: Any) -> frozenset[str]:
+    if not isinstance(data, dict):
+        return frozenset()
+    overlays = data.get("runtime_task_overlays")
+    if not isinstance(overlays, dict):
+        return frozenset()
+    return frozenset(
+        str(task_id)
+        for task_id, overlay in overlays.items()
+        if task_id and isinstance(overlay, dict)
+        and overlay.get("state") == "running"
+    )
+
+
+def _drop_running_runtime_task_ids_cache(sid: str) -> None:
+    with _RUNNING_RUNTIME_TASK_IDS_CACHE_LOCK:
+        _RUNNING_RUNTIME_TASK_IDS_CACHE.pop(sid, None)
+
+
+def _store_running_runtime_task_ids_cache(
+    sid: str,
+    signature: _SidecarSignature,
+    task_ids: frozenset[str],
+) -> None:
+    with _RUNNING_RUNTIME_TASK_IDS_CACHE_LOCK:
+        if (
+            len(_RUNNING_RUNTIME_TASK_IDS_CACHE)
+            >= _RUNNING_RUNTIME_TASK_IDS_CACHE_MAX
+            and sid not in _RUNNING_RUNTIME_TASK_IDS_CACHE
+        ):
+            _RUNNING_RUNTIME_TASK_IDS_CACHE.pop(
+                next(iter(_RUNNING_RUNTIME_TASK_IDS_CACHE)), None,
+            )
+        _RUNNING_RUNTIME_TASK_IDS_CACHE[sid] = (signature, task_ids)
+
+
+def _refresh_running_runtime_task_ids_cache(sid: str, data: dict) -> None:
+    signature = _sidecar_file_signature(_sidecar_path(sid))
+    if signature is None:
+        _drop_running_runtime_task_ids_cache(sid)
+        return
+    _store_running_runtime_task_ids_cache(
+        sid, signature, _running_runtime_task_ids_from_data(data),
+    )
 
 
 def _load_sidecar(sid: str, *, use_cache: bool = True) -> dict:
@@ -422,15 +489,15 @@ def _load_sidecar(sid: str, *, use_cache: bool = True) -> dict:
     in-flight mutations to concurrent readers (and persist them in the
     cache even if the save never happens)."""
     p = _sidecar_path(sid)
-    try:
-        st = p.stat()
-    except FileNotFoundError:
+    sig = _sidecar_file_signature(p)
+    if sig is None:
+        _SIDECAR_CACHE.pop(sid, None)
+        _drop_running_runtime_task_ids_cache(sid)
         return {"messages": {}}
-    sig = (st.st_mtime, st.st_size)
     if use_cache:
         hit = _SIDECAR_CACHE.get(sid)
-        if hit is not None and hit[0] == sig[0] and hit[1] == sig[1]:
-            return hit[2]
+        if hit is not None and hit[0] == sig:
+            return hit[1]
     try:
         d = json.loads(p.read_text(encoding="utf-8"))
         if not isinstance(d, dict):
@@ -444,7 +511,7 @@ def _load_sidecar(sid: str, *, use_cache: bool = True) -> dict:
     if use_cache:
         if len(_SIDECAR_CACHE) >= _SIDECAR_CACHE_MAX and sid not in _SIDECAR_CACHE:
             _SIDECAR_CACHE.pop(next(iter(_SIDECAR_CACHE)), None)
-        _SIDECAR_CACHE[sid] = (sig[0], sig[1], d)
+        _SIDECAR_CACHE[sid] = (sig, d)
     return d
 
 
@@ -454,6 +521,10 @@ def _save_sidecar(sid: str, data: dict) -> None:
     # Drop rather than refresh: the next _load_sidecar re-stats and caches
     # the just-written file, keeping cache state derived purely from disk.
     _SIDECAR_CACHE.pop(sid, None)
+    # The hot reconcile projection is immutable and derived from the exact
+    # object just serialized successfully, so refresh it without rereading the
+    # potentially large sidecar on the next 200 ms tick.
+    _refresh_running_runtime_task_ids_cache(sid, data)
 
 
 def indexed_session_ids() -> set[str]:
@@ -1041,6 +1112,7 @@ def delete_session(sid: str) -> bool:
                     try:
                         sidecar.unlink()
                         _SIDECAR_CACHE.pop(sid, None)
+                        _drop_running_runtime_task_ids_cache(sid)
                         removed = True
                     except OSError:
                         pass
@@ -1141,6 +1213,7 @@ def prune_empty_sessions(keep_ids: tuple | list = ()) -> list[str]:
                     try:
                         p.unlink()
                         _SIDECAR_CACHE.pop(sid, None)
+                        _drop_running_runtime_task_ids_cache(sid)
                     except OSError:
                         pass
             q = _queue_path(sid)
@@ -1687,6 +1760,55 @@ def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
     return _normalize_runtime_task_overlays(
         _load_sidecar(sid).get("runtime_task_overlays") or {}
     )
+
+
+def _running_runtime_task_ids(sid: str) -> frozenset[str]:
+    """Return one sidecar's durable running-task summary.
+
+    Cache misses decode only the overlay object and verify the file generation
+    before publishing the immutable result. Callers from async hot paths must
+    invoke the batch wrapper through ``asyncio.to_thread``; warm reads are one
+    stat plus a small set lookup and never retain the full sidecar payload.
+    """
+    latest = frozenset()
+    path = _sidecar_path(sid)
+    for _attempt in range(2):
+        signature = _sidecar_file_signature(path)
+        if signature is None:
+            _drop_running_runtime_task_ids_cache(sid)
+            return frozenset()
+        with _RUNNING_RUNTIME_TASK_IDS_CACHE_LOCK:
+            hit = _RUNNING_RUNTIME_TASK_IDS_CACHE.get(sid)
+            if hit is not None and hit[0] == signature:
+                return hit[1]
+
+        overlays = _load_runtime_task_overlays_section(sid)
+        latest = _running_runtime_task_ids_from_data({
+            "runtime_task_overlays": overlays,
+        })
+        if _sidecar_file_signature(path) != signature:
+            # An atomic external writer replaced the file while it was read.
+            # Retry once; never associate a snapshot with the wrong signature.
+            continue
+        _store_running_runtime_task_ids_cache(sid, signature, latest)
+        return latest
+
+    # A continuously changing external file still yields a valid point-in-time
+    # answer. Do not cache it; the next reconcile pass will retry naturally.
+    return latest
+
+
+def running_runtime_task_ids(
+    sids: Iterable[str],
+) -> dict[str, frozenset[str]]:
+    """Resolve durable running-task ids for many sessions from tiny summaries."""
+    ordered_sids = tuple(dict.fromkeys(
+        sid for raw_sid in sids if (sid := str(raw_sid or ""))
+    ))
+    return {
+        sid: _running_runtime_task_ids(sid)
+        for sid in ordered_sids
+    }
 
 
 _RUNTIME_TASK_TERMINAL_STATES = frozenset({

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -554,10 +554,19 @@ def _merge_sdk_with_index(
 ) -> dict:
     """Build a muselab-shaped session dict from a SDKSessionInfo + the
     muselab index entry (may be empty for sessions created outside muselab)."""
-    name = (info.custom_title
-             or m.get("name")
-             or title_from_message(info.first_prompt or "")
-             or _default_session_name())
+    # An explicit MuseLab rename is written to both stores, but the SDK session
+    # list is cached independently.  Prefer the local manual title while that
+    # cache still contains the previous customTitle/aiTitle; auto-generated
+    # local fallbacks continue to yield to the SDK-native title.
+    indexed_name = str(m.get("name") or "")
+    explicit_indexed_name = (
+        indexed_name if m.get("auto_named") is False else ""
+    )
+    name = (explicit_indexed_name
+            or info.custom_title
+            or indexed_name
+            or title_from_message(info.first_prompt or "")
+            or _default_session_name())
     return {
         "id": info.session_id,
         "name": name,

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -245,31 +245,30 @@ def _sidecar_path(sid: str) -> Path:
     return SESS_DIR / f"{sid}.sidecar.json"
 
 
-# The session index grows with every session (hundreds of rows, ~0.5MB), yet
-# is re-read + re-parsed on every _load_index() call.  The 0.2s reconcile hot
-# loop reaches it through runtime_lineages(), so an uncached json.loads there
-# saturates the event loop with redundant parse work.  Cache the last parse
-# keyed by (mtime_ns, size); drop on save so cache state stays derived purely
-# from disk (mirrors _SIDECAR_CACHE's "drop rather than refresh" policy).
-# Callers get a shallow copy so structural mutations (idx.append) never touch
-# the cached list; single-field dict writes are GIL-atomic and the cache is
-# dropped on every save, so a concurrent lock-free reader (get_session_meta)
-# only ever observes a pre- or post-mutation field value.
-_INDEX_CACHE: dict[str, Any] = {}
-_INDEX_CACHE_LOCK = threading.Lock()
+# Multiplex reconciliation needs only the runtime predecessor/successor graph.
+# Cache that private, read-only projection rather than the mutable list returned
+# by _load_index(): index mutators edit row dicts in place before _save_index,
+# so sharing cached rows with them would expose uncommitted changes and retain
+# changes whose disk write failed.  The inode is part of the signature because
+# external atomic writers can replace index.json while preserving mtime + size.
+_RUNTIME_INDEX_CACHE: dict[str, Any] = {}
+_RUNTIME_INDEX_CACHE_LOCK = threading.Lock()
 
 
-def _load_index() -> list[dict]:
+def _index_file_signature() -> tuple[int, int, int, int] | None:
     try:
         st = INDEX.stat()
     except FileNotFoundError:
-        with _INDEX_CACHE_LOCK:
-            _INDEX_CACHE.clear()
-        return []
-    sig = (st.st_mtime_ns, st.st_size)
-    with _INDEX_CACHE_LOCK:
-        if _INDEX_CACHE.get("sig") == sig:
-            return list(_INDEX_CACHE["data"])
+        return None
+    return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _clear_runtime_index_cache() -> None:
+    with _RUNTIME_INDEX_CACHE_LOCK:
+        _RUNTIME_INDEX_CACHE.clear()
+
+
+def _load_index() -> list[dict]:
     try:
         raw = INDEX.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -284,10 +283,7 @@ def _load_index() -> list[dict]:
         raise RuntimeError(f"cannot parse session index: {INDEX}") from exc
     if not isinstance(data, list):
         raise RuntimeError(f"session index must contain a list: {INDEX}")
-    with _INDEX_CACHE_LOCK:
-        _INDEX_CACHE["sig"] = sig
-        _INDEX_CACHE["data"] = data
-    return list(data)
+    return data
 
 
 def _save_index(items: list[dict]) -> None:
@@ -301,10 +297,9 @@ def _save_index(items: list[dict]) -> None:
     ]
     atomic_write_text(
         INDEX, json.dumps(canonical, ensure_ascii=False, indent=2), mode=0o600)
-    # Drop the parsed-index cache so the next _load_index re-stats and
-    # re-caches the just-written file (mirrors _save_sidecar's drop policy).
-    with _INDEX_CACHE_LOCK:
-        _INDEX_CACHE.clear()
+    # Drop rather than refresh: the next runtime projection re-stats and
+    # rebuilds from the durable file, matching the sidecar cache contract.
+    _clear_runtime_index_cache()
     # Keep the cheap metadata layer live in-place.  A one-session rename/count
     # update must not discard the independently cached transcript metadata and
     # force the next /sessions poll to enumerate every workspace JSONL again.
@@ -1289,6 +1284,35 @@ def _runtime_rows_by_id(rows: list[dict]) -> dict[str, dict]:
     }
 
 
+def _runtime_rows_snapshot() -> dict[str, dict]:
+    """Return a private cached runtime-link projection of one file version."""
+    for _attempt in range(2):
+        signature = _index_file_signature()
+        if signature is None:
+            _clear_runtime_index_cache()
+            return {}
+        with _RUNTIME_INDEX_CACHE_LOCK:
+            if _RUNTIME_INDEX_CACHE.get("signature") == signature:
+                return _RUNTIME_INDEX_CACHE["rows_by_id"]
+
+        # _load_index returns fresh mutable rows.  Keep those rows private to
+        # this read-only cache; no mutator receives or edits them.
+        rows_by_id = _runtime_rows_by_id(_load_index())
+        loaded_signature = _index_file_signature()
+        if loaded_signature != signature:
+            # An external atomic writer replaced the path while it was read.
+            # Retry once so data and signature describe the same generation.
+            continue
+        with _RUNTIME_INDEX_CACHE_LOCK:
+            _RUNTIME_INDEX_CACHE["signature"] = signature
+            _RUNTIME_INDEX_CACHE["rows_by_id"] = rows_by_id
+        return rows_by_id
+
+    # A continuously changing external file should not poison the cache.  A
+    # fresh uncached snapshot is still a valid point-in-time lineage view.
+    return _runtime_rows_by_id(_load_index())
+
+
 def _runtime_lineage_from_index(
     sid: str, by_id: dict[str, dict],
 ) -> list[str]:
@@ -1341,7 +1365,7 @@ def runtime_lineages(sids: Iterable[str]) -> dict[str, list[str]]:
     if not ordered_sids:
         return {}
     with _INDEX_LOCK:
-        by_id = _runtime_rows_by_id(_load_index())
+        by_id = _runtime_rows_snapshot()
     return {
         sid: _runtime_lineage_from_index(sid, by_id)
         for sid in ordered_sids

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -883,6 +883,10 @@ function portal() {
     // active tab. Tabs can be opened from the session picker, closed via × on
     // the tab, or created by the "+ new" button.
     openTabIds: [],
+    // Durable runtime rollovers replace one SDK session id with another. The
+    // server returns redirects for stale ids restored from localStorage so a
+    // reload repairs the strip instead of silently dropping the hidden source.
+    _sessionRedirects: {},
     _lastNewSessionAt: 0,
     _lastNewSessionMeta: null,
     NEW_SESSION_TOUCH_DEDUPE_MS: 500,
@@ -6740,6 +6744,202 @@ function portal() {
     },
 
     // ===== prefs =====
+    _resolveSessionRedirectId(id, redirects = this._sessionRedirects) {
+      const original = typeof id === "string" ? id : "";
+      if (!original || !redirects || typeof redirects !== "object") return original;
+      let current = original;
+      const seen = new Set([current]);
+      for (let step = 0; step < 32; step++) {
+        const next = typeof redirects[current] === "string"
+          ? redirects[current] : "";
+        if (!next || next === current) return current;
+        if (seen.has(next)) return original;
+        seen.add(next);
+        current = next;
+      }
+      return original;
+    },
+
+    _migrateRedirectedChatDraft(sourceSid, targetSid, targetState = null) {
+      const sourceState = this.tabState && this.tabState[sourceSid];
+      const sourceRecord = this._chatDraftRecord(sourceSid);
+      const targetRecord = this._chatDraftRecord(targetSid);
+      const sourceText = this._mergeChatDraftText(
+        sourceRecord.pending,
+        this._mergeChatDraftText(
+          sourceRecord.text,
+          sourceState && sourceState.draft ? sourceState.draft.input : "",
+        ),
+      );
+      const targetText = this._mergeChatDraftText(
+        targetRecord.pending, targetRecord.text,
+      );
+      const text = this._mergeChatDraftText(sourceText, targetText);
+      if (targetState && targetState.draft) {
+        targetState.draft.input = this._mergeChatDraftText(
+          text, targetState.draft.input || "",
+        );
+      }
+      const written = this._writeChatDraftRecord(targetSid, {
+        text: targetState && targetState.draft
+          ? targetState.draft.input : text,
+        pending: "",
+      });
+      if (written) this._deletePersistedChatDraft(sourceSid);
+    },
+
+    _migrateRedirectedTabRuntime(sourceSid, targetSid, targetMeta = null) {
+      const sourceState = this.tabState && this.tabState[sourceSid];
+      let targetState = this.tabState && this.tabState[targetSid];
+      if (!sourceState || sourceState === targetState) return targetState || null;
+
+      sourceState._backgroundSuccessorSid = targetSid;
+      if (!targetState) {
+        const pending = targetMeta && targetMeta.background_active
+          ? Math.max(1, Number(sourceState.backgroundTaskCount) || 0) : 0;
+        targetState = this._stateForDetachedSuccessor(
+          sourceSid, targetSid, sourceState, pending,
+        );
+        // The durable target is authoritative after a missed handoff. Keep the
+        // cloned rows visible for this frame, but force canonical hydration.
+        targetState._loaded = false;
+        if (!pending) {
+          targetState.inheritedBackgroundOwner = "";
+          targetState.inheritedBackgroundTaskCount = 0;
+        }
+        this.tabState[targetSid] = targetState;
+      } else if (sourceState.draft && targetState.draft) {
+        targetState.draft.input = this._mergeChatDraftText(
+          sourceState.draft.input || "", targetState.draft.input || "",
+        );
+        for (const key of ["pendingImages", "pendingDocs", "pendingQuotes"]) {
+          const existing = new Set(targetState.draft[key] || []);
+          targetState.draft[key] = [
+            ...(targetState.draft[key] || []),
+            ...(sourceState.draft[key] || []).filter(item => !existing.has(item)),
+          ];
+        }
+      }
+      if (sourceState.draft && sourceState.draft._uploadControllers) {
+        if (!targetState.draft._uploadControllers) {
+          targetState.draft._uploadControllers = new Set();
+        }
+        for (const controller of sourceState.draft._uploadControllers) {
+          targetState.draft._uploadControllers.add(controller);
+        }
+        // Ownership moved; disposing the stale transport must not abort a file
+        // upload whose callbacks still mutate the transferred entry objects.
+        sourceState.draft._uploadControllers = new Set();
+      }
+      if (this.imageEditor.ownerSid === sourceSid) {
+        this.imageEditor.ownerSid = targetSid;
+        this.imageEditor.ownerState = targetState;
+      }
+      if (this.imageGen.ownerSid === sourceSid) this.imageGen.ownerSid = targetSid;
+      this._disposeTabRuntime(sourceSid);
+      return targetState;
+    },
+
+    _applySessionRedirects(raw, incomingSessions = []) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+      const combined = { ...(this._sessionRedirects || {}) };
+      for (const [source, target] of Object.entries(raw)) {
+        if (typeof source !== "string" || !source
+            || typeof target !== "string" || !target || source === target) continue;
+        combined[source] = target;
+      }
+      const flattened = {};
+      for (const source of Object.keys(combined)) {
+        const target = this._resolveSessionRedirectId(source, combined);
+        if (target && target !== source) flattened[source] = target;
+      }
+      this._sessionRedirects = flattened;
+      const directSources = Object.keys(raw).filter(source => {
+        const target = this._resolveSessionRedirectId(source, flattened);
+        return target && target !== source;
+      });
+      if (!directSources.length) return null;
+
+      const previousCurrent = this.currentId;
+      const previousOpen = this._normalizeOpenTabIds(this.openTabIds);
+      const rewrite = id => this._resolveSessionRedirectId(id, flattened);
+      for (const sourceSid of directSources) {
+        const targetSid = rewrite(sourceSid);
+        const targetMeta = (incomingSessions || []).find(
+          row => row && row.id === targetSid,
+        ) || (this.sessions || []).find(row => row && row.id === targetSid);
+        const targetState = this._migrateRedirectedTabRuntime(
+          sourceSid, targetSid, targetMeta || null,
+        );
+        this._migrateRedirectedChatDraft(sourceSid, targetSid, targetState);
+      }
+
+      this.openTabIds = this._normalizeOpenTabIds(previousOpen.map(rewrite));
+      this.currentId = rewrite(this.currentId);
+      const lastSessions = {};
+      for (const [workspace, sid] of Object.entries(
+        this.workspaceLastSession || {},
+      )) lastSessions[workspace] = rewrite(sid);
+      this.workspaceLastSession = lastSessions;
+      this.renamingTabId = rewrite(this.renamingTabId);
+      this.renamingPickerSid = rewrite(this.renamingPickerSid);
+      this.forkingSessionId = rewrite(this.forkingSessionId);
+      this.retryingSessionId = rewrite(this.retryingSessionId);
+      if (this.tabCtxMenu && this.tabCtxMenu.id) {
+        this.tabCtxMenu = { ...this.tabCtxMenu, id: rewrite(this.tabCtxMenu.id) };
+      }
+
+      // A rename response can reveal a redirect before the next list pull. Keep
+      // one local target row so the repaired tab never renders as an ellipsis.
+      const canonicalRows = (this.sessions || []).filter(
+        row => row && rewrite(row.id) === row.id,
+      );
+      const canonicalIds = new Set(canonicalRows.map(row => row.id));
+      for (const row of this.sessions || []) {
+        if (!row || !row.id) continue;
+        const targetSid = rewrite(row.id);
+        if (targetSid === row.id || canonicalIds.has(targetSid)) continue;
+        canonicalRows.push({ ...row, id: targetSid });
+        canonicalIds.add(targetSid);
+      }
+      this.sessions = canonicalRows;
+      if (this._optimisticMetas) {
+        const optimistic = {};
+        for (const [sid, meta] of Object.entries(this._optimisticMetas)) {
+          const targetSid = rewrite(sid);
+          optimistic[targetSid] = targetSid === sid
+            ? meta : { ...meta, id: targetSid };
+        }
+        this._optimisticMetas = optimistic;
+      }
+      let activityChanged = false;
+      const events = (this.activity && this.activity.events) || [];
+      for (const item of events) {
+        if (!item || typeof item !== "object") continue;
+        for (const field of ["session_id", "thread_id"]) {
+          const targetSid = rewrite(item[field]);
+          if (targetSid && targetSid !== item[field]) {
+            item[field] = targetSid;
+            activityChanged = true;
+          }
+        }
+      }
+      if (activityChanged) this.activity.events = [...events];
+
+      const tabsChanged = previousOpen.join("\u0000") !== this.openTabIds.join("\u0000");
+      const currentChanged = previousCurrent !== this.currentId;
+      if (tabsChanged) this._writeChatTabStore(this.openTabIds);
+      if (currentChanged || Object.keys(lastSessions).length) this.savePrefs();
+      const activeState = this.currentId && this.tabState[this.currentId];
+      if (currentChanged && activeState) this._activateTabState(this.currentId);
+      if (activeState && !activeState._loaded && this._sessionsInitialized) {
+        this._requestSessionSync(
+          this.currentId, "history_load", { loadOptions: {} },
+        );
+      }
+      return { tabsChanged, currentChanged, currentId: this.currentId };
+    },
+
     _normalizeOpenTabIds(ids, validIds = null) {
       const allowed = validIds instanceof Set
         ? validIds
@@ -11760,6 +11960,10 @@ function portal() {
       if (et) this._sessionsEtag = et;
       let data = null;
       try { data = await r.json(); } catch { data = null; }
+      this._applySessionRedirects(
+        (data && data.session_redirects) || {},
+        (data && data.sessions) || [],
+      );
       this._applySessionList((data && data.sessions) || []);
       return true;
     },

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -887,6 +887,8 @@ function portal() {
     // server returns redirects for stale ids restored from localStorage so a
     // reload repairs the strip instead of silently dropping the hidden source.
     _sessionRedirects: {},
+    _sessionNameExpected: {},
+    _sessionRenameSeq: 0,
     _lastNewSessionAt: 0,
     _lastNewSessionMeta: null,
     NEW_SESSION_TOUCH_DEDUPE_MS: 500,
@@ -6872,6 +6874,14 @@ function portal() {
           sourceSid, targetSid, targetMeta || null,
         );
         this._migrateRedirectedChatDraft(sourceSid, targetSid, targetState);
+        const expected = this._sessionNameExpected[sourceSid];
+        if (expected) {
+          const current = this._sessionNameExpected[targetSid];
+          if (!current || Number(expected.seq) >= Number(current.seq)) {
+            this._sessionNameExpected[targetSid] = expected;
+          }
+          delete this._sessionNameExpected[sourceSid];
+        }
       }
 
       this.openTabIds = this._normalizeOpenTabIds(previousOpen.map(rewrite));
@@ -11987,6 +11997,21 @@ function portal() {
     async _syncSessionListQuiet() {
       return await this._pullSessionList(true);
     },
+    _retainExpectedSessionName(meta) {
+      const expected = meta && this._sessionNameExpected[meta.id];
+      if (!expected) return meta;
+      if (Date.now() - Number(expected.at || 0)
+          > this.SESSION_SETTING_EXPECTED_TTL_MS) {
+        delete this._sessionNameExpected[meta.id];
+        return meta;
+      }
+      if (String(meta.name || "") === expected.value) {
+        expected.echoed = true;
+        if (expected.settled) delete this._sessionNameExpected[meta.id];
+        return meta;
+      }
+      return { ...meta, name: expected.value, auto_named: false };
+    },
     _retainExpectedSessionSettings(meta) {
       const st = meta && this.tabState && this.tabState[meta.id];
       if (!st) return meta;
@@ -12113,6 +12138,7 @@ function portal() {
       });
       if (_handoffRows.length) next = [..._handoffRows, ...next];
       next = next
+        .map(meta => this._retainExpectedSessionName(meta))
         .map(meta => this._retainExpectedSessionSettings(meta))
         .map(meta => this._retainExpectedSessionActivity(meta));
       // Keep every warm tab's primitive mirror aligned even when the rendered
@@ -16676,6 +16702,17 @@ function portal() {
       // ledger, which can take seconds. The local session index is authoritative
       // for this view, so update immediately and let persistence finish without
       // making the tab label feel blocked on unrelated disk work.
+      sid = this._resolveSessionRedirectId(sid);
+      const renameSeq = ++this._sessionRenameSeq;
+      const expectedName = {
+        seq: renameSeq,
+        value: name,
+        previousName,
+        at: Date.now(),
+        echoed: false,
+        settled: false,
+      };
+      this._sessionNameExpected[sid] = expectedName;
       const perfNow = (typeof performance !== "undefined" && performance.now)
         ? () => performance.now() : () => Date.now();
       const started = perfNow();
@@ -16708,26 +16745,45 @@ function portal() {
       let response = null;
       const requestStarted = perfNow();
       try {
-        response = await fetch("/api/chat/sessions/" + sid, {
+        response = await fetch(
+          "/api/chat/sessions/" + encodeURIComponent(sid), {
           method: "PATCH",
           headers: { ...this.hdr(), "Content-Type": "application/json" },
           body: JSON.stringify({ name }),
-        });
+          },
+        );
       } catch (_) { /* handled by the rollback below */ }
       renamePerf.request_ms = Math.round(perfNow() - requestStarted);
       const ok = !!(response && response.ok);
       if (!ok) {
+        const canonicalSid = this._resolveSessionRedirectId(sid);
+        if (this._sessionNameExpected[canonicalSid] === expectedName) {
+          delete this._sessionNameExpected[canonicalSid];
+        }
         // Do not undo a newer rename that completed while this request was in
         // flight. Roll back only when our optimistic value still owns the row.
-        const current = this.sessions.find(row => row.id === sid);
+        const current = this.sessions.find(row => row.id === canonicalSid);
         if (current && current.name === name) {
-          this._applyRenamedSession(sid, previousName);
+          this._applyRenamedSession(canonicalSid, previousName);
           renamePerf.status = "rollback";
         }
         this.toast(this.lang === "zh" ? "重命名失败" : "Rename failed", "error", 3000);
       } else {
+        let payload = null;
+        try { payload = await response.json(); } catch (_) { payload = null; }
+        const responseSid = String(payload && payload.session_id || "");
+        if (responseSid && responseSid !== sid) {
+          this._applySessionRedirects({ [sid]: responseSid });
+          sid = responseSid;
+          this._applyRenamedSession(sid, name);
+        }
+        const owned = this._sessionNameExpected[sid] === expectedName;
+        if (owned) {
+          expectedName.settled = true;
+          if (expectedName.echoed) delete this._sessionNameExpected[sid];
+        }
         renamePerf.status = "ok";
-        if (announce) this.toast(this.t("toast.renamed"), "success");
+        if (announce && owned) this.toast(this.t("toast.renamed"), "success");
       }
       // Hidden/background tabs may suspend requestAnimationFrame indefinitely.
       // Bound diagnostics so observing first paint can never hold this action open.

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -150,6 +150,92 @@ def test_closed_tab_stays_closed_after_stale_prefs_write_and_hard_refresh(
     }
 
 
+def test_hidden_runtime_successor_restores_tab_and_draft_after_hard_refresh(
+        page: Page, backend_url, auth_token):
+    """A missed detached-runtime response must repair the persisted source id
+    to its public successor instead of dropping the tab on the next boot."""
+    _login(page, backend_url, auth_token)
+    page.locator(SEL_TAB_NEW).click()
+    target = page.evaluate(
+        "document.querySelector('#app')._x_dataStack[0].currentId")
+    source = "11111111-2222-4333-8444-555555555555"
+    draft = "draft survives runtime redirect"
+
+    def inject_redirect(route):
+        response = route.fetch()
+        if response.status != 200:
+            route.fulfill(response=response)
+            return
+        body = response.json()
+        body["session_redirects"] = {source: target}
+        route.fulfill(response=response, json=body)
+
+    page.route("**/api/chat/sessions?*", inject_redirect)
+    page.evaluate(
+        """([source, draft]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const prefs = JSON.parse(localStorage.getItem('muselab_prefs') || '{}');
+          prefs.currentId = source;
+          prefs.workspaceLastSession = {
+            ...(prefs.workspaceLastSession || {}),
+            [app.currentWorkspacePath()]: source,
+          };
+          localStorage.setItem('muselab_prefs', JSON.stringify(prefs));
+          localStorage.setItem('muselab_chat_tabs_v1', JSON.stringify({
+            schema: 1,
+            revision: 1000000,
+            openTabIds: [source],
+          }));
+          localStorage.setItem('muselab_chat_drafts_v1', JSON.stringify({
+            schema: 1,
+            drafts: {
+              [source]: { text: draft, pending: '', updatedAt: Date.now() },
+            },
+          }));
+          app._setChatMuxUnsupported();
+        }""",
+        arg=[source, draft],
+    )
+
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_function(
+        """([source, target, draft]) => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          const tabs = JSON.parse(localStorage.getItem(
+            'muselab_chat_tabs_v1') || '{}');
+          const drafts = JSON.parse(localStorage.getItem(
+            'muselab_chat_drafts_v1') || '{}').drafts || {};
+          return app && app._sessionsInitialized
+            && app.currentId === target
+            && app.openTabIds.includes(target)
+            && !app.openTabIds.includes(source)
+            && tabs.openTabIds?.includes(target)
+            && !tabs.openTabIds?.includes(source)
+            && app.tabState[target]?.draft?.input === draft
+            && !drafts[source];
+        }""",
+        arg=[source, target, draft],
+    )
+    restored = page.evaluate(
+        """([source, target]) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          return {
+            currentId: app.currentId,
+            tabs: app.openTabIds.slice(),
+            sourcePresent: app.sessions.some(row => row.id === source),
+            targetPresent: app.sessions.some(row => row.id === target),
+          };
+        }""",
+        arg=[source, target],
+    )
+    assert restored == {
+        "currentId": target,
+        "tabs": [target],
+        "sourcePresent": False,
+        "targetPresent": True,
+    }
+
+
 def test_same_origin_pages_share_strip_without_focus_theft_or_writeback(
         page: Page, backend_url, auth_token):
     """Storage events converge the strip but keep each page's active tab local."""

--- a/tests/e2e/test_multi_tab.py
+++ b/tests/e2e/test_multi_tab.py
@@ -443,9 +443,28 @@ def test_inline_rename_via_dblclick(page: Page, backend_url, auth_token):
 
     inp = page.locator(f"{SEL_TAB_ACTIVE} {SEL_TAB_RENAME}")
     expect(inp).to_be_visible()
-    inp.fill("e2e-renamed")
-    inp.press("Enter")
-    expect(active_name).to_contain_text("e2e-renamed")
+    renamed = "e2e-renamed-after-refresh"
+    inp.fill(renamed)
+    with page.expect_response(
+        lambda response: response.request.method == "PATCH"
+        and "/api/chat/sessions/" in response.url,
+    ) as response_info:
+        inp.press("Enter")
+    assert response_info.value.ok
+    expect(active_name).to_contain_text(renamed)
+
+    page.evaluate(
+        "document.querySelector('#app')._x_dataStack[0]._setChatMuxUnsupported()")
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_function(
+        """([name]) => {
+          const app = document.querySelector('#app')?._x_dataStack?.[0];
+          const current = app && app.sessions.find(row => row.id === app.currentId);
+          return app && app._sessionsInitialized && current?.name === name;
+        }""",
+        arg=[renamed],
+    )
+    expect(page.locator(f"{SEL_TAB_ACTIVE} {SEL_TAB_NAME}")).to_contain_text(renamed)
 
 
 def test_browser_title_reflects_session(page: Page, backend_url, auth_token):

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -158,6 +158,47 @@ def test_session_rename_updates_activity_ledger(chat_mod, client, monkeypatch):
     assert "After rename" not in repr(perf_events)
 
 
+def test_session_rename_follows_hidden_runtime_successor(
+    chat_mod, client, monkeypatch,
+):
+    from backend import activity as activity_module
+
+    source_sid = "11111111-2222-4333-8444-555555555555"
+    child_sid = "22222222-3333-4444-8555-666666666666"
+    chat_mod.sess.register_session(source_sid, name="source title")
+    chat_mod.sess.register_session(child_sid, name="source title")
+    assert chat_mod.sess.link_runtime_successor(source_sid, child_sid)
+    sdk_calls = []
+    activity_calls = []
+    monkeypatch.setattr(
+        chat_mod,
+        "sdk_rename_session",
+        lambda sid, name, **_kwargs: sdk_calls.append((sid, name)),
+    )
+    monkeypatch.setattr(
+        activity_module.activity,
+        "rename_session",
+        lambda sid, name: activity_calls.append((sid, name)),
+    )
+
+    response = client.patch(
+        f"/api/chat/sessions/{source_sid}",
+        headers={"X-Auth-Token": TEST_TOKEN, "Content-Type": "application/json"},
+        json={"name": "canonical title"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "session_id": child_sid,
+        "redirected_from": source_sid,
+    }
+    assert chat_mod.sess.get_session_meta(child_sid)["name"] == "canonical title"
+    assert chat_mod.sess.get_session_meta(source_sid)["name"] == "source title"
+    assert sdk_calls == [(child_sid, "canonical title")]
+    assert activity_calls == [(child_sid, "canonical title")]
+
+
 def test_session_effort_and_fast_patch_persist_and_rebuild(
     chat_mod, client, monkeypatch,
 ):

--- a/tests/test_chat_lifecycle_contracts.py
+++ b/tests/test_chat_lifecycle_contracts.py
@@ -81,7 +81,11 @@ def test_chat_lifecycle_routes_keep_response_shapes(
         json={"name": "renamed lifecycle contract"},
     )
     assert patched.status_code == 200, patched.text
-    assert patched.json() == {"ok": True}
+    assert patched.json() == {
+        "ok": True,
+        "session_id": sid,
+        "redirected_from": "",
+    }
     assert chat_mod.sess.get_session(sid)["name"] == "renamed lifecycle contract"
 
     deleted = client.delete(f"/api/chat/sessions/{sid}", headers=auth)

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import urllib.parse
 
 import pytest
@@ -293,7 +294,9 @@ def test_mux_auto_discovers_wraps_events_and_disconnect_only_unsubscribes(
     asyncio.run(exercise())
 
 
-def test_mux_reconcile_batches_runtime_lineages(chat_mod, monkeypatch):
+def test_mux_reconcile_batches_durable_projections_off_loop(
+    chat_mod, monkeypatch,
+):
     monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
     broadcasts = [
         chat_mod.TurnBroadcast("batch-lineage-a"),
@@ -302,19 +305,36 @@ def test_mux_reconcile_batches_runtime_lineages(chat_mod, monkeypatch):
     for broadcast in broadcasts:
         chat_mod._active_turns[broadcast.session_id] = broadcast
 
-    batch_calls = []
+    lineage_calls = []
+    task_calls = []
     status_calls = []
+    caller_thread = threading.get_ident()
 
     def runtime_lineages(session_ids):
         ordered = tuple(sorted(session_ids))
-        batch_calls.append(ordered)
+        lineage_calls.append((ordered, threading.get_ident()))
         return {sid: [f"owner-{sid}", sid] for sid in ordered}
 
-    def state(sid, *, runtime_lineage=None):
-        status_calls.append((sid, runtime_lineage))
+    def running_runtime_task_ids(session_ids):
+        ordered = tuple(sorted(session_ids))
+        task_calls.append((ordered, threading.get_ident()))
+        return {sid: frozenset({f"task-{sid}"}) for sid in ordered}
+
+    def state(
+        sid, *, runtime_lineage=None, durable_runtime_task_ids=None,
+    ):
+        status_calls.append((
+            sid, runtime_lineage, durable_runtime_task_ids,
+            threading.get_ident(),
+        ))
         return _active_state(chat_mod._active_turns[sid])
 
     monkeypatch.setattr(chat_mod.sess, "runtime_lineages", runtime_lineages)
+    monkeypatch.setattr(
+        chat_mod.sess,
+        "running_runtime_task_ids",
+        running_runtime_task_ids,
+    )
     monkeypatch.setattr(chat_mod, "_session_active_status", state)
 
     async def exercise():
@@ -325,9 +345,18 @@ def test_mux_reconcile_batches_runtime_lineages(chat_mod, monkeypatch):
     asyncio.run(exercise())
 
     expected_ids = ("batch-lineage-a", "batch-lineage-b")
-    assert batch_calls == [expected_ids]
+    assert [call[0] for call in lineage_calls] == [expected_ids]
+    assert [call[0] for call in task_calls] == [expected_ids]
+    assert lineage_calls[0][1] == task_calls[0][1]
+    assert lineage_calls[0][1] != caller_thread
     assert status_calls == [
-        (sid, [f"owner-{sid}", sid]) for sid in expected_ids
+        (
+            sid,
+            [f"owner-{sid}", sid],
+            frozenset({f"task-{sid}"}),
+            caller_thread,
+        )
+        for sid in expected_ids
     ]
     for broadcast in broadcasts:
         broadcast.close()

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -908,6 +908,27 @@ def test_chat_tab_ids_are_normalized_at_restore_render_and_persist_boundaries():
         'if (ev.key === "t"')
 
 
+def test_hidden_runtime_successors_repair_tabs_drafts_and_task_links():
+    app = (FRONTEND / "app.js").read_text(encoding="utf-8")
+
+    redirect_start = app.index("_applySessionRedirects(raw, incomingSessions = [])")
+    redirect_end = app.index("\n    _normalizeOpenTabIds", redirect_start)
+    redirect = app[redirect_start:redirect_end]
+    assert "this.openTabIds = this._normalizeOpenTabIds(previousOpen.map(rewrite))" in redirect
+    assert "this.currentId = rewrite(this.currentId)" in redirect
+    assert "this._writeChatTabStore(this.openTabIds)" in redirect
+    assert "this._migrateRedirectedChatDraft" in redirect
+    assert '["session_id", "thread_id"]' in redirect
+    assert "item[field] = targetSid" in redirect
+
+    pull_start = app.index("async _pullSessionListOnce(")
+    pull_end = app.index("\n    async refreshSessions()", pull_start)
+    pull = app[pull_start:pull_end]
+    assert "(data && data.session_redirects) || {}" in pull
+    assert pull.index("this._applySessionRedirects(") < pull.index(
+        "this._applySessionList(")
+
+
 def test_workspace_picker_supports_mouse_and_touch_reordering():
     app = (FRONTEND / "app.js").read_text(encoding="utf-8")
     html = (FRONTEND / "index.html").read_text(encoding="utf-8")

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1158,8 +1158,8 @@ def test_session_rename_patches_activity_without_reloading_chat():
     optimistic = helper[optimistic_start:]
     assert optimistic.index("this._applyRenamedSession(sid, name)") < optimistic.index("await fetch(")
     assert "if (current && current.name === name)" in optimistic
-    assert "this._applyRenamedSession(sid, previousName)" in optimistic
-    assert app.count("this._applyRenamedSession(") == 2
+    assert "this._applyRenamedSession(canonicalSid, previousName)" in optimistic
+    assert app.count("this._applyRenamedSession(") == 3
     assert 'this._renameSessionOptimistically(cur.id, name, cur.name, true, "modal")' in modal
     assert 'this._renameSessionOptimistically(id, name, cur.name, true, "tab")' in tab
     assert 'this._renameSessionOptimistically(sid, name, cur.name, false, "picker")' in picker
@@ -1170,6 +1170,8 @@ def test_session_rename_patches_activity_without_reloading_chat():
     assert "renamePerf.request_ms" in optimistic
     assert 'renamePerf.status = "rollback"' in optimistic
     assert "this._reportSessionRenamePerf(renamePerf)" in optimistic
+    assert "this._sessionNameExpected[sid] = expectedName" in optimistic
+    assert "this._applySessionRedirects({ [sid]: responseSid })" in optimistic
     assert "refreshSessions" not in modal
     assert "refreshSessions" not in tab
     assert "loadSession" not in helper

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -381,6 +381,84 @@ def test_runtime_lineages_loads_one_index_snapshot_for_many_sessions(
     }
 
 
+def test_runtime_lineages_cache_one_parse_per_index_generation(
+    app_module, monkeypatch,
+):
+    from backend import sessions as sess
+
+    sid = sess.create_session("cached-runtime-lineage")["id"]
+    real_load = sess._load_index
+    loads = 0
+
+    def counted_load():
+        nonlocal loads
+        loads += 1
+        return real_load()
+
+    monkeypatch.setattr(sess, "_load_index", counted_load)
+
+    assert sess.runtime_lineage(sid) == [sid]
+    assert sess.runtime_lineage(sid) == [sid]
+    assert loads == 1
+
+
+def test_runtime_index_cache_never_shares_rows_with_mutators(app_module):
+    from backend import sessions as sess
+
+    sid = sess.create_session("cache-isolation")["id"]
+    assert sess.runtime_lineage(sid) == [sid]
+
+    mutable_rows = sess._load_index()
+    mutable_row = next(row for row in mutable_rows if row["id"] == sid)
+    mutable_row["id"] = "not-persisted"
+
+    durable_rows = json.loads(sess.INDEX.read_text(encoding="utf-8"))
+    assert any(row["id"] == sid for row in durable_rows)
+    assert sess.runtime_lineage(sid) == [sid]
+
+
+def test_runtime_index_cache_invalidates_after_save(app_module):
+    from backend import sessions as sess
+
+    source = sess.create_session("cache-save-source")["id"]
+    child = sess.create_session("cache-save-child")["id"]
+    assert sess.runtime_lineage(source) == [source]
+
+    assert sess.link_runtime_successor(source, child)
+    assert sess.runtime_lineage(source) == [source, child]
+
+
+def test_runtime_index_cache_detects_same_size_mtime_atomic_replace(
+    app_module,
+):
+    from backend import sessions as sess
+
+    original_sid = sess.create_session("cache-external-replace")["id"]
+    replacement_sid = "11111111-2222-4333-8444-555555555555"
+    assert sess.runtime_lineage(original_sid) == [original_sid]
+
+    original_stat = sess.INDEX.stat()
+    rows = json.loads(sess.INDEX.read_text(encoding="utf-8"))
+    row = next(row for row in rows if row["id"] == original_sid)
+    row["id"] = replacement_sid
+    replacement = sess.INDEX.with_suffix(".replacement")
+    replacement.write_text(
+        json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf-8",
+    )
+    os.utime(
+        replacement,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    os.replace(replacement, sess.INDEX)
+    replaced_stat = sess.INDEX.stat()
+    assert replaced_stat.st_size == original_stat.st_size
+    assert replaced_stat.st_mtime_ns == original_stat.st_mtime_ns
+    assert replaced_stat.st_ino != original_stat.st_ino
+
+    assert sess.runtime_lineage(original_sid) == []
+    assert sess.runtime_lineage(replacement_sid) == [replacement_sid]
+
+
 def test_runtime_lineage_authority_uses_earliest_owner_snapshot(app_module):
     from backend import sessions as sess
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -236,6 +236,91 @@ def test_runtime_task_overlay_bounds_summary_on_write(app_module):
     assert raw["runtime_task_overlays"]["task-long"] == overlay
 
 
+def test_running_runtime_task_ids_cache_one_overlay_parse_per_generation(
+    app_module, monkeypatch,
+):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-summary-cache")["id"]
+    assert sess.set_runtime_task_overlay(
+        sid, "task-running", state="running",
+    )
+    sess._drop_running_runtime_task_ids_cache(sid)
+    real_load = sess._load_runtime_task_overlays_section
+    loads = 0
+
+    def counted_load(load_sid):
+        nonlocal loads
+        loads += 1
+        return real_load(load_sid)
+
+    monkeypatch.setattr(
+        sess, "_load_runtime_task_overlays_section", counted_load,
+    )
+    expected = {sid: frozenset({"task-running"})}
+    assert sess.running_runtime_task_ids((sid, sid)) == expected
+    assert sess.running_runtime_task_ids((sid,)) == expected
+    assert loads == 1
+
+
+def test_sidecar_save_refreshes_running_task_summary_without_reread(
+    app_module, monkeypatch,
+):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-summary-refresh")["id"]
+    assert sess.set_runtime_task_overlay(sid, "task-1", state="running")
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset({"task-1"})
+
+    monkeypatch.setattr(
+        sess,
+        "_load_runtime_task_overlays_section",
+        lambda _sid: pytest.fail("a successful sidecar save must prime summary"),
+    )
+    assert sess.set_runtime_task_overlay(sid, "task-1", state="completed")
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset()
+
+
+def test_sidecar_caches_detect_same_size_mtime_atomic_replace(app_module):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-external-replace")["id"]
+    original = {
+        "messages": {"message-1": {"model": "old"}},
+        "runtime_task_overlays": {
+            "task-1": {"task_id": "task-1", "state": "running"},
+        },
+    }
+    replacement = {
+        "messages": {"message-1": {"model": "new"}},
+        "runtime_task_overlays": {
+            "task-1": {"task_id": "task-1", "state": "stopped"},
+        },
+    }
+    sess._save_sidecar(sid, original)
+    assert sess._load_sidecar(sid)["messages"]["message-1"]["model"] == "old"
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset({"task-1"})
+
+    path = sess._sidecar_path(sid)
+    original_stat = path.stat()
+    serialized = json.dumps(replacement, ensure_ascii=False)
+    assert len(serialized.encode("utf-8")) == original_stat.st_size
+    replacement_path = path.with_suffix(".replacement")
+    replacement_path.write_text(serialized, encoding="utf-8")
+    os.utime(
+        replacement_path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    os.replace(replacement_path, path)
+    replaced_stat = path.stat()
+    assert replaced_stat.st_size == original_stat.st_size
+    assert replaced_stat.st_mtime_ns == original_stat.st_mtime_ns
+    assert replaced_stat.st_ino != original_stat.st_ino
+
+    assert sess._load_sidecar(sid)["messages"]["message-1"]["model"] == "new"
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset()
+
+
 def test_runtime_task_overlay_legacy_summary_is_bounded_then_compacted(app_module):
     from backend import sessions as sess
     from backend.task_summaries import TASK_SUMMARY_PREVIEW_CAP

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -487,6 +487,51 @@ def test_runtime_lineages_cache_one_parse_per_index_generation(
     assert loads == 1
 
 
+def test_runtime_successor_redirects_resolve_only_final_public_target(
+    app_module,
+):
+    from backend import sessions as sess
+
+    source = sess.create_session("redirect-source")["id"]
+    child = sess.create_session("redirect-child")["id"]
+    grandchild = sess.create_session("redirect-grandchild")["id"]
+    unrelated = sess.create_session("redirect-unrelated")["id"]
+    assert sess.link_runtime_successor(source, child)
+    assert sess.link_runtime_successor(child, grandchild)
+
+    assert sess.runtime_successor_redirects(
+        (source, child, grandchild, unrelated, "missing", source)
+    ) == {
+        source: grandchild,
+        child: grandchild,
+    }
+
+
+def test_session_list_repairs_hidden_open_tab_to_runtime_successor(
+    client, auth, app_module,
+):
+    from backend import sessions as sess
+
+    source = sess.create_session("hidden-open-source")["id"]
+    child = sess.create_session("hidden-open-child")["id"]
+    target = sess.create_session("visible-open-target")["id"]
+    assert sess.link_runtime_successor(source, child)
+    assert sess.link_runtime_successor(child, target)
+    newest = sess.create_session("newer-first-page-row")["id"]
+
+    response = client.get(
+        f"/api/chat/sessions?limit=1&ids={source}", headers=auth,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["session_redirects"] == {source: target}
+    returned_ids = [row["id"] for row in body["sessions"]]
+    assert returned_ids == [newest, target]
+    assert source not in returned_ids
+    assert child not in returned_ids
+
+
 def test_runtime_index_cache_never_shares_rows_with_mutators(app_module):
     from backend import sessions as sess
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1279,6 +1279,24 @@ def _sdk_session_info(sid: str, *, title: str | None = None):
     )
 
 
+def test_explicit_local_rename_beats_stale_sdk_title_cache(app_module):
+    from backend import sessions as sess
+
+    sid = "11111111-2222-4333-8444-555555555555"
+    merged = sess._merge_sdk_with_index(
+        _sdk_session_info(sid, title="stale sdk title"),
+        {"name": "manual title", "auto_named": False},
+    )
+    automatic = sess._merge_sdk_with_index(
+        _sdk_session_info(sid, title="fresh sdk title"),
+        {"name": "local fallback", "auto_named": True},
+    )
+
+    assert merged["name"] == "manual title"
+    assert merged["auto_named"] is False
+    assert automatic["name"] == "fresh sdk title"
+
+
 def _wait_for_list_refresh(sess, timeout: float = 2.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:


### PR DESCRIPTION
## 变更

- 仅缓存只读的 runtime lineage 投影；普通索引读改写继续使用独立的新鲜对象，并按 dev、inode、mtime_ns、size 失效。
- multiplex reconcile 在 worker 线程一次批量取得 lineage 与 running task 摘要，不再每 200ms 为候选会话重复解析完整 index 或大型 sidecar。
- sidecar 摘要按文件代际缓存，写盘后直接刷新；原子替换和同大小同 mtime 场景由 inode 与纳秒时间识别。
- 会话列表为 localStorage 中的隐藏 runtime predecessor 返回最终 public successor。前端原位修复 Tab 顺序、当前会话、草稿、上传对象及任务中心会话引用，支持多跳 successor。
- 会话改名自动落到最终 runtime；显式 MuseLab 名称在 SDK 列表缓存短暂陈旧时保持权威，前端在请求期间防止旧列表回滚名称。

## Commit

- 41ed84a 安全隔离 runtime index 投影缓存
- c99e8f9 避免 reconcile 热循环解析大型 sidecar
- 407dce8 持久恢复 runtime successor 会话页签与任务中心联动
- 9dc6ec5 保证会话改名落到最终 runtime

## 验证

- pytest -n 4 -q：1685 passed，162 skipped
- 定向后端与前端回归：97 passed、363 passed
- Playwright：硬刷新 successor Tab/草稿恢复、改名后硬刷新持久化均通过
- node --check frontend/app.js
- 本次改动文件 Ruff 全部通过
- runtime index 缓存基准约 136.9x（缓存命中路径）

完整 CI 全绿后再合入。