### PR TITLE
fix(chat): 后台任务期间可靠补齐最终回复

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8419,6 +8419,7 @@ function portal() {
           inheritedTicksLeft: 0,
           inheritedSourceSid: "",
           canonicalStartedAt: 0,
+          canonicalRetryN: 0,
         },
         _backgroundHandoffPromise: null,
         // Runtime rollover replaces the source tabState while a queue POST can
@@ -8678,10 +8679,14 @@ function portal() {
           pending: Object.create(null), timer: null, inFlight: null, epoch: 0,
           backgroundTicksLeft: 0, inheritedTicksLeft: 0, inheritedSourceSid: "",
           canonicalStartedAt: 0,
+          canonicalRetryN: 0,
         };
       }
       if (!st.sessionSync.pending || typeof st.sessionSync.pending !== "object") {
         st.sessionSync.pending = Object.create(null);
+      }
+      if (!Number.isFinite(Number(st.sessionSync.canonicalRetryN))) {
+        st.sessionSync.canonicalRetryN = 0;
       }
       if (st._backgroundHandoffPromise === undefined) {
         st._backgroundHandoffPromise = null;
@@ -10393,6 +10398,39 @@ function portal() {
         && (!m.task_status.owner_session_id
           || m.task_status.owner_session_id === sid));
     },
+    _refreshBackgroundCanonicalHistory(sid, st, options = {}) {
+      if (!sid || !st || this.tabState[sid] !== st) return false;
+      const watcherTurnId = String(options.turnId || "");
+      const ownedTurnId = String(st.activeTurnId || "");
+      // A delayed watcher-only frame for turn A must never retire the live
+      // transport of its already-admitted successor B.
+      if ((st.streaming || st.es) && watcherTurnId && ownedTurnId
+          && watcherTurnId !== ownedTurnId) return false;
+
+      // active=true + background=true + attachable=false is an authoritative
+      // SDK boundary: the foreground Result has landed and canonical history
+      // is readable, while only the background watcher still owns the runtime.
+      // If `done` was lost, retire that stale logical transport and use the
+      // same quiet history path as a manual refresh instead of waiting for the
+      // background task itself to settle.
+      if (st.streaming || st.es) this._retireStaleSessionStream(sid, st);
+      if (watcherTurnId && !st.activeTurnId) st.activeTurnId = watcherTurnId;
+      st._serverActiveObserved = true;
+      this._setBackgroundTaskActive(
+        sid, true, options.startedAt, options.pendingCount,
+      );
+      st._pendingExternalUpdate = true;
+      const sync = st.sessionSync;
+      const alreadyQueued = sync.inFlight?.reason === "history_revision"
+        || !!sync.pending?.history_revision;
+      if (!alreadyQueued) st._reconcileRetryN = 0;
+      void this._requestSessionSync(sid, "history_revision", {
+        targetUpdated: Number(st._reconcileTargetUpdated) || 0,
+        delayMs: Math.max(0, Number(options.delayMs) || 0),
+      });
+      this._ensureBgContPoller(sid);
+      return true;
+    },
     _ensureBgContPoller(sid) {
       const st = sid && this.tabState[sid];
       if (!st || (!this._bgHasRunningCard(sid) && !st.backgroundActive)) return;
@@ -10458,30 +10496,15 @@ function portal() {
       if (options.signal?.aborted) return false;
       if (this.tabState[sid] !== st) return false;
       sync.backgroundTickN = (Number(sync.backgroundTickN) || 0) + 1;
+      // The old fallback fetched the same canonical tail but copied only task
+      // states. Reuse the full quiet refresh chain so a Result/final assistant
+      // block missed by live SSE converges too. The 32 s cadence is unchanged.
       if (!contFound && sync.backgroundTickN % 16 === 0) {
-        try {
-          const hr = await this._fetchWithDeadline(
-            "/api/chat/sessions/" + sid + "?tail=80",
-            { headers: this.hdr(), signal: options.signal },
-          );
-          if (hr.ok) {
-            const hs = await hr.json();
-            if (this.tabState[sid] !== st) return false;
-            const settled = {};
-            (hs.messages || []).forEach(m => {
-              if (m && m.role === "tool_use" && m.id && m.task_status
-                  && m.task_status.state && m.task_status.state !== "running") {
-                settled[m.id] = m.task_status;
-              }
-            });
-            st.messages.forEach(m => {
-              if (m && m.role === "tool_use" && m.task_status
-                  && m.task_status.state === "running" && settled[m.id]) {
-                m.task_status = Object.assign({}, m.task_status, settled[m.id]);
-              }
-            });
-          }
-        } catch (_) { /* retry on the next fallback cadence */ }
+        this._refreshBackgroundCanonicalHistory(sid, st, {
+          turnId: st.activeTurnId,
+          startedAt: st._streamStartedAt / 1000,
+          pendingCount: st.backgroundTaskCount,
+        });
       }
       again();
       return true;
@@ -11698,11 +11721,17 @@ function portal() {
       }
       if (payload.attachable === false) {
         // Watcher-only ownership has no replayable turn yet. Preserve its blue
-        // dot/background state, but do not create a reducer runtime until the
-        // continuation broadcast becomes attachable.
-        if (existingState && !existingState.streaming) {
-          this._setBackgroundTaskActive(
-            sid, true, payload.started_at, payload.background_tasks_pending);
+        // dot/background state, and pull the completed foreground Result from
+        // canonical history even though the watcher keeps aggregate active=true.
+        if (existingState && payload.background) {
+          this._refreshBackgroundCanonicalHistory(sid, existingState, {
+            turnId,
+            startedAt: payload.started_at,
+            pendingCount: payload.background_tasks_pending,
+          });
+        } else if (existingState && !existingState.streaming) {
+          this._setBackgroundTaskActive(sid, true, payload.started_at,
+            payload.background_tasks_pending);
         }
         return;
       }
@@ -12243,16 +12272,11 @@ function portal() {
         if (d.active) {
           st._serverActiveObserved = true;
           if (d.background && d.attachable === false) {
-            try { if (st.es) st.es.close(); } catch (_) {}
-            if (st._stallWatch) clearInterval(st._stallWatch);
-            st._stallWatch = null;
-            st.es = null;
-            st.streaming = false;
-            st.streamPhase = "";
-            this._setBackgroundTaskActive(
-              sid, true, d.started_at, d.background_tasks_pending);
-            this._ensureBgContPoller(sid);
-            return true;
+            return this._refreshBackgroundCanonicalHistory(sid, st, {
+              turnId: d.turn_id,
+              startedAt: d.started_at,
+              pendingCount: d.background_tasks_pending,
+            });
           }
           const silenceMs = Date.now() - (Number(st._lastSseActivity)
             || Number(st._streamStartedAt) || Date.now());
@@ -12300,6 +12324,7 @@ function portal() {
       st._canonicalResyncPending = true;
       if (!st.sessionSync.canonicalStartedAt) {
         st.sessionSync.canonicalStartedAt = Date.now();
+        st.sessionSync.canonicalRetryN = 0;
       }
       this._requestSessionSync(sid, "canonical_replay", {
         minimumWaitMs, delayMs: 250,
@@ -12328,23 +12353,37 @@ function portal() {
         });
         return true;
       }
+      const retryN = Math.max(
+        0, Number(st.sessionSync.canonicalRetryN) || 0);
       this._retireStaleSessionStream(sid, st);
       st._pendingExternalUpdate = true;
       const loaded = await this.loadSession(sid, {
         quiet: true, signal: options.signal,
       });
       if (this.tabState[sid] !== st) return false;
-      st._canonicalResyncPending = false;
-      st.sessionSync.canonicalStartedAt = 0;
       if (loaded) {
+        st._canonicalResyncPending = false;
+        st.sessionSync.canonicalStartedAt = 0;
+        st.sessionSync.canonicalRetryN = 0;
         st._loaded = true;
         st._pendingExternalUpdate = false;
         this._syncQueueFromServer(sid);
         this.$nextTick(() => this._drainPendingQueue(
           sid, st.activeTurnId || "",
         ));
+        return true;
       }
-      return !!loaded;
+      // A slow/busy backend can make the first quiet load hit its deadline.
+      // Keep the recovery obligation alive; otherwise the only remaining path
+      // to the persisted final reply is a full page refresh.
+      st._canonicalResyncPending = true;
+      st.sessionSync.canonicalStartedAt = startedAt;
+      st.sessionSync.canonicalRetryN = retryN + 1;
+      this._requestSessionSync(sid, "canonical_replay", {
+        minimumWaitMs,
+        delayMs: Math.min(10_000, 500 * (2 ** Math.min(retryN, 4))),
+      });
+      return false;
     },
 
     _retireStaleSessionStream(sid, st) {
@@ -12541,16 +12580,18 @@ function portal() {
         const seen = Number(st._seenUpdated);
         const hasSeen = st._seenUpdated !== undefined && Number.isFinite(seen);
         const stillBehind = targetUpdated > 0 && (!hasSeen || targetUpdated > seen);
-        if (stillBehind) st._pendingExternalUpdate = true;
+        const needsRetry = !succeeded || stillBehind;
+        if (needsRetry) st._pendingExternalUpdate = true;
         else if (succeeded) st._pendingExternalUpdate = false;
         const retries = Number(st._reconcileRetryN) || 0;
-        if (!stillBehind) st._reconcileRetryN = 0;
-        if (succeeded && stillBehind && !st.streaming && !st.es && retries < 6) {
+        if (!needsRetry) st._reconcileRetryN = 0;
+        if (needsRetry && !st.streaming && !st.es && retries < 30) {
           st._reconcileRetryN = retries + 1;
           this._requestSessionSync(sid, "history_revision", {
             attach: !!options.attach,
             targetUpdated,
-            delayMs: Math.min(2000, 250 * (retries + 1)),
+            delayMs: Math.min(
+              10_000, 500 * (2 ** Math.min(retries, 4))),
           });
         }
       }
@@ -17508,12 +17549,11 @@ function portal() {
           }
         }
         if (d.active && d.background && d.attachable === false) {
-          st._serverActiveObserved = true;
-          if (d.turn_id) st.activeTurnId = d.turn_id;
-          this._setBackgroundTaskActive(
-            sid, true, d.started_at, d.background_tasks_pending);
-          this._ensureBgContPoller(sid);
-          return;
+          return this._refreshBackgroundCanonicalHistory(sid, st, {
+            turnId: d.turn_id,
+            startedAt: d.started_at,
+            pendingCount: d.background_tasks_pending,
+          });
         }
         if (d.active && !st.streaming && !st.es) {
           st._serverActiveObserved = true;
@@ -33866,10 +33906,15 @@ function portal() {
               // Main ResultMessage landed while this transport was down, but
               // its SDK background task still owns the session reader. There
               // is no broadcast to attach to yet: preserve the running footer
-              // and let the continuation poller discover the next broadcast.
+              // and pull the completed Result from canonical history while the
+              // continuation poller discovers the next broadcast.
               _markDone(false, true, true);
               _stopTimer();
-              this._ensureBgContPoller(streamSid);
+              this._refreshBackgroundCanonicalHistory(streamSid, streamState, {
+                turnId: d.turn_id,
+                startedAt: d.started_at,
+                pendingCount: d.background_tasks_pending,
+              });
               return;
             }
             // Re-subscribe via the existing reconnect plumbing.

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -485,7 +485,15 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
           const app = document.querySelector('#app')._x_dataStack[0];
           const sid = app.currentId;
           const st = app._ensureTabState(sid);
-          const meta = app.sessions.find(session => session.id === sid);
+          // Activity expectations replace the session row immutably. Always
+          // observe and update the current row instead of retaining a stale
+          // object from before the first inactive frame.
+          const sessionMeta = () => app.sessions.find(session => session.id === sid);
+          const setMetaActive = active => {
+            const current = sessionMeta();
+            if (current) current.active = active;
+          };
+          const metaActive = () => sessionMeta() && sessionMeta().active;
           const originalReload = app._scheduleCanonicalStreamReload;
           let reloads = 0;
           app._scheduleCanonicalStreamReload = () => { reloads += 1; return true; };
@@ -496,7 +504,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
             st.streamPhase = '';
             st.activeTurnId = '';
             st.es = null;
-            if (meta) meta.active = true;
+            setMetaActive(true);
 
             // A fast server-drained queue turn can start and finish before this
             // browser ever owns its mux channel. Its inactive aggregate frame is
@@ -511,7 +519,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
               activeTurnId: st.activeTurnId,
               reloads,
               text: st.messages[0] && st.messages[0].text,
-              metaActive: meta && meta.active,
+              metaActive: metaActive(),
             };
 
             st.streaming = true;
@@ -524,7 +532,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
             st.streamElapsed = 5;
             st._streamTimer = setInterval(() => {}, 1000);
             st._stallWatch = setInterval(() => {}, 1000);
-            if (meta) meta.active = true;
+            setMetaActive(true);
 
             window.__emitMux('session_state', {
               session_id: sid, turn_id: 'turn-a', active: false,
@@ -541,7 +549,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
               elapsed: st.streamElapsed,
               reloads,
               text: st.messages[0] && st.messages[0].text,
-              metaActive: meta && meta.active,
+              metaActive: metaActive(),
             };
 
             st.streaming = true;
@@ -552,7 +560,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
             app._activateChatMuxChannel(st.es);
             st._streamTimer = setInterval(() => {}, 1000);
             st._stallWatch = setInterval(() => {}, 1000);
-            if (meta) meta.active = true;
+            setMetaActive(true);
             const successorEs = st.es;
             const successorTimer = st._streamTimer;
 
@@ -568,7 +576,7 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
               sameTimer: st._streamTimer === successorTimer,
               activeTurnId: st.activeTurnId,
               reloads,
-              metaActive: meta && meta.active,
+              metaActive: metaActive(),
             };
             clearInterval(st._streamTimer);
             clearInterval(st._stallWatch);
@@ -606,6 +614,189 @@ def test_mux_inactive_retires_matching_turn_without_harming_successor(
         "activeTurnId": "turn-b",
         "reloads": 2,
         "metaActive": True,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_mux_background_watcher_refreshes_final_after_history_retry(
+    page: Page, backend_url, auth_token,
+):
+    """Watcher-only activity pulls a missed Result without a page refresh."""
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    page.route(
+        "**/api/chat/stream/mux/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "mux-background-canonical-retry"}),
+        ),
+    )
+    sid = "mux-background-canonical-retry"
+    turn_id = "turn-background-canonical-retry"
+    final_marker = "BACKGROUND_FINAL_VISIBLE_WITHOUT_REFRESH"
+    canonical_messages = [
+        {
+            "role": "user",
+            "text": "run a background task",
+            "uuid": "background-retry-user",
+            "_turnId": turn_id,
+        },
+        {
+            "role": "tool_use",
+            "id": "background-retry-task",
+            "name": "Bash",
+            "summary": "long background work",
+            "uuid": "background-retry-tool",
+            "task_status": {
+                "state": "running",
+                "owner_session_id": sid,
+            },
+        },
+        {
+            "role": "assistant",
+            "text": final_marker,
+            "html": f"<p>{final_marker}</p>",
+            "uuid": "background-retry-assistant",
+            "turn_status": "completed",
+        },
+    ]
+    history_requests: list[str] = []
+
+    def handle_history(route):
+        history_requests.append(route.request.url)
+        if len(history_requests) == 1:
+            route.fulfill(
+                status=503,
+                content_type="application/json",
+                body=json.dumps({"detail": "transient history overload"}),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "id": sid,
+                "name": "Background canonical retry",
+                "model": "e2e-model",
+                "permission": "bypassPermissions",
+                "thinking": True,
+                "messages": canonical_messages,
+                "offset": 0,
+                "total": len(canonical_messages),
+                "has_more": False,
+                "history_order": "normal",
+                "history_generation": "background-retry-gen",
+                "updated_at": 2,
+            }),
+        )
+
+    page.route(f"**/api/chat/sessions/{sid}?*", handle_history)
+    page.route(
+        f"**/api/chat/sessions/{sid}/active*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "active": True,
+                "background": True,
+                "attachable": False,
+                "continuation": False,
+                "turn_id": turn_id,
+                "started_at": int(time.time()),
+                "background_tasks_pending": 1,
+            }),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+    _bootstrap_session_for_real_load(page, sid, "Background canonical retry")
+    _app_eval(
+        page,
+        """
+        const st = app._ensureTabState(arg.sid);
+        st._loaded = true;
+        st._seenUpdated = 1;
+        st._installedCanonicalCount = 2;
+        st.messages = [
+          {
+            role: "user", text: "run a background task",
+            uuid: "background-retry-user", _turnId: arg.turnId,
+            _k: `${arg.sid}:live:1`,
+          },
+          {
+            role: "tool_use", id: "background-retry-task", name: "Bash",
+            summary: "long background work", uuid: "background-retry-tool",
+            task_status: {state: "running", owner_session_id: arg.sid},
+            _k: `${arg.sid}:live:2`,
+          },
+        ];
+        st.messageRange.visibleStart = 0;
+        st.messageRange.visibleEnd = st.messages.length;
+        st.messageRange.total = st.messages.length;
+        st.streaming = true;
+        st.streamPhase = "running";
+        st.activeTurnId = arg.turnId;
+        st.es = app._chatMuxChannel(arg.sid, arg.turnId);
+        app._activateChatMuxChannel(st.es);
+        app._activateTabState(arg.sid);
+        window.__emitMux("session_state", {
+          session_id: arg.sid,
+          active: true,
+          background: true,
+          attachable: false,
+          continuation: false,
+          turn_id: arg.turnId,
+          started_at: Math.floor(Date.now() / 1000),
+          background_tasks_pending: 1,
+        });
+        return true;
+        """,
+        {"sid": sid, "turnId": turn_id},
+    )
+    page.wait_for_function(
+        """({sid, marker}) => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const st = app.tabState[sid];
+          const pane = document.querySelector(
+            `.msg-pane[data-tid="${CSS.escape(sid)}"]`);
+          return !st.streaming && !st.es && st.backgroundActive
+            && st.messages.some(message => message.text === marker)
+            && pane?.textContent.includes(marker)
+            && st._pendingExternalUpdate === false;
+        }""",
+        arg={"sid": sid, "marker": final_marker},
+        timeout=10000,
+    )
+    result = _app_eval(
+        page,
+        """
+        const st = app.tabState[arg];
+        const task = st.messages.find(message => message.id === "background-retry-task");
+        return {
+          streaming: st.streaming,
+          hasEs: !!st.es,
+          backgroundActive: st.backgroundActive,
+          backgroundTaskCount: st.backgroundTaskCount,
+          taskState: task?.task_status?.state || "",
+          finalText: st.messages.find(
+            message => message.uuid === "background-retry-assistant")?.text || "",
+          pendingExternal: st._pendingExternalUpdate,
+          retryN: st._reconcileRetryN,
+        };
+        """,
+        sid,
+    )
+    assert len(history_requests) >= 2
+    assert result == {
+        "streaming": False,
+        "hasEs": False,
+        "backgroundActive": True,
+        "backgroundTaskCount": 1,
+        "taskState": "running",
+        "finalText": final_marker,
+        "pendingExternal": False,
+        "retryN": 0,
     }
     _assert_no_browser_errors(page, errors)
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1078,7 +1078,9 @@ def test_chat_refresh_and_stats_requests_run_concurrently():
     assert "const stillBehind" in reconcile
     assert "st._pendingExternalUpdate = true" in reconcile
     assert 'this._requestSessionSync(sid, "history_revision"' in reconcile
-    assert "delayMs: Math.min(2000, 250 * (retries + 1))" in reconcile
+    assert "const needsRetry = !succeeded || stillBehind" in reconcile
+    assert "retries < 30" in reconcile
+    assert "10_000, 500 * (2 ** Math.min(retries, 4))" in reconcile
 
 
 def test_session_history_and_workspace_use_distinct_icons():
@@ -1268,7 +1270,7 @@ def test_session_synchronization_has_one_per_tab_coordinator():
     for field in (
         "pending: Object.create(null)", "timer: null", "inFlight: null",
         "epoch: 0", "backgroundTicksLeft: 0", "inheritedTicksLeft: 0",
-        'inheritedSourceSid: ""', "canonicalStartedAt: 0",
+        'inheritedSourceSid: ""', "canonicalStartedAt: 0", "canonicalRetryN: 0",
     ):
         assert field in state
     assert "if (sync.inFlight) return" in coordinator
@@ -1368,10 +1370,13 @@ def test_session_sync_transitions_preserve_canonical_and_view_ownership():
     assert 'delayMs: 2000' in inherited
     assert "this.tabState[sid] !== st" in background
     assert 'delayMs: 2000' in background
-    assert "st.messages.forEach" in background
+    assert "this._refreshBackgroundCanonicalHistory(sid, st" in background
     assert "quiet: true, probeActive: false" in revision
     assert "targetUpdated > seen" in revision
-    assert "delayMs: Math.min(2000, 250 * (retries + 1))" in revision
+    assert "const needsRetry = !succeeded || stillBehind" in revision
+    assert "retries < 30" in revision
+    assert "2 ** Math.min(retries, 4)" in revision
+    assert "st.messages.forEach" not in background
 
     # Synchronization changes only the canonical per-tab repository. Keep the
     # ordered messages + range model and composer ownership established earlier.
@@ -5664,8 +5669,10 @@ def test_midturn_reconnect_storm_guards_are_in_place():
     #    loop whenever the transcript never reaches the list's target revision,
     #    and every round costs a full ?tail= reload of the visible pane.
     assert "st._reconcileRetryN = retries + 1;" in reconcile
-    assert "&& retries < 6" in reconcile
-    assert "Math.min(2000, 250 * (retries + 1))" in reconcile
+    assert "&& retries < 30" in reconcile
+    assert "Math.min(" in reconcile
+    assert "10_000, 500 * (2 ** Math.min(retries, 4))" in reconcile
+    assert "const needsRetry = !succeeded || stillBehind" in reconcile
 
 
 def test_turn_busy_race_falls_back_to_durable_queue():


### PR DESCRIPTION
修复前台 Result 已落盘、后台任务仍运行且终止 SSE 丢失时，消息只能刷新页面后出现的问题。Watcher-only 状态现在复用规范历史刷新链路；首次历史加载失败会保留同步义务并指数重试，同时保持后台任务状态与后继 turn 的 ABA 保护。测试：RUN_E2E=1 uv run pytest -q -n 6 tests/test_frontend_lint.py tests/e2e/test_chat_render_perf.py（252 passed）。