### PR TITLE
perf: 消除运行时热循环的大文件 I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           mkdir -p $MUSELAB_ROOT
           uv run --with pytest-cov pytest tests/ -q \
+            -n auto --dist=worksteal \
             --cov=backend --cov-report=term-missing
 
   lint:

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1857,15 +1857,13 @@ def _runtime_task_overlay(
     if usage:
         fields["usage"] = dict(usage)
     try:
-        current = owner
-        seen: set[str] = set()
-        for _ in range(32):
-            if not current or current in seen:
-                break
-            seen.add(current)
+        lineage = sess.runtime_lineage(owner)
+        if owner in lineage:
+            targets = lineage[lineage.index(owner):]
+        else:
+            targets = [owner]
+        for current in targets:
             sess.set_runtime_task_overlay(current, tid, **fields)
-            current_meta = sess.get_session_meta(current) or {}
-            current = str(current_meta.get("runtime_successor") or "")
     except Exception as exc:
         sys.stderr.write(
             f"[chat] runtime task overlay failed sid={owner[:8]} "

--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -42,6 +42,8 @@ _QUEUE_LIMIT = 8
 _WATCH_DEBOUNCE_MS = 350
 _WATCH_STEP_MS = 100
 _WATCH_RETRY_S = 1.5
+_WATCH_RETRY_MAX_S = 10.0
+_WATCH_STABLE_RESET_S = 30.0
 _RECONCILE_RETRY_BASE_S = 0.25
 _RECONCILE_RETRY_MAX_S = 30.0
 _MAX_WATCHED_ROOTS = 16
@@ -124,6 +126,7 @@ class _WatchState:
     watch_ready: asyncio.Event = field(default_factory=asyncio.Event)
     watch_paths: tuple[Path, ...] = ()
     needs_closing_reconcile: bool = False
+    watch_failures: int = 0
     reconcile_pending: bool = False
     reconcile_running: bool = False
     reconcile_attempts: int = 0
@@ -137,6 +140,21 @@ class _WatchState:
     native_budget_wait_cost: int = 0
     native_watch_cost: int = 0
     native_budget_degraded: bool = False
+
+
+def _next_watch_retry_delay(
+    state: _WatchState,
+    armed_for_s: float,
+) -> float:
+    """Back off repeated broken generations without hiding watch gaps."""
+    if armed_for_s >= _WATCH_STABLE_RESET_S:
+        state.watch_failures = 0
+    state.watch_failures += 1
+    exponent = min(state.watch_failures - 1, 16)
+    return min(
+        _WATCH_RETRY_MAX_S,
+        _WATCH_RETRY_S * (2 ** exponent),
+    )
 
 
 @dataclass(frozen=True)
@@ -1848,6 +1866,7 @@ class FileWatchManager:
             budget_ready_task: asyncio.Task[bool] | None = None
             native_lease = False
             keep_budget_waiter = False
+            armed_at: float | None = None
             try:
                 revision = state.watch_revision
                 directories = await self._watch_directories(state)
@@ -1930,6 +1949,8 @@ class FileWatchManager:
                         except StopAsyncIteration:
                             break
                     else:
+                        if armed_at is None:
+                            armed_at = monotonic()
                         state.watch_paths = directories
                         state.watch_ready.set()
                         if state.needs_closing_reconcile:
@@ -1976,6 +1997,8 @@ class FileWatchManager:
 
                     # An immediately available successful batch also proves the
                     # generator installed/entered this watcher generation.
+                    if armed_at is None:
+                        armed_at = monotonic()
                     state.watch_paths = directories
                     state.watch_ready.set()
                     if state.needs_closing_reconcile:
@@ -2030,6 +2053,21 @@ class FileWatchManager:
                             reason="resource_exhaustion",
                             error_type=type(exc).__name__,
                         )
+                armed_for_s = (
+                    max(0.0, monotonic() - armed_at)
+                    if armed_at is not None else 0.0
+                )
+                retry_delay = _next_watch_retry_delay(
+                    state, armed_for_s,
+                )
+                _perf_event(
+                    "files.watcher_retry",
+                    workspace=short_id(state.workspace_id),
+                    error_type=type(exc).__name__,
+                    failures=state.watch_failures,
+                    delay_ms=round(retry_delay * 1000),
+                    armed_ms=round(armed_for_s * 1000),
+                )
                 # There is an uncovered interval between this failed generation
                 # and its replacement. Defer the closing reconciliation until
                 # the retry is genuinely armed, coalescing with any pass already
@@ -2037,7 +2075,7 @@ class FileWatchManager:
                 state.needs_closing_reconcile = True
                 state.watch_ready.clear()
                 state.watch_paths = ()
-                await asyncio.sleep(_WATCH_RETRY_S)
+                await asyncio.sleep(retry_delay)
             finally:
                 if next_batch is not None and not next_batch.done():
                     next_batch.cancel()

--- a/backend/hook_traces.py
+++ b/backend/hook_traces.py
@@ -5,12 +5,15 @@ small rendering projection: event kind, terminal status, exit code and timing.
 Raw commands, paths, stdout/stderr, HTTP bodies, headers and hook outputs never
 enter this store or its SSE payloads.
 """
+
 from __future__ import annotations
 
 import copy
 import hashlib
+from collections import OrderedDict
 import json
 import re
+import stat
 import threading
 import time
 import uuid
@@ -32,19 +35,32 @@ _MAX_TRACES = 256
 _SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 _SAFE_EVENT = re.compile(r"^[A-Za-z][A-Za-z0-9]{0,63}$")
 _HOOK_SUBTYPES = frozenset({"hook_started", "hook_progress", "hook_response"})
-_FAILURE_OUTCOMES = frozenset({
-    "error", "failed", "failure", "blocked", "cancelled", "canceled",
-})
-_lock = threading.RLock()
+_FAILURE_OUTCOMES = frozenset(
+    {
+        "error",
+        "failed",
+        "failure",
+        "blocked",
+        "cancelled",
+        "canceled",
+    }
+)
+
+# Hook progress can be very chatty and several sessions may stream it at once.
+# Keep disk I/O isolated per session instead of serialising every SDK stream on
+# one process-wide lock.  The small cache avoids reparsing the same bounded
+# projection for polling reads and for every lifecycle message.
+_TRACE_LOCKS = tuple(threading.RLock() for _ in range(64))
+_TraceSignature = tuple[int, int, int, int]
+_TRACE_CACHE: OrderedDict[str, tuple[_TraceSignature, tuple[dict[str, Any], ...]]] = OrderedDict()
+_TRACE_CACHE_LOCK = threading.Lock()
+_TRACE_CACHE_MAX = 128
 
 
 def is_hook_message(message: Any) -> bool:
-    return (
-        isinstance(message, HookEventMessage)
-        or (
-            isinstance(message, SystemMessage)
-            and str(getattr(message, "subtype", "") or "") in _HOOK_SUBTYPES
-        )
+    return isinstance(message, HookEventMessage) or (
+        isinstance(message, SystemMessage)
+        and str(getattr(message, "subtype", "") or "") in _HOOK_SUBTYPES
     )
 
 
@@ -91,11 +107,7 @@ def _hook_event_name(message: Any, data: Mapping[str, Any]) -> str:
 
 
 def _hook_identity(message: Any, data: Mapping[str, Any]) -> str:
-    return _opaque_id(
-        data.get("hook_id")
-        or data.get("id")
-        or getattr(message, "uuid", None)
-    )
+    return _opaque_id(data.get("hook_id") or data.get("id") or getattr(message, "uuid", None))
 
 
 def _exit_code(data: Mapping[str, Any]) -> int | None:
@@ -118,10 +130,77 @@ def _response_status(data: Mapping[str, Any], exit_code: int | None) -> str:
     return "succeeded"
 
 
+def _trace_lock(session_id: str) -> threading.RLock:
+    return _TRACE_LOCKS[hash(session_id) % len(_TRACE_LOCKS)]
+
+
+def _trace_signature(path: Path) -> _TraceSignature | None:
+    try:
+        file_stat = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(file_stat.st_mode):
+        return None
+    return (file_stat.st_dev, file_stat.st_ino, file_stat.st_mtime_ns, file_stat.st_size)
+
+
+def _cache_key(session_id: str) -> str:
+    # Tests and embedded deployments can relocate SESS_DIR while retaining a
+    # session id.  Key by the concrete store path so those roots never alias.
+    return str(_trace_path(session_id))
+
+
+def _drop_cache(session_id: str) -> None:
+    with _TRACE_CACHE_LOCK:
+        _TRACE_CACHE.pop(_cache_key(session_id), None)
+
+
+def _cached_traces(
+    session_id: str,
+    signature: _TraceSignature,
+) -> list[dict[str, Any]] | None:
+    key = _cache_key(session_id)
+    with _TRACE_CACHE_LOCK:
+        hit = _TRACE_CACHE.get(key)
+        if hit is None or hit[0] != signature:
+            if hit is not None:
+                _TRACE_CACHE.pop(key, None)
+            return None
+        _TRACE_CACHE.move_to_end(key)
+        return [copy.deepcopy(row) for row in hit[1]]
+
+
+def _store_cache(
+    session_id: str,
+    signature: _TraceSignature | None,
+    traces: list[dict[str, Any]],
+) -> None:
+    key = _cache_key(session_id)
+    with _TRACE_CACHE_LOCK:
+        if signature is None:
+            _TRACE_CACHE.pop(key, None)
+            return
+        _TRACE_CACHE[key] = (
+            signature,
+            tuple(copy.deepcopy(row) for row in traces[-_MAX_TRACES:]),
+        )
+        _TRACE_CACHE.move_to_end(key)
+        while len(_TRACE_CACHE) > _TRACE_CACHE_MAX:
+            _TRACE_CACHE.popitem(last=False)
+
+
 def _load_locked(session_id: str) -> list[dict[str, Any]]:
     path = _trace_path(session_id)
     if not ensure_private_regular_file(path):
+        _drop_cache(session_id)
         return []
+    signature = _trace_signature(path)
+    if signature is None:
+        _drop_cache(session_id)
+        return []
+    cached = _cached_traces(session_id, signature)
+    if cached is not None:
+        return cached
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -131,7 +210,9 @@ def _load_locked(session_id: str) -> list[dict[str, Any]]:
     traces = payload.get("traces")
     if not isinstance(traces, list):
         return []
-    return [copy.deepcopy(row) for row in traces[-_MAX_TRACES:] if isinstance(row, dict)]
+    loaded = [copy.deepcopy(row) for row in traces[-_MAX_TRACES:] if isinstance(row, dict)]
+    _store_cache(session_id, signature, loaded)
+    return loaded
 
 
 def _write_locked(session_id: str, traces: list[dict[str, Any]]) -> None:
@@ -141,9 +222,13 @@ def _write_locked(session_id: str, traces: list[dict[str, Any]]) -> None:
     }
     write_private_bytes(
         _trace_path(session_id),
-        (json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
-            "utf-8"
-        ),
+        (json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8"),
+    )
+    # Publish cache state only after the atomic durable write succeeds.
+    _store_cache(
+        session_id,
+        _trace_signature(_trace_path(session_id)),
+        traces,
     )
 
 
@@ -166,14 +251,15 @@ def observe(
     hook_event = _hook_event_name(message, data)
     now = max(0, int(observed_at_ms or time.time() * 1000))
     safe_origin = "background" if origin == "background" else "foreground"
+    safe_session_id = _safe_session_id(session_id)
 
-    with _lock:
-        traces = _load_locked(session_id)
+    with _trace_lock(safe_session_id):
+        traces = _load_locked(safe_session_id)
         trace = next(
             (
-                row for row in reversed(traces)
-                if row.get("trace_id") == trace_id
-                and row.get("status") == "running"
+                row
+                for row in reversed(traces)
+                if row.get("trace_id") == trace_id and row.get("status") == "running"
             ),
             None,
         )
@@ -218,21 +304,31 @@ def observe(
             trace["status"] = _response_status(data, exit_code)
             trace["exit_code"] = exit_code
             trace["finished_at_ms"] = now
-            trace["duration_ms"] = max(
-                0, now - int(trace.get("started_at_ms") or now)
-            )
+            trace["duration_ms"] = max(0, now - int(trace.get("started_at_ms") or now))
             trace["updated_at_ms"] = now
             if not trace.get("turn_id"):
                 trace["turn_id"] = _bounded_turn_id(turn_id)
             trace["origin"] = safe_origin
 
-        _write_locked(session_id, traces)
+        if subtype == "hook_progress":
+            # Progress carries no persisted output and changes only a heartbeat
+            # timestamp.  Keep it live in the bounded cache/SSE projection;
+            # hook_started and hook_response remain the durable boundaries.
+            # This turns an unbounded progress stream into zero disk writes.
+            _store_cache(
+                safe_session_id,
+                _trace_signature(_trace_path(safe_session_id)),
+                traces,
+            )
+        else:
+            _write_locked(safe_session_id, traces)
         return copy.deepcopy(trace)
 
 
 def list_traces(session_id: str, *, turn_id: str = "") -> list[dict[str, Any]]:
-    with _lock:
-        traces = _load_locked(session_id)
+    safe_session_id = _safe_session_id(session_id)
+    with _trace_lock(safe_session_id):
+        traces = _load_locked(safe_session_id)
     if turn_id:
         safe_turn = _bounded_turn_id(turn_id)
         if not safe_turn:
@@ -242,10 +338,12 @@ def list_traces(session_id: str, *, turn_id: str = "") -> list[dict[str, Any]]:
 
 
 def purge(session_id: str) -> bool:
-    path = _trace_path(session_id)
-    with _lock:
+    safe_session_id = _safe_session_id(session_id)
+    path = _trace_path(safe_session_id)
+    with _trace_lock(safe_session_id):
         kind = private_path_kind(path)
         if kind == "missing":
+            _drop_cache(safe_session_id)
             return False
         if kind != "file":
             return False
@@ -253,4 +351,5 @@ def purge(session_id: str) -> bool:
             path.unlink()
         except OSError:
             return False
+        _drop_cache(safe_session_id)
         return True

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -32,6 +32,7 @@ from collections.abc import Iterable
 import json
 import os
 import re
+import stat
 import sys
 import threading
 import time
@@ -48,6 +49,11 @@ from typing import Any, get_args
 from claude_agent_sdk import list_sessions as sdk_list_sessions
 from claude_agent_sdk import get_session_info as sdk_get_session_info
 from claude_agent_sdk.types import PermissionMode
+from .private_storage import (
+    ensure_private_regular_file,
+    private_path_kind,
+    write_private_bytes,
+)
 from .settings import ROOT, atomic_write_text
 from .task_summaries import normalize_task_summary_fields
 from .workspaces import registry as workspace_registry
@@ -245,6 +251,10 @@ def _sidecar_path(sid: str) -> Path:
     return SESS_DIR / f"{sid}.sidecar.json"
 
 
+def _runtime_task_overlay_path(sid: str) -> Path:
+    return SESS_DIR / "runtime-task-overlays" / f"{sid}.json"
+
+
 # Multiplex reconciliation needs only the runtime predecessor/successor graph.
 # Cache that private, read-only projection rather than the mutable list returned
 # by _load_index(): index mutators edit row dicts in place before _save_index,
@@ -414,6 +424,19 @@ _SidecarSignature = tuple[int, int, int, int]
 _SIDECAR_CACHE: dict[str, tuple[_SidecarSignature, dict]] = {}
 _SIDECAR_CACHE_MAX = 64
 
+# Runtime task state changes frequently while a background task is active. It
+# must not share the annotation sidecar, which can contain megabytes of image
+# payloads. A separate private file keeps every lifecycle update proportional
+# to the small task projection. Reads and writes for distinct sessions do not
+# share the annotation sidecar's process-wide mutation lock.
+_RUNTIME_TASK_OVERLAY_SCHEMA_VERSION = 1
+_RUNTIME_TASK_OVERLAY_LOCKS = tuple(threading.RLock() for _ in range(64))
+_RUNTIME_TASK_OVERLAY_CACHE: dict[
+    str, tuple[_SidecarSignature, dict[str, dict]]
+] = {}
+_RUNTIME_TASK_OVERLAY_CACHE_LOCK = threading.Lock()
+_RUNTIME_TASK_OVERLAY_CACHE_MAX = 256
+
 # Multiplex reconciliation needs only the ids of durable runtime tasks whose
 # overlay is still running. Keeping that tiny immutable projection separately
 # prevents the 64-entry full-sidecar cache from forcing repeated reads of MB-
@@ -428,10 +451,29 @@ _RUNNING_RUNTIME_TASK_IDS_CACHE_MAX = 4096
 
 def _sidecar_file_signature(path: Path) -> _SidecarSignature | None:
     try:
-        st = path.stat()
-    except FileNotFoundError:
+        st = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode):
         return None
     return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _runtime_task_overlay_lock(sid: str) -> threading.RLock:
+    return _RUNTIME_TASK_OVERLAY_LOCKS[
+        hash(sid) % len(_RUNTIME_TASK_OVERLAY_LOCKS)
+    ]
+
+
+def _runtime_task_overlay_source_signature(
+    sid: str,
+) -> _SidecarSignature | None:
+    # Once the dedicated store exists it is authoritative. The legacy sidecar
+    # remains a read-only fallback so rollback/restart never destroys old data.
+    signature = _sidecar_file_signature(_runtime_task_overlay_path(sid))
+    if signature is not None:
+        return signature
+    return _sidecar_file_signature(_sidecar_path(sid))
 
 
 def _running_runtime_task_ids_from_data(data: Any) -> frozenset[str]:
@@ -470,13 +512,18 @@ def _store_running_runtime_task_ids_cache(
         _RUNNING_RUNTIME_TASK_IDS_CACHE[sid] = (signature, task_ids)
 
 
-def _refresh_running_runtime_task_ids_cache(sid: str, data: dict) -> None:
-    signature = _sidecar_file_signature(_sidecar_path(sid))
+def _refresh_running_runtime_task_ids_cache(
+    sid: str,
+    overlays: Any,
+    signature: _SidecarSignature | None,
+) -> None:
     if signature is None:
         _drop_running_runtime_task_ids_cache(sid)
         return
     _store_running_runtime_task_ids_cache(
-        sid, signature, _running_runtime_task_ids_from_data(data),
+        sid,
+        signature,
+        _running_runtime_task_ids_from_data({"runtime_task_overlays": overlays}),
     )
 
 
@@ -492,7 +539,10 @@ def _load_sidecar(sid: str, *, use_cache: bool = True) -> dict:
     sig = _sidecar_file_signature(p)
     if sig is None:
         _SIDECAR_CACHE.pop(sid, None)
-        _drop_running_runtime_task_ids_cache(sid)
+        if _sidecar_file_signature(
+            _runtime_task_overlay_path(sid)
+        ) is None:
+            _drop_running_runtime_task_ids_cache(sid)
         return {"messages": {}}
     if use_cache:
         hit = _SIDECAR_CACHE.get(sid)
@@ -521,10 +571,15 @@ def _save_sidecar(sid: str, data: dict) -> None:
     # Drop rather than refresh: the next _load_sidecar re-stats and caches
     # the just-written file, keeping cache state derived purely from disk.
     _SIDECAR_CACHE.pop(sid, None)
-    # The hot reconcile projection is immutable and derived from the exact
-    # object just serialized successfully, so refresh it without rereading the
-    # potentially large sidecar on the next 200 ms tick.
-    _refresh_running_runtime_task_ids_cache(sid, data)
+    # Before a legacy overlay is migrated, annotation writes still change its
+    # source generation. Once the dedicated file exists, ordinary sidecar
+    # writes must neither invalidate nor overwrite the authoritative summary.
+    if _sidecar_file_signature(_runtime_task_overlay_path(sid)) is None:
+        _refresh_running_runtime_task_ids_cache(
+            sid,
+            data.get("runtime_task_overlays"),
+            _sidecar_file_signature(_sidecar_path(sid)),
+        )
 
 
 def indexed_session_ids() -> set[str]:
@@ -1125,6 +1180,9 @@ def delete_session(sid: str) -> bool:
                         removed = True
                     except OSError:
                         pass
+            with _runtime_task_overlay_lock(sid):
+                if _delete_runtime_task_overlays(sid):
+                    removed = True
             for path in (
                 SESS_DIR / f"{sid}.transcript-index.json",
                 _queue_path(sid),
@@ -1225,6 +1283,8 @@ def prune_empty_sessions(keep_ids: tuple | list = ()) -> list[str]:
                         _drop_running_runtime_task_ids_cache(sid)
                     except OSError:
                         pass
+            with _runtime_task_overlay_lock(sid):
+                _delete_runtime_task_overlays(sid)
             q = _queue_path(sid)
             if q.exists():
                 try:
@@ -1715,6 +1775,13 @@ def _sidecar_has_runtime_task_overlays(sid: str) -> bool:
     deliberately return true so the authoritative loader still fails closed.
     """
     path = _sidecar_path(sid)
+    overlay_kind = private_path_kind(_runtime_task_overlay_path(sid))
+    if overlay_kind == "file":
+        return True
+    if overlay_kind != "missing":
+        # Preserve fail-closed startup behaviour for unsafe private paths.
+        return True
+
     overlap = len(_RUNTIME_TASK_OVERLAY_MARKER) - 1
     carry = b""
     try:
@@ -1773,6 +1840,133 @@ def _normalize_runtime_task_overlays(raw: Any) -> dict[str, dict]:
         if task_id and isinstance(value, dict)
     }
 
+def _runtime_task_overlay_cache_key(sid: str) -> str:
+    return str(_runtime_task_overlay_path(sid))
+
+
+def _drop_runtime_task_overlay_cache(sid: str) -> None:
+    with _RUNTIME_TASK_OVERLAY_CACHE_LOCK:
+        _RUNTIME_TASK_OVERLAY_CACHE.pop(
+            _runtime_task_overlay_cache_key(sid), None,
+        )
+
+
+def _cached_runtime_task_overlays(
+    sid: str,
+    signature: _SidecarSignature,
+) -> dict[str, dict] | None:
+    key = _runtime_task_overlay_cache_key(sid)
+    with _RUNTIME_TASK_OVERLAY_CACHE_LOCK:
+        hit = _RUNTIME_TASK_OVERLAY_CACHE.get(key)
+        if hit is None or hit[0] != signature:
+            if hit is not None:
+                _RUNTIME_TASK_OVERLAY_CACHE.pop(key, None)
+            return None
+        return _normalize_runtime_task_overlays(hit[1])
+
+
+def _store_runtime_task_overlay_cache(
+    sid: str,
+    signature: _SidecarSignature | None,
+    overlays: dict[str, dict],
+) -> None:
+    key = _runtime_task_overlay_cache_key(sid)
+    with _RUNTIME_TASK_OVERLAY_CACHE_LOCK:
+        if signature is None:
+            _RUNTIME_TASK_OVERLAY_CACHE.pop(key, None)
+            return
+        if (
+            len(_RUNTIME_TASK_OVERLAY_CACHE)
+            >= _RUNTIME_TASK_OVERLAY_CACHE_MAX
+            and key not in _RUNTIME_TASK_OVERLAY_CACHE
+        ):
+            _RUNTIME_TASK_OVERLAY_CACHE.pop(
+                next(iter(_RUNTIME_TASK_OVERLAY_CACHE)), None,
+            )
+        _RUNTIME_TASK_OVERLAY_CACHE[key] = (
+            signature,
+            _normalize_runtime_task_overlays(overlays),
+        )
+
+
+def _load_runtime_task_overlay_file(
+    sid: str,
+) -> dict[str, dict] | None:
+    path = _runtime_task_overlay_path(sid)
+    if not ensure_private_regular_file(path):
+        _drop_runtime_task_overlay_cache(sid)
+        return None
+    signature = _sidecar_file_signature(path)
+    if signature is None:
+        _drop_runtime_task_overlay_cache(sid)
+        return None
+    cached = _cached_runtime_task_overlays(sid, signature)
+    if cached is not None:
+        return cached
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"cannot parse runtime task overlay store: {path}"
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version")
+        != _RUNTIME_TASK_OVERLAY_SCHEMA_VERSION
+        or not isinstance(payload.get("runtime_task_overlays"), dict)
+    ):
+        raise RuntimeError(
+            f"cannot parse runtime task overlay store: {path}"
+        )
+    overlays = _normalize_runtime_task_overlays(
+        payload["runtime_task_overlays"],
+    )
+    _store_runtime_task_overlay_cache(sid, signature, overlays)
+    return overlays
+
+
+def _save_runtime_task_overlays(
+    sid: str,
+    overlays: dict[str, dict],
+) -> None:
+    normalized = _normalize_runtime_task_overlays(overlays)
+    payload = {
+        "schema_version": _RUNTIME_TASK_OVERLAY_SCHEMA_VERSION,
+        "runtime_task_overlays": normalized,
+    }
+    path = _runtime_task_overlay_path(sid)
+    write_private_bytes(
+        path,
+        (
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+            + "\n"
+        ).encode("utf-8"),
+    )
+    signature = _sidecar_file_signature(path)
+    _store_runtime_task_overlay_cache(sid, signature, normalized)
+    _refresh_running_runtime_task_ids_cache(
+        sid, normalized, signature,
+    )
+
+
+def _delete_runtime_task_overlays(sid: str) -> bool:
+    path = _runtime_task_overlay_path(sid)
+    kind = private_path_kind(path)
+    if kind == "missing":
+        _drop_runtime_task_overlay_cache(sid)
+        _drop_running_runtime_task_ids_cache(sid)
+        return False
+    if kind != "file":
+        return False
+    try:
+        path.unlink()
+    except OSError:
+        return False
+    _drop_runtime_task_overlay_cache(sid)
+    _drop_running_runtime_task_ids_cache(sid)
+    return True
+
+
 
 def _load_runtime_task_overlays_section(sid: str) -> dict[str, dict]:
     """Decode only the overlay object, not the sidecar's large message map."""
@@ -1798,6 +1992,28 @@ def _load_runtime_task_overlays_section(sid: str) -> dict[str, dict]:
         raise RuntimeError(f"cannot parse session sidecar: {path}") from exc
     return _normalize_runtime_task_overlays(value)
 
+def _migrate_legacy_runtime_task_overlays(sid: str) -> bool:
+    """Atomically promote one legacy embedded projection on a safe fence."""
+    with session_lifecycle_lock(sid):
+        with _QUEUE_LOCK:
+            if sid in _DELETED_SESSION_IDS:
+                return False
+        with _runtime_task_overlay_lock(sid):
+            kind = private_path_kind(_runtime_task_overlay_path(sid))
+            if kind == "file":
+                return False
+            if kind != "missing":
+                # The dedicated path is authoritative even when unsafe. Never
+                # overwrite it with a legacy snapshot.
+                ensure_private_regular_file(_runtime_task_overlay_path(sid))
+                return False
+            overlays = _load_runtime_task_overlays_section(sid)
+            if not overlays:
+                return False
+            _save_runtime_task_overlays(sid, overlays)
+            return True
+
+
 
 def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
     """Return UI-only background task cards keyed by task id.
@@ -1806,9 +2022,13 @@ def get_runtime_task_overlays(sid: str) -> dict[str, dict]:
     overlay lets their copied tool card reflect that process's lifecycle while
     remaining completely absent from model context.
     """
-    return _normalize_runtime_task_overlays(
-        _load_sidecar(sid).get("runtime_task_overlays") or {}
-    )
+    with _runtime_task_overlay_lock(sid):
+        dedicated = _load_runtime_task_overlay_file(sid)
+        if dedicated is not None:
+            return _normalize_runtime_task_overlays(dedicated)
+        return _normalize_runtime_task_overlays(
+            _load_runtime_task_overlays_section(sid),
+        )
 
 
 def _running_runtime_task_ids(sid: str) -> frozenset[str]:
@@ -1820,9 +2040,8 @@ def _running_runtime_task_ids(sid: str) -> frozenset[str]:
     stat plus a small set lookup and never retain the full sidecar payload.
     """
     latest = frozenset()
-    path = _sidecar_path(sid)
     for _attempt in range(2):
-        signature = _sidecar_file_signature(path)
+        signature = _runtime_task_overlay_source_signature(sid)
         if signature is None:
             _drop_running_runtime_task_ids_cache(sid)
             return frozenset()
@@ -1831,13 +2050,13 @@ def _running_runtime_task_ids(sid: str) -> frozenset[str]:
             if hit is not None and hit[0] == signature:
                 return hit[1]
 
-        overlays = _load_runtime_task_overlays_section(sid)
+        overlays = get_runtime_task_overlays(sid)
         latest = _running_runtime_task_ids_from_data({
             "runtime_task_overlays": overlays,
         })
-        if _sidecar_file_signature(path) != signature:
-            # An atomic external writer replaced the file while it was read.
-            # Retry once; never associate a snapshot with the wrong signature.
+        if _runtime_task_overlay_source_signature(sid) != signature:
+            # An atomic external writer replaced the authoritative store while
+            # it was read. Retry once; never cache under the wrong generation.
             continue
         _store_running_runtime_task_ids_cache(sid, signature, latest)
         return latest
@@ -1903,18 +2122,14 @@ def set_runtime_task_overlay(
         with _QUEUE_LOCK:
             if sid in _DELETED_SESSION_IDS:
                 return False
-        with _SIDECAR_LOCK:
-            data = _load_sidecar(sid, use_cache=False)
-            overlays = data.setdefault("runtime_task_overlays", {})
-            if not isinstance(overlays, dict):
-                overlays = {}
+        with _runtime_task_overlay_lock(sid):
+            overlays = get_runtime_task_overlays(sid)
             overlays_compacted = False
             if sid not in _RUNTIME_TASK_OVERLAY_COMPACTED_SIDS:
                 normalized_overlays = _normalize_runtime_task_overlays(overlays)
                 overlays_compacted = normalized_overlays != overlays
                 overlays = normalized_overlays
                 _RUNTIME_TASK_OVERLAY_COMPACTED_SIDS.add(sid)
-            data["runtime_task_overlays"] = overlays
             stored = overlays.get(task_id)
             current = dict(stored) if isinstance(stored, dict) else {
                 "task_id": task_id,
@@ -1984,7 +2199,7 @@ def set_runtime_task_overlay(
                 return False
             if target_changed:
                 overlays[task_id] = updated
-            _save_sidecar(sid, data)
+            _save_runtime_task_overlays(sid, overlays)
             return True
 
 
@@ -2081,15 +2296,11 @@ def _replace_runtime_task_overlay_snapshots(
         with _QUEUE_LOCK:
             if sid in _DELETED_SESSION_IDS:
                 return 0
-        with _SIDECAR_LOCK:
-            data = _load_sidecar(sid, use_cache=False)
-            overlays = data.setdefault("runtime_task_overlays", {})
-            if not isinstance(overlays, dict):
-                overlays = {}
+        with _runtime_task_overlay_lock(sid):
+            overlays = get_runtime_task_overlays(sid)
             normalized_overlays = _normalize_runtime_task_overlays(overlays)
             overlays_compacted = normalized_overlays != overlays
             overlays = normalized_overlays
-            data["runtime_task_overlays"] = overlays
             changed = 0
             for task_id, snapshot in snapshots.items():
                 replacement = normalize_task_summary_fields(snapshot)
@@ -2099,7 +2310,7 @@ def _replace_runtime_task_overlay_snapshots(
                 overlays[task_id] = replacement
                 changed += 1
             if changed or overlays_compacted:
-                _save_sidecar(sid, data)
+                _save_runtime_task_overlays(sid, overlays)
             return changed
 
 
@@ -2125,6 +2336,11 @@ def reconcile_runtime_task_overlay_chains() -> int:
     if not overlay_sids:
         return 0
 
+    # Each session migration is independently atomic and fenced against
+    # deletion. A crash simply leaves the remaining legacy files for the next
+    # startup; an existing dedicated file is never overwritten.
+    for overlay_sid in sorted(overlay_sids):
+        _migrate_legacy_runtime_task_overlays(overlay_sid)
     repaired = 0
     visited: set[str] = set()
     for indexed_sid in indexed_ids:
@@ -2138,7 +2354,7 @@ def reconcile_runtime_task_overlay_chains() -> int:
             continue
         overlays_by_sid = {
             row_sid: (
-                _load_runtime_task_overlays_section(row_sid)
+                get_runtime_task_overlays(row_sid)
                 if row_sid in overlay_sids else {}
             )
             for row_sid in lineage
@@ -2196,7 +2412,7 @@ def stop_stale_runtime_task_overlays() -> int:
     for sid in indexed_session_ids():
         if not _sidecar_has_runtime_task_overlays(sid):
             continue
-        for task_id, overlay in _load_runtime_task_overlays_section(sid).items():
+        for task_id, overlay in get_runtime_task_overlays(sid).items():
             if overlay.get("state") != "running":
                 continue
             changed = set_runtime_task_overlay(

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -2375,6 +2375,7 @@ def test_session_todo_modal_uses_large_desktop_board(
     todo_state = _app_eval(
         page,
         """
+        await app._syncTodosFromServer();
         const originalId = app.currentId;
         app.userTodos = [
           {id: 'todo-high', text: 'High item', completed: false, priority: 'high'},
@@ -2382,6 +2383,7 @@ def test_session_todo_modal_uses_large_desktop_board(
           {id: 'todo-low', text: 'Low item', completed: false, priority: 'low'},
         ];
         app._persistGlobalUserTodos();
+        await app._todoPushPromise;
         const beforeSwitch = app.sessionTodoItems().map(item => item.id);
         app.currentId = 'different-conversation';
         const afterSwitch = app.sessionTodoItems().map(item => item.id);

--- a/tests/test_chat_lifecycle_contracts.py
+++ b/tests/test_chat_lifecycle_contracts.py
@@ -5,6 +5,7 @@ import asyncio
 import inspect
 import json
 
+import pytest
 from fastapi.routing import APIRoute
 
 
@@ -25,6 +26,45 @@ def _chat_route_contract(chat_mod):
                 route.response_model,
             )
     return contract
+
+
+def test_runtime_task_overlay_uses_one_lineage_snapshot_and_forward_suffix(
+    app_module, monkeypatch,
+):
+    from backend import chat as chat_mod
+
+    lineage_reads = []
+    writes = []
+
+    def runtime_lineage(sid):
+        lineage_reads.append(sid)
+        return ["predecessor", "owner", "child", "grandchild"]
+
+    def write_overlay(sid, task_id, **fields):
+        writes.append((sid, task_id, fields))
+        return True
+
+    monkeypatch.setattr(chat_mod.sess, "runtime_lineage", runtime_lineage)
+    monkeypatch.setattr(
+        chat_mod.sess,
+        "get_session_meta",
+        lambda _sid: pytest.fail("propagation must use one lineage snapshot"),
+    )
+    monkeypatch.setattr(
+        chat_mod.sess, "set_runtime_task_overlay", write_overlay,
+    )
+
+    chat_mod._runtime_task_overlay(
+        "owner",
+        "task-1",
+        state="running",
+        description="background task",
+    )
+
+    assert lineage_reads == ["owner"]
+    assert [row[0] for row in writes] == ["owner", "child", "grandchild"]
+    assert all(row[1] == "task-1" for row in writes)
+    assert all(row[2]["owner_session_id"] == "owner" for row in writes)
 
 
 def test_chat_lifecycle_routes_keep_fastapi_contract(app_module):

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -364,6 +364,26 @@ async def test_watch_limit_fallback_polls_only_indexed_shallow_directories(
                 "error_type": "RuntimeError",
             },
         ),
+        (
+            "files.watcher_retry",
+            {
+                "workspace": file_events.short_id(workspace_id),
+                "error_type": "RuntimeError",
+                "failures": 1,
+                "delay_ms": 0,
+                "armed_ms": 0,
+            },
+        ),
+        (
+            "files.watcher_retry",
+            {
+                "workspace": file_events.short_id(workspace_id),
+                "error_type": "RuntimeError",
+                "failures": 2,
+                "delay_ms": 0,
+                "armed_ms": 0,
+            },
+        ),
     ]
     await manager.shutdown()
 
@@ -1490,6 +1510,31 @@ async def test_failed_generation_reconciles_only_after_retry_is_armed(
             for row in store.delta(workspace_id, baseline)["changes"]
         }
     await manager.shutdown()
+
+
+def test_watch_retry_backoff_is_scoped_and_resets_after_stable_generation(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    monkeypatch.setattr(file_events, "_WATCH_RETRY_S", 1.5)
+    monkeypatch.setattr(file_events, "_WATCH_RETRY_MAX_S", 10.0)
+    monkeypatch.setattr(file_events, "_WATCH_STABLE_RESET_S", 30.0)
+    first = file_events._WatchState(root=temp_root / "first")
+    second = file_events._WatchState(root=temp_root / "second")
+
+    assert [
+        file_events._next_watch_retry_delay(first, 0.0)
+        for _ in range(5)
+    ] == [1.5, 3.0, 6.0, 10.0, 10.0]
+    assert first.watch_failures == 5
+    assert file_events._next_watch_retry_delay(second, 0.0) == 1.5
+    assert second.watch_failures == 1
+
+    assert file_events._next_watch_retry_delay(first, 30.0) == 1.5
+    assert first.watch_failures == 1
 
 
 def test_reconcile_backoff_is_scoped_to_each_workspace(

--- a/tests/test_hook_traces.py
+++ b/tests/test_hook_traces.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from claude_agent_sdk import HookEventMessage, SystemMessage
+
 
 def _hook(
     subtype: str,
@@ -26,7 +29,8 @@ def _hook(
 
 
 def test_started_and_response_persist_only_privacy_safe_projection(
-    app_module, temp_root,
+    app_module,
+    temp_root,
 ):
     from backend import hook_traces
     from backend import sessions as sess
@@ -75,8 +79,11 @@ def test_started_and_response_persist_only_privacy_safe_projection(
     path = sess.SESS_DIR / "hook-traces" / f"{sid}.json"
     raw = path.read_text(encoding="utf-8")
     for secret in (
-        "cat /private/file", "Bearer secret", "never persist this output",
-        "never persist this stdout", "never persist this stderr",
+        "cat /private/file",
+        "Bearer secret",
+        "never persist this output",
+        "never persist this stdout",
+        "never persist this stderr",
     ):
         assert secret not in raw
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
@@ -102,8 +109,94 @@ def test_progress_updates_timing_without_persisting_output(app_module):
 
     assert progress["status"] == "running"
     assert progress["updated_at_ms"] == 2050
-    assert "secret" not in json.dumps(
-        hook_traces.list_traces(sid), ensure_ascii=False)
+    assert "secret" not in json.dumps(hook_traces.list_traces(sid), ensure_ascii=False)
+
+
+def test_progress_does_not_rewrite_durable_trace(app_module, monkeypatch):
+    from backend import hook_traces
+
+    sid = "trace-session-progress-writes"
+    hook_traces.observe(
+        sid,
+        _hook("hook_started"),
+        turn_id="turn-1",
+        observed_at_ms=2_000,
+    )
+    writes = 0
+    real_write = hook_traces._write_locked
+
+    def counted_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(hook_traces, "_write_locked", counted_write)
+    for offset in range(1, 101):
+        progress = hook_traces.observe(
+            sid,
+            _hook("hook_progress"),
+            turn_id="turn-1",
+            observed_at_ms=2_000 + offset,
+        )
+        assert progress is not None
+
+    assert writes == 0
+    assert hook_traces.list_traces(sid)[0]["updated_at_ms"] == 2_100
+
+    hook_traces.observe(
+        sid,
+        _hook("hook_response", exit_code=0),
+        turn_id="turn-1",
+        observed_at_ms=2_200,
+    )
+    assert writes == 1
+    durable = json.loads(hook_traces._trace_path(sid).read_text(encoding="utf-8"))["traces"][0]
+    assert durable["status"] == "succeeded"
+    assert durable["updated_at_ms"] == 2_200
+    assert durable["finished_at_ms"] == 2_200
+
+
+def test_trace_writes_for_distinct_sessions_do_not_share_io_lock(
+    app_module,
+    monkeypatch,
+):
+    from backend import hook_traces
+
+    blocked = threading.Event()
+    release = threading.Event()
+    real_write = hook_traces.write_private_bytes
+    slow_sid = "trace-session-slow"
+    fast_sid = next(
+        f"trace-session-fast-{index}"
+        for index in range(256)
+        if hook_traces._trace_lock(f"trace-session-fast-{index}")
+        is not hook_traces._trace_lock(slow_sid)
+    )
+
+    def controlled_write(path, data):
+        if path.name == f"{slow_sid}.json":
+            blocked.set()
+            assert release.wait(timeout=2)
+        return real_write(path, data)
+
+    monkeypatch.setattr(hook_traces, "write_private_bytes", controlled_write)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        slow = pool.submit(
+            hook_traces.observe,
+            slow_sid,
+            _hook("hook_started", hook_id="hook-slow"),
+        )
+        assert blocked.wait(timeout=1)
+        fast = pool.submit(
+            hook_traces.observe,
+            fast_sid,
+            _hook("hook_started", hook_id="hook-fast"),
+        )
+        try:
+            assert fast.result(timeout=1)["trace_id"] == "hook-fast"
+        finally:
+            release.set()
+        assert slow.result(timeout=1)["trace_id"] == "hook-slow"
 
 
 def test_progress_without_stable_started_identity_is_not_guessed(app_module):
@@ -117,12 +210,15 @@ def test_progress_without_stable_started_identity_is_not_guessed(app_module):
         observed_at_ms=3_000,
     )
 
-    assert hook_traces.observe(
-        sid,
-        _hook("hook_progress", hook_id="hook-b", output="unbound"),
-        turn_id="turn-1",
-        observed_at_ms=3_010,
-    ) is None
+    assert (
+        hook_traces.observe(
+            sid,
+            _hook("hook_progress", hook_id="hook-b", output="unbound"),
+            turn_id="turn-1",
+            observed_at_ms=3_010,
+        )
+        is None
+    )
     assert len(hook_traces.list_traces(sid)) == 1
 
 
@@ -140,12 +236,16 @@ def test_trace_store_is_bounded(app_module, monkeypatch):
         )
 
     assert [row["trace_id"] for row in hook_traces.list_traces(sid)] == [
-        "hook-2", "hook-3", "hook-4",
+        "hook-2",
+        "hook-3",
+        "hook-4",
     ]
 
 
 def test_authenticated_trace_endpoint_supports_turn_filter(
-    app_module, client, auth,
+    app_module,
+    client,
+    auth,
 ):
     from backend import hook_traces
     from backend import sessions as sess
@@ -172,7 +272,8 @@ def test_authenticated_trace_endpoint_supports_turn_filter(
 
 @pytest.mark.asyncio
 async def test_stream_observer_publishes_safe_trace_to_active_turn(
-    app_module, monkeypatch,
+    app_module,
+    monkeypatch,
 ):
     from backend import chat as chat_mod
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -232,7 +232,9 @@ def test_runtime_task_overlay_bounds_summary_on_write(app_module):
     assert len(overlay["summary"]) == TASK_SUMMARY_PREVIEW_CAP
     assert overlay["summary_length"] == len(full)
     assert overlay["summary_truncated"] is True
-    raw = json.loads(sess._sidecar_path(sid).read_text(encoding="utf-8"))
+    raw = json.loads(
+        sess._runtime_task_overlay_path(sid).read_text(encoding="utf-8")
+    )
     assert raw["runtime_task_overlays"]["task-long"] == overlay
 
 
@@ -246,7 +248,7 @@ def test_running_runtime_task_ids_cache_one_overlay_parse_per_generation(
         sid, "task-running", state="running",
     )
     sess._drop_running_runtime_task_ids_cache(sid)
-    real_load = sess._load_runtime_task_overlays_section
+    real_load = sess._load_runtime_task_overlay_file
     loads = 0
 
     def counted_load(load_sid):
@@ -255,7 +257,7 @@ def test_running_runtime_task_ids_cache_one_overlay_parse_per_generation(
         return real_load(load_sid)
 
     monkeypatch.setattr(
-        sess, "_load_runtime_task_overlays_section", counted_load,
+        sess, "_load_runtime_task_overlay_file", counted_load,
     )
     expected = {sid: frozenset({"task-running"})}
     assert sess.running_runtime_task_ids((sid, sid)) == expected
@@ -263,7 +265,7 @@ def test_running_runtime_task_ids_cache_one_overlay_parse_per_generation(
     assert loads == 1
 
 
-def test_sidecar_save_refreshes_running_task_summary_without_reread(
+def test_overlay_save_refreshes_running_task_summary_without_reread(
     app_module, monkeypatch,
 ):
     from backend import sessions as sess
@@ -271,13 +273,13 @@ def test_sidecar_save_refreshes_running_task_summary_without_reread(
     sid = sess.create_session("runtime-overlay-summary-refresh")["id"]
     assert sess.set_runtime_task_overlay(sid, "task-1", state="running")
     assert sess.running_runtime_task_ids((sid,))[sid] == frozenset({"task-1"})
+    assert sess.set_runtime_task_overlay(sid, "task-1", state="completed")
 
     monkeypatch.setattr(
         sess,
-        "_load_runtime_task_overlays_section",
-        lambda _sid: pytest.fail("a successful sidecar save must prime summary"),
+        "_load_runtime_task_overlay_file",
+        lambda _sid: pytest.fail("a successful overlay save must prime summary"),
     )
-    assert sess.set_runtime_task_overlay(sid, "task-1", state="completed")
     assert sess.running_runtime_task_ids((sid,))[sid] == frozenset()
 
 
@@ -339,12 +341,116 @@ def test_runtime_task_overlay_legacy_summary_is_bounded_then_compacted(app_modul
                ["runtime_task_overlays"]["task-old"]["summary"]) == len(full)
 
     assert sess.set_runtime_task_overlay(sid, "task-new", state="running")
-    raw = json.loads(sess._sidecar_path(sid).read_text(encoding="utf-8"))
-    compacted = raw["runtime_task_overlays"]["task-old"]
+    legacy_raw = json.loads(
+        sess._sidecar_path(sid).read_text(encoding="utf-8")
+    )
+    assert len(
+        legacy_raw["runtime_task_overlays"]["task-old"]["summary"]
+    ) == len(full)
+    dedicated_raw = json.loads(
+        sess._runtime_task_overlay_path(sid).read_text(encoding="utf-8")
+    )
+    compacted = dedicated_raw["runtime_task_overlays"]["task-old"]
     assert len(compacted["summary"]) == TASK_SUMMARY_PREVIEW_CAP
     assert compacted["summary_length"] == len(full)
     assert compacted["summary_truncated"] is True
 
+
+def test_runtime_overlay_updates_do_not_touch_large_annotation_sidecar(
+    app_module, monkeypatch,
+):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-large-sidecar")["id"]
+    assert sess.set_runtime_task_overlay(
+        sid, "task-large", state="running",
+    )
+    sidecar = sess._sidecar_path(sid)
+    sess._save_sidecar(sid, {
+        "messages": {
+            "message-large": {
+                "images": [{"data": "x" * 2_400_000}],
+            },
+        },
+    })
+    before_bytes = sidecar.read_bytes()
+    before = sidecar.stat()
+
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("runtime overlay hot writes must not touch the main sidecar")
+
+    monkeypatch.setattr(sess, "_load_sidecar", forbidden)
+    monkeypatch.setattr(sess, "_save_sidecar", forbidden)
+    assert sess.set_runtime_task_overlay(
+        sid,
+        "task-large",
+        state="completed",
+        summary="finished",
+    )
+
+    after = sidecar.stat()
+    assert sidecar.read_bytes() == before_bytes
+    assert (after.st_ino, after.st_mtime_ns, after.st_size) == (
+        before.st_ino, before.st_mtime_ns, before.st_size,
+    )
+    assert sess.get_runtime_task_overlays(sid)["task-large"]["state"] == "completed"
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset()
+    overlay_path = sess._runtime_task_overlay_path(sid)
+    assert overlay_path.stat().st_size < 16 * 1024
+    assert overlay_path.stat().st_mode & 0o777 == 0o600
+    assert overlay_path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_runtime_overlay_store_detects_same_size_mtime_atomic_replace(
+    app_module,
+):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-store-replace")["id"]
+    assert sess.set_runtime_task_overlay(sid, "task-1", state="running")
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset({"task-1"})
+
+    path = sess._runtime_task_overlay_path(sid)
+    original_stat = path.stat()
+    replacement = json.loads(path.read_text(encoding="utf-8"))
+    replacement["runtime_task_overlays"]["task-1"]["state"] = "stopped"
+    serialized = (
+        json.dumps(replacement, ensure_ascii=False, separators=(",", ":"))
+        + "\n"
+    )
+    assert len(serialized.encode("utf-8")) == original_stat.st_size
+    replacement_path = path.with_suffix(".replacement")
+    replacement_path.write_text(serialized, encoding="utf-8")
+    os.utime(
+        replacement_path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    os.replace(replacement_path, path)
+
+    replaced_stat = path.stat()
+    assert replaced_stat.st_size == original_stat.st_size
+    assert replaced_stat.st_mtime_ns == original_stat.st_mtime_ns
+    assert replaced_stat.st_ino != original_stat.st_ino
+    assert sess.get_runtime_task_overlays(sid)["task-1"]["state"] == "stopped"
+    assert sess.running_runtime_task_ids((sid,))[sid] == frozenset()
+
+
+def test_corrupt_runtime_overlay_store_is_never_overwritten(app_module):
+    from backend import sessions as sess
+
+    sid = sess.create_session("runtime-overlay-corrupt")["id"]
+    assert sess.set_runtime_task_overlay(sid, "task-1", state="running")
+    path = sess._runtime_task_overlay_path(sid)
+    broken = b'{"schema_version":1,"runtime_task_overlays":'
+    path.write_bytes(broken)
+
+    with pytest.raises(
+        RuntimeError,
+        match="cannot parse runtime task overlay store",
+    ):
+        sess.set_runtime_task_overlay(sid, "task-1", state="completed")
+
+    assert path.read_bytes() == broken
 
 @pytest.mark.parametrize(
     "terminal_state", ["completed", "failed", "stopped", "done"],
@@ -609,15 +715,15 @@ def test_runtime_lineage_authority_uses_earliest_owner_snapshot(app_module):
     assert sess.copy_runtime_task_overlays(source, child) == 1
 
     # Simulate a pre-fix successor that rewrote both owner and lifecycle state.
-    child_data = sess._load_sidecar(child, use_cache=False)
-    child_overlay = child_data["runtime_task_overlays"]["source-task"]
+    child_overlays = sess.get_runtime_task_overlays(child)
+    child_overlay = child_overlays["source-task"]
     child_overlay.update({
         "owner_session_id": child,
         "state": "stopped",
         "summary": "false successor stop",
         "tool_use_id": "tool-recovered-from-copy",
     })
-    sess._save_sidecar(child, child_data)
+    sess._save_runtime_task_overlays(child, child_overlays)
     assert sess.set_runtime_task_overlay(
         child,
         "child-task",
@@ -714,14 +820,14 @@ def test_reconcile_runtime_task_overlay_chains_repairs_forward_copies(
         summary="real result",
     )
     assert sess.copy_runtime_task_overlays(source, child) == 1
-    child_data = sess._load_sidecar(child, use_cache=False)
-    child_data["runtime_task_overlays"]["source-task"].update({
+    child_overlays = sess.get_runtime_task_overlays(child)
+    child_overlays["source-task"].update({
         "owner_session_id": child,
         "state": "stopped",
         "summary": "false successor stop",
         "restart_recovered": True,
     })
-    sess._save_sidecar(child, child_data)
+    sess._save_runtime_task_overlays(child, child_overlays)
     assert sess.set_runtime_task_overlay(
         child,
         "child-task",
@@ -730,17 +836,16 @@ def test_reconcile_runtime_task_overlay_chains_repairs_forward_copies(
         description="child launch",
     )
 
-    original_load = sess._load_sidecar
-    mutation_loads = []
+    original_save = sess._save_runtime_task_overlays
+    mutation_saves = []
 
-    def tracked_load(sid, *, use_cache=True):
-        if not use_cache:
-            mutation_loads.append(sid)
-        return original_load(sid, use_cache=use_cache)
+    def tracked_save(sid, overlays):
+        mutation_saves.append(sid)
+        return original_save(sid, overlays)
 
-    monkeypatch.setattr(sess, "_load_sidecar", tracked_load)
+    monkeypatch.setattr(sess, "_save_runtime_task_overlays", tracked_save)
     assert sess.reconcile_runtime_task_overlay_chains() == 3
-    assert sorted(mutation_loads) == sorted([child, grandchild])
+    assert sorted(mutation_saves) == sorted([child, grandchild])
     assert sess.reconcile_runtime_task_overlay_chains() == 0
 
     source_visible = sess.get_authoritative_runtime_task_overlays(source)
@@ -1904,8 +2009,15 @@ def test_delete_session_clears_sidecar(client, auth, app_module):
     meta = sess.create_session("ephemeral")
     sid = meta["id"]
     assert sess.get_session_meta(sid) is not None
+    assert sess.set_runtime_task_overlay(sid, "task-delete", state="running")
+    sidecar = sess._sidecar_path(sid)
+    overlay = sess._runtime_task_overlay_path(sid)
+    assert sidecar.exists()
+    assert overlay.exists()
     assert sess.delete_session(sid) is True
     assert sess.get_session_meta(sid) is None
+    assert not sidecar.exists()
+    assert not overlay.exists()
     assert sess.delete_session(sid) is False
 
 


### PR DESCRIPTION
## 变更\n- 合并 Hook progress 高频写入，并按会话隔离锁\n- 将运行时任务 overlay 从大 sidecar 拆到独立私有小文件，兼容旧数据迁移\n- watcher 连续故障采用 1.5/3/6/10 秒退避，同时保留就绪后的 closing reconcile\n\n## 验证\n- uv run ruff check backend tests\n- MUSELAB_TOKEN=测试占位值 uv run pytest -q -n 8\n- 1692 passed, 163 skipped\n- 针对 Hook、overlay、文件 watcher 的并行专项测试均通过