### PR TITLE
perf(files): WSL 原生文件系统使用 inotify

### DIFF
--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -8,6 +8,7 @@ import errno
 import json
 import multiprocessing
 import os
+import re
 import sys
 from collections import OrderedDict
 from collections.abc import AsyncIterator
@@ -65,6 +66,101 @@ _FORCE_POLLING: bool | None = (
     if _POLLING_ENV is None
     else _POLLING_ENV.strip().lower() in {"1", "true", "yes", "on"}
 )
+_MOUNTINFO_PATH = Path("/proc/self/mountinfo")
+_MOUNTINFO_ESCAPE_RE = re.compile(r"\\(040|011|012|134)")
+_MOUNTINFO_ESCAPES = {
+    "040": " ",
+    "011": "\t",
+    "012": "\n",
+    "134": "\\",
+}
+_WSL_NATIVE_WATCH_FILESYSTEMS = frozenset({
+    "btrfs",
+    "ext2",
+    "ext3",
+    "ext4",
+    "f2fs",
+    "jfs",
+    "overlay",
+    "ramfs",
+    "reiserfs",
+    "tmpfs",
+    "xfs",
+    "zfs",
+})
+
+
+def _running_on_wsl() -> bool:
+    if sys.platform != "linux":
+        return False
+    with contextlib.suppress(AttributeError):
+        return "microsoft-standard" in os.uname().release.lower()
+    return False
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    return _MOUNTINFO_ESCAPE_RE.sub(
+        lambda match: _MOUNTINFO_ESCAPES[match.group(1)],
+        value,
+    )
+
+
+def _mount_filesystem_types(
+    paths: tuple[Path, ...],
+    *,
+    mountinfo_path: Path = _MOUNTINFO_PATH,
+) -> frozenset[str] | None:
+    """Resolve every watched path to its deepest Linux mount type."""
+    try:
+        rows = mountinfo_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    mounts: dict[Path, str] = {}
+    for row in rows:
+        left, separator, right = row.partition(" - ")
+        left_fields = left.split()
+        right_fields = right.split()
+        if not separator or len(left_fields) < 5 or not right_fields:
+            continue
+        mountpoint = Path(_decode_mountinfo_path(left_fields[4]))
+        mounts[mountpoint] = right_fields[0]
+    if not mounts:
+        return None
+
+    filesystems: set[str] = set()
+    for path in paths:
+        candidate = Path(os.path.abspath(path))
+        while candidate not in mounts and candidate.parent != candidate:
+            candidate = candidate.parent
+        filesystem = mounts.get(candidate)
+        if filesystem is None:
+            return None
+        filesystems.add(filesystem)
+    return frozenset(filesystems)
+
+
+def _effective_watchfiles_force_polling(
+    configured: bool | None,
+    directories: tuple[Path, ...],
+) -> bool | None:
+    """Use inotify for WSL's Linux filesystems, polling for host mounts."""
+    if configured is not None:
+        return configured
+    if not _running_on_wsl():
+        return None
+    filesystems = _mount_filesystem_types(directories)
+    if (
+        filesystems
+        and filesystems <= _WSL_NATIVE_WATCH_FILESYSTEMS
+    ):
+        # watchfiles otherwise forces polling for every WSL path, including
+        # native ext4. On large home workspaces that burns a core rescanning
+        # unchanged trees. Explicit False selects reliable inotify here.
+        return False
+    # Windows/9p, mixed, and unknown mounts keep watchfiles' conservative
+    # correctness-preserving polling behavior.
+    return True
 
 
 def _default_native_directory_watch_budget() -> int:
@@ -1708,17 +1804,6 @@ class FileWatchManager:
         return directories or (state.root,)
 
     @staticmethod
-    def _watchfiles_uses_polling(force_polling: bool | None) -> bool:
-        """Mirror watchfiles' explicit and WSL automatic polling decision."""
-        if force_polling is not None:
-            return force_polling
-        if sys.platform != "linux":
-            return False
-        with contextlib.suppress(AttributeError):
-            return "microsoft-standard" in os.uname().release.lower()
-        return False
-
-    @staticmethod
     def _native_watch_cost(directories: tuple[Path, ...]) -> int:
         """Estimate non-recursive inotify descriptors from unique directories."""
         return max(1, len(dict.fromkeys(directories)))
@@ -1872,8 +1957,11 @@ class FileWatchManager:
                 directories = await self._watch_directories(state)
                 if revision != state.watch_revision:
                     continue
-                force_polling = state.force_polling
-                if not self._watchfiles_uses_polling(force_polling):
+                force_polling = _effective_watchfiles_force_polling(
+                    state.force_polling,
+                    directories,
+                )
+                if force_polling is not True:
                     watch_cost = self._native_watch_cost(directories)
                     (
                         native_lease,

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -1036,6 +1036,100 @@ async def test_native_watcher_slot_waits_for_evicted_owner(
     await manager.shutdown()
 
 
+def test_mount_filesystem_types_uses_deepest_mount_and_decodes_paths(
+    app_module,
+    temp_root,
+):
+    import backend.file_events as file_events
+
+    native_root = temp_root / "native root"
+    host_mount = native_root / "host"
+    encoded_native = str(native_root).replace(" ", r"\040")
+    encoded_host = str(host_mount).replace(" ", r"\040")
+    mountinfo = temp_root / "mountinfo"
+    mountinfo.write_text(
+        "\n".join((
+            "20 1 0:1 / / rw - ext4 /dev/root rw",
+            f"21 20 0:2 / {encoded_native} rw - ext4 /dev/sdb rw",
+            f"22 21 0:3 / {encoded_host} rw - 9p drvfs rw",
+        )),
+        encoding="utf-8",
+    )
+
+    assert file_events._mount_filesystem_types(
+        (native_root / "notes", host_mount / "project"),
+        mountinfo_path=mountinfo,
+    ) == frozenset({"ext4", "9p"})
+
+
+def test_wsl_native_filesystem_overrides_automatic_polling(
+    app_module,
+    temp_root,
+    monkeypatch,
+):
+    import backend.file_events as file_events
+
+    monkeypatch.setattr(file_events, "_running_on_wsl", lambda: True)
+    monkeypatch.setattr(
+        file_events,
+        "_mount_filesystem_types",
+        lambda _paths: frozenset({"ext4"}),
+    )
+
+    assert file_events._effective_watchfiles_force_polling(
+        None,
+        (temp_root,),
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "filesystems",
+    [
+        frozenset({"9p"}),
+        frozenset({"ext4", "9p"}),
+        None,
+    ],
+)
+def test_wsl_host_or_unknown_filesystem_keeps_polling(
+    app_module,
+    temp_root,
+    monkeypatch,
+    filesystems,
+):
+    import backend.file_events as file_events
+
+    monkeypatch.setattr(file_events, "_running_on_wsl", lambda: True)
+    monkeypatch.setattr(
+        file_events,
+        "_mount_filesystem_types",
+        lambda _paths: filesystems,
+    )
+
+    assert file_events._effective_watchfiles_force_polling(
+        None,
+        (temp_root,),
+    ) is True
+
+
+@pytest.mark.parametrize("configured", [False, True])
+def test_explicit_polling_configuration_has_priority(
+    app_module,
+    temp_root,
+    monkeypatch,
+    configured,
+):
+    import backend.file_events as file_events
+
+    def unexpected_probe():
+        raise AssertionError("explicit configuration must avoid WSL probing")
+
+    monkeypatch.setattr(file_events, "_running_on_wsl", unexpected_probe)
+    assert file_events._effective_watchfiles_force_polling(
+        configured,
+        (temp_root,),
+    ) is configured
+
+
 @pytest.mark.asyncio
 async def test_native_directory_budget_is_fifo_and_cancellation_safe(
     app_module,
@@ -1847,7 +1941,11 @@ async def test_watcher_uses_shallow_indexed_directories_and_closes_refresh_gap(
     assert nested in second_paths
     assert first_options["recursive"] is False
     assert second_options["recursive"] is False
-    assert first_options["force_polling"] is file_events._FORCE_POLLING
+    assert first_options["force_polling"] is (
+        file_events._effective_watchfiles_force_polling(
+            file_events._FORCE_POLLING, first_paths,
+        )
+    )
 
     indexed = {
         row["path"]


### PR DESCRIPTION
## 背景

`watchfiles` 会在 WSL 全局自动启用轮询。对于位于 Linux 原生文件系统上的大 workspace，这会让 `notify-rs poll` 持续递归检查未变化目录并占用 CPU。

## 修复

- 读取 Linux mountinfo，按最深挂载点识别所有实际监听目录的文件系统。
- WSL 的 ext4 等原生文件系统显式使用 inotify。
- 9p、混合挂载、未知挂载继续使用 polling，显式环境配置仍有最高优先级。
- 保留现有原生 watch 预算、资源耗尽降级与 closing reconcile 语义。

## 验证

- `ruff check backend/file_events.py tests/test_file_events.py`
- `pytest -q -n 8 tests/test_file_events.py`：71 passed
- `pytest -q -n 8`：1699 passed, 163 skipped
- WSL 实机挂载判定：Linux 原生盘 -> inotify；9p 主机盘 -> polling