### PR TITLE
fix(chat): 修复实时回复卡住直到刷新

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -1043,6 +1043,10 @@ class TurnBroadcast:
         # carry the same sequence so clients can discard duplicate delivery
         # without guessing from event content.
         self._event_seq = 0
+        # Accepted turns are synchronously offered to every live multiplex
+        # subscription exactly once. Periodic discovery remains a recovery
+        # path, not the primary notification mechanism.
+        self.mux_announced = False
         # Set in finish(). Used by the _recent_turns grace-keep map to TTL-evict
         # broadcasts that ended a while ago.
         self.finished_at: float = 0.0
@@ -1371,6 +1375,10 @@ class TurnBroadcast:
     def replay_count(self) -> int:
         return len(self.events) + (1 if self._compact_kind is not None else 0)
 
+    @property
+    def latest_event_seq(self) -> int:
+        return self._event_seq
+
     def replay_events(self):
         yield from self.events
         if self._compact_kind is not None:
@@ -1526,6 +1534,24 @@ _active_turns: dict[str, TurnBroadcast] = {}
 _recent_turns: dict[str, TurnBroadcast] = {}
 _recent_turn_expiry_handles: dict[str, asyncio.TimerHandle] = {}
 _RECENT_TURN_TTL = env_int("MUSELAB_RECENT_TURN_TTL", 60, min_value=1)
+
+# A root multiplex stream must not depend on a 200 ms registry scan to notice
+# an ordinary turn. A fast reply can be accepted, completed, and removed from
+# `_active_turns` between two scans. These callbacks attach a replay reader at
+# the admission boundary, before the runtime can publish or finish the turn.
+_mux_turn_listeners: set[Callable[[TurnBroadcast], None]] = set()
+
+
+def _announce_mux_turn(broadcast: TurnBroadcast) -> None:
+    if broadcast.mux_announced:
+        return
+    broadcast.mux_announced = True
+    for listener in tuple(_mux_turn_listeners):
+        try:
+            listener(broadcast)
+        except Exception:
+            # One disconnected browser must never affect turn admission.
+            continue
 
 
 def _evict_recent_turn(
@@ -14498,6 +14524,7 @@ async def _watch_inflight_tasks(
             existing = _active_turns.get(session_id)
             if existing is None or existing.done:
                 _active_turns[session_id] = b
+                _announce_mux_turn(b)
         cont = b
         cont_state = {
             "tool_use_names": {},
@@ -15921,6 +15948,7 @@ async def _admit_turn(
     if broadcast.cancelled:
         return await _finish_cancelled_startup(session_id, broadcast)
     broadcast.perf_admission_ms = obs.elapsed_ms(admission_started)
+    _announce_mux_turn(broadcast)
     return broadcast
 
 
@@ -19414,10 +19442,19 @@ def _mux_wrap_event(session_id: str, event: dict) -> dict:
 
 
 def _mux_session_state_fingerprint(state: dict) -> str:
-    stable = {
-        key: value for key, value in state.items()
-        if key not in {"events_so_far", "runtime_ui_revision"}
-    }
+    stable = {}
+    for key, value in state.items():
+        if key in {
+            "events_so_far", "latest_event_seq", "runtime_ui_revision",
+        }:
+            continue
+        # Announcement states are intentionally memory-only and may omit
+        # default-valued durable fields. Treat omitted and explicit defaults as
+        # equivalent so the next periodic pass does not emit a duplicate frame.
+        if (value is None or value is False or value == "" or value == 0
+                or value == [] or value == {}):
+            continue
+        stable[key] = value
     return json.dumps(stable, sort_keys=True, ensure_ascii=False)
 
 
@@ -19439,26 +19476,18 @@ async def _subscribe_multiplex(
     *,
     mobile: bool = False,
 ):
-    """Merge attachable broadcasts while periodically discovering new ones."""
-    # Flush the SSE response headers before discovery. Starlette's global
-    # GZipMiddleware deliberately skips compressing ``text/event-stream``, but
-    # its responder still buffers ``http.response.start`` until it sees the
-    # first body frame. An idle mux (no checkpoints and no active turns) has no
-    # session event to yield, so without this handshake frame the browser waits
-    # for sse-starlette's 15-second heartbeat and our 5-second EventSource open
-    # timeout fires first. ``ping`` is already part of the mux protocol and is
-    # ignored by panes that have no active channel.
-    yield {"event": "ping", "data": ""}
-
+    """Merge exact turn broadcasts without blocking their live tail."""
     # Bound the aggregate handoff so a stalled HTTP client leaves each child
     # parked on its disk-backed subscriber cursor instead of growing RAM.
     output: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
     children: dict[tuple[str, str], asyncio.Task] = {}
+    preparing: dict[tuple[str, str], asyncio.Task] = {}
     completed: set[tuple[str, str]] = set()
     state_fingerprints: dict[str, str] = {}
     state_payloads: dict[str, dict] = {}
     scheduled_history_cursors: dict[str, _ScheduledHistoryCursor] = {}
     last_scheduled_history_poll = 0.0
+    closed = False
     # Checkpoints are one-shot reconnect intents for this root SSE handshake.
     # Copy them so consumption is private to the subscription lifecycle.
     pending_checkpoints = {
@@ -19469,14 +19498,10 @@ async def _subscribe_multiplex(
     async def _pump_child(
         session_id: str,
         broadcast: TurnBroadcast,
-        last_event_seq: int,
+        subscriber: _TurnSubscriber,
     ) -> None:
         try:
-            async for event in _subscribe_broadcast(
-                broadcast,
-                mobile=mobile,
-                last_event_seq=last_event_seq,
-            ):
+            while (event := await subscriber.get()) is not None:
                 await output.put(_mux_wrap_event(session_id, event))
         except asyncio.CancelledError:
             raise
@@ -19491,20 +19516,116 @@ async def _subscribe_multiplex(
                     "turn_id": broadcast.turn_id,
                 }),
             })
+        finally:
+            broadcast.unsubscribe(subscriber)
 
     def _start_child(
         session_id: str,
         broadcast: TurnBroadcast,
         last_event_seq: int,
+        *,
+        state_payload: dict | None = None,
+        prefix_events: tuple[dict, ...] = (),
     ) -> None:
         key = (session_id, broadcast.turn_id)
-        if key in children or key in completed:
+        if key in children or key in preparing or key in completed:
             return
-        children[key] = asyncio.create_task(
-            _pump_child(session_id, broadcast, last_event_seq))
+        subscriber = _attach_broadcast_subscriber(
+            broadcast, mobile=mobile, last_event_seq=last_event_seq)
+        if state_payload is None and not prefix_events:
+            children[key] = asyncio.create_task(
+                _pump_child(session_id, broadcast, subscriber))
+            return
+
+        async def _adopt() -> None:
+            started = False
+            try:
+                for event in prefix_events:
+                    await output.put(event)
+                if state_payload is not None:
+                    fingerprint = _mux_session_state_fingerprint(state_payload)
+                    state_payloads[session_id] = state_payload
+                    if state_fingerprints.get(session_id) != fingerprint:
+                        state_fingerprints[session_id] = fingerprint
+                        await output.put({
+                            "event": "session_state",
+                            "data": json.dumps(
+                                state_payload, ensure_ascii=False),
+                        })
+                children[key] = asyncio.create_task(
+                    _pump_child(session_id, broadcast, subscriber))
+                started = True
+            finally:
+                preparing.pop(key, None)
+                if not started:
+                    broadcast.unsubscribe(subscriber)
+
+        preparing[key] = asyncio.create_task(_adopt())
+
+    def _offer_broadcast(broadcast: TurnBroadcast) -> None:
+        """Synchronously attach before an accepted turn can finish."""
+        if closed:
+            return
+        session_id = broadcast.session_id
+        checkpoint = pending_checkpoints.get(session_id)
+        resume_seq = 0
+        prefix_events: tuple[dict, ...] = ()
+        if checkpoint is not None:
+            requested_turn_id = str(checkpoint.get("turn_id") or "")
+            if requested_turn_id == broadcast.turn_id:
+                resume_seq = int(
+                    checkpoint.get("last_event_seq", 0) or 0)
+            elif requested_turn_id:
+                # Preserve the exact-owner ABA rule without delaying attachment
+                # to the successor: canonicalize the stale owner first, then
+                # advertise and replay this accepted turn.
+                prefix_events = ({
+                    "event": "resync",
+                    "data": json.dumps({
+                        "reason": "turn_changed",
+                        "fallback": "canonical_history",
+                        "retryable": False,
+                        "requested_turn_id": requested_turn_id,
+                        "current_turn_id": broadcast.turn_id,
+                        "session_id": session_id,
+                        "turn_id": requested_turn_id,
+                    }),
+                },)
+            pending_checkpoints.pop(session_id, None)
+        state_payload = _mux_broadcast_state(broadcast)
+        state_payload["session_id"] = session_id
+        _start_child(
+            session_id,
+            broadcast,
+            resume_seq,
+            state_payload=state_payload,
+            prefix_events=prefix_events,
+        )
+
+    # Register and snapshot without an await between them. Turn admission runs
+    # on this same event loop, so no accepted broadcast can fall into the gap.
+    _mux_turn_listeners.add(_offer_broadcast)
+    for session_id, checkpoint in tuple(pending_checkpoints.items()):
+        requested_turn_id = str(checkpoint.get("turn_id") or "")
+        recent = _get_recent_turn(session_id)
+        if recent is not None and recent.turn_id == requested_turn_id:
+            _start_child(
+                session_id,
+                recent,
+                int(checkpoint.get("last_event_seq", 0) or 0),
+            )
+            pending_checkpoints.pop(session_id, None)
+    for broadcast in tuple(_active_turns.values()):
+        if not broadcast.done:
+            _offer_broadcast(broadcast)
 
     async def _reconcile() -> None:
         nonlocal last_scheduled_history_poll
+        for key, task in list(preparing.items()):
+            if task.done():
+                preparing.pop(key, None)
+                with suppress(asyncio.CancelledError, Exception):
+                    task.result()
         for key, task in list(children.items()):
             if task.done():
                 children.pop(key, None)
@@ -19674,6 +19795,7 @@ async def _subscribe_multiplex(
                     })
 
         retained_completed = set(children)
+        retained_completed.update(preparing)
         retained_completed.update(
             (session_id, broadcast.turn_id)
             for session_id, broadcast in _active_turns.items()
@@ -19687,7 +19809,8 @@ async def _subscribe_multiplex(
             # while it can still enqueue done/cancelled/error frames; once the
             # task is done, every child frame is already ahead of this state
             # transition in the same FIFO output queue.
-            if any(key[0] == session_id for key in children):
+            if any(key[0] == session_id
+                   for key in (*children, *preparing)):
                 continue
             previous = state_payloads.pop(session_id, {"session_id": session_id})
             state_fingerprints.pop(session_id, None)
@@ -19703,20 +19826,73 @@ async def _subscribe_multiplex(
                 "data": json.dumps(inactive, ensure_ascii=False),
             })
 
-    try:
+    async def _reconcile_loop() -> None:
+        deadline = time.monotonic()
         while True:
             await _reconcile()
-            try:
-                event = await asyncio.wait_for(
-                    output.get(), timeout=_MUX_RECONCILE_INTERVAL_S)
-            except asyncio.TimeoutError:
-                continue
+            deadline += _MUX_RECONCILE_INTERVAL_S
+            now = time.monotonic()
+            if deadline <= now:
+                # A slow disk/status pass must never trigger catch-up spins.
+                deadline = now + _MUX_RECONCILE_INTERVAL_S
+            await asyncio.sleep(max(0.0, deadline - now))
+
+    reconcile_task = asyncio.create_task(_reconcile_loop())
+    output_get: asyncio.Task | None = None
+    try:
+        # Flush the SSE headers only after listener registration. Starlette's
+        # event-stream responder buffers response.start until the first frame.
+        yield {"event": "ping", "data": ""}
+        while True:
+            output_get = asyncio.create_task(output.get())
+            done, _ = await asyncio.wait(
+                {output_get, reconcile_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if reconcile_task in done:
+                output_get.cancel()
+                await asyncio.gather(output_get, return_exceptions=True)
+                output_get = None
+                reconcile_task.result()
+            event = output_get.result()
+            output_get = None
             yield event
     finally:
+        closed = True
+        _mux_turn_listeners.discard(_offer_broadcast)
+        if output_get is not None:
+            output_get.cancel()
+        reconcile_task.cancel()
+        for task in preparing.values():
+            task.cancel()
         for task in children.values():
             task.cancel()
-        if children:
-            await asyncio.gather(*children.values(), return_exceptions=True)
+        await asyncio.gather(
+            *(
+                ([output_get] if output_get is not None else [])
+                + [reconcile_task]
+                + list(preparing.values())
+                + list(children.values())
+            ),
+            return_exceptions=True,
+        )
+
+
+def _attach_broadcast_subscriber(
+    broadcast: TurnBroadcast,
+    *,
+    mobile: bool = False,
+    last_event_seq: int = 0,
+) -> _TurnSubscriber:
+    subscriber = broadcast.subscribe(
+        mobile=mobile, last_event_seq=last_event_seq)
+    if (getattr(broadcast, "is_continuation", False)
+            and not subscriber._resync_payload):
+        broadcast.continuation_consumed = True
+    if (getattr(broadcast, "is_scheduled_delivery", False)
+            and not subscriber._resync_payload):
+        broadcast.scheduled_delivery_consumed = True
+    return subscriber
 
 
 async def _subscribe_broadcast(
@@ -19733,18 +19909,9 @@ async def _subscribe_broadcast(
     then tails the same append-only spool, so stalled HTTP connections retain a
     file cursor rather than an unbounded Python queue.
     """
-    subscriber = broadcast.subscribe(
+    subscriber = _attach_broadcast_subscriber(
+        broadcast,
         mobile=mobile, last_event_seq=last_event_seq)
-    # A real subscriber is now attached. For a CONTINUATION broadcast this is
-    # the one-and-only reconnect that replays the finished task's card flip +
-    # reaction. A replay-gap fallback is not an attachment and must not consume
-    # the continuation advertisement before canonical reconciliation starts.
-    if (getattr(broadcast, "is_continuation", False)
-            and not subscriber._resync_payload):
-        broadcast.continuation_consumed = True
-    if (getattr(broadcast, "is_scheduled_delivery", False)
-            and not subscriber._resync_payload):
-        broadcast.scheduled_delivery_consumed = True
     try:
         while True:
             ev = await subscriber.get()
@@ -19753,6 +19920,34 @@ async def _subscribe_broadcast(
             yield ev
     finally:
         broadcast.unsubscribe(subscriber)
+
+
+def _mux_broadcast_state(b: TurnBroadcast) -> dict:
+    """Build the in-memory state needed to gate an exact mux replay."""
+    return {
+        "active": True,
+        "stopping": bool(b.cancelled),
+        "attachable": True,
+        "background": False,
+        "background_tasks_pending": len(
+            _sessions_with_inflight_tasks.get(b.session_id, ())),
+        "runtime_background_tasks_pending": 0,
+        "runtime_continuation_pending": False,
+        "runtime_ui_revision": "",
+        **_sdk_scheduled_snapshot(b.session_id),
+        "turn_id": b.turn_id,
+        "parent_turn_id": b.parent_turn_id,
+        "model": b.model,
+        "started_at": b.started_at,
+        "events_so_far": b.replay_count(),
+        "latest_event_seq": b.latest_event_seq,
+        "continuation": getattr(b, "is_continuation", False),
+        "scheduled": getattr(b, "is_scheduled_delivery", False),
+        "activity_source": b.activity_source,
+        "user_text": b.user_text or "",
+        "user_images": b.user_images or [],
+        "user_docs": b.user_docs or [],
+    }
 
 
 def _session_active_status(
@@ -19861,39 +20056,14 @@ def _session_active_status(
                 ),
             }
     _hydrate_staged_attachment_display(b)
-    return {
-        "active": True,
-        "stopping": bool(b.cancelled),
-        "attachable": True,
-        "background": False,
-        "background_tasks_pending": len(
-            _sessions_with_inflight_tasks.get(sid, ())),
+    state = _mux_broadcast_state(b)
+    state.update({
         "runtime_background_tasks_pending": runtime_background_pending,
         "runtime_continuation_pending": runtime_continuation_pending,
         "runtime_ui_revision": runtime_ui_revision,
         **scheduled_state,
-        "turn_id": b.turn_id,
-        "parent_turn_id": b.parent_turn_id,
-        "model": b.model,
-        "started_at": b.started_at,
-        "events_so_far": b.replay_count(),
-        # True when this is a HEADLESS CONTINUATION turn opened by the bg-task
-        # watcher (no user prompt). The frontend attaches in "continuation"
-        # mode — same reconnect SSE, but it must NOT truncate the in-flight
-        # portion (the launching tool_use card lives there; the replayed
-        # task_notification flips it to ✅done).
-        "continuation": getattr(b, "is_continuation", False),
-        "scheduled": getattr(b, "is_scheduled_delivery", False),
-        "activity_source": b.activity_source,
-        # The turn's user prompt + attachments. The browser needs these to
-        # render the user bubble when it LIVE-reconnects to a turn the server
-        # drained from the queue headlessly (the browser never "sent" it, so
-        # the bubble isn't in `messages`). Same fields _broadcast_to_ui_messages
-        # injects on a reload-rebuild — keeps the two reconnect paths in sync.
-        "user_text": b.user_text or "",
-        "user_images": b.user_images or [],
-        "user_docs": b.user_docs or [],
-    }
+    })
+    return state
 
 
 @router.get("/sessions/{sid}/active", dependencies=[Depends(require_token)])
@@ -20523,6 +20693,7 @@ async def _register_scheduled_delivery(
                     _remember_recent_turn(session_id, delivery.broadcast)
                     return False
                 _active_turns[session_id] = delivery.broadcast
+                _announce_mux_turn(delivery.broadcast)
                 return True
         await asyncio.sleep(0.02)
     return False

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -394,6 +394,9 @@ function portal() {
     _chatMuxReconnectAttempts: 0,
     _chatMuxSupported: null,
     _chatMuxConnected: false,
+    _chatMuxOpenedAt: 0,
+    _chatMuxLastTransportAt: 0,
+    _chatMuxLastApplicationAt: 0,
     _splashHintTimer: null,
     _splashHardTimeout: null,
 
@@ -8471,7 +8474,13 @@ function portal() {
         _streamPlainRenderCount: 0,
         _deferredStreamRich: [],
         _deferredStreamRichHandle: null,
-        _lastSseActivity: 0,
+        // Transport liveness and actual session progress are intentionally
+        // separate. A healthy root heartbeat must not hide a stuck mux child.
+        _lastSseTransportAt: 0,
+        _lastSseProgressAt: 0,
+        _muxHealthRecoveryKey: "",
+        _muxFullReplayTurnId: "",
+        _muxFullReplayAttempts: 0,
         _stallWatch: null,
         _serverActiveObserved: false,
         // A terminal SSE event is newer than the last polled session-list
@@ -8644,6 +8653,17 @@ function portal() {
       if (st._lastTerminalTurnId === undefined) st._lastTerminalTurnId = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
       if (st._streamOwnerToken === undefined) st._streamOwnerToken = "";
+      if (!Number.isFinite(Number(st._lastSseTransportAt))) {
+        st._lastSseTransportAt = 0;
+      }
+      if (!Number.isFinite(Number(st._lastSseProgressAt))) {
+        st._lastSseProgressAt = 0;
+      }
+      if (st._muxHealthRecoveryKey === undefined) st._muxHealthRecoveryKey = "";
+      if (st._muxFullReplayTurnId === undefined) st._muxFullReplayTurnId = "";
+      if (!Number.isFinite(Number(st._muxFullReplayAttempts))) {
+        st._muxFullReplayAttempts = 0;
+      }
       if (!Number.isFinite(st.lastEventSeq)) st.lastEventSeq = 0;
       if (st.permission === undefined) st.permission = "";
       if (st.effort === undefined) st.effort = "auto";
@@ -11395,11 +11415,73 @@ function portal() {
     _setChatMuxUnsupported() {
       this._chatMuxSupported = false;
       this._chatMuxConnected = false;
+      this._chatMuxOpenedAt = 0;
       if (this._chatMuxReconnectTimer) clearTimeout(this._chatMuxReconnectTimer);
       this._chatMuxReconnectTimer = null;
       try { if (this._chatMuxSource) this._chatMuxSource.close(); } catch (_) {}
       this._chatMuxSource = null;
       for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+    },
+    async _forceChatMuxReconnect(ownerSource, sid, turnId) {
+      if (!ownerSource || this._chatMuxSource !== ownerSource
+          || this._chatMuxSupported === false || !this.token) return false;
+      if (!this._allowReconnect(sid, turnId)) return false;
+      if (this._chatMuxReconnectTimer) {
+        clearTimeout(this._chatMuxReconnectTimer);
+        this._chatMuxReconnectTimer = null;
+      }
+      try { ownerSource.close(); } catch (_) {}
+      if (this._chatMuxSource !== ownerSource) return false;
+      this._chatMuxSource = null;
+      this._chatMuxConnected = false;
+      this._chatMuxOpenedAt = 0;
+      for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+      return await this._ensureChatMux({ reconnect: true });
+    },
+    async _restartChatMuxFromBeginning(
+      sid, st, ownerChannel, ownerSource, options = {},
+    ) {
+      if (!sid || !st || this.tabState[sid] !== st || st.es !== ownerChannel
+          || !ownerChannel || !ownerChannel._muxChannel
+          || this._chatMuxSource !== ownerSource) return false;
+      const turnId = String(options.turnId || st.activeTurnId || "");
+      if (!turnId) return false;
+      if (st._muxFullReplayTurnId !== turnId) {
+        st._muxFullReplayTurnId = turnId;
+        st._muxFullReplayAttempts = 0;
+      }
+      if ((Number(st._muxFullReplayAttempts) || 0) >= 1
+          || !this._allowReconnect(sid, turnId)) return false;
+      st._muxFullReplayAttempts = (Number(st._muxFullReplayAttempts) || 0) + 1;
+      if (this._chatMuxReconnectTimer) {
+        clearTimeout(this._chatMuxReconnectTimer);
+        this._chatMuxReconnectTimer = null;
+      }
+      // Remove this logical checkpoint before opening the new root. Sequence
+      // zero asks the still-live broadcast for its complete disk-backed replay;
+      // send(reconnect) then truncates only this turn's mutable local suffix.
+      try { ownerChannel.close(); } catch (_) {}
+      if (st._stallWatch) clearInterval(st._stallWatch);
+      st._stallWatch = null;
+      if (st.es === ownerChannel) st.es = null;
+      st.streaming = false;
+      st.lastEventSeq = 0;
+      st._canonicalResyncPending = false;
+      try { ownerSource.close(); } catch (_) {}
+      if (this._chatMuxSource === ownerSource) {
+        this._chatMuxSource = null;
+        this._chatMuxConnected = false;
+        this._chatMuxOpenedAt = 0;
+      }
+      for (const channel of this._chatMuxChannels.values()) channel.disconnect();
+      await this.send({
+        reconnect: true,
+        sessionId: sid,
+        turnId,
+        startedAt: options.startedAt,
+        scheduled: !!options.scheduled,
+      });
+      return this.tabState[sid] === st && st.streaming && !!st.es;
     },
     _scheduleChatMuxReconnect() {
       if (this._chatMuxSupported === false || !this.token
@@ -11427,8 +11509,11 @@ function portal() {
     },
     async _openChatMux() {
       try { if (this._chatMuxSource) this._chatMuxSource.close(); } catch (_) {}
+      const connectingAt = Date.now();
       this._chatMuxSource = null;
       this._chatMuxConnected = false;
+      this._chatMuxOpenedAt = 0;
+      this._chatMuxLastTransportAt = connectingAt;
       for (const channel of this._chatMuxChannels.values()) channel.disconnect();
       let response;
       try {
@@ -11462,6 +11547,13 @@ function portal() {
       const source = new EventSource(
         "/api/chat/stream/mux?ticket=" + encodeURIComponent(payload.ticket));
       this._chatMuxSource = source;
+      const markRootFrame = application => {
+        if (this._chatMuxSource !== source) return false;
+        const now = Date.now();
+        this._chatMuxLastTransportAt = now;
+        if (application) this._chatMuxLastApplicationAt = now;
+        return true;
+      };
       let openSettled = false;
       let settleOpen;
       const opened = new Promise(resolve => { settleOpen = resolve; });
@@ -11479,6 +11571,9 @@ function portal() {
       }, 5000);
       source.onopen = () => {
         if (this._chatMuxSource !== source) return;
+        const now = Date.now();
+        this._chatMuxOpenedAt = now;
+        this._chatMuxLastTransportAt = now;
         clearTimeout(openTimeout);
         this._chatMuxConnected = true;
         this._chatMuxReconnectAttempts = 0;
@@ -11488,32 +11583,28 @@ function portal() {
         }
       };
       source.addEventListener("session_state", ev => {
-        if (this._chatMuxSource !== source) return;
+        if (!markRootFrame(true)) return;
         let state = {};
         try { state = JSON.parse(ev.data) || {}; } catch (_) {}
         void this._handleChatMuxSessionState(state);
       });
       source.addEventListener("scheduled_history", ev => {
-        if (this._chatMuxSource !== source) return;
+        if (!markRootFrame(true)) return;
         let payload = {};
         try { payload = JSON.parse(ev.data) || {}; } catch (_) {}
         this._handleScheduledHistoryUpdate(payload);
       });
       for (const type of CHAT_MUX_STREAM_EVENTS) {
         source.addEventListener(type, ev => {
-          if (this._chatMuxSource !== source) return;
+          if (!markRootFrame(type !== "ping")) return;
           if (type === "error" && (ev.data === undefined || ev.data === "")) {
             this._handleChatMuxDisconnect(source);
             return;
           }
-          if (type === "ping" && !ev.data) {
-            for (const channel of this._chatMuxChannels.values()) {
-              if (channel._activated && channel.readyState !== 2) {
-                channel.dispatchEvent(new MessageEvent("ping", { data: "" }));
-              }
-            }
-            return;
-          }
+          // Root heartbeat proves only socket liveness. Forwarding it to every
+          // logical channel used to reset their progress clock and masked a
+          // reconciler/child stream that had stopped delivering real events.
+          if (type === "ping") return;
           this._dispatchChatMuxEvent(type, ev.data);
         });
       }
@@ -11530,6 +11621,7 @@ function portal() {
       try { source.close(); } catch (_) {}
       this._chatMuxSource = null;
       this._chatMuxConnected = false;
+      this._chatMuxOpenedAt = 0;
       for (const channel of this._chatMuxChannels.values()) channel.disconnect();
       // The per-session reducers retain logical ownership while the one native
       // transport reconnects. In particular, do not synthesize `error`/`done`.
@@ -11752,8 +11844,13 @@ function portal() {
       if (this._chatMuxAttachPromises.has(sid)) return;
       const attach = (async () => {
         const st = this._ensureTabState(sid);
+        // Establish the reducer first. A cold history response is guarded from
+        // installing once the live owner claims the pane, while mux events no
+        // longer wait behind a multi-second transcript read or overflow at 512.
         if (!st._loaded && !st.streaming && !st.es) {
-          await this.loadSession(sid, { quiet: true, probeActive: false });
+          void this.loadSession(
+            sid, { quiet: true, probeActive: false },
+          ).catch(() => false);
         }
         if (st.streaming || st.es || this.tabState[sid] !== st) return;
         st.parentTurnId = String(payload.parent_turn_id || "");
@@ -12245,21 +12342,35 @@ function portal() {
         return Promise.resolve(false);
       }
       const ownerEs = st.es;
+      const ownerMuxSource = ownerEs && ownerEs._muxChannel
+        ? this._chatMuxSource : null;
       if (ownerEs && ownerEs._muxChannel && !this._chatMuxConnected) {
         this._scheduleChatMuxReconnect();
         return Promise.resolve(false);
       }
-      const observedActivity = Number(st._lastSseActivity)
+      const observedProgress = Number(st._lastSseProgressAt)
         || Number(st._streamStartedAt) || Date.now();
       const transportClosed = !!(ownerEs && Number(ownerEs.readyState) === 2);
-      if (!transportClosed && Date.now() - observedActivity < 18_000) {
+      const rootTransportAt = Number(this._chatMuxLastTransportAt)
+        || Number(this._chatMuxOpenedAt) || Date.now();
+      const rootSilent = !!ownerMuxSource
+        && Date.now() - rootTransportAt >= 40_000;
+      if (!transportClosed && !rootSilent
+          && Date.now() - observedProgress < 18_000) {
         return Promise.resolve(false);
       }
-      return this._requestSessionSync(sid, "stream_health", { ownerEs });
+      return this._requestSessionSync(sid, "stream_health", {
+        ownerEs, ownerMuxSource,
+      });
     },
     async _runStreamHealthSync(sid, st, options = {}) {
       const ownerEs = options.ownerEs;
-      if (this.tabState[sid] !== st || st.es !== ownerEs) return false;
+      const ownerMuxSource = options.ownerMuxSource;
+      const ownsMuxRoot = !ownerEs || !ownerEs._muxChannel
+        || this._chatMuxSource === ownerMuxSource;
+      if (this.tabState[sid] !== st || st.es !== ownerEs || !ownsMuxRoot) {
+        return false;
+      }
       try {
         const r = await this._fetchWithDeadline(
           `/api/chat/sessions/${sid}/active`,
@@ -12268,7 +12379,9 @@ function portal() {
         );
         if (!r.ok) return false;
         const d = await r.json();
-        if (this.tabState[sid] !== st || st.es !== ownerEs) return false;
+        if (this.tabState[sid] !== st || st.es !== ownerEs
+            || (ownerEs && ownerEs._muxChannel
+              && this._chatMuxSource !== ownerMuxSource)) return false;
         if (d.active) {
           st._serverActiveObserved = true;
           if (d.background && d.attachable === false) {
@@ -12278,8 +12391,37 @@ function portal() {
               pendingCount: d.background_tasks_pending,
             });
           }
-          const silenceMs = Date.now() - (Number(st._lastSseActivity)
+          const silenceMs = Date.now() - (Number(st._lastSseProgressAt)
             || Number(st._streamStartedAt) || Date.now());
+          if (ownerEs && ownerEs._muxChannel) {
+            const serverTurnId = String(d.turn_id || st.activeTurnId || "");
+            const localTurnId = String(st.activeTurnId || "");
+            const serverSeq = Math.max(0, Number(d.latest_event_seq) || 0);
+            const localSeq = Math.max(0, Number(st.lastEventSeq) || 0);
+            const turnChanged = !!serverTurnId && !!localTurnId
+              && serverTurnId !== localTurnId;
+            const serverAhead = turnChanged || ((!serverTurnId || !localTurnId
+              || serverTurnId === localTurnId) && serverSeq > localSeq);
+            const rootTransportAt = Number(this._chatMuxLastTransportAt)
+              || Number(this._chatMuxOpenedAt) || Date.now();
+            const rootSilent = !this._chatMuxConnected || !ownerMuxSource
+              || Number(ownerMuxSource.readyState) === 2
+              || Date.now() - rootTransportAt >= 40_000;
+            if (!rootSilent && (!serverAhead || silenceMs < 18_000)) {
+              return false;
+            }
+            const recoveryKey = `${serverTurnId}:${serverSeq}:${localSeq}`;
+            if (!rootSilent && st._muxHealthRecoveryKey === recoveryKey) {
+              return false;
+            }
+            const recovered = await this._forceChatMuxReconnect(
+              ownerMuxSource, sid, serverTurnId || localTurnId,
+            );
+            if (recovered && this.tabState[sid] === st) {
+              st._muxHealthRecoveryKey = recoveryKey;
+            }
+            return recovered;
+          }
           const serverHasReplay = Math.max(0, Number(d.events_so_far) || 0) > 0;
           const closedNow = !!(st.es && Number(st.es.readyState) === 2);
           if (!st.es || (!closedNow && (!serverHasReplay || silenceMs < 18_000))) {
@@ -12502,19 +12644,20 @@ function portal() {
         const streamAgeMs = st._streamStartedAt
           ? Math.max(0, Date.now() - st._streamStartedAt) : Infinity;
         if (cur.active) st._serverActiveObserved = true;
+        const canonicalCommitted = canonicalSuffixMissing || visibleNewer
+          || messageCountChanged || turnCountChanged;
         const serverSettled = !cur.active && (
           st._serverActiveObserved
           || !!(previous && previous.active)
           || (newer && streamAgeMs >= 5000)
         );
         if ((st.streaming || st.es) && serverSettled) {
-          const sseSilentMs = Date.now() - (Number(st._lastSseActivity)
-            || Number(st._streamStartedAt) || Date.now());
-          const transportDead = !st.es
-            || Number(st.es.readyState) === 2
-            || sseSilentMs >= 32_000;
-          if (transportDead) this._retireStaleSessionStream(sid, st);
           st._pendingExternalUpdate = true;
+          // Canonical metadata is authoritative once it proves a committed
+          // suffix. Root pings cannot postpone retirement of a logical stream
+          // whose terminal event was lost.
+          if (canonicalCommitted) this._retireStaleSessionStream(sid, st);
+          else this._recoverStalledStream(sid);
         }
         if (st.streaming || st.es) {
           if (visibleNewer || canonicalSuffixMissing) {
@@ -31930,6 +32073,9 @@ function portal() {
         streamState._reconnectGateTurn = "";
         streamState._reconnectGateCount = 0;
         streamState._reconnectGateAt = 0;
+        streamState._muxHealthRecoveryKey = "";
+        streamState._muxFullReplayTurnId = "";
+        streamState._muxFullReplayAttempts = 0;
       }
       // A live owner supersedes any foreground history shield. Advancing the
       // visual generation makes an older load response unable to turn the live
@@ -32034,6 +32180,11 @@ function portal() {
         streamState.activeTurnId = "";
         streamState.parentTurnId = "";
         streamState.lastEventSeq = 0;
+        streamState._lastSseTransportAt = 0;
+        streamState._lastSseProgressAt = 0;
+        streamState._muxHealthRecoveryKey = "";
+        streamState._muxFullReplayTurnId = "";
+        streamState._muxFullReplayAttempts = 0;
         streamState.streamingModel = "";
       };
       const _mintLegacyTicket = async () => await fetch("/api/chat/stream/start", {
@@ -32195,7 +32346,7 @@ function portal() {
       // "0.0s" immediately instead of waiting through the SSE handshake, and
       // (b) mid-stream reconnects don't visibly reset the displayed elapsed.
       es.onopen = () => {
-        streamState._lastSseActivity = Date.now();
+        streamState._lastSseTransportAt = Date.now();
         if (!hasDetachedText && !isReconnect && !resumed) {
           this._commitChatRecoveryDraft(sendSid, composerInput);
         }
@@ -32208,14 +32359,11 @@ function portal() {
       // `done`. The turn then spins forever even though the server finished
       // and persisted the full reply (confirmed 2026-06-08: JSONL had the
       // complete answer; the client only ever rendered the thinking block).
-      // The server now heartbeats a NAMED `ping` every 15s; we bump
-      // _lastSseActivity on EVERY inbound event (incl. ping) and, if the
-      // stream goes fully silent past 2× the ping interval, synthesize an
-      // `error` event to reuse the transport-level reconnect path below
-      // (close → /active probe → re-subscribe or load the finished reply
-      // from disk). Reconnect is idempotent (broadcast replay), so a false
-      // trigger only costs a reconnect, never data.
-      streamState._lastSseActivity = Date.now();
+      // A root heartbeat only proves socket liveness; actual per-session
+      // progress has its own clock and is verified against latest_event_seq.
+      const streamClockStarted = Date.now();
+      streamState._lastSseTransportAt = streamClockStarted;
+      streamState._lastSseProgressAt = streamClockStarted;
       const _bumpSse = (ev) => {
         // An older EventSource may deliver one final buffered event after a
         // reconnect replaced it. It no longer owns this tab state.
@@ -32223,7 +32371,8 @@ function portal() {
           if (ev && ev.stopImmediatePropagation) ev.stopImmediatePropagation();
           return;
         }
-        streamState._lastSseActivity = Date.now();
+        const frameAt = Date.now();
+        streamState._lastSseTransportAt = frameAt;
         if (ev && ev.type !== "ping") {
           let meta = null;
           try { meta = JSON.parse(ev.data); } catch (_) {}
@@ -32257,6 +32406,10 @@ function portal() {
               streamState.lastEventSeq = eventSeq;
             }
           }
+        }
+        if (ev && !["ping", "error", "resync"].includes(ev.type)) {
+          streamState._lastSseProgressAt = frameAt;
+          streamState._muxHealthRecoveryKey = "";
         }
         if (sentUserBubble && !["ping", "error", "resync"].includes(ev && ev.type)) {
           sentUserBubble._admissionPending = false;
@@ -32298,17 +32451,19 @@ function portal() {
       if (streamState._stallWatch) clearInterval(streamState._stallWatch);
       streamState._stallWatch = setInterval(() => {
         if (!streamState.streaming) return;
-        const silentMs = Date.now() - (streamState._lastSseActivity || 0);
+        const progressSilentMs = Date.now() - (
+          streamState._lastSseProgressAt || streamState._streamStartedAt || Date.now());
+        const transportAt = es._muxChannel
+          ? (this._chatMuxLastTransportAt || this._chatMuxOpenedAt)
+          : streamState._lastSseTransportAt;
+        const transportSilentMs = Date.now() - (transportAt || Date.now());
         const sync = streamState.sessionSync;
         const healthProbePending = !!(sync && (
           (sync.inFlight && sync.inFlight.reason === "stream_health")
           || (sync.pending && sync.pending.stream_health)
         ));
-        if (silentMs > 40000 && !healthProbePending) {
-          // A mux channel never owns the native socket. Reconnect the one root
-          // transport without sending a synthetic per-session terminal/error.
+        if (transportSilentMs > 40000 && !healthProbePending) {
           if (es._muxChannel) {
-            this._scheduleChatMuxReconnect();
             this._recoverStalledStream(streamSid);
             return;
           }
@@ -32316,7 +32471,7 @@ function portal() {
           clearInterval(streamState._stallWatch);
           streamState._stallWatch = null;
           try { es.dispatchEvent(new Event("error")); } catch (_) {}
-        } else if (silentMs > 18000) {
+        } else if (progressSilentMs > 18000) {
           this._recoverStalledStream(streamSid);
         }
       }, 10000);
@@ -33528,28 +33683,53 @@ function portal() {
         try { payload = JSON.parse(ev.data) || {}; } catch (_) {}
         const reason = payload.reason || "replay_truncated";
         const fallback = payload.fallback || "canonical_history";
-        streamState._canonicalResyncPending = true;
         streamState._serverActiveObserved = true;
-        try { es.close(); } catch (_) {}
-        if (streamState._stallWatch) clearInterval(streamState._stallWatch);
-        streamState._stallWatch = null;
-        streamState.es = null;
-        if (streamState._flushLivePresentation === flushLivePresentation) {
-          streamState._flushLivePresentation = null;
-        }
-        pendingTaskProgress.clear();
         if (streamMobile && reason === "replay_truncated") {
           this.toast(this.lang === "zh"
             ? "回复数据量较大，完成后会自动从会话记录同步"
             : "This reply exceeded the live replay window; canonical history will sync when it finishes",
             "info", 5000);
         }
-        // The protocol names the authoritative recovery source. Unknown/older
-        // values still fail closed to canonical history rather than reconnecting
-        // the same unavailable sequence in a loop.
-        streamState._canonicalResyncFallback = fallback;
-        this._scheduleCanonicalStreamReload(streamSid, streamState);
         streamState._canonicalResyncReason = reason;
+        const canonicalFallback = () => {
+          streamState._canonicalResyncPending = true;
+          try { es.close(); } catch (_) {}
+          if (streamState._stallWatch) clearInterval(streamState._stallWatch);
+          streamState._stallWatch = null;
+          if (streamState.es === es) streamState.es = null;
+          if (streamState._flushLivePresentation === flushLivePresentation) {
+            streamState._flushLivePresentation = null;
+          }
+          pendingTaskProgress.clear();
+          streamState._canonicalResyncFallback = fallback;
+          this._scheduleCanonicalStreamReload(streamSid, streamState);
+        };
+        const fullReplayReasons = new Set([
+          "bootstrap_overflow", "replay_gap", "live_backlog",
+          "live_barrier_missing", "child_stream_error",
+        ]);
+        if (es._muxChannel && !isContinuation && fullReplayReasons.has(reason)) {
+          const ownerRoot = this._chatMuxSource;
+          void this._restartChatMuxFromBeginning(
+            streamSid,
+            streamState,
+            es,
+            ownerRoot,
+            {
+              turnId: payload.turn_id || streamTurnId,
+              startedAt: streamState._streamStartedAt / 1000,
+              scheduled: isScheduledDelivery,
+            },
+          ).then(restarted => {
+            if (!restarted && this.tabState[streamSid] === streamState) {
+              canonicalFallback();
+            }
+          });
+          return;
+        }
+        // Unknown and exact-owner-change failures stay fail-closed to canonical
+        // history; replaying sequence zero for the wrong turn is unsafe.
+        canonicalFallback();
       });
       es.addEventListener("error", async ev => {
         flushTerminalPresentation();

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -464,6 +464,401 @@ def test_mux_routes_two_sessions_reconnects_with_checkpoints_and_defers_watcher_
     _assert_no_browser_errors(page, errors)
 
 
+def test_mux_ping_does_not_mask_missing_application_events(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    mux_starts: list[dict] = []
+
+    def handle_mux_start(route) -> None:
+        mux_starts.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": f"mux-stall-{len(mux_starts)}"}),
+        )
+
+    page.route("**/api/chat/stream/mux/start", handle_mux_start)
+    page.route(
+        "**/api/chat/turns/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "accepted": True,
+                "session_id": route.request.post_data_json["session_id"],
+                "turn_id": "turn-stalled-root",
+                "started_at": int(time.time()),
+            }),
+        ),
+    )
+    page.route(
+        "**/api/chat/sessions/*/active",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "active": True,
+                "attachable": True,
+                "turn_id": "turn-stalled-root",
+                "started_at": int(time.time()),
+                "events_so_far": 3,
+                "latest_event_seq": 3,
+            }),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          app._confirmSessionBusy = async () => false;
+          app._awaitRuntimeSettingPatches = async () => true;
+          app.availableModels = [{
+            model: 'mux-stall-model', label: 'Mux stall', group: 'e2e',
+            supports_thinking: true,
+          }];
+          app.model = 'mux-stall-model';
+          app.permission = 'default';
+          app.sessions = app.sessions.map(session => session.id === sid
+            ? {...session, model: 'mux-stall-model', permission: 'default'}
+            : session);
+          st.permission = 'default';
+          st.draft.input = 'STALL_PROMPT';
+          app._activateComposerState(sid);
+          await app.send();
+          window.__emitMux('text', {
+            session_id: sid, turn_id: 'turn-stalled-root', event_seq: 1,
+            text: 'A',
+          });
+          await new Promise(resolve => setTimeout(resolve, 50));
+          const ownerChannel = st.es;
+          const ownerRoot = app._chatMuxSource;
+          const ownerAssistant = st.messages.find(
+            message => message.role === 'assistant' && message.text === 'A');
+          st._lastSseProgressAt = Date.now() - 20_000;
+          window.__emitMux('ping', '');
+          await app._recoverStalledStream(sid);
+          for (let i = 0; i < 120 && window.__fakeMuxStreams().length < 2; i++) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          const reconnected = window.__fakeMuxStreams().length === 2;
+          if (reconnected) {
+            window.__emitMux('text', {
+              session_id: sid, turn_id: 'turn-stalled-root', event_seq: 2,
+              text: 'OLD_ROOT_POISON',
+            }, 0);
+            window.__emitMux('text', {
+              session_id: sid, turn_id: 'turn-stalled-root', event_seq: 2,
+              text: 'B',
+            });
+          }
+          await new Promise(resolve => setTimeout(resolve, 50));
+          return {
+            sid,
+            reconnected,
+            ownerChannelPreserved: st.es === ownerChannel,
+            ownerAssistantPreserved: st.messages.includes(ownerAssistant),
+            text: ownerAssistant && ownerAssistant.text,
+            lastEventSeq: st.lastEventSeq,
+            oldRootClosed: !!ownerRoot.closed,
+          };
+        }""",
+    )
+
+    assert result == {
+        "sid": result["sid"],
+        "reconnected": True,
+        "ownerChannelPreserved": True,
+        "ownerAssistantPreserved": True,
+        "text": "AB",
+        "lastEventSeq": 2,
+        "oldRootClosed": True,
+    }
+    assert len(mux_starts) == 2
+    checkpoints = {
+        (row["session_id"], row["turn_id"]): row["last_event_seq"]
+        for row in mux_starts[1]["checkpoints"]
+    }
+    assert checkpoints[(result["sid"], "turn-stalled-root")] == 1
+    _assert_no_browser_errors(page, errors)
+
+
+def test_mux_resync_replays_from_zero_without_duplicate_live_suffix(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    mux_starts: list[dict] = []
+
+    def handle_mux_start(route) -> None:
+        mux_starts.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": f"mux-full-{len(mux_starts)}"}),
+        )
+
+    page.route("**/api/chat/stream/mux/start", handle_mux_start)
+    page.route(
+        "**/api/chat/turns/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "accepted": True,
+                "session_id": route.request.post_data_json["session_id"],
+                "turn_id": "turn-full-replay",
+                "started_at": int(time.time()),
+            }),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          app._confirmSessionBusy = async () => false;
+          app._awaitRuntimeSettingPatches = async () => true;
+          app.availableModels = [{
+            model: 'mux-full-model', label: 'Mux full', group: 'e2e',
+            supports_thinking: true,
+          }];
+          app.model = 'mux-full-model';
+          app.permission = 'default';
+          app.sessions = app.sessions.map(session => session.id === sid
+            ? {...session, model: 'mux-full-model', permission: 'default'}
+            : session);
+          st.permission = 'default';
+          st.draft.input = 'FULL_REPLAY_PROMPT';
+          app._activateComposerState(sid);
+          await app.send();
+          const firstChannel = st.es;
+          const firstRoot = app._chatMuxSource;
+          window.__emitMux('text', {
+            session_id: sid, turn_id: 'turn-full-replay', event_seq: 1,
+            text: 'A',
+          });
+          await new Promise(resolve => setTimeout(resolve, 50));
+          window.__emitMux('resync', {
+            session_id: sid, turn_id: 'turn-full-replay',
+            reason: 'replay_gap', fallback: 'canonical_history',
+            retryable: false,
+          });
+          for (let i = 0; i < 150 && window.__fakeMuxStreams().length < 2; i++) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          for (let i = 0; i < 150 && (!st.es || st.es === firstChannel); i++) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          const restarted = window.__fakeMuxStreams().length === 2
+            && !!st.es && st.es !== firstChannel;
+          if (restarted) {
+            window.__emitMux('text', {
+              session_id: sid, turn_id: 'turn-full-replay', event_seq: 2,
+              text: 'AB',
+            });
+          }
+          await new Promise(resolve => setTimeout(resolve, 60));
+          if (st._flushLivePresentation) st._flushLivePresentation();
+          const assistantTexts = st.messages
+            .filter(message => message.role === 'assistant')
+            .map(message => message.text || '');
+          return {
+            sid,
+            restarted,
+            oldRootClosed: !!firstRoot.closed,
+            oldChannelClosed: firstChannel.readyState === 2,
+            assistantTexts,
+            lastEventSeq: st.lastEventSeq,
+          };
+        }""",
+    )
+
+    assert result == {
+        "sid": result["sid"],
+        "restarted": True,
+        "oldRootClosed": True,
+        "oldChannelClosed": True,
+        "assistantTexts": ["AB"],
+        "lastEventSeq": 2,
+    }
+    assert len(mux_starts) == 2
+    matching = [
+        row for row in mux_starts[1]["checkpoints"]
+        if row["session_id"] == result["sid"]
+        and row["turn_id"] == "turn-full-replay"
+    ]
+    assert not matching or matching == [{
+        "session_id": result["sid"],
+        "turn_id": "turn-full-replay",
+        "last_event_seq": 0,
+    }]
+    _assert_no_browser_errors(page, errors)
+
+
+def test_committed_canonical_suffix_retires_stream_even_with_recent_transport(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+
+    result = page.evaluate(
+        """() => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = app.currentId;
+          const st = app._ensureTabState(sid);
+          const previous = app.sessions.find(session => session.id === sid);
+          const previousUpdated = Number(previous.updated_at) || 1;
+          previous.active = true;
+          previous.turn_active = true;
+          previous.background_active = false;
+          previous.message_count = 1;
+          previous.turn_count = 1;
+          let closed = false;
+          st._loaded = true;
+          st._installedCanonicalCount = 1;
+          st._seenUpdated = previousUpdated;
+          st._serverActiveObserved = true;
+          st._streamStartedAt = Date.now() - 6000;
+          st._lastSseTransportAt = Date.now();
+          st._lastSseProgressAt = Date.now();
+          st.streaming = true;
+          st.activeTurnId = 'turn-missing-terminal';
+          st.es = {
+            readyState: 1,
+            close() { closed = true; this.readyState = 2; },
+          };
+          const requests = [];
+          const originalRequest = app._requestSessionSync;
+          app._requestSessionSync = (targetSid, reason, options) => {
+            requests.push({ targetSid, reason, options });
+            return Promise.resolve(true);
+          };
+          try {
+            app._reconcileOpenSession([{
+              ...previous,
+              active: false,
+              turn_active: false,
+              updated_at: previousUpdated + 1,
+              message_count: 2,
+              turn_count: 2,
+            }]);
+            return {
+              streaming: st.streaming,
+              hasStream: !!st.es,
+              closed,
+              pendingExternalUpdate: st._pendingExternalUpdate,
+              reasons: requests.map(request => request.reason),
+            };
+          } finally {
+            app._requestSessionSync = originalRequest;
+          }
+        }""",
+    )
+
+    assert result == {
+        "streaming": False,
+        "hasStream": False,
+        "closed": True,
+        "pendingExternalUpdate": False,
+        "reasons": ["history_revision"],
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+def test_mux_live_attach_does_not_wait_for_cold_history(
+    page: Page, backend_url, auth_token,
+):
+    errors = _capture_browser_errors(page)
+    _install_fake_mux_event_source(page)
+    page.route(
+        "**/api/chat/stream/mux/start",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ticket": "mux-cold-history"}),
+        ),
+    )
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("window.__fakeMuxStreams().length === 1")
+
+    result = page.evaluate(
+        """async () => {
+          const app = document.querySelector('#app')._x_dataStack[0];
+          const sid = 'mux-history-pending';
+          app.sessions.push({
+            id: sid, name: 'History pending', model: app.model,
+            permission: 'default', cwd: app.currentWorkspacePath(), active: true,
+          });
+          if (!app.openTabIds.includes(sid)) app.openTabIds.push(sid);
+          app.currentId = sid;
+          app._activateComposerState(sid);
+          const st = app._ensureTabState(sid);
+          st._loaded = false;
+          st.permission = 'default';
+          let releaseHistory;
+          const historyGate = new Promise(resolve => { releaseHistory = resolve; });
+          const originalLoadSession = app.loadSession;
+          app.loadSession = async targetSid => {
+            if (targetSid !== sid) return originalLoadSession.call(app, targetSid);
+            await historyGate;
+            return true;
+          };
+          try {
+            window.__emitMux('session_state', {
+              session_id: sid, active: true, attachable: true,
+              background: false, continuation: false,
+              turn_id: 'turn-cold-history',
+              started_at: Math.floor(Date.now() / 1000),
+              user_text: 'COLD_HISTORY_PROMPT',
+            });
+            for (let i = 0; i < 100 && !st.es; i++) {
+              await new Promise(resolve => setTimeout(resolve, 10));
+            }
+            const attachedWhileHistoryPending = !!st.es;
+            for (let i = 1; i <= 520; i++) {
+              window.__emitMux('text', {
+                session_id: sid, turn_id: 'turn-cold-history', event_seq: i,
+                text: 'x',
+              });
+            }
+            await new Promise(resolve => setTimeout(resolve, 80));
+            if (st._flushLivePresentation) st._flushLivePresentation();
+            const liveText = st.messages
+              .filter(message => message.role === 'assistant')
+              .map(message => message.text || '').join('');
+            releaseHistory();
+            await new Promise(resolve => setTimeout(resolve, 0));
+            return {
+              attachedWhileHistoryPending,
+              liveLength: liveText.length,
+              lastEventSeq: st.lastEventSeq,
+              pendingMuxEvents: app._chatMuxPendingEvents.get(sid)?.length || 0,
+            };
+          } finally {
+            releaseHistory();
+            app.loadSession = originalLoadSession;
+          }
+        }""",
+    )
+
+    assert result == {
+        "attachedWhileHistoryPending": True,
+        "liveLength": 520,
+        "lastEventSeq": 520,
+        "pendingMuxEvents": 0,
+    }
+    _assert_no_browser_errors(page, errors)
+
+
 def test_mux_inactive_retires_matching_turn_without_harming_successor(
     page: Page, backend_url, auth_token,
 ):

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -362,6 +362,148 @@ def test_mux_reconcile_batches_durable_projections_off_loop(
         broadcast.close()
 
 
+def test_mux_forwards_live_event_while_next_reconcile_is_blocked(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    broadcast = chat_mod.TurnBroadcast("slow-reconcile-live-tail")
+    chat_mod._active_turns[broadcast.session_id] = broadcast
+    monkeypatch.setattr(
+        chat_mod,
+        "_session_active_status",
+        lambda _sid, **_kwargs: _active_state(broadcast),
+    )
+    reconcile_started = threading.Event()
+    release_reconcile = threading.Event()
+    calls = 0
+
+    def projections(_session_ids):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            reconcile_started.set()
+            release_reconcile.wait(timeout=2)
+        return {}, {}
+
+    monkeypatch.setattr(chat_mod, "_runtime_reconcile_projections", projections)
+
+    async def exercise():
+        stream = await _open_mux(chat_mod, {})
+        state = await asyncio.wait_for(anext(stream), timeout=0.5)
+        assert state["event"] == "session_state"
+        for _ in range(50):
+            if broadcast.subscribers:
+                break
+            await asyncio.sleep(0.002)
+        assert broadcast.subscribers
+
+        pending = asyncio.create_task(anext(stream))
+        started = await asyncio.to_thread(
+            reconcile_started.wait, 0.5)
+        assert started
+        broadcast.publish({
+            "event": "text",
+            "data": json.dumps({"text": "must not wait for reconcile"}),
+        })
+        try:
+            event = await asyncio.wait_for(pending, timeout=0.2)
+            assert event["event"] == "text"
+            assert json.loads(event["data"])["text"] == (
+                "must not wait for reconcile")
+        finally:
+            release_reconcile.set()
+        await stream.aclose()
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_reconcile.set()
+        broadcast.close()
+
+
+def test_mux_full_output_does_not_deadlock_control_state(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    broadcast = chat_mod.TurnBroadcast("full-output-control-state")
+    for index in range(400):
+        broadcast.publish({
+            "event": "tool_result",
+            "data": json.dumps({"id": f"result-{index}"}),
+        })
+    chat_mod._active_turns[broadcast.session_id] = broadcast
+    background_pending = {"count": 0}
+
+    def state(_sid, **_kwargs):
+        payload = _active_state(broadcast)
+        payload["background_tasks_pending"] = background_pending["count"]
+        return payload
+
+    monkeypatch.setattr(chat_mod, "_session_active_status", state)
+    monkeypatch.setattr(
+        chat_mod, "_runtime_reconcile_projections", lambda _ids: ({}, {}))
+
+    async def exercise():
+        stream = await _open_mux(chat_mod, {})
+        initial = await asyncio.wait_for(anext(stream), timeout=0.5)
+        assert initial["event"] == "session_state"
+        for _ in range(100):
+            if broadcast.subscribers:
+                break
+            await asyncio.sleep(0.002)
+        assert broadcast.subscribers
+        # Let the child fill all 256 aggregate handoff slots and block on the
+        # remaining replay. A changed fingerprint makes reconcile publish one
+        # control frame while the data queue is full.
+        await asyncio.sleep(0.05)
+        background_pending["count"] = 1
+        event = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert event["event"] == "tool_result"
+        await stream.aclose()
+
+    asyncio.run(exercise())
+    broadcast.close()
+
+
+def test_mux_replays_plain_turn_that_finishes_between_reconciles(
+        chat_mod, monkeypatch):
+    monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)
+    monkeypatch.setattr(
+        chat_mod,
+        "_session_active_status",
+        lambda _sid, **_kwargs: {"active": False},
+    )
+    monkeypatch.setattr(
+        chat_mod, "_runtime_reconcile_projections", lambda _ids: ({}, {}))
+
+    async def exercise():
+        stream = await _open_mux(chat_mod, {})
+        broadcast = chat_mod.TurnBroadcast("recent-during-subscription")
+        chat_mod._announce_mux_turn(broadcast)
+        state = await asyncio.wait_for(anext(stream), timeout=0.2)
+        assert state["event"] == "session_state"
+        assert json.loads(state["data"])["turn_id"] == broadcast.turn_id
+
+        broadcast.publish({
+            "event": "text",
+            "data": json.dumps({"text": "fast complete reply"}),
+        })
+        broadcast.publish({
+            "event": "done",
+            "data": json.dumps({"status": "completed"}),
+        })
+        broadcast.finish()
+        chat_mod._remember_recent_turn(broadcast.session_id, broadcast)
+        try:
+            event = await asyncio.wait_for(anext(stream), timeout=0.2)
+            assert event["event"] == "text"
+            assert json.loads(event["data"])["text"] == "fast complete reply"
+        finally:
+            await stream.aclose()
+            chat_mod._evict_recent_turn(
+                broadcast.session_id, broadcast.turn_id)
+
+    asyncio.run(exercise())
+
+
 def test_mux_watcher_state_can_become_attachable_dynamically(
         chat_mod, monkeypatch):
     monkeypatch.setattr(chat_mod, "_MUX_RECONCILE_INTERVAL_S", 0.01)

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1419,15 +1419,17 @@ def test_silent_stream_recovers_without_manual_refresh():
     end = app.index("\n    _scheduleCanonicalStreamReload", start)
     recovery = app[start:end]
 
-    assert "Date.now() - observedActivity < 18_000" in recovery
+    assert "Date.now() - observedProgress < 18_000" in recovery
     assert 'this._requestSessionSync(sid, "stream_health"' in recovery
-    assert "d.events_so_far" in recovery
+    assert "d.latest_event_seq" in recovery
     assert "st._serverActiveObserved = true" in recovery
-    assert "await this.send({" in recovery
-    assert "reconnect: true" in recovery
+    assert "await this._forceChatMuxReconnect(" in recovery
+    assert "ownerMuxSource" in recovery
+    assert "st._muxHealthRecoveryKey" in recovery
     assert "this._retireStaleSessionStream(sid, st)" in recovery
     assert "quiet: true, probeActive: false" in recovery
     assert "this._recoverStalledStream(streamSid)" in app
+    assert 'if (type === "ping") return;' in app
 
 
 def test_stream_reconnect_is_pinned_to_backend_turn_identity():
@@ -5607,9 +5609,11 @@ def test_midturn_reconnect_storm_guards_are_in_place():
     assert "hasTurnActivityFlag ? !!cur.turn_active" in reconcile
     assert "!!cur.active && !cur.background_active" in reconcile
     assert "if (wantsAttach && st._loaded) this._checkActiveTurn(sid);" in reconcile
-    # 2. A HEALTHY transport is never retired on one stale `active:false` tick.
-    assert "const transportDead = !st.es" in reconcile
-    assert "if (transportDead) this._retireStaleSessionStream(sid, st);" in reconcile
+    # 2. A healthy transport is retired only when the same metadata snapshot
+    #    proves that a newer canonical suffix has actually committed.
+    assert "const canonicalCommitted = canonicalSuffixMissing || visibleNewer" in reconcile
+    assert "|| messageCountChanged || turnCountChanged" in reconcile
+    assert "if (canonicalCommitted) this._retireStaleSessionStream(sid, st);" in reconcile
 
     # 3. Quiet reconciliation loads must not re-probe /active (that probe is
     #    what turned every poll-driven reload into a full-turn replay).
@@ -5631,7 +5635,10 @@ def test_midturn_reconnect_storm_guards_are_in_place():
     assert "if (!this._allowReconnect(sid, d.turn_id)) return;" in check
     recover = js[js.index("    _recoverStalledStream(sid = this.currentId) {"):]
     recover = recover[:recover.index("\n    _scheduleCanonicalStreamReload(")]
-    assert "if (!this._allowReconnect(sid, d.turn_id || st.activeTurnId)) return false;" in recover
+    assert "await this._forceChatMuxReconnect(" in recover
+    force = js[js.index("    async _forceChatMuxReconnect("):]
+    force = force[:force.index("\n    _scheduleChatMuxReconnect(")]
+    assert "if (!this._allowReconnect(sid, turnId)) return false;" in force
 
     # 5. The MAX_ATTEMPTS ceiling must stay reachable: a fresh turn is the only
     #    place the counter resets. Every reconnect opens its EventSource


### PR DESCRIPTION
## 问题

multiplex SSE 存在多条会让消息停在旧状态、刷新后才突然补齐的链路：

- reconcile 与事件消费串行，慢状态检查会阻塞实时帧，队列满时还会自锁；
- 快速 turn 可能在 200ms 轮询间隔内开始并结束，multiplex 从未订阅；
- 根连接 ping 被当作每个会话的业务进展，掩盖逻辑流卡住；
- 同一条“已连接但不再出业务事件”的根流上重建逻辑 channel 无法恢复；
- 冷历史加载会挡住 live reducer，积压后 resync 只能等最终历史。

## 修复

- 后端将固定频率 reconcile 与输出消费解耦，并在 turn 被接纳时精确通知 multiplex；
- 保持 checkpoint/replay 顺序，避免满队列死锁和慢 reconcile 阻塞；
- 前端区分传输心跳与业务进展，以服务端序号识别缺帧并重连根流；
- resync 对安全原因从 seq=0 完整回放，避免重复或残缺后缀；
- 冷会话先建立实时 reducer，历史异步补齐；
- canonical 已提交时即使近期仍有 ping，也立即收敛到持久化历史。

## 验证

- pytest -q -n auto --dist=worksteal tests/：1702 passed, 167 skipped
- RUN_E2E=1 pytest -q tests/e2e/test_chat_render_perf.py：73 passed
- pytest -q tests/test_frontend_lint.py：183 passed
- pytest -q tests/test_chat_multiplex_stream.py：16 passed
- pytest -q tests/test_chat_stream.py tests/test_chat_multiplex_stream.py：209 passed
- ruff check、scripts/lint.sh、Python/Node syntax checks：通过
