### PR TITLE
fix(chat): 补齐完成回复并解除后台任务刷新阻塞

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11141,13 +11141,15 @@ function portal() {
             }
           }
         }
-        // The old completion UUID may have aged out of the bounded tail after
-        // many successor tool turns. A stable, idle canonical snapshot permits
-        // following its latest assistant boundary instead of waiting forever.
+        // A stable, idle snapshot with a committed turn identity is authoritative
+        // even when the live final text was incomplete or its UUID was missing.
+        // This also covers an older completion aged out of the bounded tail
+        // after fast successors. Do not require live text equality to adopt the
+        // very canonical suffix that is supposed to repair that live text.
         if (finalIndex < 0 && committedState?.stable === true
             && !committedState.active && !history.has_later) {
           let boundaryConfirmed = !!(committedState.completed_turn_id
-            && completedTurnId && committedState.completed_turn_id !== completedTurnId);
+            && completedTurnId);
           if (!boundaryConfirmed && expectedAssistantUuid && Number(history.offset) > 0) {
             const boundaryResponse = await this._fetchWithDeadline(
               "/api/chat/sessions/" + sid + "?around_uuid=" + encodeURIComponent(expectedAssistantUuid)
@@ -12959,22 +12961,39 @@ function portal() {
     },
     async _runCanonicalReplaySync(sid, st, options = {}) {
       if (this.tabState[sid] !== st) return false;
+      const ownedTurnId = String(st.activeTurnId || "");
+      const ownedStream = st.es;
       const startedAt = Number(st.sessionSync.canonicalStartedAt) || Date.now();
       const minimumWaitMs = Math.max(0, Number(options.minimumWaitMs) || 0);
       let active = true;
+      let activity = null;
       try {
         const r = await this._fetchWithDeadline(
           `/api/chat/sessions/${encodeURIComponent(sid)}/active`,
           { headers: this.hdr(), signal: options.signal },
         );
-        if (r.ok) active = !!(await r.json()).active;
+        if (r.ok) {
+          activity = await r.json();
+          active = !!activity.active;
+        }
       } catch (_) {
         if (options.signal?.aborted) return false;
         active = true;
       }
-      if (this.tabState[sid] !== st) return false;
+      if (this.tabState[sid] !== st || options.signal?.aborted) return false;
       const waited = Date.now() - startedAt;
-      if ((active || waited < minimumWaitMs) && waited < 31 * 60_000) {
+      const backgroundOnly = active && activity?.background === true
+        && activity.attachable === false;
+      const activityTurnId = String(activity?.turn_id || "");
+      // Watcher-only activity means the foreground Result is already readable.
+      // Preserve a successor admitted before/during this probe, including its
+      // optimistic prompt; an old watcher must never retire the newer stream.
+      const preserveOwner = this._hasPendingAdmission(st)
+        || st.es !== ownedStream || String(st.activeTurnId || "") !== ownedTurnId
+        || (backgroundOnly && (st.streaming || st.es)
+          && activityTurnId && ownedTurnId && activityTurnId !== ownedTurnId);
+      if (preserveOwner || (((active && !backgroundOnly) || waited < minimumWaitMs)
+          && waited < 31 * 60_000)) {
         this._requestSessionSync(sid, "canonical_replay", {
           minimumWaitMs, delayMs: 1000,
         });
@@ -12983,6 +13002,14 @@ function portal() {
       const retryN = Math.max(
         0, Number(st.sessionSync.canonicalRetryN) || 0);
       this._retireStaleSessionStream(sid, st);
+      if (backgroundOnly) {
+        st._serverActiveObserved = true;
+        if (activityTurnId && !st.activeTurnId) st.activeTurnId = activityTurnId;
+        this._setBackgroundTaskActive(
+          sid, true, activity.started_at, activity.background_tasks_pending,
+        );
+        this._ensureBgContPoller(sid);
+      }
       st._pendingExternalUpdate = true;
       const loaded = await this.loadSession(sid, {
         quiet: true, signal: options.signal,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11142,14 +11142,17 @@ function portal() {
           }
         }
         // A stable, idle snapshot with a committed turn identity is authoritative
-        // even when the live final text was incomplete or its UUID was missing.
+        // when the live final text was incomplete and its UUID was missing.
         // This also covers an older completion aged out of the bounded tail
         // after fast successors. Do not require live text equality to adopt the
         // very canonical suffix that is supposed to repair that live text.
+        // A known UUID is still a required boundary for this same turn: its
+        // absence must not authorize installing an unrelated successor suffix.
         if (finalIndex < 0 && committedState?.stable === true
             && !committedState.active && !history.has_later) {
           let boundaryConfirmed = !!(committedState.completed_turn_id
-            && completedTurnId);
+            && completedTurnId && (committedState.completed_turn_id !== completedTurnId
+              || !expectedAssistantUuid));
           if (!boundaryConfirmed && expectedAssistantUuid && Number(history.offset) > 0) {
             const boundaryResponse = await this._fetchWithDeadline(
               "/api/chat/sessions/" + sid + "?around_uuid=" + encodeURIComponent(expectedAssistantUuid)

--- a/tests/e2e/test_completion_visibility.py
+++ b/tests/e2e/test_completion_visibility.py
@@ -1,8 +1,9 @@
 """Final-history recovery must converge without a browser reload.
 
-Stable completed-turn identity is stronger than a possibly incomplete live
-text/UUID, and detached background work must not gate the foreground history.
-Keep both rules covered alongside successor and quiet-rendering protections.
+When the live UUID is missing, stable completed-turn identity can repair
+incomplete text. A known UUID still requires its own canonical boundary.
+Detached background work must not gate the foreground history. Keep these
+rules covered alongside successor and quiet-rendering protections.
 """
 import pytest
 
@@ -98,7 +99,7 @@ def _prepare(page, backend_url, auth_token, *, state=None, activity=None, histor
 
 @pytest.mark.parametrize("width", [1440, 390])
 @pytest.mark.parametrize("expected_uuid,expected_text", [
-    ("", "LIVE_PARTIAL"), ("missing-live-uuid", "LIVE_PARTIAL"), ("", ""),
+    ("", "LIVE_PARTIAL"), ("", ""),
 ])
 def test_completed_identity_recovers_incomplete_live_reply(
     page, backend_url, auth_token, width, expected_uuid, expected_text,
@@ -130,24 +131,26 @@ def test_completed_identity_recovers_incomplete_live_reply(
     _assert_no_browser_errors(page, errors)
 
 
-@pytest.mark.parametrize("state", [
-    {"stable": False},
-    {"active": True, "turn_id": "fixture-turn"},
-    {"active": True, "turn_id": "successor-turn"},
-    {"completed_turn_id": ""},
+@pytest.mark.parametrize("state,expected_uuid", [
+    ({"stable": False}, ""),
+    ({"active": True, "turn_id": "fixture-turn"}, ""),
+    ({"active": True, "turn_id": "successor-turn"}, ""),
+    ({"completed_turn_id": ""}, ""),
+    ({}, "missing-live-uuid"),
 ])
 def test_incomplete_live_reply_still_requires_stable_idle_commit(
-    page, backend_url, auth_token, state,
+    page, backend_url, auth_token, state, expected_uuid,
 ):
     errors, _, _ = _prepare(page, backend_url, auth_token, state=state)
     result = _app_eval(page, """
-        const st = app.tabState[arg];
-        const loaded = await app._runCompletedTurnSync(arg, st, {
+        const st = app.tabState[arg.sid];
+        const loaded = await app._runCompletedTurnSync(arg.sid, st, {
           expectedText: 'LIVE_PARTIAL', completedTurnId: 'fixture-turn',
+          expectedAssistantUuid: arg.uuid,
         });
         return {loaded, text: st.messages.at(-1).text,
           reasons: window.visibilityRequests.map(r => r.reason)};
-    """, SID)
+    """, {"sid": SID, "uuid": expected_uuid})
     assert result == {"loaded": False, "text": "LIVE_PARTIAL", "reasons": ["completed_turn"]}
     _assert_no_browser_errors(page, errors)
 

--- a/tests/e2e/test_completion_visibility.py
+++ b/tests/e2e/test_completion_visibility.py
@@ -1,0 +1,270 @@
+"""Final-history recovery must converge without a browser reload.
+
+Stable completed-turn identity is stronger than a possibly incomplete live
+text/UUID, and detached background work must not gate the foreground history.
+Keep both rules covered alongside successor and quiet-rendering protections.
+"""
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import expect  # noqa: E402
+
+from tests.e2e.test_chat_render_perf import (
+    _app_eval,
+    _assert_no_browser_errors,
+    _capture_browser_errors,
+    _login,
+)
+
+
+SID = "completion-visibility-fixture"
+FINAL = "CANONICAL_FINAL_COMPLETE"
+
+
+def _prepare(page, backend_url, auth_token, *, state=None, activity=None, history_failures=0):
+    errors = _capture_browser_errors(page)
+    _login(page, backend_url, auth_token)
+    history = {
+        "id": SID, "name": "Completion fixture", "model": "e2e-model",
+        "permission": "bypassPermissions", "thinking": True,
+        "messages": [
+            {"role": "user", "text": "FIXTURE_PROMPT", "uuid": "fixture-user",
+             "_turnRoot": True},
+            {"role": "assistant", "text": FINAL, "uuid": "fixture-final"},
+        ],
+        "offset": 0, "total": 2, "message_count": 2, "pre_total": 0,
+        "history_order": "normal", "history_generation": "fixture-generation",
+        "has_more": False, "has_later": False, "updated_at": 2,
+        "completion_state": {
+            "stable": True, "active": False, "turn_id": "",
+            "completed_turn_id": "fixture-turn", **(state or {}),
+        },
+    }
+    reads = []
+
+    def respond(route):
+        nonlocal history_failures
+        reads.append(route.request.url)
+        if "?tail=" in route.request.url and history_failures > 0:
+            history_failures -= 1
+            route.fulfill(status=503, json={"detail": "fixture retry"})
+            return
+        route.fulfill(json=activity if route.request.url.endswith("/active") else history)
+
+    page.route(f"**/api/chat/sessions/{SID}?*", respond)
+    page.route(f"**/api/chat/sessions/{SID}/active", respond)
+    _app_eval(page, """
+        const sid = arg;
+        app.refreshSessions = async () => {};
+        app._syncSessionListQuiet = async () => {};
+        app._fetchTabUsage = async () => {};
+        app._scheduleIdlePreload = () => {};
+        app._checkActiveTurn = () => {};
+        app._syncQueueFromServer = async () => {};
+        app._drainPendingQueue = async () => {};
+        app.sessions = [{id: sid, name: 'Completion fixture', message_count: 2}];
+        app.openTabIds = [sid];
+        app.tabState = {};
+        app.currentId = sid;
+        app.mobileTab = 'chat';
+        const st = app._ensureTabState(sid);
+        st._loaded = true;
+        st.atBottom = true;
+        st.messages.push(
+          {role: 'user', text: 'FIXTURE_PROMPT', uuid: 'fixture-user',
+           _turnRoot: true, _k: `${sid}:uuid:fixture-user`},
+          {role: 'assistant', text: 'LIVE_PARTIAL', _k: `${sid}:live:partial`},
+        );
+        Object.assign(st.messageRange, {
+          visibleStart: 0, visibleEnd: 2, offset: 0, total: 2,
+          preTotal: 0, order: 'normal', generation: 'fixture-live',
+        });
+        app._activateTabState(sid);
+        window.visibilityRequests = [];
+        window.realVisibilityRequest = app._requestSessionSync.bind(app);
+        app._requestSessionSync = (id, reason, options) => {
+          window.visibilityRequests.push({id, reason, options});
+          return Promise.resolve(false);
+        };
+        window.visibilityScrolls = [];
+        const originalLoad = app.loadSession.bind(app);
+        app.loadSession = async (id, options) => {
+          window.visibilityScrolls.push(options.followTail === true);
+          return originalLoad(id, options);
+        };
+    """, SID)
+    return errors, history, reads
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+@pytest.mark.parametrize("expected_uuid,expected_text", [
+    ("", "LIVE_PARTIAL"), ("missing-live-uuid", "LIVE_PARTIAL"), ("", ""),
+])
+def test_completed_identity_recovers_incomplete_live_reply(
+    page, backend_url, auth_token, width, expected_uuid, expected_text,
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    errors, _, reads = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st._userScrollAt = 12;
+        const options = {
+          expectedText: arg.text, expectedAssistantUuid: arg.uuid,
+          completedTurnId: 'fixture-turn', followTail: true,
+          followTailUserScrollAt: 11,
+        };
+        st._pendingCompletedTurnSync = options;
+        const loaded = await app._runCompletedTurnSync(arg.sid, st, options);
+        await new Promise(resolve => app.$nextTick(resolve));
+        return {loaded, pending: st._pendingCompletedTurnSync,
+          text: st.messages.at(-1).text, ready: st.messagesReady,
+          loading: st.messagesLoading, requests: window.visibilityRequests.length,
+          followTail: window.visibilityScrolls};
+    """, {"sid": SID, "uuid": expected_uuid, "text": expected_text})
+    assert result == {
+        "loaded": True, "pending": None, "text": FINAL, "ready": True,
+        "loading": False, "requests": 0, "followTail": [False],
+    }
+    assert len(reads) == 1
+    expect(page.locator(f'.msg-pane[data-tid="{SID}"]')).to_contain_text(FINAL)
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("state", [
+    {"stable": False},
+    {"active": True, "turn_id": "fixture-turn"},
+    {"active": True, "turn_id": "successor-turn"},
+    {"completed_turn_id": ""},
+])
+def test_incomplete_live_reply_still_requires_stable_idle_commit(
+    page, backend_url, auth_token, state,
+):
+    errors, _, _ = _prepare(page, backend_url, auth_token, state=state)
+    result = _app_eval(page, """
+        const st = app.tabState[arg];
+        const loaded = await app._runCompletedTurnSync(arg, st, {
+          expectedText: 'LIVE_PARTIAL', completedTurnId: 'fixture-turn',
+        });
+        return {loaded, text: st.messages.at(-1).text,
+          reasons: window.visibilityRequests.map(r => r.reason)};
+    """, SID)
+    assert result == {"loaded": False, "text": "LIVE_PARTIAL", "reasons": ["completed_turn"]}
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+def test_replay_gap_loads_final_while_detached_background_is_active(
+    page, backend_url, auth_token, width,
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    errors, _, reads = _prepare(page, backend_url, auth_token, activity={
+        "active": True, "background": True, "attachable": False,
+        "turn_id": "fixture-turn", "background_tasks_pending": 1,
+    })
+    result = _app_eval(page, """
+        const st = app.tabState[arg];
+        st._canonicalResyncPending = true;
+        st.sessionSync.canonicalStartedAt = Date.now() - 5000;
+        st.activeTurnId = 'fixture-turn';
+        st.streaming = true;
+        let closed = 0;
+        st.es = {close: () => {closed += 1;}};
+        const loaded = await app._runCanonicalReplaySync(arg, st);
+        await new Promise(resolve => app.$nextTick(resolve));
+        return {loaded, pending: st._canonicalResyncPending,
+          text: st.messages.at(-1).text, streaming: st.streaming, closed,
+          ready: st.messagesReady, loading: st.messagesLoading,
+          background: st.backgroundActive,
+          retries: window.visibilityRequests.filter(r => r.reason === 'canonical_replay').length};
+    """, SID)
+    assert result == {
+        "loaded": True, "pending": False, "text": FINAL, "streaming": False,
+        "closed": 1, "ready": True, "loading": False, "background": True,
+        "retries": 0,
+    }
+    assert any("?tail=" in url for url in reads)
+    expect(page.locator(f'.msg-pane[data-tid="{SID}"]')).to_contain_text(FINAL)
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("case", [
+    "foreground", "attachable", "successor", "admission",
+    "successor_during_probe", "stream_during_probe",
+])
+def test_replay_recovery_preserves_foreground_owner(
+    page, backend_url, auth_token, case,
+):
+    errors, _, reads = _prepare(page, backend_url, auth_token, activity={
+        "active": True, "background": case != "foreground",
+        "attachable": case == "attachable", "turn_id": "fixture-turn",
+    })
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st._canonicalResyncPending = true;
+        st.sessionSync.canonicalStartedAt = Date.now() - 5000;
+        st.activeTurnId = arg.testCase === 'successor' ? 'successor-turn' : 'fixture-turn';
+        st._composerSubmitToken = arg.testCase === 'admission' ? 'new-submit' : null;
+        st.streaming = true;
+        let closed = 0;
+        st.es = {close: () => {closed += 1;}};
+        const originalFetch = app._fetchWithDeadline.bind(app);
+        app._fetchWithDeadline = async (...args) => {
+          const response = await originalFetch(...args);
+          if (arg.testCase === 'successor_during_probe') {
+            st.activeTurnId = 'successor-turn';
+          }
+          if (arg.testCase === 'stream_during_probe') {
+            st.es = {close: () => {closed += 1;}};
+          }
+          return response;
+        };
+        await app._runCanonicalReplaySync(arg.sid, st);
+        return {text: st.messages.at(-1).text, streaming: st.streaming, closed,
+          pending: st._canonicalResyncPending,
+          retries: window.visibilityRequests.filter(r => r.reason === 'canonical_replay').length};
+    """, {"sid": SID, "testCase": case})
+    assert result == {
+        "text": "LIVE_PARTIAL", "streaming": True, "closed": 0,
+        "pending": True, "retries": 1,
+    }
+    assert len(reads) == 1 and reads[0].endswith("/active")
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("mode", ["completed", "replay", "replay_retry"])
+def test_final_visibility_converges_through_real_session_scheduler(
+    page, backend_url, auth_token, mode,
+):
+    errors, _, reads = _prepare(page, backend_url, auth_token, activity={
+        "active": True, "background": True, "attachable": False,
+        "turn_id": "fixture-turn", "background_tasks_pending": 1,
+    }, history_failures=int(mode == "replay_retry"))
+    _app_eval(page, """
+        app._requestSessionSync = window.realVisibilityRequest;
+        const st = app.tabState[arg.sid];
+        if (arg.mode === 'completed') {
+          app._reconcileCompletedTurn(
+            arg.sid, st, 'LIVE_PARTIAL', 0, '', 'fixture-turn');
+        } else {
+          st.activeTurnId = 'fixture-turn';
+          st.streaming = true;
+          st.es = {close: () => {}};
+          app._scheduleCanonicalStreamReload(arg.sid, st);
+        }
+    """, {"sid": SID, "mode": mode})
+    pane = page.locator(f'.msg-pane[data-tid="{SID}"]')
+    expect(pane).to_contain_text(FINAL, timeout=10000)
+    expect(pane).to_contain_text("FIXTURE_PROMPT")
+    result = _app_eval(page, """
+        const st = app.tabState[arg];
+        app._stopBgContPoller(arg);
+        return {streaming: st.streaming, pending: st._canonicalResyncPending,
+          completedPending: st._pendingCompletedTurnSync || null,
+          ready: st.messagesReady, loading: st.messagesLoading};
+    """, SID)
+    assert result == {
+        "streaming": False, "pending": False, "completedPending": None,
+        "ready": True, "loading": False,
+    }
+    assert sum("?tail=" in url for url in reads) == (2 if mode == "replay_retry" else 1)
+    _assert_no_browser_errors(page, errors)


### PR DESCRIPTION
## 变更说明

- 完成记录已经稳定且没有活跃主轮次时，允许在最终 UUID 缺失的情况下，依据服务端已完成轮次标识补齐不完整的流式回复。
- 已知 UUID 仍须满足原有的记录边界保护，不能因找不到该 UUID 就采用不相关的后续回复。
- 断线恢复区分仍在运行的主轮次与不可附加的后台任务，不再等待后台任务结束才读取完整历史。
- 保留正在提交的消息、后续轮次、探测期间切换的连接和用户滚动位置；恢复后台任务显示与后续轮询。
- 新增 20 个浏览器回归案例，包含桌面、手机、并发发送保护及真实同步调度器的失败重试。

## 测试情况

- 两条代表性回归案例在修复前失败，修复后通过。
- 首轮 CI 发现已知 UUID 的边界保护过宽；已补充修正，保留原有失败用例不变。
- 修正后本地全量 Playwright：224 passed，无重试。
- 前端静态与消息队列回归：266 passed。
- `node --check frontend/app.js`、新增测试的 Ruff 检查及 `git diff --check` 通过。

## 变更范围

仅修改 `frontend/app.js` 并新增 `tests/e2e/test_completion_visibility.py`；不包含其他文档或配置改动。
