### PR TITLE
fix(runtime): 修复会话收尾与记忆生成可靠性

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -94,6 +94,7 @@ from .ask_user_question import (
 from . import permission_request as perm
 from . import memory_client as mem0
 from . import observability as obs
+from . import replay_io
 from .private_storage import (
     UnsafePrivatePath,
     ensure_private_directory,
@@ -680,6 +681,8 @@ class _ReplaySpool:
         self._bytes = 0
         self._closed = False
         self._usable = True
+        self._written_bytes = 0
+        self._io = replay_io.ReplayIO()
 
     def append(self, event: dict) -> None:
         if self._closed:
@@ -688,7 +691,17 @@ class _ReplaySpool:
             raise RuntimeError("replay spool is unusable")
         payload = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
         blob = payload.encode("utf-8") + b"\n"
-        start = self._bytes
+        self._io.check()
+        if replay_io.in_event_loop():
+            self._io.submit(lambda: self._write_blob(blob), size=len(blob))
+        else:
+            self._io.flush()
+            self._write_blob(blob)
+        self._count += 1
+        self._bytes += len(blob)
+
+    def _write_blob(self, blob: bytes) -> None:
+        start = self._written_bytes
         written = 0
         try:
             while written < len(blob):
@@ -703,8 +716,10 @@ class _ReplaySpool:
             except OSError:
                 self._usable = False
             raise
-        self._count += 1
-        self._bytes += len(blob)
+        self._written_bytes += len(blob)
+
+    async def flush_async(self) -> None:
+        await self._io.flush_async()
 
     def size(self) -> int:
         """Bytes written so far. A subscriber records this at attach time to
@@ -714,13 +729,14 @@ class _ReplaySpool:
         return self._bytes
 
     def open_reader(self):
-        return self.path.open("rb")
+        return replay_io.ReplayReader(self.path, self._io, lambda: self._written_bytes)
 
     def __len__(self) -> int:
         return self._count
 
     def __iter__(self):
-        with self.open_reader() as reader:
+        self._io.flush()
+        with self.path.open("rb") as reader:
             for line in reader:
                 yield _decode_replay_record(line)
 
@@ -738,6 +754,15 @@ class _ReplaySpool:
         if self._closed:
             return
         self._closed = True
+        if replay_io.in_event_loop():
+            self._io.submit(self._close_file, cleanup=True)
+        else:
+            try:
+                self._io.flush()
+            finally:
+                self._close_file()
+
+    def _close_file(self):
         os.close(self._fd)
         with suppress(OSError):
             self.path.unlink()
@@ -783,6 +808,8 @@ class _TurnSubscriber:
         self._draining_live_barrier = False
         self._wake = asyncio.Event()
         self._done = False
+        self._pending_spool_read = None
+        self._replay_revision = 0
 
     async def get(self):
         while True:
@@ -798,6 +825,18 @@ class _TurnSubscriber:
                     "data": json.dumps(payload),
                 }
             if self._initial_events:
+                if self._replay is not None and hasattr(self._replay, "ready"):
+                    try:
+                        await self._replay.ready()
+                    except (OSError, RuntimeError):
+                        self.resync("replay_storage_error")
+                        self._initial_events.clear()
+                        continue
+                if self._resync_payload:
+                    continue
+                if self._replay is None:
+                    self._initial_events.clear()
+                    return None
                 event = dict(self._initial_events.popleft())
                 event.pop("_coalesced", None)
                 return event
@@ -828,7 +867,7 @@ class _TurnSubscriber:
                     continue
                 await self._wake.wait()
                 continue
-            event = self._next_spool_event()
+            event = await self._next_spool_event()
             if self._resync_payload:
                 continue
             if event is _LIVE_MESSAGE_BARRIER:
@@ -850,7 +889,7 @@ class _TurnSubscriber:
             self._wake.clear()
             # Close the clear/append race: publish() may have written between
             # the first EOF read and clear(). Recheck before sleeping.
-            event = self._next_spool_event()
+            event = await self._next_spool_event()
             if self._resync_payload:
                 continue
             if event is _LIVE_MESSAGE_BARRIER:
@@ -868,27 +907,52 @@ class _TurnSubscriber:
                 return None
             await self._wake.wait()
 
-    def _next_spool_event(self):
-        """Next spool line this subscriber should actually emit, or None when
-        the spool is exhausted. Drops coalesced text that this subscriber
-        already received as live deltas."""
+    async def _read_spool_record(self, reader):
+        revision = self._replay_revision
+        if hasattr(reader, "ready"):
+            await reader.ready()
+        def read():
+            offset = reader.tell()
+            line = reader.readline()
+            return offset, _decode_replay_record(line) if line else None
+        offset, event = await replay_io.read_io(read)
+        return revision, offset, event
+
+    async def _next_spool_event(self):
         while True:
-            offset = self._replay.tell()
-            line = self._replay.readline()
-            if not line:
+            reader = self._replay
+            if reader is None:
                 return None
+            if self._pending_spool_read is None:
+                self._pending_spool_read = asyncio.create_task(
+                    self._read_spool_record(reader))
+                # A disconnected subscriber may never consume a late disk failure.
+                self._pending_spool_read.add_done_callback(
+                    lambda task: task.exception() if not task.cancelled() else None)
+            task = self._pending_spool_read
             try:
-                event = _decode_replay_record(line)
+                # HTTP wait_for timeouts must not lose a record whose disk read
+                # continues. The next get() consumes this same completed read.
+                revision, offset, event = await asyncio.shield(task)
             except _ReplayRecordCorruption:
+                self._pending_spool_read = None
                 self.resync("replay_corrupt")
+                return None
+            except (OSError, RuntimeError, ValueError):
+                self._pending_spool_read = None
+                self.resync("replay_storage_error")
+                return None
+            self._pending_spool_read = None
+            if self._replay is not reader:
+                return None
+            if event is None:
+                # A publish/finish during the worker read invalidates EOF. In
+                # particular, never let mux inactivity overtake an accepted done.
+                if revision != self._replay_revision:
+                    continue
                 return None
             coalesced = event.pop("_coalesced", False)
             if coalesced and offset >= self._skip_from:
-                # Streamed to us live, token by token — emitting the coalesced
-                # form too would duplicate the whole message. Stop at its
-                # live-channel delimiter before reading a later tool/done row;
-                # otherwise a slow subscriber observes `done` before the text
-                # still queued for this exact segment.
                 return _LIVE_MESSAGE_BARRIER
             return event
 
@@ -897,6 +961,7 @@ class _TurnSubscriber:
 
     def publish(self, event: dict) -> bool:
         """Wake this subscriber for a newly-appended spool event."""
+        self._replay_revision += 1
         if self._done:
             return False
         self._wake.set()
@@ -937,6 +1002,7 @@ class _TurnSubscriber:
         self._wake.set()
 
     def close(self) -> None:
+        self._replay_revision += 1
         self._done = True
         self._wake.set()
 
@@ -1794,15 +1860,14 @@ _TASK_STOP_SETTLE_GRACE_S = max(
     0.1, env_float("MUSELAB_TASK_STOP_SETTLE_GRACE_S", 5.0))
 _TASK_TERMINATION_RETRY_S = max(
     0.1, env_float("MUSELAB_TASK_TERMINATION_RETRY_S", 5.0))
-# After the LAST in-flight task delivers its terminal notification, the CLI
-# auto-continues a short turn (model reacts to the result). The probe (§3.4)
-# measured it landing ~1.3s later, but it's not strictly guaranteed for every
-# task type / status. So once all tasks have settled and a continuation
-# broadcast is open, the watcher waits at most this long for the auto-continue's
-# AssistantMessage + ResultMessage before closing the continuation and
-# unpinning — bounding the worst case (no auto-continue ever comes) instead of
-# holding the client + the _active_turns slot for the full _TASK_WATCH_TIMEOUT.
+# Allow a short window for the CLI to START its automatic continuation before
+# nudging it once. This is not an inter-message timeout: thinking and foreground
+# tools in an already-started continuation routinely take longer than 8 seconds.
 _CONTINUATION_GRACE = env_int("MUSELAB_CONTINUATION_GRACE", 8, min_value=2)
+# Once requested/started, use an absolute lease, including silent model/tool
+# execution. Expiry must terminate the owning runtime before admitting a turn.
+_CONTINUATION_TIMEOUT = env_int(
+    "MUSELAB_CONTINUATION_TIMEOUT", _TASK_WATCH_TIMEOUT, min_value=60)
 # Short grace for USER-STOPPED tasks: the CLI doesn't auto-continue after a
 # deliberate stop, so the watcher only needs a token window before closing
 # the continuation (frees the attached FE from an idle "streaming…" footer).
@@ -2626,6 +2691,16 @@ def _capability_from_model_item(item: Any, *, source: str) -> dict | None:
         "context_limit_source": source,
         "context_limit_is_estimate": False,
     }
+
+
+async def _post_turn_context_usage(client) -> dict:
+    """Finish promptly; warm an exact-client measurement for the next turn."""
+    if isinstance(client, MuseLabSDKClient):
+        cached = client.cached_context_usage(max_age_s=300)
+        client.warm_context_usage()
+        return cached or {}
+    # Keep the adapter seam for runtimes/tests without the owned probe API.
+    return await asyncio.wait_for(client.get_context_usage(), timeout=3.0)
 
 
 async def _detect_gateway_context_capability(model: str) -> dict | None:
@@ -4334,6 +4409,8 @@ async def shutdown_runtime() -> None:
     }.values()
     for broadcast in broadcasts:
         broadcast.close()
+    await asyncio.gather(*(broadcast.events.flush_async() for broadcast in broadcasts),
+                         return_exceptions=True)
     for delivery in scheduled_deliveries:
         if delivery.broadcast.activity_started:
             await _finish_activity(
@@ -14666,6 +14743,7 @@ async def _watch_inflight_tasks(
     subagent_mux = chat_subagents.SubagentStreamMux(session_id)
     watcher_failed = False
     watcher_cancelled = False
+    runtime_terminated = False
     # The continuation is a real assistant turn for display/accounting even
     # though it has no user bubble.  Keep the session's public model id on its
     # broadcast so live and persisted footers do not reload with a blank model.
@@ -14721,6 +14799,8 @@ async def _watch_inflight_tasks(
             # reaction starts. In that case the watcher explicitly nudges the
             # same SDK session once; this flag prevents an infinite retry loop.
             "explicit_resume_requested": False,
+            "started": False,
+            "wait_started_at": None,
             "incomplete_error": None,
         }
 
@@ -14760,11 +14840,12 @@ async def _watch_inflight_tasks(
     async def _close_continuation(
         cancelled: bool = False,
         duration_ms: int | None = None,
+        result: ResultMessage | None = None,
     ) -> None:
         """Emit a terminal `done`, finish the broadcast, drop it from
         _active_turns (identity-checked so we never pop a newer turn's slot),
         and grace-keep it for a slightly-late FE reconnect."""
-        nonlocal cont, cont_state
+        nonlocal cont, cont_state, watcher_failed, watcher_cancelled, watch_error_kind
         b = cont
         state = cont_state
         cont = None
@@ -14776,6 +14857,25 @@ async def _watch_inflight_tasks(
         # a streamed prefix is not a truthful completed Agent reply.
         cancelled = bool(cancelled or b.cancelled)
         incomplete_error = (state or {}).get("incomplete_error")
+        result_error = _sdk_result_error(result) if result is not None else None
+        error_message = str(
+            (result_error or {}).get("message") or incomplete_error or "")
+        error_class = (
+            _classify_stream_error(error_message) if result_error else
+            {"kind": "background_continuation_incomplete", "cta": "retry",
+             "retryable": True} if incomplete_error else {}
+        )
+        terminal_reason = sdk_lifecycle.normalize_terminal_reason(
+            getattr(result, "terminal_reason", None))
+        terminal_status = sdk_lifecycle.terminal_status(
+            terminal_reason, is_error=bool(error_message), cancelled=cancelled)
+        cancelled = terminal_status == "cancelled"
+        b.cancelled = cancelled
+        watcher_cancelled = watcher_cancelled or cancelled
+        watcher_failed = watcher_failed or terminal_status in {"failed", "stopped"}
+        if error_message:
+            watcher_failed = True
+            watch_error_kind = str(error_class.get("kind") or "unknown")
         completed_at_ms = int(time.time() * 1000)
         assistant_uuid = str((state or {}).get("assistant_uuid") or "")
         cont_elapsed = (
@@ -14783,15 +14883,10 @@ async def _watch_inflight_tasks(
             if duration_ms
             else round(max(0.0, time.time() - b.started_at), 1)
         )
-        terminal_status = (
-            "cancelled" if cancelled else
-            "failed" if incomplete_error else
-            "completed"
-        )
-        b.perf_status = terminal_status
+        b.perf_status = "failed" if terminal_status == "stopped" else terminal_status
         b.perf_error_kind = (
             "cancelled" if cancelled else
-            "background_continuation_incomplete" if incomplete_error else
+            str(error_class.get("kind") or "unknown") if error_message else
             "none"
         )
         b.perf_background_count = len(pending)
@@ -14805,13 +14900,17 @@ async def _watch_inflight_tasks(
             "completed_at_ms": completed_at_ms,
             "background_tasks_pending": len(pending),
         }
-        if incomplete_error:
+        done_payload.update({
+            "is_error": bool(error_message),
+            "status": terminal_status,
+            "terminal_reason": terminal_reason,
+        })
+        if error_message:
             done_payload.update({
-                "is_error": True,
-                "error": incomplete_error,
-                "kind": "background_continuation_incomplete",
-                "cta": "retry",
-                "retryable": True,
+                "error": error_message,
+                **error_class,
+                "result_subtype": getattr(result, "subtype", None),
+                "api_error_status": (result_error or {}).get("api_error_status"),
             })
         # AssistantMessage already supplied the exact persisted UUID. Commit its
         # footer before publishing done so an immediate refresh cannot beat the
@@ -14857,7 +14956,7 @@ async def _watch_inflight_tasks(
                 completed_at_ms=completed_at_ms,
                 elapsed_s=cont_elapsed,
                 terminal_status=terminal_status,
-                incomplete_error=str(incomplete_error or ""),
+                incomplete_error=error_message,
                 file_path=_runtime_continuation_outbox_path(
                     session_id, str(b.turn_id or "")),
             )
@@ -14873,8 +14972,9 @@ async def _watch_inflight_tasks(
         """Ask the existing SDK session to finish the originating request.
 
         Claude Code normally starts this turn itself after a completed
-        TaskNotification. A stream EOF or grace timeout before ResultMessage
-        means that auto-resume was missed. Send one metadata-only user record
+        TaskNotification. Only nudge a continuation that has not started;
+        silence during model/tool execution does not mean it was missed.
+        Send one metadata-only user record
         so it is available to the live model but excluded from normal
         transcript rendering/conversation counts by the SDK's `isMeta`
         semantics.
@@ -14882,6 +14982,7 @@ async def _watch_inflight_tasks(
         nonlocal watcher_failed, watch_error_kind
         if (pending or cont is None or cont_state is None
                 or last_settle_status == "stopped"
+                or cont_state["started"]
                 or cont_state["explicit_resume_requested"]):
             return False
         cont_state["explicit_resume_requested"] = True
@@ -14908,7 +15009,12 @@ async def _watch_inflight_tasks(
             sys.stderr.write(
                 f"[chat] task watcher: auto-continuation missing "
                 f"sid={session_id[:8]} ({reason}); requesting explicit resume\n")
-            await client.query(_meta_prompt())
+            waited = (
+                asyncio.get_running_loop().time() - cont_state["wait_started_at"]
+                if cont_state["wait_started_at"] is not None else 0.0)
+            await asyncio.wait_for(
+                client.query(_meta_prompt()),
+                timeout=max(0.001, _CONTINUATION_TIMEOUT - waited))
             return True
         except Exception as e:
             watcher_failed = True
@@ -14924,8 +15030,9 @@ async def _watch_inflight_tasks(
             return False
 
     def _mark_incomplete() -> None:
-        nonlocal watcher_failed
+        nonlocal watcher_failed, watch_error_kind
         watcher_failed = True
+        watch_error_kind = "background_continuation_incomplete"
         if cont_state is not None and not cont_state.get("incomplete_error"):
             cont_state["incomplete_error"] = (
                 "后台任务已经完成，但没有生成最终答复。请发送“继续”让 Muse "
@@ -14965,9 +15072,8 @@ async def _watch_inflight_tasks(
     # intent), so waiting the full _CONTINUATION_GRACE leaves the attached
     # frontend spinning "streaming…" after the card already flipped ⏹
     # (2026-06-11 footer complaint). Use a short grace
-    # for stopped settles; a reaction that somehow arrives later is not
-    # lost — it buffers in the SDK queue and the next turn's in-turn
-    # dispatch drains it.
+    # for stopped settles. Without a Result boundary, disconnect the runtime
+    # before releasing the reader; late reactions must never reach a new turn.
     last_settle_status: str | None = None
 
     async def _consume_timeout_terminal(msg: Any) -> bool:
@@ -15058,6 +15164,36 @@ async def _watch_inflight_tasks(
                 })
         last_settle_status = "stopped"
 
+    async def _terminate_runtime() -> None:
+        """Keep ownership until exact-client cleanup confirms process death.
+
+        This also applies after every task has settled: a missing Result can
+        leave the parent model/tools running, independently of task pins.
+        Disconnect attempts use the existing bounded TERM/KILL lifecycle and
+        sticky admission fence; failed attempts cannot open a queue window.
+        """
+        nonlocal runtime_terminated
+        attempt = 0
+        while not runtime_terminated and _owns_generation():
+            attempt += 1
+            try:
+                await _disconnect_background_task_owner(session_id, client)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if attempt == 1 or attempt % 6 == 0:
+                    sys.stderr.write(
+                        f"[chat] task watcher sid={session_id[:8]} "
+                        f"runtime termination pending attempt={attempt} "
+                        f"exc={type(exc).__name__}\n")
+                    sys.stderr.flush()
+                await asyncio.sleep(min(
+                    30.0, _TASK_TERMINATION_RETRY_S * attempt))
+                continue
+            runtime_terminated = True
+            if pending:
+                await _settle_after_confirmed_disconnect()
+
     async def _terminate_expired_tasks(reason: str) -> None:
         """Stop expired tasks without ever opening an unsafe queue window.
 
@@ -15131,7 +15267,7 @@ async def _watch_inflight_tasks(
                 continue
             if isinstance(msg, ResultMessage):
                 await _close_continuation(
-                    duration_ms=getattr(msg, "duration_ms", None))
+                    duration_ms=getattr(msg, "duration_ms", None), result=msg)
             elif cont is not None and cont_state is not None:
                 for event in _render_continuation_message(msg, cont_state):
                     cont.publish(event)
@@ -15139,30 +15275,7 @@ async def _watch_inflight_tasks(
         if not pending:
             return
 
-        # No terminal marker arrived.  Stop the entire owning runtime so a
-        # late command/result cannot cross into the queued user turn.  SDK
-        # disconnect already owns graceful -> TERM -> KILL escalation.  If it
-        # is still running at its bounded public deadline, keep this watcher
-        # and its pins alive and retry; never turn a timeout into an unpin.
-        attempt = 0
-        while pending and _owns_generation():
-            attempt += 1
-            try:
-                await _disconnect_background_task_owner(session_id, client)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                if attempt == 1 or attempt % 6 == 0:
-                    sys.stderr.write(
-                        f"[chat] task watcher sid={session_id[:8]} "
-                        f"runtime termination pending attempt={attempt} "
-                        f"exc={type(exc).__name__}\n")
-                    sys.stderr.flush()
-                await asyncio.sleep(min(
-                    30.0, _TASK_TERMINATION_RETRY_S * attempt))
-                continue
-            await _settle_after_confirmed_disconnect()
-            return
+        await _terminate_runtime()
 
     try:
         async with asyncio.timeout(
@@ -15176,15 +15289,24 @@ async def _watch_inflight_tasks(
                     None if remaining is None else loop.time() + remaining)
 
             while True:
-                # Once every task has settled and we're only waiting on the
-                # auto-continue, cap the read so a task that produces no
-                # continuation can't pin the client for the full watch timeout.
                 read_to = None
-                if not pending and cont is not None:
-                    read_to = (_STOPPED_CONTINUATION_GRACE
-                               if last_settle_status == "stopped"
-                               else _CONTINUATION_GRACE)
+                if not pending and cont_state is not None:
+                    now = loop.time()
+                    if cont_state["wait_started_at"] is None:
+                        cont_state["wait_started_at"] = now
+                    elapsed = now - cont_state["wait_started_at"]
+                    lease = _CONTINUATION_TIMEOUT
+                    if not (cont_state["started"]
+                            or cont_state["explicit_resume_requested"]):
+                        lease = (_STOPPED_CONTINUATION_GRACE
+                                 if last_settle_status == "stopped"
+                                 else _CONTINUATION_GRACE)
+                    # Absolute lease, never refreshed by progress/heartbeat
+                    # messages. Started model/tool execution may be silent.
+                    read_to = lease - elapsed
                 try:
+                    if read_to is not None and read_to <= 0:
+                        raise asyncio.TimeoutError
                     msg = await _next_message(read_to)
                 except asyncio.TimeoutError:
                     if await _request_explicit_resume("continuation grace elapsed"):
@@ -15204,7 +15326,8 @@ async def _watch_inflight_tasks(
                         await _terminate_expired_tasks(
                             "message stream ended before task settlement")
                         break
-                    if await _request_explicit_resume("message stream ended"):
+                    if (bg_q is None
+                            and await _request_explicit_resume("message stream ended")):
                         _reopen_stream()
                         continue
                     if (not pending and cont is not None
@@ -15306,6 +15429,9 @@ async def _watch_inflight_tasks(
                         )
                     )
                     if accepted_start:
+                        if cont_state is not None:
+                            cont_state["started"] = True
+                            cont_state["wait_started_at"] = None
                         watched_task_ids.add(tid)
                         pending[tid] = desc
                         _pin_background_task(session_id, tid)
@@ -15372,11 +15498,18 @@ async def _watch_inflight_tasks(
                     # continuation. If tasks remain in flight, keep reading for
                     # their (later) notifications; otherwise we're done.
                     await _close_continuation(
-                        duration_ms=getattr(msg, "duration_ms", None))
+                        duration_ms=getattr(msg, "duration_ms", None), result=msg)
                     if not pending:
                         break
                 else:
                     if cont is not None and cont_state is not None:
+                        if isinstance(msg, (StreamEvent, AssistantMessage)) or (
+                            isinstance(msg, UserMessage)
+                            and isinstance(msg.content, list)
+                            and any(isinstance(block, ToolResultBlock)
+                                    for block in msg.content)
+                        ):
+                            cont_state["started"] = True
                         for ev in _render_continuation_message(msg, cont_state):
                             cont.publish(ev)
     except asyncio.CancelledError:
@@ -15399,6 +15532,14 @@ async def _watch_inflight_tasks(
             f"{type(e).__name__}; entering safe termination\n")
         await _terminate_expired_tasks("failed before task settlement")
     finally:
+        # An open collector has not received ResultMessage. Task settlement is
+        # not a parent-turn boundary: stop the exact runtime before releasing
+        # its reader, including EOF, stopped tasks, timeout and cancellation.
+        # A replacement generation already owns cleanup; never kill its client.
+        if cont is not None and _owns_generation():
+            if not watcher_cancelled and last_settle_status != "stopped":
+                _mark_incomplete()
+            await _terminate_runtime()
         # Release our slot on the session pump so a later turn's messages are
         # not routed to a watcher that has exited.
         if _bg_stream is not None and bg_q is not None:
@@ -16724,7 +16865,7 @@ async def _start_turn(
             # This probe is advisory when no compact is needed. Never let a
             # wedged SDK control request delay the user's real prompt for the
             # full compact window.
-            cached = (client.cached_context_usage()
+            cached = (client.cached_context_usage(max_age_s=300)
                       if isinstance(client, MuseLabSDKClient) else None)
             # Reuse only an unchanged, freshly measured SDK generation with
             # ample headroom. Background/scheduled writers always force a probe.
@@ -18298,7 +18439,7 @@ async def _start_turn(
                 # its real context ceiling.
                 sdk_max = sdk_raw = sdk_threshold = sdk_total = 0
                 try:
-                    cu = await asyncio.wait_for(client.get_context_usage(), timeout=3.0)
+                    cu = await _post_turn_context_usage(client)
                     sdk_max = _positive_int(cu.get("maxTokens"))
                     sdk_raw = _positive_int(cu.get("rawMaxTokens"))
                     sdk_threshold = _positive_int(cu.get("autoCompactThreshold"))
@@ -18339,7 +18480,7 @@ async def _start_turn(
                         / sess_u["context_limit"] * 100, 1)
             else:
                 try:
-                    cu = await asyncio.wait_for(client.get_context_usage(), timeout=3.0)
+                    cu = await _post_turn_context_usage(client)
                     real_max = int(cu.get("maxTokens") or 0)
                     real_total = int(cu.get("totalTokens") or 0)
                     if real_max:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1393,18 +1393,30 @@ async def client_performance_log(payload: dict = Body(...)) -> dict:
         return min(100_000_000, max(0, value))
 
     allowed_fields = {
-        "status", "mode", "foreground", "total_ms", "fetch_ms", "parse_ms",
+        "status", "mode", "foreground", "visibility", "cancel_reason",
+        "total_ms", "fetch_ms", "receive_ms", "parse_ms", "first_reveal_ms",
         "shape_ms", "markdown_ms", "install_ms", "response_bytes",
         "block_count", "assistant_blocks", "long_task_count", "longest_task_ms",
     }
     if any(name not in allowed_fields for name in payload):
         return JSONResponse(
             {"ok": False, "error": "invalid_payload"}, status_code=422)
+    visibility = payload.get("visibility", "unknown")
+    cancel_reason = payload.get("cancel_reason", "none")
+    if (not isinstance(visibility, str) or not isinstance(cancel_reason, str)
+            or visibility not in {"visible", "hidden", "unknown"}
+            or cancel_reason not in {"none", "superseded", "live_owner",
+                                     "revision_changed", "anchor_missing", "aborted"}):
+        return JSONResponse({"ok": False, "error": "invalid_payload"}, status_code=422)
     try:
         perf_event(
             "client.history_load",
             status=status,
             mode=mode,
+            visibility=visibility,
+            cancel_reason=cancel_reason,
+            receive_ms=bounded_int("receive_ms"),
+            first_reveal_ms=bounded_int("first_reveal_ms"),
             foreground=bool(payload.get("foreground")),
             total_ms=bounded_int("total_ms"),
             fetch_ms=bounded_int("fetch_ms"),

--- a/backend/memory_engine.py
+++ b/backend/memory_engine.py
@@ -37,6 +37,7 @@ from .memory_providers import (
     EmbeddingProvider,
     GenerationError,
     GenerationProvider,
+    generation_job_ref,
     Reranker,
     vector_store,
 )
@@ -184,6 +185,8 @@ def classify_memory_failure(exc: BaseException) -> tuple[bool, dict[str, object]
     }
     if status is not None:
         detail["status"] = status
+    if isinstance(exc, GenerationError) and exc.reason != "unknown":
+        detail["reason"] = exc.reason
     return retryable, detail
 
 
@@ -578,6 +581,9 @@ class MemoryEngine:
             failure: dict[str, object] | None = None
             attempts = int(job.get("attempts", 0)) + 1
             safe_kind = job["kind"] if job.get("kind") in _KNOWN_JOB_KINDS else "unknown"
+            job_ref = hashlib.sha256(str(job["id"]).encode()).hexdigest()[:12]
+            perf_event("memory.job_start", job_ref=job_ref, kind=safe_kind, attempt=attempts)
+            job_trace_token = generation_job_ref.set(job_ref)
             try:
                 # Owner fence. Jobs carry the owner that enqueued them; the
                 # handlers below resolve everything else from the LIVE config.
@@ -607,19 +613,25 @@ class MemoryEngine:
             except Exception as exc:
                 retryable, failure = classify_memory_failure(exc)
                 error = _failure_record(failure)
-                log.warning(
-                    "memory job failed category=%s exception_class=%s status=%s",
-                    failure["category"], failure["exception_class"],
-                    failure.get("status"),
-                )
+            finally:
+                generation_job_ref.reset(job_trace_token)
             retry_seconds = (
                 min(300.0, 2 ** attempts)
                 if error and retryable and attempts < 3 else None
             )
+            outcome = "retry" if retry_seconds is not None else "failed" if error else "done"
+            if failure:
+                log.warning(
+                    "memory job outcome=%s job_ref=%s attempt=%s category=%s reason=%s status=%s",
+                    outcome, job_ref, attempts, failure["category"],
+                    failure.get("reason", "unknown"), failure.get("status"))
             await self._store_call(lambda store: store.finish_job(
                 job["id"], error=error, retry_seconds=retry_seconds))
             perf_event(
                 "memory.job",
+                job_ref=job_ref,
+                retry_seconds=retry_seconds,
+                reason=failure.get("reason") if failure else None,
                 kind=safe_kind,
                 attempt=attempts,
                 duration_ms=elapsed_ms(started),

--- a/backend/memory_providers.py
+++ b/backend/memory_providers.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+from contextvars import ContextVar
+import time
 import json
 import logging
 import math
@@ -505,12 +508,15 @@ def _classify_sdk_result_error(message: Any) -> tuple[bool, str, int | None]:
     return False, "generation_failure", None
 
 
+generation_job_ref: ContextVar[str] = ContextVar("memory_generation_job_ref", default="")
+
+
 class GenerationError(RuntimeError):
     """Sanitized generation failure carrying only retry/log metadata."""
 
     def __init__(self, *, retryable: bool, provider: str = "", model: str = "",
                  api_error_status: int | None = None,
-                 category: str | None = None):
+                 category: str | None = None, reason: str = "unknown"):
         category = category or (
             "transient_provider" if retryable else "generation_failure")
         super().__init__(category)
@@ -519,6 +525,11 @@ class GenerationError(RuntimeError):
         self.model = model
         self.api_error_status = api_error_status
         self.category = category
+        self.reason = reason if reason in {
+            "unknown", "timeout", "transport_error", "http_error", "sdk_exception",
+            "sdk_result_error", "missing_terminal", "empty_output", "invalid_json",
+            "non_object_json", "configuration", "exception",
+        } else "unknown"
 
 
 class GenerationProvider:
@@ -568,11 +579,18 @@ class GenerationProvider:
                        max_tokens: int = 3000) -> str:
         provider, configured_model = self.metadata()
         timeout = generation_timeout_seconds()
+        started = time.perf_counter()
+        route_kind, outcome, reason, cause_kind = "unresolved", "error", "unknown", "none"
+        response_chars = 0
         try:
             async with asyncio.timeout(timeout):
                 route = self._route()
                 if route is None:
-                    return await self._complete_with_sdk(system, prompt)
+                    route_kind = "ducc" if configured_model.startswith("ducc:") else "sdk"
+                    result = await self._complete_with_sdk(system, prompt)
+                    response_chars, outcome = len(result), "done"
+                    return result
+                route_kind = "http"
                 url, key, model = route
                 payload = {"model": model, "max_tokens": max_tokens, "temperature": 0,
                            "system": system,
@@ -605,7 +623,7 @@ class GenerationProvider:
                             provider=provider,
                             model=configured_model,
                             api_error_status=response.status_code,
-                            category="malformed_response",
+                            category="malformed_response", reason="invalid_json",
                         ) from exc
                 if not isinstance(body, dict) or not isinstance(body.get("content"), list):
                     raise GenerationError(
@@ -613,7 +631,7 @@ class GenerationProvider:
                         provider=provider,
                         model=configured_model,
                         api_error_status=response.status_code,
-                        category="malformed_response",
+                        category="malformed_response", reason="empty_output",
                     )
                 blocks = body["content"]
                 text_blocks = [block.get("text") for block in blocks
@@ -627,18 +645,37 @@ class GenerationProvider:
                         provider=provider,
                         model=configured_model,
                         api_error_status=response.status_code,
-                        category="malformed_response",
+                        category="malformed_response", reason="empty_output",
                     )
-                return "".join(text_blocks)
+                result = "".join(text_blocks)
+                response_chars, outcome = len(result), "done"
+                return result
         except asyncio.CancelledError:
+            outcome, reason = "cancelled", "unknown"
             raise
-        except GenerationError:
+        except GenerationError as exc:
+            reason = exc.reason
             raise
         except Exception as exc:
             status = _generation_error_status(exc)
+            reason = (
+                "timeout" if isinstance(exc, (TimeoutError, httpx.TimeoutException))
+                else "transport_error" if isinstance(exc, httpx.TransportError)
+                else "http_error" if status is not None
+                else "sdk_exception" if _sdk_error_names(exc)
+                else "configuration" if isinstance(exc, ValueError)
+                else "exception")
+            name = type(exc).__name__
+            cause_kind = name if name in {
+                "TimeoutError", "ConnectTimeout", "ReadTimeout", "WriteTimeout",
+                "PoolTimeout", "ConnectError", "ReadError", "WriteError",
+                "RemoteProtocolError", "HTTPStatusError",
+                *_SDK_RETRYABLE_ERROR_NAMES, *_SDK_TERMINAL_ERROR_NAMES,
+            } else "OtherError"
             retryable = is_retryable_generation_error(exc)
             raise GenerationError(
                 retryable=retryable,
+                reason=reason,
                 provider=provider,
                 model=configured_model,
                 api_error_status=status,
@@ -650,6 +687,16 @@ class GenerationProvider:
                         else "generation_failure")
                 ),
             ) from exc
+
+        finally:
+            from .observability import perf_event
+            perf_event(
+                "memory.generation", job_ref=generation_job_ref.get(), route=route_kind, outcome=outcome,
+                reason=reason, cause_kind=cause_kind,
+                model_ref=hashlib.sha256(configured_model.encode()).hexdigest()[:12],
+                timeout_seconds=timeout, response_chars=response_chars,
+                duration_ms=round((time.perf_counter() - started) * 1000),
+            )
 
     async def _complete_with_sdk(self, system: str, prompt: str) -> str:
         from claude_agent_sdk import ClaudeAgentOptions, query
@@ -696,27 +743,43 @@ class GenerationProvider:
             **options_kwargs,
         )
         parts: list[str] = []
-        async for message in query(prompt=prompt, options=options):
-            if isinstance(message, AssistantMessage):
-                for block in message.content or []:
-                    if isinstance(block, TextBlock):
-                        parts.append(block.text or "")
-            elif isinstance(message, ResultMessage) and message.is_error:
-                retryable, category, status = _classify_sdk_result_error(message)
-                provider, model = self.metadata()
-                raise GenerationError(
-                    retryable=retryable,
-                    provider=provider,
-                    model=model,
-                    api_error_status=status,
-                    category=category,
-                )
-        text = "".join(parts)
+        final_text = ""
+        completed = False
+        terminal_error = None
+        # ResultMessage may contain the only final answer. Drain the public
+        # query iterator before returning/raising: its nested SDK generators
+        # own subprocess cleanup, which an early break can defer until GC.
+        from contextlib import aclosing
+        async with aclosing(query(prompt=prompt, options=options)) as messages:
+            async for message in messages:
+                if completed:
+                    continue
+                if isinstance(message, AssistantMessage):
+                    for block in message.content or []:
+                        if isinstance(block, TextBlock):
+                            parts.append(block.text or "")
+                elif isinstance(message, ResultMessage):
+                    completed = True
+                    if message.is_error:
+                        retryable, category, status = _classify_sdk_result_error(message)
+                        provider, model = self.metadata()
+                        terminal_error = GenerationError(
+                            retryable=retryable, provider=provider, model=model,
+                            api_error_status=status, category=category, reason="sdk_result_error")
+                    elif isinstance(message.result, str):
+                        final_text = message.result
+        if terminal_error is not None:
+            raise terminal_error
+        if not completed:
+            provider, model = self.metadata()
+            raise GenerationError(retryable=True, provider=provider, model=model,
+                                  category="transient_provider", reason="missing_terminal")
+        text = final_text if final_text.strip() else "".join(parts)
         if not text.strip():
             provider, model = self.metadata()
             raise GenerationError(
                 retryable=False, provider=provider, model=model,
-                category="malformed_response")
+                category="malformed_response", reason="empty_output")
         return text
 
     async def complete_json(self, system: str, prompt: str) -> dict:
@@ -735,12 +798,12 @@ class GenerationProvider:
             provider, model = self.metadata()
             raise GenerationError(
                 retryable=False, provider=provider, model=model,
-                category="malformed_response") from exc
+                category="malformed_response", reason="invalid_json") from exc
         if not isinstance(value, dict):
             provider, model = self.metadata()
             raise GenerationError(
                 retryable=False, provider=provider, model=model,
-                category="malformed_response")
+                category="malformed_response", reason="non_object_json")
         return value
 
     async def probe(self) -> dict:

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -204,7 +204,7 @@ def perf_event(event: str, /, **fields: Any) -> None:
         raise ValueError(
             "sensitive or invalid performance field(s): " + ", ".join(unsafe)
         )
-    payload: dict[str, Any] = {"event": event}
+    payload: dict[str, Any] = {"event": event, "at_ms": round(time.time() * 1000)}
     for name, value in fields.items():
         if value is not None:
             payload[name] = _safe_value(value)

--- a/backend/replay_io.py
+++ b/backend/replay_io.py
@@ -1,0 +1,164 @@
+"""Ordered replay I/O off the event loop, with bounded pending writes.
+
+The queue is not a best-effort diagnostic sink: errors propagate to flush/read
+and subsequent writes. A reader never observes a record before its write ends.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
+
+_WRITE_POOL = ThreadPoolExecutor(max_workers=4, thread_name_prefix="muselab-replay-write")
+_READ_POOL = ThreadPoolExecutor(max_workers=4, thread_name_prefix="muselab-replay-read")
+_budget_lock = threading.Lock()
+_pending_bytes = _pending_jobs = 0
+MAX_PENDING_BYTES = 64 * 1024 * 1024
+MAX_PENDING_JOBS = 8192
+
+
+class ReplayBacklogExceeded(RuntimeError):
+    def __init__(self):
+        super().__init__("replay write backlog exceeded its memory budget")
+
+
+def in_event_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
+async def read_io(callback, *args):
+    return await asyncio.get_running_loop().run_in_executor(
+        _READ_POOL, partial(callback, *args))
+
+
+class ReplayIO:
+    """One FIFO per file; no worker waits for another worker's future."""
+
+    def __init__(self):
+        self._queue = deque()
+        self._lock = threading.Lock()
+        self._running = False
+        self._error: BaseException | None = None
+        self._tail: Future | None = None
+
+    def check(self):
+        if self._error is not None:
+            raise OSError("replay storage unavailable") from self._error
+
+    def submit(self, callback, *, size=0, cleanup=False):
+        global _pending_bytes, _pending_jobs
+        if not cleanup:
+            self.check()
+        future = Future()
+        with _budget_lock:
+            if not cleanup and (_pending_jobs >= MAX_PENDING_JOBS
+                                or _pending_bytes + size > MAX_PENDING_BYTES):
+                raise ReplayBacklogExceeded()
+            _pending_bytes += size
+            _pending_jobs += 1
+        with self._lock:
+            self._queue.append((callback, size, future, cleanup))
+            self._tail = future
+            if not self._running:
+                self._running = True
+                _WRITE_POOL.submit(self._drain)
+        return future
+
+    def _drain(self):
+        global _pending_bytes, _pending_jobs
+        while True:
+            with self._lock:
+                if not self._queue:
+                    self._running = False
+                    return
+                callback, size, future, cleanup = self._queue.popleft()
+            try:
+                if not cleanup:
+                    self.check()
+                result = callback()
+            except BaseException as exc:
+                # Do not retain exception frames carrying private event blobs.
+                if self._error is None:
+                    self._error = OSError(getattr(exc, "errno", None) or 5,
+                                          "replay storage unavailable")
+                future.set_exception(OSError("replay storage unavailable"))
+            else:
+                future.set_result(result)
+            finally:
+                with _budget_lock:
+                    _pending_bytes -= size
+                    _pending_jobs -= 1
+
+    def flush(self):
+        future = self._tail
+        if future is not None:
+            future.result()
+        self.check()
+
+    async def flush_async(self):
+        future = self._tail
+        if future is not None:
+            # Cancelling an HTTP reader must not cancel the accepted disk write.
+            await asyncio.shield(asyncio.wrap_future(future))
+        self.check()
+
+
+class ReplayReader:
+    """Lazy descriptor: subscribe/seek/close never wait on filesystem I/O."""
+
+    def __init__(self, path, writer: ReplayIO, committed_size, offset=0):
+        self._path, self._writer = path, writer
+        self._committed_size = committed_size
+        self._limit = 0
+        self._offset = offset
+        self._reader = None
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def tell(self):
+        return self._offset
+
+    def seek(self, offset):
+        # Only called before the first read, to skip records covered by a cursor.
+        if self._reader is not None:
+            raise RuntimeError("cannot reposition an active replay reader")
+        self._offset = offset
+
+    def readline(self):
+        with self._lock:
+            if self._closed:
+                return b""
+            if self._reader is None:
+                self._reader = self._path.open("rb")
+                self._reader.seek(self._offset)
+            # A later write may be in progress after ready() completed. Never
+            # mistake its partial trailing record for a corrupt committed line.
+            remaining = self._limit - self._offset
+            if remaining <= 0:
+                return b""
+            line = self._reader.readline(remaining)
+            self._offset = self._reader.tell()
+            return line
+
+    async def ready(self):
+        await self._writer.flush_async()
+        self._limit = self._committed_size()
+
+    def close(self):
+        self._closed = True
+        if in_event_loop():
+            _READ_POOL.submit(self._close)
+        else:
+            self._close()
+
+    def _close(self):
+        with self._lock:
+            if self._reader is not None:
+                self._reader.close()
+                self._reader = None

--- a/backend/sdk_compat.py
+++ b/backend/sdk_compat.py
@@ -180,6 +180,8 @@ class MuseLabSDKClient(ClaudeSDKClient):
         self._muselab_input_lock = asyncio.Lock()
         self._muselab_context_revision = 0
         self._muselab_context_snapshot = None
+        self._muselab_context_probes = {}
+        self._muselab_context_warmup = None
 
     def _invalidate_context_snapshot(self) -> None:
         self._muselab_context_revision += 1
@@ -187,10 +189,46 @@ class MuseLabSDKClient(ClaudeSDKClient):
 
     async def get_context_usage(self) -> dict:
         revision = self._muselab_context_revision
-        usage = await super().get_context_usage()
-        if revision == self._muselab_context_revision:
-            self._muselab_context_snapshot = (revision, time.monotonic(), dict(usage))
-        return usage
+        probes = self._muselab_context_probes
+        task = probes.get(revision)
+        if task is None:
+            async def measure():
+                usage = await asyncio.wait_for(super(MuseLabSDKClient, self).get_context_usage(), 10)
+                if revision == self._muselab_context_revision:
+                    self._muselab_context_snapshot = (revision, time.monotonic(), dict(usage))
+                return usage
+            task = asyncio.create_task(measure())
+            probes[revision] = task
+            def settled(done):
+                if probes.get(revision) is done:
+                    probes.pop(revision, None)
+                if not done.cancelled():
+                    done.exception()
+            task.add_done_callback(settled)
+        # A UI deadline must not destroy a useful measurement shared with an
+        # idle warmup. The probe itself has a hard deadline and a client owner.
+        return dict(await asyncio.shield(task))
+
+    def warm_context_usage(self) -> None:
+        task = self._muselab_context_warmup
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self.get_context_usage())
+        self._muselab_context_warmup = task
+        task.add_done_callback(lambda done: done.exception() if not done.cancelled() else None)
+
+    async def disconnect(self) -> None:
+        pending = set(self._muselab_context_probes.values())
+        if self._muselab_context_warmup is not None:
+            pending.add(self._muselab_context_warmup)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._muselab_context_probes.clear()
+        self._muselab_context_warmup = None
+        self._invalidate_context_snapshot()
+        await super().disconnect()
 
     def cached_context_usage(self, *, max_age_s: float = 20.0) -> dict | None:
         snapshot = self._muselab_context_snapshot

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,6 +70,64 @@ short correlation IDs only. Tune the slow-request boundary with
 `MUSELAB_SLOW_REQUEST_MS` (default `500`); set `MUSELAB_PERF_LOG=0` only when
 you need to disable these summaries entirely.
 
+**Separate slow history loading from a stalled service.**
+Performance events include `at_ms`, the Unix millisecond time when the event was
+created. For `client.history_load`, `fetch_ms` ends at response headers,
+`receive_ms` covers reading the response and scheduling delays, and `parse_ms`
+measures only `JSON.parse`. Older `parse_ms` values also included response
+reading and cannot be interpreted as JSON CPU time. History deadlines and
+upstream cancellation now cover response consumption.
+
+`first_reveal_ms` records the selected session's first DOM batch becoming ready;
+`install_ms` includes subsequent incremental batches. Neither measures actual
+browser paint. `visibility` describes document visibility at load start;
+`foreground` only identifies the selected session at log completion.
+`cancel_reason` distinguishes abortion, superseded views, live ownership,
+revision changes, and missing anchors. Protective exits are not request failures.
+
+Replay appends, subscriber reads, and decoding use dedicated threads while
+preserving per-file write order. Pending writes share a 64 MiB / 8192-job budget;
+overflow fails explicitly. Disk failures produce `resync` instead of presenting
+missing replay as completed. This isolates event-loop stalls but cannot repair
+slow disks, network mounts, or insufficient disk space. Persistent I/O stalls
+still require investigation on the deployment host.
+
+Post-turn SDK context measurements run in the background with a 10-second
+limit; requests for the same state share a probe. The next turn reuses a sample
+only when state is unchanged, age is at most five minutes, usage is below half
+the window, and no background writer is present. Near-limit turns still probe.
+Memory generation prefers final text from a successful `ResultMessage`; missing
+or error terminal results cannot make intermediate text a successful output.
+Network and authentication failures still require provider configuration checks.
+
+**A completed reply appears only after reloading.**
+Completion reconciliation binds an unambiguous incomplete live assistant row to
+its verified final UUID, preserving the mounted key and the reader's scroll
+position. A known UUID still cannot be replaced by an unrelated successor.
+The session-list deadline covers reading its complete response, and its ETag
+advances only after a valid list is installed; a broken response retains the
+last good list so the next poll can recover.
+
+**Background tasks finished but the final reply is incomplete.**
+`MUSELAB_CONTINUATION_GRACE` (default `8` seconds) waits only for a continuation
+to start. Once the parent emits thinking, text, or tool activity, it uses the
+absolute `MUSELAB_CONTINUATION_TIMEOUT` instead. That limit defaults to
+`MUSELAB_TASK_WATCH_TIMEOUT` (`3600` seconds); activity does not reset it.
+An explicit resume is sent at most once. Missing terminal results require the
+old runtime to be cleaned up before another turn can acquire it. SDK error
+results remain failures in both live delivery and persisted completion state.
+
+**Memory generation repeatedly fails.**
+Default performance logs include `memory.job_start`, `memory.generation`, and
+`memory.job`. Correlate calls and retries using `job_ref`; `attempt`, `outcome`,
+and `retry_seconds` distinguish retries from terminal failures. Generation
+records include SDK/DUCC/HTTP route, timeout setting, duration, and a hashed
+model reference. `reason` distinguishes `timeout`, `transport_error`,
+`sdk_result_error`, `missing_terminal`, `empty_output`, `invalid_json`, and
+`non_object_json`; `cause_kind` retains only an allowed underlying error type.
+Prompts, responses, raw exceptions, raw model configuration, and credentials
+are excluded.
+
 **Service stops when I log out (Linux).**
 Enable lingering so the user service keeps running:
 `sudo loginctl enable-linger $USER`.

--- a/docs/troubleshooting_zh.md
+++ b/docs/troubleshooting_zh.md
@@ -46,6 +46,50 @@ log show --predicate 'process == "muselab"' --last 5m
 
 `[perf]` 行只包含阶段耗时、计数、状态分类和短关联 ID。慢请求阈值可通过 `MUSELAB_SLOW_REQUEST_MS` 调整（默认 `500`）；仅在确实要完全关闭性能摘要时设置 `MUSELAB_PERF_LOG=0`。
 
+**如何区分历史加载慢和服务卡顿。**
+性能事件的 `at_ms` 是生成事件时的 Unix 毫秒时间，可用于对齐前后端记录。
+`client.history_load` 的 `fetch_ms` 记录收到响应头前的等待，`receive_ms`
+记录读取响应内容和调度等待，`parse_ms` 仅记录 `JSON.parse`。
+旧版本的 `parse_ms` 包含内容读取，不能直接解释为 JSON 解析占用 CPU。
+历史请求的超时和上游取消现在覆盖响应内容读取。
+
+`first_reveal_ms` 记录当前会话首批 DOM 就绪，`install_ms` 包括后续分批安装；
+两者都不是浏览器实际绘制时间。`visibility` 是加载开始时页面的可见状态，
+`foreground` 仅表示日志结束时是否为选中会话。`cancel_reason` 区分请求取消、
+视图被替换、流接管、版本变化和锚点缺失；这些保护性退出不等同于请求失败。
+
+回放的追加、订阅读取和解码在专用线程执行，保持每个回放文件的写入顺序。
+待写任务共享 64 MiB / 8192 项上限；超限会显式失败。写盘失败的订阅回退到
+`resync`，不会把缺失回放当作完成。该机制缓解事件循环阻塞，但不能修复慢盘、
+网络挂载或磁盘空间不足；长期 I/O 停顿仍需检查部署机器。
+
+完成后的 SDK 上下文测量在后台运行，最长 10 秒；同一状态的请求共享测量。
+下一轮仅在状态未变化、缓存不超过 5 分钟、用量低于窗口一半且没有后台写入时
+复用，临近上限仍重新检查。记忆生成优先采用成功 `ResultMessage` 的最终文本；
+缺少终止结果或错误结果均不会把中间文本作为成功输出。网络和认证失败仍需
+检查对应 provider 配置。
+
+**完成的答复需要刷新页面才能看到。**
+完成同步会把可明确识别的不完整实时答复绑定到已验证的最终 UUID，保留消息节点
+和阅读位置；已知 UUID 仍不能被无关的后续轮次替换。会话列表的超时覆盖完整响应
+读取，ETag 只在有效列表安装后更新；响应失败时保留上一份列表，让下一次轮询恢复。
+
+**后台任务完成后，最终答复仍提示未完成。**
+`MUSELAB_CONTINUATION_GRACE`（默认 8 秒）仅用于等待续答启动。一旦主模型开始
+思考、输出文字或调用工具，就改用绝对总时限 `MUSELAB_CONTINUATION_TIMEOUT`。
+该时限默认继承 `MUSELAB_TASK_WATCH_TIMEOUT`（默认 3600 秒），不会因持续消息而
+延长。系统最多补发一次续答请求；缺少结束结果时，须先完成旧运行时清理，下一轮
+才能接管。SDK 返回的失败结果会在实时消息与持久化完成状态中一致标为失败。
+
+**记忆生成反复失败。**
+默认性能日志会输出 `memory.job_start`、`memory.generation` 和 `memory.job`。
+用相同的 `job_ref` 关联同一任务的调用与重试；`attempt`、`outcome` 和
+`retry_seconds` 区分重试与最终失败。生成记录包含 SDK/DUCC/HTTP 路径、
+超时设置、耗时，以及哈希化的模型标识。`reason` 区分 `timeout`、
+`transport_error`、`sdk_result_error`、`missing_terminal`、`empty_output`、
+`invalid_json` 和 `non_object_json`；`cause_kind` 保留受限的底层错误类型。
+这些日志不输出提示词、回答、原始异常、模型配置原文或凭据。
+
 **注销后服务就停了（Linux）。**
 开启 lingering，让用户服务持续运行：`sudo loginctl enable-linger $USER`。
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5959,7 +5959,7 @@ function portal() {
       return error;
     },
     async _fetchWithDeadline(
-      url, options = {}, deadlineMs = this.REQUEST_DEADLINE_MS,
+      url, options = {}, deadlineMs = this.REQUEST_DEADLINE_MS, consumeResponse = null,
     ) {
       const upstream = options.signal;
       if (upstream && upstream.aborted) throw this._abortError();
@@ -5986,7 +5986,12 @@ function portal() {
       try {
         // Keep the explicit race even though native fetch observes AbortSignal:
         // test doubles and embedded WebViews are not always abort-cooperative.
-        return await Promise.race([fetch(url, fetchOptions), control]);
+        const operation = (async () => {
+          const response = await fetch(url, fetchOptions);
+          if (consumeResponse) await consumeResponse(response);
+          return response;
+        })();
+        return await Promise.race([operation, control]);
       } finally {
         settled = true;
         clearTimeout(timer);
@@ -11304,6 +11309,10 @@ function portal() {
           followTail: followTailStillOwned,
           signal: options.signal,
           historySnapshot: history,
+          completedBoundary: (expectedAssistantUuid
+              ? messages[finalIndex].uuid === expectedAssistantUuid
+              : committedState?.completed_turn_id === completedTurnId)
+            ? { uuid: messages[finalIndex].uuid, text: expectedText } : null,
         });
         if (!loaded) retry();
         else {
@@ -12641,21 +12650,19 @@ function portal() {
         }
       }
       const _ids = encodeURIComponent(_idSet.join(","));
-      let r;
-      const controller = new AbortController();
-      const timeout = setTimeout(
-        () => controller.abort(),
-        Math.max(100, Number(this._sessionListTimeoutMs) || 8000),
-      );
+      let r, data;
       try {
-        r = await fetch(`/api/chat/sessions?limit=100&ids=${_ids}`, {
-          headers,
-          signal: controller.signal,
-        });
+        r = await this._fetchWithDeadline(
+          `/api/chat/sessions?limit=100&ids=${_ids}`, { headers },
+          Math.max(100, Number(this._sessionListTimeoutMs) || 8000),
+          async response => {
+            if (response.ok) data = await response.json();
+          },
+        );
       } catch (_) {
-        return false;  // network blip; next tick retries
-      } finally {
-        clearTimeout(timeout);
+        // Preserve both the installed list and its ETag when headers arrive
+        // but the response body fails or stalls. The next poll owns a new read.
+        return false;
       }
       if (r.status === 304) {
         // A transcript revision may have been deferred while its local stream
@@ -12663,16 +12670,11 @@ function portal() {
         this._reconcileOpenSession(this.sessions);
         return false;
       }
-      if (!r.ok) return false;
-      const et = r.headers.get("etag");
-      if (et) this._sessionsEtag = et;
-      let data = null;
-      try { data = await r.json(); } catch { data = null; }
-      this._applySessionRedirects(
-        (data && data.session_redirects) || {},
-        (data && data.sessions) || [],
-      );
-      this._applySessionList((data && data.sessions) || []);
+      if (!r.ok || !data || !Array.isArray(data.sessions)) return false;
+      this._applySessionRedirects(data.session_redirects || {}, data.sessions);
+      this._applySessionList(data.sessions);
+      // Commit the cache validator only after its complete body is installed.
+      this._sessionsEtag = r.headers.get("etag") || "";
       return true;
     },
     async refreshSessions() {
@@ -18105,7 +18107,7 @@ function portal() {
       // One privacy-bounded summary per canonical history load. Never include a
       // session id, message text, URL, model name, or error string.
       const numeric = [
-        "total_ms", "fetch_ms", "parse_ms", "shape_ms", "markdown_ms",
+        "total_ms", "fetch_ms", "receive_ms", "parse_ms", "first_reveal_ms", "shape_ms", "markdown_ms",
         "install_ms", "response_bytes", "block_count", "assistant_blocks",
         "long_task_count", "longest_task_ms",
       ];
@@ -18115,6 +18117,9 @@ function portal() {
         mode: ["cold", "quiet", "prefetch"].includes(fields.mode)
           ? fields.mode : "cold",
         foreground: !!fields.foreground,
+        visibility: ["visible", "hidden"].includes(fields.visibility) ? fields.visibility : "unknown",
+        cancel_reason: ["none", "superseded", "live_owner", "revision_changed", "anchor_missing", "aborted"]
+          .includes(fields.cancel_reason) ? fields.cancel_reason : "none",
       };
       for (const name of numeric) {
         const value = Math.round(Number(fields[name]) || 0);
@@ -18465,7 +18470,9 @@ function portal() {
         status: "cancelled",
         mode: quiet ? "quiet" : (isCurrent ? "cold" : "prefetch"),
         foreground: isCurrent,
-        total_ms: 0, fetch_ms: 0, parse_ms: 0, shape_ms: 0,
+        cancel_reason: "none",
+        visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+        total_ms: 0, fetch_ms: 0, receive_ms: 0, parse_ms: 0, first_reveal_ms: 0, shape_ms: 0,
         markdown_ms: 0, install_ms: 0, response_bytes: 0,
         block_count: 0, assistant_blocks: 0,
         long_task_count: 0, longest_task_ms: 0,
@@ -18505,8 +18512,26 @@ function portal() {
           : preserveFullOrder
             ? "?full=1&tail=" + requestedTail
             : "?tail=" + requestedTail;
-        let r;
+        let r, parsedSession;
         const fetchStarted = perfNow();
+        let receivedHeaders = false;
+        const consumeHistory = async response => {
+          receivedHeaders = true;
+          historyPerf.fetch_ms = Math.round(perfNow() - fetchStarted);
+          if (!response.ok) return;
+          const receiveStarted = perfNow();
+          if (typeof response.text === "function") {
+            const raw = await response.text();
+            historyPerf.receive_ms = Math.round(perfNow() - receiveStarted);
+            const parseStarted = perfNow();
+            parsedSession = JSON.parse(raw);
+            historyPerf.parse_ms = Math.round(perfNow() - parseStarted);
+          } else {
+            // Reusable in-memory snapshots and older response adapters.
+            parsedSession = await response.json();
+            historyPerf.receive_ms = Math.round(perfNow() - receiveStarted);
+          }
+        };
         try {
           const snapshot = opts.historySnapshot;
           const reusable = snapshot && !full && !preserveFullOrder
@@ -18519,19 +18544,22 @@ function portal() {
               offset: (Number(snapshot.offset) || 0) + trim,
               has_more: (Number(snapshot.offset) || 0) + trim > 0,
             }) };
+            await consumeHistory(r);
           } else {
           r = await this._fetchWithDeadline(
             "/api/chat/sessions/" + sid + qs,
             { headers: this.hdr(), signal: opts.signal },
             full ? 60_000
               : Math.max(100, Number(this._sessionReadTimeoutMs) || 15000),
+            consumeHistory,
           );
           }
         } catch (_) {
-          historyPerf.status = "error";
+          historyPerf.status = opts.signal?.aborted ? "cancelled" : "error";
+          if (opts.signal?.aborted) historyPerf.cancel_reason = "aborted";
           return false;
         } finally {
-          historyPerf.fetch_ms = Math.round(perfNow() - fetchStarted);
+          if (!receivedHeaders) historyPerf.fetch_ms = Math.round(perfNow() - fetchStarted);
         }
         if (!r.ok) {
           historyPerf.status = "error";
@@ -18539,15 +18567,16 @@ function portal() {
         }
         historyPerf.response_bytes = Math.max(
           0, Number(r.headers.get("content-length")) || 0);
-        const parseStarted = perfNow();
-        const parsedSession = await r.json();
-        historyPerf.parse_ms = Math.round(perfNow() - parseStarted);
         const s = this._retainExpectedSessionSettings(parsedSession);
         if (this.tabState[sid] !== st
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
+          historyPerf.cancel_reason = "superseded";
           return false;
         }
-        if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
+        if (st.streaming || st.es || this._hasAdmissionBubble(st)) {
+          historyPerf.cancel_reason = "live_owner";
+          return false;
+        }
         const loadedRuntimeUiRevision = String(s.runtime_ui_revision || "");
         const currentRuntimeUiRevision = String(st.runtimeUiRevision || "");
         // A different load for this same tab adopted another presentation
@@ -18557,6 +18586,7 @@ function portal() {
         // server revision is picked up by the existing poll/reconcile retry.
         if (currentRuntimeUiRevision !== runtimeUiRevisionAtLoad
             && currentRuntimeUiRevision !== loadedRuntimeUiRevision) {
+          historyPerf.cancel_reason = "revision_changed";
           return false;
         }
         const loadedUpdated = Number(s.updated_at) || 0;
@@ -18605,7 +18635,22 @@ function portal() {
           // in-place splice so Alpine keeps the existing bubble elements
           // mounted instead of destroying `sid:live:*` nodes and recreating
           // them as `sid:uuid:*` / `sid:hist:*`.
-          all = this._preserveCanonicalMessageIdentity(st, all);
+          let completedBoundary = opts.completedBoundary;
+          const completion = s.completion_state;
+          // A lost done frame reaches us through revision/replay recovery,
+          // rather than completed_turn. A stable idle snapshot for the exact
+          // retired stream supplies the same boundary without guessing across
+          // successor turns or an older around/full history window.
+          if (!completedBoundary && !s.has_later && completion?.stable
+              && !completion.active && completion.completed_turn_id
+              && [st.activeTurnId, st._lastTerminalTurnId]
+                .includes(completion.completed_turn_id)) {
+            const final = all.findLast(message => message.role === "assistant"
+              && message.uuid && !message.display_kind);
+            const live = st.messages.findLast(message => message.role === "assistant");
+            if (final && live) completedBoundary = { uuid: final.uuid, text: live.text || "" };
+          }
+          all = this._preserveCanonicalMessageIdentity(st, all, completedBoundary);
         }
         const incomingCount = all.length;
         historyPerf.block_count = incomingCount;
@@ -18632,6 +18677,7 @@ function portal() {
         if (this.tabState[sid] !== st || st.streaming || st.es
             || this._hasAdmissionBubble(st)
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
+          historyPerf.cancel_reason = "superseded";
           return false;
         }
         // Publish the canonical repository atomically. A 100-row in-place
@@ -18639,7 +18685,10 @@ function portal() {
         // make Alpine's keyed mover observe an inconsistent intermediate
         // lookup. The matched message objects and their `_k` values are still
         // reused, so stable bubbles keep their DOM identity on the normal path.
-        if (st.streaming || st.es || this._hasAdmissionBubble(st)) return false;
+        if (st.streaming || st.es || this._hasAdmissionBubble(st)) {
+          historyPerf.cancel_reason = "live_owner";
+          return false;
+        }
         // _virtualStart/_virtualEnd are LOCAL to the revealed slice. A quiet
         // canonical refresh can move visibleStart from a narrow recent tail to
         // an older coordinate; carrying the same numbers across that change
@@ -18665,6 +18714,7 @@ function portal() {
         // repository and expose the jump-to-latest affordance instead of silently
         // applying old numeric indices to unrelated messages.
         if (quiet && !quietRangeResolved) {
+          historyPerf.cancel_reason = "anchor_missing";
           st.atBottom = false;
           return false;
         }
@@ -18692,12 +18742,15 @@ function portal() {
         if (quiet) {
           await new Promise(resolve => this.$nextTick(resolve));
         } else {
-          await this._revealMessagesChunked(sid, st, visible, true);
+          await this._revealMessagesChunked(sid, st, visible, true, () => {
+            historyPerf.first_reveal_ms = Math.round(perfNow() - historyPerfStarted);
+          });
         }
         historyPerf.install_ms = Math.round(perfNow() - installStarted);
         if (this.tabState[sid] !== st || st.streaming || st.es
             || this._hasAdmissionBubble(st)
             || !this._historyReplaceStillOwns(st, historyReplaceToken)) {
+          historyPerf.cancel_reason = "superseded";
           return false;
         }
         if (quiet) {
@@ -19010,7 +19063,7 @@ function portal() {
     // Reveal the resident repository in small coordinate steps. The newest tail is
     // immediate; older rows are installed through _yieldHistoryInstall so mobile
     // input gets priority instead of Alpine occupying every animation frame.
-    async _revealMessagesChunked(sid, st, visible, tailFirst = true) {
+    async _revealMessagesChunked(sid, st, visible, tailFirst = true, onFirstReveal = null) {
       // Alpine row creation is the remaining dominant long task: one row can
       // contain many nested directives, tool cards and x-html bodies. Keep each
       // commit deliberately small so transcript installation yields to shell
@@ -19062,6 +19115,7 @@ function portal() {
         await new Promise(resolve => this.$nextTick(resolve));
         if (active && sid === this.currentId && this.tabState[sid] === st) {
           if (!st.messagesReady) st.messagesReady = true;
+          if (onFirstReveal) { onFirstReveal(); onFirstReveal = null; }
           if (st.atBottom !== false) {
             this._scrollChatTailNow(sid, st);
           } else if (scrollEl) {
@@ -19376,7 +19430,7 @@ function portal() {
       push("summary", m.summary);
       return out;
     },
-    _preserveCanonicalMessageIdentity(st, incoming) {
+    _preserveCanonicalMessageIdentity(st, incoming, completedBoundary = null) {
       const existing = st.messages;
       if (!existing.length || !(incoming && incoming.length)) return incoming || [];
       const existingTail = existing[existing.length - 1];
@@ -19479,6 +19533,26 @@ function portal() {
         result[index] = matched;
         return true;
       };
+
+      // Completion reconciliation already verified the exact persisted final
+      // boundary and that no successor owns the pane. Its live text may be
+      // incomplete, so ordinary text matching cannot retain the viewport node.
+      // Bind only one unambiguous live assistant to that verified boundary;
+      // durable identities and repeated prose never get reassigned by this hint.
+      if (completedBoundary?.uuid) {
+        const canonicalIndexes = incoming.map((message, index) => (
+          message.role === "assistant" && message.uuid === completedBoundary.uuid
+            ? index : -1
+        )).filter(index => index >= 0);
+        const liveMatches = existing.filter(message =>
+          message.role === "assistant" && !message.uuid
+          && (!message.forkUuid || message.forkUuid === completedBoundary.uuid)
+          && String(message._k || "").includes(":live:")
+          && String(message.text || "") === completedBoundary.text);
+        if (canonicalIndexes.length === 1 && liveMatches.length === 1) {
+          adopt(canonicalIndexes[0], liveMatches[0], "strong");
+        }
+      }
 
       // Reserve every durable identity before considering prose continuity.
       // Otherwise canonical turn B can weak-match turn A's identical text and
@@ -19731,6 +19805,10 @@ function portal() {
         followTail: st.atBottom !== false && !this._messageRangeHasLater(st),
         startIdentity: this._historyMessageIdentity(st.messages[start]),
         endIdentity: this._historyMessageIdentity(st.messages[end - 1]),
+        // A completed live row can acquire its UUID during reconciliation.
+        // Its retained render key still identifies the same viewport node.
+        startKey: st.messages[start]?._k || "",
+        endKey: st.messages[end - 1]?._k || "",
         visibleCount: Math.max(0, end - start),
         order: range.order,
         generation: range.generation,
@@ -19746,8 +19824,13 @@ function portal() {
         };
       }
       const count = Math.max(1, Number(snapshot.visibleCount) || 1);
-      const startIndex = this._historyMessageIndex(messages, snapshot.startIdentity);
-      const endIndex = this._historyMessageIndex(messages, snapshot.endIdentity);
+      const resolveIndex = (identity, key) => {
+        const index = this._historyMessageIndex(messages, identity);
+        return index >= 0 || !key ? index
+          : messages.findIndex(message => message._k === key);
+      };
+      const startIndex = resolveIndex(snapshot.startIdentity, snapshot.startKey);
+      const endIndex = resolveIndex(snapshot.endIdentity, snapshot.endKey);
       if (startIndex >= 0 && endIndex >= startIndex) {
         return { start: startIndex, end: endIndex + 1 };
       }

--- a/tests/e2e/test_chat_render_perf.py
+++ b/tests/e2e/test_chat_render_perf.py
@@ -3106,7 +3106,7 @@ def test_effort_fast_capabilities_and_session_restore(
             status: 200,
             headers: { get: () => null },
             json: async () => payload,
-            text: async () => "",
+            text: async () => JSON.stringify(payload),
           });
           try {
             app._fetchTabUsage = async () => {};

--- a/tests/e2e/test_completion_visibility.py
+++ b/tests/e2e/test_completion_visibility.py
@@ -271,3 +271,64 @@ def test_final_visibility_converges_through_real_session_scheduler(
     }
     assert sum("?tail=" in url for url in reads) == (2 if mode == "replay_retry" else 1)
     _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+@pytest.mark.parametrize("known_uuid", [True, False])
+def test_completed_partial_viewport_adopts_final_without_refresh(
+    page, backend_url, auth_token, width, known_uuid,
+):
+    """A verified completion keeps the scrolled live node as it acquires a UUID."""
+    page.set_viewport_size({"width": width, "height": 900})
+    errors, _, _ = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st.atBottom = false;
+        st.messageRange.visibleStart = 1;
+        st.messageRange.visibleEnd = 2;
+        st._userScrollAt = 10;
+        const live = st.messages.at(-1);
+        const loaded = await app._runCompletedTurnSync(arg.sid, st, {
+          expectedText: 'LIVE_PARTIAL',
+          expectedAssistantUuid: arg.known ? 'fixture-final' : '',
+          completedTurnId: 'fixture-turn', followTail: false,
+        });
+        return {loaded, text: st.messages.at(-1).text,
+          sameNodeOwner: st.messages.at(-1) === live,
+          key: st.messages.at(-1)._k, atBottom: st.atBottom,
+          pending: st._pendingCompletedTurnSync,
+          followTail: window.visibilityScrolls};
+    """, {"sid": SID, "known": known_uuid})
+    assert result == {
+        "loaded": True, "text": FINAL, "sameNodeOwner": True,
+        "key": f"{SID}:live:partial", "atBottom": False,
+        "pending": None, "followTail": [False],
+    }
+    expect(page.locator(f'.msg-pane[data-tid="{SID}"]')).to_contain_text(FINAL)
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("same_turn", [True, False])
+def test_lost_done_viewport_uses_only_retired_turn_commit(
+    page, backend_url, auth_token, same_turn,
+):
+    """List recovery gets the same mapping only for its exact retired stream."""
+    errors, _, _ = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st.atBottom = false;
+        st.messageRange.visibleStart = 1;
+        st.messageRange.visibleEnd = 2;
+        st.activeTurnId = arg.same ? 'fixture-turn' : 'another-turn';
+        st.streaming = true;
+        const live = st.messages.at(-1);
+        app._retireStaleSessionStream(arg.sid, st);
+        const loaded = await app._runHistoryRevisionSync(arg.sid, st);
+        return {loaded, text:st.messages.at(-1).text,
+          sameOwner:st.messages.at(-1) === live, atBottom:st.atBottom};
+    """, {"sid": SID, "same": same_turn})
+    assert result == {
+        "loaded": same_turn, "text": FINAL if same_turn else "LIVE_PARTIAL",
+        "sameOwner": True, "atBottom": False,
+    }
+    _assert_no_browser_errors(page, errors)

--- a/tests/e2e/test_history_response_deadline.py
+++ b/tests/e2e/test_history_response_deadline.py
@@ -1,0 +1,61 @@
+"""Real-browser checks for history response consumption and cancellation."""
+import pytest
+from .test_chat_render_perf import _app_eval, _login
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+def test_history_body_is_covered_by_deadline_and_upstream_cancel(page, backend_url, auth_token, cancel):
+    _login(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const original = window.fetch;
+        const upstream = new AbortController();
+        let transportSignal, consumeEntered = false;
+        window.fetch = async (url, options) => {
+          if (url !== '/fixture') return original(url, options);
+          transportSignal = options.signal;
+          return new Response('{}');
+        };
+        try {
+          const pending = app._fetchWithDeadline('/fixture', {signal: upstream.signal}, 100,
+            async response => {
+              consumeEntered = true;
+              if (arg) setTimeout(() => upstream.abort(), 10);
+              // Non-cooperative body reader still cannot hold the UI forever.
+              await new Promise(() => {});
+            });
+          let name = '';
+          try { await pending; } catch (error) { name = error.name; }
+          return {name, consumeEntered, aborted: transportSignal.aborted};
+        } finally { window.fetch = original; }
+    """, cancel)
+    assert result == {"name": "AbortError", "consumeEntered": True, "aborted": True}
+
+
+def test_history_load_measures_body_wait_separately_from_json_parse(page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const sid = 'history-body-fixture';
+        const st = app._ensureTabState(sid);
+        const original = window.fetch, report = app._reportHistoryLoadPerf;
+        let metrics;
+        app._reportHistoryLoadPerf = value => {metrics = {...value};};
+        window.fetch = async (url, options) => {
+          if (!String(url).includes('/sessions/' + sid)) return original(url, options);
+          return {ok: true, headers: new Headers(), text: async () => {
+            await new Promise(resolve => setTimeout(resolve, 120));
+            return JSON.stringify({messages: [], total: 0});
+          }};
+        };
+        try {
+          const loaded = await app.loadSession(sid);
+          return {loaded, metrics, ready: st.messagesReady};
+        } finally {
+          window.fetch = original;
+          app._reportHistoryLoadPerf = report;
+          delete app.tabState[sid];
+        }
+    """)
+    assert result["loaded"] and result["ready"]
+    assert result["metrics"]["receive_ms"] >= 100
+    assert result["metrics"]["parse_ms"] < result["metrics"]["receive_ms"]
+    assert result["metrics"]["visibility"] == "visible"

--- a/tests/e2e/test_session_list_recovery.py
+++ b/tests/e2e/test_session_list_recovery.py
@@ -1,0 +1,76 @@
+"""The conditional list poll must retain valid state through partial responses."""
+import pytest
+
+from .test_completion_visibility import _prepare
+from .test_chat_render_perf import _app_eval, _assert_no_browser_errors
+
+
+def test_session_list_body_deadline_releases_next_poll(page, backend_url, auth_token):
+    errors, _, _ = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const originalFetch = window.fetch;
+        let calls = 0, releaseBody, aborted = false;
+        const body = new Promise(resolve => {releaseBody = resolve;});
+        const oldSessions = app.sessions;
+        app._sessionListTimeoutMs = 100;
+        app._sessionsEtag = '"old-list"';
+        window.fetch = async (url, options) => {
+          if (!String(url).includes('/api/chat/sessions?limit=')) return originalFetch(url, options);
+          calls++;
+          if (calls > 1) return {status:304, ok:false};
+          options.signal.addEventListener('abort', () => {aborted = true;});
+          return {status:200, ok:true, headers:new Headers({etag:'"new-list"'}), json:() => body};
+        };
+        try {
+          const first = await app._pullSessionList(true);
+          const second = await app._pullSessionList(true);
+          releaseBody({sessions:[]});
+          await new Promise(resolve => setTimeout(resolve, 0));
+          return {first, second, calls, aborted,
+            held:!!app._sessionListPullPromise, retained:app.sessions === oldSessions,
+            etag:app._sessionsEtag};
+        } finally {window.fetch = originalFetch;}
+    """)
+    assert result == {
+        "first": False, "second": False, "calls": 2, "aborted": True,
+        "held": False, "retained": True, "etag": '"old-list"',
+    }
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("failure", ["body_error", "invalid_shape"])
+def test_list_failure_keeps_validator_and_next_poll_recovers(
+    page, backend_url, auth_token, failure,
+):
+    errors, _, _ = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const originalFetch = window.fetch;
+        let calls = 0;
+        const etags = [];
+        const saved = app.sessions;
+        app._sessionsEtag = '"old-list"';
+        window.fetch = async (url, options) => {
+          if (!String(url).includes('/api/chat/sessions?limit=')) return originalFetch(url, options);
+          calls++;
+          etags.push(options.headers['If-None-Match']);
+          if (calls > 1) return {status:200, ok:true,
+            headers:new Headers({etag:'"new-list"'}), json:async () => ({sessions:[]})};
+          return {status:200, ok:true, headers:new Headers({etag:'"new-list"'}),
+            json:async () => {
+              if (arg === 'body_error') throw new TypeError('synthetic interrupted body');
+              return {};
+            }};
+        };
+        try {
+          const first = await app._pullSessionList(true);
+          const retained = app.sessions === saved;
+          const second = await app._pullSessionList(true);
+          return {first, retained, second, count:app.sessions.length,
+            etags, finalEtag:app._sessionsEtag};
+        } finally {window.fetch = originalFetch;}
+    """, failure)
+    assert result == {
+        "first": False, "retained": True, "second": True, "count": 0,
+        "etags": ['"old-list"', '"old-list"'], "finalEtag": '"new-list"',
+    }
+    _assert_no_browser_errors(page, errors)

--- a/tests/test_background_continuation.py
+++ b/tests/test_background_continuation.py
@@ -1,0 +1,345 @@
+"""Continuation boundaries use the real watcher and sole SDK stream router."""
+import asyncio
+import json
+from contextlib import suppress
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage, ResultMessage, StreamEvent, TaskNotificationMessage,
+    TextBlock, ToolUseBlock,
+)
+
+from tests.test_chat_stream import stream_env as _stream_env
+
+
+stream_env = _stream_env
+
+
+class QueueClient:
+    EOF = object()
+
+    def __init__(self):
+        self.messages = asyncio.Queue()
+        self.queries = []
+        self.resume_requested = asyncio.Event()
+        self.disconnect_started = asyncio.Event()
+        self.allow_disconnect = asyncio.Event()
+        self.allow_disconnect.set()
+        self.disconnect_calls = 0
+        self.fail_first_disconnect = False
+
+    async def receive_messages(self):
+        while True:
+            msg = await self.messages.get()
+            if msg is self.EOF:
+                return
+            yield msg
+
+    async def query(self, prompt):
+        self.queries.append([item async for item in prompt])
+        self.resume_requested.set()
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        self.disconnect_started.set()
+        if self.fail_first_disconnect and self.disconnect_calls == 1:
+            raise RuntimeError("synthetic cleanup retry")
+        await self.allow_disconnect.wait()
+
+
+def notification(sid, *, status="completed"):
+    return TaskNotificationMessage(
+        subtype="task_notification", data={}, task_id="synthetic-task",
+        status=status, output_file=None, summary="synthetic task",
+        uuid="synthetic-notification", session_id=sid, tool_use_id="synthetic-tool",
+    )
+
+
+def result(sid, **overrides):
+    args = dict(
+        subtype="success", duration_ms=100, duration_api_ms=80,
+        is_error=False, num_turns=1, session_id=sid,
+        total_cost_usd=0.0, usage={},
+    )
+    args.update(overrides)
+    return ResultMessage(**args)
+
+
+def assistant(*, content=None):
+    return AssistantMessage(
+        content=content or [TextBlock(text="synthetic response")],
+        model="claude-sonnet-4-6", usage={}, uuid="synthetic-assistant",
+    )
+
+
+async def wait_until(predicate):
+    async with asyncio.timeout(2):
+        while not predicate():
+            await asyncio.sleep(0.001)
+
+
+def start_watcher(chat, sid, client, *, generation=None):
+    chat._pin_background_task(sid, "synthetic-task")
+    key = (sid, "claude-sonnet-4-6", "", "")
+    chat._clients[key] = client
+    stream = chat._ensure_session_stream(key, client)
+    watcher = asyncio.create_task(chat._watch_inflight_tasks(
+        sid, client, {"synthetic-task": "synthetic"}, generation))
+    chat._task_watchers[sid] = watcher
+    return stream, watcher
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first", ["text", "tool", "message_start"])
+async def test_started_continuation_survives_long_model_and_tool_silence(
+    stream_env, monkeypatch, first,
+):
+    chat = stream_env
+    sid = "continued-after-silence"
+    monkeypatch.setattr(chat, "_CONTINUATION_GRACE", 0.01)
+    monkeypatch.setattr(chat, "_CONTINUATION_TIMEOUT", 1)
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    if first == "message_start":
+        signal = StreamEvent(uuid="synthetic-event", session_id=sid,
+                             event={"type": "message_start"})
+    elif first == "tool":
+        signal = assistant(content=[ToolUseBlock(
+            id="synthetic-bash", name="Bash", input={"command": "true"})])
+    else:
+        signal = assistant()
+    client.messages.put_nowait(signal)
+    stream, watcher = start_watcher(chat, sid, client)
+    try:
+        await wait_until(lambda: sid in chat._active_turns)
+        await asyncio.sleep(0.04)
+        assert not watcher.done()
+        assert client.queries == []
+        client.messages.put_nowait(assistant())
+        await asyncio.sleep(0.04)
+        assert not watcher.done()
+        assert client.queries == []
+        client.messages.put_nowait(result(sid))
+        await asyncio.wait_for(watcher, 2)
+        done = json.loads(chat._recent_turns[sid].events[-1]["data"])
+        assert done["status"] == "completed"
+        assert done["is_error"] is False
+        assert client.disconnect_calls == 0
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_resume_has_a_full_response_lease(stream_env, monkeypatch):
+    chat = stream_env
+    sid = "slow-explicit-resume"
+    monkeypatch.setattr(chat, "_CONTINUATION_GRACE", 0.01)
+    monkeypatch.setattr(chat, "_CONTINUATION_TIMEOUT", 1)
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    stream, watcher = start_watcher(chat, sid, client)
+    try:
+        await asyncio.wait_for(client.resume_requested.wait(), 2)
+        await asyncio.sleep(0.04)
+        assert not watcher.done()
+        client.messages.put_nowait(assistant())
+        client.messages.put_nowait(result(sid))
+        await asyncio.wait_for(watcher, 2)
+        assert len(client.queries) == 1
+        assert client.queries[0][0]["isMeta"] is True
+        assert chat._recent_turns[sid].perf_status == "completed"
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_kind", ["deadline", "eof", "cancel", "stopped"])
+async def test_missing_result_fences_exact_runtime_before_queue_release(
+    stream_env, monkeypatch, exit_kind,
+):
+    chat = stream_env
+    sid = "missing-continuation-boundary"
+    monkeypatch.setattr(chat, "_CONTINUATION_GRACE", 0.01)
+    monkeypatch.setattr(chat, "_STOPPED_CONTINUATION_GRACE", 0.01)
+    monkeypatch.setattr(chat, "_CONTINUATION_TIMEOUT", 0.04)
+    monkeypatch.setattr(chat, "_TASK_TERMINATION_RETRY_S", 0.001)
+    drains = []
+
+    async def drain(sid):
+        drains.append(sid)
+
+    monkeypatch.setattr(chat, "_maybe_drain_queue", drain)
+    client = QueueClient()
+    client.fail_first_disconnect = exit_kind == "deadline"
+    client.allow_disconnect.clear()
+    client.messages.put_nowait(notification(
+        sid, status="stopped" if exit_kind == "stopped" else "completed"))
+    if exit_kind != "stopped":
+        client.messages.put_nowait(assistant())
+    stream, watcher = start_watcher(chat, sid, client)
+    try:
+        await wait_until(lambda: sid in chat._active_turns)
+        if exit_kind == "cancel":
+            watcher.cancel()
+        elif exit_kind == "eof":
+            client.messages.put_nowait(client.EOF)
+        await asyncio.wait_for(client.disconnect_started.wait(), 2)
+        assert not watcher.done()
+        assert chat._task_watchers[sid] is watcher
+        assert drains == []
+        assert sid in chat._active_turns
+        # A late SDK boundary cannot enter a new user turn, even while process
+        # cleanup is awaiting confirmation. The sole reader is closed first.
+        assert stream._closed
+        client.messages.put_nowait(result(sid))
+        new_queue = stream.attach_turn()
+        await asyncio.sleep(0.015)
+        assert new_queue.empty()
+        client.allow_disconnect.set()
+        if exit_kind == "cancel":
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(watcher, 2)
+        else:
+            await asyncio.wait_for(watcher, 2)
+        assert drains == [sid]
+        done = json.loads(chat._recent_turns[sid].events[-1]["data"])
+        if exit_kind not in {"cancel", "stopped"}:
+            assert done["kind"] == "background_continuation_incomplete"
+            assert done["is_error"] is True
+        if exit_kind == "cancel":
+            assert done["cancelled"] is True
+        if exit_kind == "deadline":
+            assert client.disconnect_calls >= 2
+        assert client.queries == []
+    finally:
+        client.allow_disconnect.set()
+        if not watcher.done():
+            watcher.cancel()
+            with suppress(asyncio.CancelledError):
+                await watcher
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_progress_messages_do_not_extend_absolute_continuation_lease(
+    stream_env, monkeypatch,
+):
+    chat = stream_env
+    sid = "bounded-continuation"
+    monkeypatch.setattr(chat, "_CONTINUATION_GRACE", 0.01)
+    monkeypatch.setattr(chat, "_CONTINUATION_TIMEOUT", 0.04)
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    client.messages.put_nowait(assistant())
+    stream, watcher = start_watcher(chat, sid, client)
+
+    async def progress():
+        while not watcher.done():
+            client.messages.put_nowait(StreamEvent(
+                uuid="synthetic-progress", session_id=sid,
+                event={"type": "message_delta"}))
+            await asyncio.sleep(0.002)
+
+    producer = asyncio.create_task(progress())
+    try:
+        await asyncio.wait_for(watcher, 1)
+        assert client.disconnect_calls == 1
+        assert chat._recent_turns[sid].perf_status == "failed"
+        assert client.queries == []
+    finally:
+        producer.cancel()
+        with suppress(asyncio.CancelledError):
+            await producer
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_replacement_generation_retains_runtime_ownership(stream_env):
+    chat = stream_env
+    sid = "replacement-keeps-runtime"
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    client.messages.put_nowait(assistant())
+    chat._continuation_generations[sid] = 1
+    stream, watcher = start_watcher(chat, sid, client, generation=1)
+    try:
+        await wait_until(lambda: sid in chat._active_turns)
+        chat._continuation_generations[sid] = 2
+        watcher.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await watcher
+        assert client.disconnect_calls == 0
+        assert not stream.task.done()
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal", [
+    {"subtype": "error_max_turns", "errors": ["synthetic turn limit"]},
+    {"subtype": "error_during_execution", "result": "synthetic 429 rate limit",
+     "api_error_status": 429},
+    {"subtype": "error_max_turns", "errors": ["synthetic turn limit"],
+     "terminal_reason": "max_turns"},
+])
+async def test_sdk_error_reaches_done_footer_and_runtime_outbox(
+    stream_env, monkeypatch, terminal,
+):
+    chat = stream_env
+    sid = "f8fb8250-4c95-4a95-806c-77eac5f4820f"
+    chat.sess.register_session(sid, name="synthetic", model="claude-sonnet-4-6")
+    outbox = []
+
+    def persist(_sid, _broadcast, **fields):
+        outbox.append(fields)
+        return ""
+
+    monkeypatch.setattr(chat, "_persist_runtime_continuation_outbox", persist)
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    client.messages.put_nowait(assistant())
+    client.messages.put_nowait(result(sid, is_error=True, **terminal))
+    stream, watcher = start_watcher(chat, sid, client)
+    try:
+        await asyncio.wait_for(watcher, 2)
+        bc = chat._recent_turns[sid]
+        done = json.loads(bc.events[-1]["data"])
+        expected_status = "stopped" if terminal.get("terminal_reason") == "max_turns" else "failed"
+        assert done["is_error"] is True
+        assert done["status"] == expected_status
+        assert done["result_subtype"] == terminal["subtype"]
+        assert done["api_error_status"] == terminal.get("api_error_status")
+        assert bc.perf_status == "failed"
+        if terminal.get("api_error_status") == 429:
+            assert done["kind"] == "quota"
+        assert chat.sess.get_message_annotations(sid)["synthetic-assistant"]["turn_status"] == expected_status
+        assert outbox[0]["terminal_status"] == expected_status
+        assert outbox[0]["incomplete_error"] == done["error"]
+        assert client.disconnect_calls == 0
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sdk_aborted_result_stays_cancelled_in_background_accounting(
+    stream_env, monkeypatch,
+):
+    chat = stream_env
+    sid = "sdk-cancelled-continuation"
+    perf = []
+    monkeypatch.setattr(chat, "_perf_event", lambda event, **fields: perf.append((event, fields)))
+    client = QueueClient()
+    client.messages.put_nowait(notification(sid))
+    client.messages.put_nowait(assistant())
+    client.messages.put_nowait(result(sid, terminal_reason="aborted_streaming"))
+    stream, watcher = start_watcher(chat, sid, client)
+    try:
+        await asyncio.wait_for(watcher, 2)
+        done = json.loads(chat._recent_turns[sid].events[-1]["data"])
+        assert done["status"] == "cancelled"
+        assert done["cancelled"] is True
+        background = next(fields for event, fields in perf if event == "chat.background")
+        assert background["status"] == "cancelled"
+        assert client.disconnect_calls == 0
+    finally:
+        await stream.aclose()

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -2251,6 +2251,9 @@ class _FakeWatchClient:
     def __init__(self, messages):
         self._messages = messages
 
+    async def disconnect(self):
+        pass
+
     async def receive_messages(self):
         for m in self._messages:
             yield m
@@ -2268,6 +2271,9 @@ class _BatchedWatchClient:
         self._batches = list(batches)
         self.queries = []
         self._receive_count = 0
+
+    async def disconnect(self):
+        pass
 
     async def query(self, prompt_or_gen):
         items = []
@@ -3186,6 +3192,9 @@ async def test_watcher_shutdown_partial_never_projects_completed_bubble(
     )
 
     class _PartialClient:
+        async def disconnect(self):
+            pass
+
         async def receive_messages(self):
             yield notification
             yield partial
@@ -4242,6 +4251,8 @@ def test_replay_corruption_is_typed_and_subscriber_resyncs_once(
     chat_mod = stream_env
     monkeypatch.setenv("MUSELAB_RUNTIME_DIR", str(tmp_path / "runtime"))
     spool = chat_mod._ReplaySpool()
+    # Corrupt an accepted record, not bytes outside the committed replay prefix.
+    spool.append({"event": "done", "data": "{}"})
     spool.path.write_bytes(b'{"event":"done","data":7}\n')
     try:
         with pytest.raises(chat_mod._ReplayRecordCorruption):
@@ -6822,6 +6833,9 @@ def test_watcher_timeout_waits_for_terminal_stop_before_queue_drain(
             self.stop_calls = []
             self.stop_requested = asyncio.Event()
             self.release_terminal = asyncio.Event()
+
+        async def disconnect(self):
+            pass
 
         async def stop_task(self, requested):
             self.stop_calls.append(requested)

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -925,7 +925,8 @@ def test_hidden_runtime_successors_repair_tabs_drafts_and_task_links():
     pull_start = app.index("async _pullSessionListOnce(")
     pull_end = app.index("\n    async refreshSessions()", pull_start)
     pull = app[pull_start:pull_end]
-    assert "(data && data.session_redirects) || {}" in pull
+    assert "this._applySessionRedirects(data.session_redirects || {}, data.sessions)" in pull
+    assert "!Array.isArray(data.sessions)" in pull
     assert pull.index("this._applySessionRedirects(") < pull.index(
         "this._applySessionList(")
 
@@ -1340,7 +1341,7 @@ def test_session_sync_deadlines_and_activity_transport_backoff_are_bounded():
     fetch_start = app.index("    async _fetchWithDeadline(")
     fetch_end = app.index("\n    _staticAssetUrl", fetch_start)
     deadline_fetch = app[fetch_start:fetch_end]
-    assert "Promise.race([fetch(url, fetchOptions), control])" in deadline_fetch
+    assert "Promise.race([operation, control])" in deadline_fetch
     assert 'abort("request deadline exceeded")' in deadline_fetch
 
     activity_start = app.index("    async fetchActivity(opts = {}) {")
@@ -1772,7 +1773,7 @@ def test_failed_transcript_refresh_preserves_last_good_messages():
     load = app[start:end]
     failed = load[
         load.index("if (!r.ok) {"):
-        load.index("const parsedSession = await r.json()")
+        load.index("const s = this._retainExpectedSessionSettings(parsedSession)")
     ]
 
     assert "return false" in failed
@@ -2821,7 +2822,7 @@ def test_runtime_continuation_history_identity_footer_and_fork_guards():
     assert "m._steeringAdjustment === true || m._turnRoot === false" in continuity
 
     preserve_start = app.index(
-        "    _preserveCanonicalMessageIdentity(st, incoming) {")
+        "    _preserveCanonicalMessageIdentity(st, incoming, completedBoundary = null) {")
     preserve_end = app.index("\n    _assignLiveKey", preserve_start)
     preserve = app[preserve_start:preserve_end]
     assert preserve.index("Reserve every durable identity") < preserve.index(
@@ -3245,7 +3246,7 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     assert "st._composerSubmitToken || st._queueAdmission" in app
     assert "|| this._hasAdmissionBubble(st)" in app
     assert "this.tabState[sid] !== st || st.streaming || st.es" in load
-    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true)")
+    reveal_start = app.index("async _revealMessagesChunked(sid, st, visible, tailFirst = true, onFirstReveal = null)")
     reveal = app[reveal_start:app.index("async _fillDeferredHead", reveal_start)]
     assert "this.tabState[sid] !== st || st.streaming || st.es" in reveal
     assert "const CH = this._isMobileLayout() ? 1 : 2" in reveal
@@ -3270,12 +3271,12 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     assert "expectedText" in app
     assert "const stillOwned = () => this.tabState[sid] === ownerState" in app
     assert "if (!isContinuation)" in send
-    assert "all = this._preserveCanonicalMessageIdentity(st, all)" in load
+    assert "all = this._preserveCanonicalMessageIdentity(st, all, completedBoundary)" in load
     assert "const quietRangeSnapshot = quiet" in load
     assert "this._resolveMessageRangeSnapshot(all, quietRangeSnapshot)" in load
     assert "this._historyReplaceStillOwns(st, historyReplaceToken)" in load
     assert "await new Promise(resolve => this.$nextTick(resolve))" in load
-    assert "this._revealMessagesChunked(sid, st, visible, true)" in load
+    assert "this._revealMessagesChunked(sid, st, visible, true, () =>" in load
     assert "this._revealMessagesChunked(sid, st, visible, !quiet)" not in load
     assert "delete canonicalFields._k" in app
     assert "matched._k = mountedKey" in app
@@ -3631,7 +3632,7 @@ def test_done_immediately_stamps_tool_tail_and_quietly_adopts_fork_boundary():
     fork = app[fork_start:fork_end]
     assert "if (message.forkUuid) return message.forkUuid" in fork
 
-    preserve_start = app.index("_preserveCanonicalMessageIdentity(st, incoming)")
+    preserve_start = app.index("_preserveCanonicalMessageIdentity(st, incoming, completedBoundary = null)")
     preserve_end = app.index("\n    _assignLiveKey", preserve_start)
     preserve = app[preserve_start:preserve_end]
     assert 'mountedKey.includes(":live:")' in preserve
@@ -4067,8 +4068,8 @@ def test_quiet_canonical_reload_rebases_virtual_window_before_alpine_paints():
     range_helper_end = app.index("    _captureViewportMessageAnchor", range_helper_start)
     range_helper = app[range_helper_start:range_helper_end]
     assert "startIdentity:" in range_helper and "endIdentity:" in range_helper
-    assert "_historyMessageIndex(messages, snapshot.startIdentity)" in range_helper
-    assert "_historyMessageIndex(messages, snapshot.endIdentity)" in range_helper
+    assert "resolveIndex(snapshot.startIdentity, snapshot.startKey)" in range_helper
+    assert "resolveIndex(snapshot.endIdentity, snapshot.endKey)" in range_helper
     assert "_historyReplaceStillOwns" in range_helper
     assert "_historyPageStillOwns" in range_helper
 

--- a/tests/test_main_observability.py
+++ b/tests/test_main_observability.py
@@ -357,3 +357,22 @@ def test_severe_loop_watchdog_attributes_privacy_safe_site_and_rate_limits(
     assert "/home/" not in repr(events)
     assert "prompt" not in repr(events)
     assert events[1][1]["lag_ms"] == 65000
+
+
+def test_history_perf_keeps_receive_parse_and_cancel_reason_private(app_module, client, monkeypatch):
+    events = []
+    monkeypatch.setattr(app_module, "_perf_enabled", lambda: False)
+    monkeypatch.setattr(app_module, "perf_event", lambda event, **fields: events.append(fields))
+    headers = {"X-Auth-Token": TEST_TOKEN}
+    payload = {"status": "cancelled", "mode": "quiet", "visibility": "hidden",
+               "cancel_reason": "anchor_missing", "receive_ms": 400,
+               "parse_ms": 2, "first_reveal_ms": 20}
+    assert client.post("/api/log/client-perf", headers=headers, json=payload).status_code == 200
+    assert events[0]["receive_ms"] == 400
+    assert events[0]["parse_ms"] == 2
+    assert events[0]["visibility"] == "hidden"
+    assert events[0]["cancel_reason"] == "anchor_missing"
+    for field in ("visibility", "cancel_reason"):
+        assert client.post("/api/log/client-perf", headers=headers,
+                           json={**payload, field: "private detail"}).status_code == 422
+    assert len(events) == 1

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -804,7 +804,15 @@ def _run_worker_job(tmp_path, monkeypatch, failures, *, kind="reindex_memory"):
     monkeypatch.setattr(instance.store, "finish_job", finish_and_advance)
     _run(instance._worker())
     job = next(row for row in instance.store.list_jobs() if row["id"] == job_id)
-    return calls, job, events
+    starts = [fields for event, fields in events if event == "memory.job_start"]
+    outcomes = [(event, fields) for event, fields in events if event == "memory.job"]
+    assert len(starts) == len(outcomes)
+    assert len({fields["job_ref"] for _, fields in outcomes}) == 1
+    for start, (_, finish) in zip(starts, outcomes):
+        assert start["job_ref"] == finish["job_ref"]
+        assert len(start["job_ref"]) == 12
+        assert start["attempt"] == finish["attempt"]
+    return calls, job, outcomes
 
 
 @pytest.mark.parametrize(("exc", "retryable", "category", "status"), [

--- a/tests/test_memory_providers.py
+++ b/tests/test_memory_providers.py
@@ -181,7 +181,7 @@ def test_pgvector_table_name_is_not_interpolatable():
 def test_claude_oauth_generation_uses_fresh_no_tool_sdk_query(
         tmp_path, monkeypatch):
     import claude_agent_sdk
-    from claude_agent_sdk.types import AssistantMessage, TextBlock
+    from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
     from backend.memory_config import MemoryConfig
     from backend.memory_providers import GenerationProvider
 
@@ -193,6 +193,8 @@ def test_claude_oauth_generation_uses_fresh_no_tool_sdk_query(
         seen["prompt"] = prompt
         seen["options"] = options
         yield AssistantMessage(content=[TextBlock("ok")], model="claude")
+        yield ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                            is_error=False, num_turns=1, session_id="fixture")
 
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
     provider = GenerationProvider(MemoryConfig(generation_model="claude-sonnet-4-6"))
@@ -496,3 +498,148 @@ def test_sdk_exception_classification_is_sanitized(
     assert caught.value.retryable is retryable
     assert caught.value.api_error_status is None
     assert secret not in str(caught.value)
+
+
+@pytest.mark.parametrize("intermediate,final", [
+    (None, '{"memories": []}'),
+    ('partial output', '{"memories": []}'),
+    ('{"memories": []}', None),
+])
+def test_sdk_memory_uses_completed_final_answer_and_closes_iterator(
+        tmp_path, monkeypatch, intermediate, final):
+    import claude_agent_sdk
+    from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationProvider
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("MUSELAB_MEMORY_DIR", str(tmp_path / "memory"))
+    closed = []
+
+    async def fake_query(*, prompt, options):
+        try:
+            if intermediate is not None:
+                yield AssistantMessage(content=[TextBlock(intermediate)], model="fixture")
+            yield ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                                is_error=False, num_turns=1, session_id="fixture",
+                                result=final)
+            yield AssistantMessage(content=[TextBlock("ignored after terminal")], model="fixture")
+        finally:
+            closed.append(True)
+
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    provider = GenerationProvider(MemoryConfig(generation_model="claude-sonnet-4-6"))
+    assert _run(provider.complete_json("system", "prompt")) == {"memories": []}
+    assert closed == [True]
+
+
+@pytest.mark.parametrize("terminal", ["missing", "error"])
+def test_sdk_memory_rejects_partial_output_when_completion_fails(
+        tmp_path, monkeypatch, terminal):
+    import claude_agent_sdk
+    from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationError, GenerationProvider
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("MUSELAB_MEMORY_DIR", str(tmp_path / "memory"))
+    closed = []
+
+    async def fake_query(*, prompt, options):
+        try:
+            yield AssistantMessage(content=[TextBlock('{"memories": []}')], model="fixture")
+            if terminal == "error":
+                yield ResultMessage(subtype="error", duration_ms=1, duration_api_ms=1,
+                                    is_error=True, num_turns=1, session_id="fixture",
+                                    result="sensitive detail", api_error_status=500)
+        finally:
+            closed.append(True)
+
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    provider = GenerationProvider(MemoryConfig(generation_model="claude-sonnet-4-6"))
+    with pytest.raises(GenerationError) as caught:
+        _run(provider.complete_json("system", "prompt"))
+    assert caught.value.retryable
+    assert caught.value.category == "transient_provider"
+    assert "sensitive" not in str(caught.value)
+    assert closed == [True]
+
+
+def test_sdk_memory_drains_nested_query_cleanup_before_return(tmp_path, monkeypatch):
+    import claude_agent_sdk
+    from claude_agent_sdk.types import ResultMessage
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationProvider
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("MUSELAB_MEMORY_DIR", str(tmp_path / "memory"))
+    closed = []
+
+    async def inner():
+        try:
+            yield ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                                is_error=False, num_turns=1, session_id="fixture", result="ok")
+        finally:
+            closed.append(True)
+
+    # Mirrors the public SDK wrapper's nested async-for ownership.
+    async def fake_query(*, prompt, options):
+        async for message in inner():
+            yield message
+
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    provider = GenerationProvider(MemoryConfig(generation_model="claude-sonnet-4-6"))
+
+    async def exercise():
+        assert await provider.complete("system", "prompt") == "ok"
+        # Assert before asyncio.run's shutdown_asyncgens can hide a leaked query.
+        assert closed == [True]
+
+    _run(exercise())
+
+
+def test_generation_diagnostics_correlate_timeout_without_private_details(monkeypatch, capsys):
+    import httpx
+    from backend import observability
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationError, GenerationProvider, generation_job_ref
+
+    monkeypatch.setenv("MUSELAB_PERF_LOG", "1")
+    monkeypatch.setattr(observability, "_perf_writer", None)
+    provider = GenerationProvider(MemoryConfig(generation_model="private-model-detail"))
+    monkeypatch.setattr(provider, "_route", lambda: None)
+
+    async def fail(*args):
+        raise httpx.ReadTimeout("private-request-detail")
+
+    monkeypatch.setattr(provider, "_complete_with_sdk", fail)
+    token = generation_job_ref.set("012345abcdef")
+    try:
+        with pytest.raises(GenerationError) as caught:
+            _run(provider.complete("private-system-detail", "private-prompt-detail"))
+        assert caught.value.reason == "timeout"
+    finally:
+        generation_job_ref.reset(token)
+    output = capsys.readouterr().err
+    assert '"event":"memory.generation"' in output
+    assert '"job_ref":"012345abcdef"' in output
+    assert '"cause_kind":"ReadTimeout"' in output
+    assert '"reason":"timeout"' in output
+    assert "private-" not in output
+
+
+@pytest.mark.parametrize("value,reason", [("not JSON", "invalid_json"), ("[]", "non_object_json")])
+def test_generation_json_diagnostics_have_safe_specific_reason(monkeypatch, value, reason):
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationError, GenerationProvider
+    from backend.memory_engine import classify_memory_failure
+    provider = GenerationProvider(MemoryConfig())
+
+    async def complete(*args):
+        return value
+
+    monkeypatch.setattr(provider, "complete", complete)
+    with pytest.raises(GenerationError) as caught:
+        _run(provider.complete_json("system", "prompt"))
+    assert classify_memory_failure(caught.value)[1]["reason"] == reason
+    assert GenerationError(retryable=False, reason="private detail").reason == "unknown"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -29,6 +29,7 @@ def test_perf_event_is_one_bounded_structured_line(monkeypatch, capsys):
     )
 
     payload = _payload(capsys.readouterr().err)
+    assert isinstance(payload.pop("at_ms"), int)
     assert payload == {
         "event": "chat.turn",
         "sid": "12345678",

--- a/tests/test_replay_io.py
+++ b/tests/test_replay_io.py
@@ -1,0 +1,202 @@
+"""Slow-disk regressions for live delivery, replay order and cancellation."""
+import asyncio
+import json
+import threading
+
+import pytest
+
+from .test_chat_stream import stream_env as stream_env
+
+
+@pytest.mark.asyncio
+async def test_slow_write_keeps_loop_responsive_and_done_behind_record(stream_env, monkeypatch):
+    broadcast = stream_env.TurnBroadcast("slow-write")
+    reader = broadcast.subscribe()
+    entered, release = threading.Event(), threading.Event()
+    write = broadcast.events._write_blob
+
+    def delayed(blob):
+        entered.set()
+        assert release.wait(3), "disk remained blocked while the event loop could not release it"
+        write(blob)
+
+    monkeypatch.setattr(broadcast.events, "_write_blob", delayed)
+    try:
+        broadcast.publish({"event": "tool_result", "data": '{"id":"first"}'})
+        broadcast.publish({"event": "done", "data": "{}"})
+        broadcast.finish()
+        assert await asyncio.to_thread(entered.wait, 1)
+        pending = asyncio.create_task(reader.get())
+        await asyncio.sleep(0.02)
+        assert not pending.done(), "terminal delivery must wait for preceding disk writes"
+        release.set()
+        first = await asyncio.wait_for(pending, 2)
+        assert first["event"] == "tool_result"
+        assert (await reader.get())["event"] == "done"
+        assert await reader.get() is None
+    finally:
+        release.set()
+        broadcast.close()
+        await broadcast.events.flush_async()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_slow_read_is_reused_without_losing_record(stream_env, monkeypatch):
+    broadcast = stream_env.TurnBroadcast("slow-read")
+    broadcast.publish({"event": "tool_result", "data": '{"id":"first"}'})
+    broadcast.publish({"event": "done", "data": "{}"})
+    broadcast.finish()
+    await broadcast.events.flush_async()
+    reader = broadcast.subscribe()
+    entered, release = threading.Event(), threading.Event()
+    read = reader._replay.readline
+
+    def delayed():
+        if not entered.is_set():
+            entered.set()
+            assert release.wait(3), "disk read blocked the event loop"
+        return read()
+
+    monkeypatch.setattr(reader._replay, "readline", delayed)
+    try:
+        pending = asyncio.create_task(reader.get())
+        assert await asyncio.to_thread(entered.wait, 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        release.set()
+        first = await asyncio.wait_for(reader.get(), 2)
+        assert json.loads(first["data"])["id"] == "first"
+        assert (await reader.get())["event"] == "done"
+        assert await reader.get() is None
+    finally:
+        release.set()
+        broadcast.close()
+        await broadcast.events.flush_async()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cursor", [0, 1])
+async def test_disk_failure_resyncs_once_without_false_done(stream_env, monkeypatch, cursor):
+    broadcast = stream_env.TurnBroadcast("disk-error")
+    release = threading.Event()
+    def broken(_blob):
+        assert release.wait(3)
+        raise OSError(28, "private disk failure detail")
+    monkeypatch.setattr(broadcast.events, "_write_blob", broken)
+    broadcast.publish({"event": "tool_result", "data": "{}"})
+    broadcast.publish({"event": "done", "data": "{}"})
+    broadcast.finish()
+    reader = broadcast.subscribe(last_event_seq=cursor)
+    release.set()
+    try:
+        first = await asyncio.wait_for(reader.get(), 2)
+        assert first["event"] == "resync"
+        assert json.loads(first["data"])["reason"] == "replay_storage_error"
+        assert "private" not in first["data"]
+        assert await reader.get() is None
+    finally:
+        broadcast.close()
+
+
+def test_pending_write_budget_is_shared_and_rejects_overflow(monkeypatch):
+    from backend import replay_io
+    entered, release = threading.Event(), threading.Event()
+    first, second = replay_io.ReplayIO(), replay_io.ReplayIO()
+    monkeypatch.setattr(replay_io, "MAX_PENDING_BYTES", 100)
+    def blocked():
+        entered.set()
+        assert release.wait(3)
+    future = first.submit(blocked, size=80)
+    try:
+        assert entered.wait(1)
+        with pytest.raises(replay_io.ReplayBacklogExceeded):
+            second.submit(lambda: None, size=80)
+    finally:
+        release.set()
+        future.result(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_close_during_pending_write_does_not_reuse_or_leak_descriptor(stream_env, monkeypatch):
+    broadcast = stream_env.TurnBroadcast("pending-close")
+    entered, release = threading.Event(), threading.Event()
+    write = broadcast.events._write_blob
+    def delayed(blob):
+        entered.set()
+        assert release.wait(3)
+        write(blob)
+    monkeypatch.setattr(broadcast.events, "_write_blob", delayed)
+    path = broadcast.events.path
+    try:
+        broadcast.publish({"event": "done", "data": "{}"})
+        assert await asyncio.to_thread(entered.wait, 1)
+        broadcast.close()
+        assert path.exists()
+        release.set()
+        await asyncio.wait_for(broadcast.events.flush_async(), 2)
+        assert not path.exists()
+    finally:
+        release.set()
+        broadcast.close()
+
+
+@pytest.mark.asyncio
+async def test_closed_cursor_reader_does_not_spin_on_initial_events(stream_env):
+    broadcast = stream_env.TurnBroadcast("closed-cursor")
+    broadcast.publish({"event": "tool_result", "data": "{}"})
+    broadcast.publish({"event": "done", "data": "{}"})
+    broadcast.finish()
+    await broadcast.events.flush_async()
+    reader = broadcast.subscribe(last_event_seq=1)
+    reader.close_reader()
+    assert await reader.get() is None
+    broadcast.close()
+    await broadcast.events.flush_async()
+
+
+@pytest.mark.asyncio
+async def test_reader_does_not_decode_an_in_progress_trailing_record(stream_env, monkeypatch):
+    import os
+    broadcast = stream_env.TurnBroadcast("partial-write-race")
+    broadcast.publish({"event": "tool_result", "data": '{"id":"first"}'})
+    reader = broadcast.subscribe()
+    assert (await reader.get())["event"] == "tool_result"
+    entered_read, release_read = threading.Event(), threading.Event()
+    entered_write, release_write = threading.Event(), threading.Event()
+    read = reader._replay.readline
+    write = os.write
+
+    def delayed_read():
+        if not entered_read.is_set():
+            entered_read.set()
+            assert release_read.wait(3)
+        return read()
+
+    def partial_write(fd, data):
+        if fd == broadcast.events._fd and not entered_write.is_set():
+            count = write(fd, data[:5])
+            entered_write.set()
+            assert release_write.wait(3)
+            return count
+        return write(fd, data)
+
+    monkeypatch.setattr(reader._replay, "readline", delayed_read)
+    monkeypatch.setattr(os, "write", partial_write)
+    pending = asyncio.create_task(reader.get())
+    try:
+        assert await asyncio.to_thread(entered_read.wait, 1)
+        broadcast.publish({"event": "tool_result", "data": '{"id":"second"}'})
+        assert await asyncio.to_thread(entered_write.wait, 1)
+        release_read.set()
+        await asyncio.sleep(0.02)
+        assert not pending.done(), "partial trailing data must not cause a corruption resync"
+        release_write.set()
+        event = await asyncio.wait_for(pending, 2)
+        assert event["event"] == "tool_result"
+        assert json.loads(event["data"])["id"] == "second"
+    finally:
+        release_read.set()
+        release_write.set()
+        broadcast.close()
+        await broadcast.events.flush_async()

--- a/tests/test_ux_performance.py
+++ b/tests/test_ux_performance.py
@@ -94,3 +94,61 @@ async def test_old_hook_generation_cannot_recreate_purged_trace(app_module, monk
     chat._hook_diagnostic_generations[sid] = 1
     chat._hook_trace_job(asyncio.get_running_loop(), sid, object(), "", "foreground", None, 0)
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_context_probe_shared_and_survives_one_caller_cancellation(monkeypatch):
+    from backend.sdk_compat import MuseLabSDKClient, ClaudeSDKClient
+    client = MuseLabSDKClient()
+    entered, release = asyncio.Event(), asyncio.Event()
+    calls = []
+
+    async def context(self):
+        calls.append(True)
+        entered.set()
+        await release.wait()
+        return {"totalTokens": 100, "maxTokens": 10000}
+
+    monkeypatch.setattr(ClaudeSDKClient, "get_context_usage", context)
+    first = asyncio.create_task(client.get_context_usage())
+    await entered.wait()
+    second = asyncio.create_task(client.get_context_usage())
+    await asyncio.sleep(0)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    release.set()
+    assert await second == {"totalTokens": 100, "maxTokens": 10000}
+    assert calls == [True]
+    assert client.cached_context_usage()["totalTokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_post_turn_warmup_does_not_delay_completion_and_is_owned(app_module, monkeypatch):
+    from backend import chat
+    from backend.sdk_compat import MuseLabSDKClient, ClaudeSDKClient
+    client = MuseLabSDKClient()
+    entered, cancelled = asyncio.Event(), asyncio.Event()
+    disconnects = []
+
+    async def context(self):
+        entered.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.set()
+
+    async def disconnect(self):
+        disconnects.append(True)
+
+    monkeypatch.setattr(ClaudeSDKClient, "get_context_usage", context)
+    monkeypatch.setattr(ClaudeSDKClient, "disconnect", disconnect)
+    assert await asyncio.wait_for(chat._post_turn_context_usage(client), 0.2) == {}
+    await entered.wait()
+    client.warm_context_usage()
+    assert len(client._muselab_context_probes) == 1
+    await client.disconnect()
+    assert cancelled.is_set()
+    assert disconnects == [True]
+    assert client._muselab_context_probes == {}
+    assert client.cached_context_usage() is None


### PR DESCRIPTION
会话完成后，静默历史同步可能因实时消息尚无 UUID 而被滚动锚点保护拒绝；后台续答也可能在已经开始思考或执行工具时，被 8 秒消息间隔误判为未完成。此变更修复这两条路径，并保留后续轮次与用户阅读位置的所有权。

- 使用已验证的最终消息边界保留实时节点，覆盖正常结束与结束事件丢失后的恢复。
- 区分等待后台续答启动和续答执行总时限；缺少终止结果时，完成旧运行时清理后再推进队列。SDK 的错误、停止、取消状态同步到实时事件和持久化状态。
- 会话列表超时覆盖响应正文，失败时保留有效列表；仅在完整列表安装成功后更新 ETag。
- 记忆生成采用成功 ResultMessage 的最终文本，拒绝缺失或失败的终止结果，并增加不含原文的失败分类和重试关联日志。
- 将回放读写移出事件循环，保持写入顺序、错误传播与资源上限；复用有界 SDK 上下文测量，并拆分历史响应读取与 JSON 解析耗时。

验证：本地完整单元测试 1867 项通过；PR 的全量 Playwright 253 项通过，Linux Python 3.12／3.13、macOS Python 3.12 单元测试步骤均通过。后台专项 48 项、memory／回放／上下文专项 133 项通过；Ruff、前端语法、项目 lint、依赖安全与 Docker 运行检查通过。
