### PR TITLE
feat(workspace): allow operators to extend subtree ignore list via env

### DIFF
--- a/backend/workspace_store.py
+++ b/backend/workspace_store.py
@@ -51,6 +51,22 @@ _IGNORED_SUBTREES = frozenset({
     "share_space",
     "content_agent_freshdoc",
 })
+
+
+def _env_subtree_names(env_name: str) -> frozenset[str]:
+    """Return a trimmed, de-duplicated set of names from a CSV env var."""
+    raw = os.environ.get(env_name, "")
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+# Operators can extend the built-in list (or add prefix families for
+# timestamped snapshot/backup trees) via env, so a workspace rooted at a large
+# directory (e.g. $HOME) can keep bulk data/cache/env trees out of
+# workspace-state.sqlite3 without patching the source.
+_IGNORED_SUBTREES |= _env_subtree_names("MUSELAB_IGNORED_SUBTREES")
+# Snapshot/backup directories often carry a per-export timestamp suffix, so
+# they cannot be matched by exact name; prune whole families by prefix instead.
+_IGNORED_SUBTREE_PREFIXES = _env_subtree_names("MUSELAB_IGNORED_SUBTREE_PREFIXES")
 # A pathological workspace must yield the worker back instead of monopolizing a
 # thread indefinitely. Partial scans merge only observed rows and never infer
 # deletions; a later pass can still establish an authoritative full snapshot.
@@ -105,10 +121,17 @@ def _parent_path(path: str) -> str:
     return path.rpartition("/")[0]
 
 
+def _is_ignored_name(name: str) -> bool:
+    """Return whether a directory name is pruned (exact or prefix match)."""
+    if name in _IGNORED_SUBTREES:
+        return True
+    return any(name.startswith(prefix) for prefix in _IGNORED_SUBTREE_PREFIXES)
+
+
 def is_ignored_descendant(path: str | Path) -> bool:
     """Return whether a path sits below an intentionally opaque subtree."""
     return any(
-        part in _IGNORED_SUBTREES
+        _is_ignored_name(part)
         for part in Path(path).parts[:-1]
     )
 
@@ -212,7 +235,7 @@ def scan_workspace(
                     if (
                         is_dir
                         and not is_symlink
-                        and child.name not in _IGNORED_SUBTREES
+                        and not _is_ignored_name(child.name)
                     ):
                         stack.append((Path(child.path), logical, 0, None))
             if not prefix_verified:
@@ -635,7 +658,7 @@ class WorkspaceStore:
             relative = Path(row["path"])
             if (
                 not relative.parts
-                or relative.name in _IGNORED_SUBTREES
+                or _is_ignored_name(relative.name)
                 or is_ignored_descendant(relative)
             ):
                 continue
@@ -949,7 +972,7 @@ class WorkspaceStore:
                     "added" not in kinds_by_path[path]
                     or not is_dir
                     or is_symlink
-                    or Path(path).name in _IGNORED_SUBTREES
+                    or _is_ignored_name(Path(path).name)
                 ):
                     continue
 

--- a/tests/test_workspace_store_ignore.py
+++ b/tests/test_workspace_store_ignore.py
@@ -1,0 +1,58 @@
+"""Workspace index subtree-ignore list (exact + prefix, env-extensible) tests."""
+
+from __future__ import annotations
+
+
+def test_is_ignored_name_matches_exact_and_prefix(app_module, monkeypatch):
+    from backend import workspace_store as ws
+
+    monkeypatch.setattr(ws, "_IGNORED_SUBTREE_PREFIXES", frozenset({"snapshot."}))
+
+    # Exact matches from the built-in list still prune.
+    assert ws._is_ignored_name("node_modules")
+    assert ws._is_ignored_name(".git")
+    # Prefix matches prune timestamped snapshot families.
+    assert ws._is_ignored_name("snapshot.20260720")
+    assert ws._is_ignored_name("snapshot.2026")
+    # A prefix must not swallow the bare name or unrelated siblings.
+    assert not ws._is_ignored_name("snapshot")
+    assert not ws._is_ignored_name("snapshots")
+    assert not ws._is_ignored_name("src")
+
+
+def test_ignored_descendant_prunes_prefix_dirs(app_module, monkeypatch):
+    from backend import workspace_store as ws
+
+    monkeypatch.setattr(ws, "_IGNORED_SUBTREE_PREFIXES", frozenset({"backup."}))
+
+    assert ws.is_ignored_descendant("backup.20260101/file.txt")
+    assert ws.is_ignored_descendant("a/backup.20260101/file.txt")
+    assert not ws.is_ignored_descendant("a/backup/file.txt")
+
+
+def test_env_subtree_names_parses_csv(app_module, monkeypatch):
+    from backend import workspace_store as ws
+
+    monkeypatch.setenv("MUSELAB_IGNORED_SUBTREES", " bigdata , caches ,, snap ")
+    assert ws._env_subtree_names("MUSELAB_IGNORED_SUBTREES") == frozenset(
+        {"bigdata", "caches", "snap"}
+    )
+    monkeypatch.delenv("MUSELAB_IGNORED_SUBTREES")
+    assert ws._env_subtree_names("MUSELAB_IGNORED_SUBTREES") == frozenset()
+
+
+def test_env_extends_ignored_subtrees(app_module, monkeypatch):
+    import importlib
+
+    from backend import workspace_store as ws
+
+    monkeypatch.setenv("MUSELAB_IGNORED_SUBTREES", "bigdata")
+    monkeypatch.setenv("MUSELAB_IGNORED_SUBTREE_PREFIXES", "snap.")
+    importlib.reload(ws)
+    try:
+        assert "bigdata" in ws._IGNORED_SUBTREES
+        assert ws._is_ignored_name("snap.20260720")
+    finally:
+        monkeypatch.delenv("MUSELAB_IGNORED_SUBTREES", raising=False)
+        monkeypatch.delenv("MUSELAB_IGNORED_SUBTREE_PREFIXES", raising=False)
+        importlib.reload(ws)


### PR DESCRIPTION
The recursive index walk prunes a hardcoded set of generated/cache/bulk
trees. A workspace rooted at a large directory (e.g. `$HOME`) can still pick
up huge data/cache/env trees that aren't in the built-in list, ballooning
`workspace-state.sqlite3` to multi-GB and stalling the event loop.

Add two comma-separated env vars so operators can extend the list without
patching the source, and support prefix families so timestamped
snapshot/backup directories can be pruned wholesale:

* `MUSELAB_IGNORED_SUBTREES` — extra exact directory names
* `MUSELAB_IGNORED_SUBTREE_PREFIXES` — extra directory-name prefixes

Also unify the scattered exact-name checks behind `_is_ignored_name()` so
exact and prefix pruning share one predicate.

Tests: `tests/test_workspace_store_ignore.py` (4 cases, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
