### PR TITLE
fix(ui): 修复完成后阅读锚点丢失阻塞内容恢复

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -18786,13 +18786,28 @@ function portal() {
         const followTailAtInstall = quiet && (
           opts.followTail === true || !!(quietRangeSnapshot && quietRangeSnapshot.followTail)
         );
+        // Only a complete, stable snapshot of the retired turn can prove a
+        // missing reader anchor was removed, rather than merely outside a tail
+        // page. Rebase to a surviving neighbor in that case; preserve the old
+        // window for partial/full-order or successor snapshots.
+        const completion = s.completion_state;
+        const verifiedCompletion = completion?.stable === true && !completion.active
+          && (opts.completedBoundary?.uuid
+            ? all.some(message => message.uuid === opts.completedBoundary.uuid)
+            : !!completion.completed_turn_id
+              && [st.activeTurnId, st._lastTerminalTurnId]
+                .includes(completion.completed_turn_id));
+        const allowRemovedAnchors = verifiedCompletion
+          && !full && !preserveFullOrder && !s.has_more && !s.has_later
+          && Number(s.offset) === 0 && Number(s.total) === all.length;
         const quietRangeResolved = quiet
           ? (followTailAtInstall
             ? {
               start: Math.max(0, all.length - this._liveMessageDomCap()),
               end: all.length,
             }
-            : this._resolveMessageRangeSnapshot(all, quietRangeSnapshot))
+            : this._resolveMessageRangeSnapshot(
+              all, quietRangeSnapshot, allowRemovedAnchors))
           : null;
         // A quiet response that no longer contains the reader's stable message
         // anchor belongs to another coordinate system (for example full/around vs
@@ -19889,6 +19904,13 @@ function portal() {
       const end = Math.max(start, Math.min(range.visibleEnd, st.messages.length));
       return {
         followTail: st.atBottom !== false && !this._messageRangeHasLater(st),
+        // Edges may be transient tool/live blocks removed by canonicalization.
+        // Retain identities throughout the range, plus neighbors for a verified
+        // complete replacement. Never infer identity from repeated prose.
+        anchors: st.messages.map((message, index) => ({
+          identity: this._historyMessageIdentity(message),
+          key: message._k || "", relativeIndex: index - start,
+        })),
         startIdentity: this._historyMessageIdentity(st.messages[start]),
         endIdentity: this._historyMessageIdentity(st.messages[end - 1]),
         // A completed live row can acquire its UUID during reconciliation.
@@ -19900,7 +19922,7 @@ function portal() {
         generation: range.generation,
       };
     },
-    _resolveMessageRangeSnapshot(messages, snapshot) {
+    _resolveMessageRangeSnapshot(messages, snapshot, allowRemovedAnchors = false) {
       if (!snapshot) return null;
       if (snapshot.followTail) {
         const end = messages.length;
@@ -19925,6 +19947,26 @@ function portal() {
       }
       if (endIndex >= 0) {
         return { start: Math.max(0, endIndex - count + 1), end: endIndex + 1 };
+      }
+      // Surviving interior rows are as authoritative as the old endpoints.
+      // Preserve their relative position when transient range edges disappear.
+      const anchors = snapshot.anchors || [];
+      const interior = anchors.filter(anchor => anchor.relativeIndex >= 0
+        && anchor.relativeIndex < count);
+      const neighbors = allowRemovedAnchors
+        ? anchors.filter(anchor => anchor.relativeIndex < 0
+            || anchor.relativeIndex >= count).sort((a, b) => {
+          const distance = anchor => anchor.relativeIndex < 0
+            ? -anchor.relativeIndex : anchor.relativeIndex - count + 1;
+          return distance(a) - distance(b);
+        }) : [];
+      for (const anchor of [...interior, ...neighbors]) {
+        const index = resolveIndex(anchor.identity, anchor.key);
+        if (index < 0) continue;
+        const start = Math.max(0, Math.min(
+          index - anchor.relativeIndex, Math.max(0, messages.length - count),
+        ));
+        return { start, end: Math.min(messages.length, start + count) };
       }
       return null;
     },

--- a/tests/e2e/test_completion_visibility.py
+++ b/tests/e2e/test_completion_visibility.py
@@ -332,3 +332,96 @@ def test_lost_done_viewport_uses_only_retired_turn_commit(
         "sameOwner": True, "atBottom": False,
     }
     _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+@pytest.mark.parametrize("anchor_kind", ["interior", "transient_only"])
+@pytest.mark.parametrize("background", [False, True])
+def test_completion_recovers_removed_range_edges(
+    page, backend_url, auth_token, anchor_kind, background, width,
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    errors, _, reads = _prepare(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st.atBottom = false;
+        const prompt = st.messages[0];
+        const partial = st.messages[1];
+        const ephemeral = n => ({role:'assistant', text:'transient ' + n,
+            _k:arg.sid + ':live:transient-' + n});
+        st.messages = arg.kind === 'interior'
+          ? [ephemeral(1), prompt, ephemeral(2), partial]
+          : [prompt, ephemeral(1), partial];
+        st.messageRange.visibleStart = arg.kind === 'interior' ? 0 : 1;
+        st.messageRange.visibleEnd = arg.kind === 'interior' ? 3 : 2;
+        st.messageRange.total = st.messages.length;
+        st._userScrollAt = 10;
+        if (arg.background) app.currentId = 'other-tab';
+        const loaded = await app._runCompletedTurnSync(arg.sid, st, {
+          expectedText:'LIVE_PARTIAL', expectedAssistantUuid:'fixture-final',
+          completedTurnId:'fixture-turn', followTail:false,
+        });
+        const first = {loaded, final:st.messages.at(-1).text,
+          atBottom:st.atBottom, pending:!!st._pendingCompletedTurnSync};
+        if (arg.background) {app.currentId = arg.sid; app._activateTabState(arg.sid);}
+        return first;
+    """, {"sid": SID, "kind": anchor_kind, "background": background})
+    assert result == {"loaded": True, "final": FINAL,
+                      "atBottom": False, "pending": False}
+    expect(page.locator(f'.msg-pane[data-tid="{SID}"]')).to_contain_text(FINAL)
+    _assert_no_browser_errors(page, errors)
+
+
+@pytest.mark.parametrize("boundary", ["partial", "full_order", "unrelated", "active"])
+def test_missing_reader_anchor_does_not_authorize_unrelated_replacement(
+    page, backend_url, auth_token, boundary,
+):
+    errors, history, _ = _prepare(page, backend_url, auth_token)
+    if boundary == "partial":
+        history.update(offset=20, total=22, has_more=True)
+    elif boundary == "active":
+        history["completion_state"]["active"] = True
+    elif boundary == "unrelated":
+        history["completion_state"]["completed_turn_id"] = "another-turn"
+    result = _app_eval(page, """
+        const st = app.tabState[arg.sid];
+        st.activeTurnId = 'fixture-turn';
+        st.atBottom = false;
+        st.messages.splice(1, 0, {role:'assistant', text:'reader anchor',
+          _k:arg.sid + ':live:reader'});
+        st.messageRange.visibleStart = 1;
+        st.messageRange.visibleEnd = 2;
+        st.messageRange.total = 3;
+        if (arg.boundary === 'full_order') st.messageRange.order = 'full';
+        const anchor = st.messages[1];
+        const loaded = await app.loadSession(arg.sid, {quiet:true, probeActive:false});
+        return {loaded, preserved:st.messages[1] === anchor, atBottom:st.atBottom};
+    """, {"sid": SID, "boundary": boundary})
+    assert result == {"loaded": False, "preserved": True, "atBottom": False}
+    _assert_no_browser_errors(page, errors)
+
+
+def test_removed_anchor_recovery_settles_real_scheduler(page, backend_url, auth_token):
+    errors, _, reads = _prepare(page, backend_url, auth_token)
+    _app_eval(page, """
+        const st = app.tabState[arg];
+        st.atBottom = false;
+        st.messages.splice(1, 0, {role:'assistant', text:'transient reader block',
+          _k:arg + ':live:reader'});
+        Object.assign(st.messageRange, {visibleStart:1, visibleEnd:2, total:3});
+        app._requestSessionSync = window.realVisibilityRequest;
+        app._reconcileCompletedTurn(arg, st, 'LIVE_PARTIAL', 0,
+          'fixture-final', 'fixture-turn', {followTail:false});
+    """, SID)
+    page.wait_for_function("""sid => {
+        const st = document.querySelector('#app')._x_dataStack[0].tabState[sid];
+        return !st._pendingCompletedTurnSync && st._installedCanonicalCount === 2;
+    }""", arg=SID)
+    result = _app_eval(page, """
+        const st = app.tabState[arg];
+        return {atBottom:st.atBottom, text:st.messages.at(-1).text};
+    """, SID)
+    assert result == {"atBottom": False, "text": FINAL}
+    expect(page.locator(f'.msg-pane[data-tid="{SID}"]')).to_contain_text(FINAL)
+    assert sum('?tail=' in url for url in reads) == 1
+    _assert_no_browser_errors(page, errors)

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3271,7 +3271,7 @@ def test_active_stream_owns_messages_and_continuation_reconciles_canonical_histo
     assert "if (!isContinuation)" in send
     assert "all = this._preserveCanonicalMessageIdentity(st, all, completedBoundary)" in load
     assert "const quietRangeSnapshot = quiet" in load
-    assert "this._resolveMessageRangeSnapshot(all, quietRangeSnapshot)" in load
+    assert re.search(r"this\._resolveMessageRangeSnapshot\(\s*all, quietRangeSnapshot, allowRemovedAnchors\)", load)
     assert "this._historyReplaceStillOwns(st, historyReplaceToken)" in load
     assert "await new Promise(resolve => this.$nextTick(resolve))" in load
     assert "this._revealMessagesChunked(sid, st, visible, true, () =>" in load
@@ -4059,7 +4059,7 @@ def test_quiet_canonical_reload_rebases_virtual_window_before_alpine_paints():
     assert converge.index(mismatch) < converge.index(takeover) < converge.index(remount)
     assert converge.count(takeover) == 2
     assert "opts.followTail === true" in load
-    assert "this._resolveMessageRangeSnapshot(all, quietRangeSnapshot)" in load
+    assert re.search(r"this\._resolveMessageRangeSnapshot\(\s*all, quietRangeSnapshot, allowRemovedAnchors\)", load)
     assert "if (quiet && !quietRangeResolved)" in load
 
     range_helper_start = app.index("    _captureMessageRangeSnapshot(st) {")


### PR DESCRIPTION
## What this changes

Recover quiet completion refreshes when the visible range's first and last rows disappear during canonicalization. Match surviving interior identities first. A complete, stable snapshot of the retired turn may also use a surviving neighboring row to restore the range. Partial history windows, full-order views, and unverified turn boundaries retain the existing rejection guard.

## Why

A missing range edge could make every completion retry return `anchor_missing`, leaving the conversation stale until a cold reload. Retrying the same snapshot never repairs that missing anchor. This change allows safe range recovery while preserving the user's decision not to follow the tail.

## Testing

- Four new browser cases failed against the main-branch baseline before the fix.
- Completion recovery suite: 39 passed, covering desktop/mobile, foreground/background, partial history, full-order history, unrelated/active turns, and the real recovery scheduler.
- Strengthened nine recovery cases verify the final content without reload or jump-to-latest assistance: 9 passed.
- Full local browser suite: 283 passed, one test initially failed on missing runner environment configuration; after creating the isolated root and setting the test token, that test passed separately.
- Remote full Playwright: 284 passed, with one automatic retry of the existing settings-timeout case; the new recovery cases passed without retries.
- Frontend static suite: 183 passed. Node syntax, Ruff, and diff whitespace checks passed.

## Checklist

- [x] No secrets or private log data committed.
- [x] Regression tests and recovery invariants documented in code.
- [x] No runtime dependency changes.
