### PR TITLE
fix(context): DUCC 默认 200K，并添加窗口填写示例

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2405,6 +2405,7 @@ MODEL_CONTEXT_LIMITS = {
     "gpt-5.5":                        272_000,
 }
 DEFAULT_CONTEXT_LIMIT = 128_000
+DUCC_DEFAULT_CONTEXT_LIMIT = 200_000
 CODEX_DEFAULT_EFFECTIVE_CONTEXT_PERCENT = 95
 _CONTEXT_CAPABILITY_CACHE_TTL = max(
     1.0, env_float("MUSELAB_CONTEXT_CATALOG_TTL_S", 300.0))
@@ -2894,13 +2895,18 @@ def _context_limit_details(
             "context_limit_source": override_source,
             "context_limit_is_estimate": False,
         }
+    # DUCC uses a 200K fallback budget, not a claim of measured capacity.
+    # Runtime evidence and explicit overrides retain their existing priority.
+    fallback = MODEL_CONTEXT_LIMITS.get(
+        model, DUCC_DEFAULT_CONTEXT_LIMIT
+        if endpoints.is_ducc_model(model) else DEFAULT_CONTEXT_LIMIT)
     # A configured budget cached in usage is not a measured SDK capacity.
     # Removing an override must restore automatic resolution immediately.
     if stored_source in ("settings_model", "settings_provider", "env_override"):
         stored = 0
     if not endpoints.is_third_party(model):
         limit = (_positive_int(sdk_max) or _positive_int(stored)
-                 or MODEL_CONTEXT_LIMITS.get(model, DEFAULT_CONTEXT_LIMIT))
+                 or fallback)
         raw = _positive_int(sdk_raw) or limit
         source = ("sdk" if _positive_int(sdk_max) else
                   "session_sdk" if _positive_int(stored) else "model_fallback")
@@ -2920,7 +2926,7 @@ def _context_limit_details(
         if _positive_int(detected):
             return _capability_from_model_item(
                 {"max_input_tokens": detected}, source="gateway_models_api") or {}
-        raw = MODEL_CONTEXT_LIMITS.get(model, DEFAULT_CONTEXT_LIMIT)
+        raw = fallback
         pct = CODEX_DEFAULT_EFFECTIVE_CONTEXT_PERCENT
         return {
             "context_limit": max(1, raw * pct // 100),
@@ -2931,7 +2937,7 @@ def _context_limit_details(
             "context_limit_source": "model_fallback",
             "context_limit_is_estimate": True,
         }
-    hardcoded = MODEL_CONTEXT_LIMITS.get(model, DEFAULT_CONTEXT_LIMIT)
+    hardcoded = fallback
     limit = _positive_int(sdk_max) or max(_positive_int(stored), hardcoded)
     source = "sdk" if _positive_int(sdk_max) else "model_fallback"
     return {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4771,7 +4771,8 @@
                 <template x-for="model in contextModels()" :key="model"><option :value="model" x-text="model"></option></template>
               </select></div>
             <div class="settings-row"><label for="context-tokens" x-text="lang==='zh'?'有效上下文（tokens）':'Effective context (tokens)'"></label>
-              <input id="context-tokens" class="settings-input" type="number" min="1024" max="10000000" step="1" placeholder="Auto" x-model="settings.contextDraft.tokens" :disabled="settings.contextSaving" /></div>
+              <input id="context-tokens" class="settings-input" type="number" min="1024" max="10000000" step="1" placeholder="Auto" aria-describedby="context-tokens-hint" x-model="settings.contextDraft.tokens" :disabled="settings.contextSaving" /></div>
+            <p id="context-tokens-hint" class="settings-hint" x-text="lang==='zh'?'单位：token。例如 200K 填 200000，300K 填 300000；留空使用 Auto。':'Unit: tokens. For example, enter 200000 for 200K or 300000 for 300K; leave blank for Auto.'"></p>
             <div class="settings-inline-error" role="alert" x-show="settings.contextError" x-text="settings.contextError"></div>
             <button class="btn-primary sm" @click="saveContextLimit()" :disabled="settings.contextSaving" x-text="lang==='zh'?'保存上下文预算':'Save context budget'"></button>
           </details>

--- a/tests/test_context_limits_settings.py
+++ b/tests/test_context_limits_settings.py
@@ -27,7 +27,7 @@ def test_provider_model_precedence_and_durable_auto_reset(client, auth, isolated
         assert r.status_code == 200, r.text
 
     model = "ducc:glm-5"
-    assert _context_limit_details(model)["context_limit"] == 128000
+    assert _context_limit_details(model)["context_limit"] == 200000
     assert _context_limit_details(model, sdk_max=200000)["context_limit"] == 200000
     put("providers", "ducc", 500000)
     assert _context_limit_details(model, sdk_max=200000)["context_limit"] == 500000
@@ -85,7 +85,7 @@ def test_context_key_cannot_interpolate_environment_on_restart(client, auth, iso
     assert not isolated.ENV_PATH.exists()
 
 
-@pytest.mark.parametrize("sdk_window,expected", [(0, 128000), (200000, 200000)])
+@pytest.mark.parametrize("sdk_window,expected", [(0, 200000), (128000, 128000), (300000, 300000)])
 def test_reset_auto_does_not_reuse_cached_settings_budget(client, auth, isolated, sdk_window, expected):
     from backend import chat
     sid = "context-settings-reset-fixture"
@@ -97,3 +97,20 @@ def test_reset_auto_does_not_reuse_cached_settings_budget(client, auth, isolated
     assert response.status_code == 200, response.text
     assert response.json()["context_limit"] == expected
     assert response.json()["context_limit_source"] != "settings_provider"
+
+
+@pytest.mark.parametrize("model", ["ducc:glm-5", "ducc:future-model"])
+def test_ducc_auto_default_preserves_runtime_evidence(isolated, model):
+    from backend.chat import _context_limit_details
+
+    automatic = _context_limit_details(model)
+    assert automatic["context_limit"] == 200000
+    assert automatic["context_limit_is_estimate"] is True
+    for measured in (128000, 300000):
+        live = _context_limit_details(model, sdk_max=measured)
+        assert live["context_limit"] == measured
+        assert live["context_limit_source"] == "sdk"
+        restored = _context_limit_details(
+            model, stored=measured, stored_source="session_sdk")
+        assert restored["context_limit"] == measured
+    assert _context_limit_details("unknown-model")["context_limit"] == 128000


### PR DESCRIPTION
DUCC 在没有运行时窗口信息时原先回退到 128K，现在默认使用 200K（200000 tokens）。运行时报告、单模型设置、Provider 设置和环境变量继续按原有优先级生效；其他 Provider 的默认值保持不变。该值是 MuseLab 的预算估计，不代表上游容量保证。

设置输入框新增中英文填写示例：200K 填 200000，300K 填 300000，留空使用 Auto，并通过 aria-describedby 关联提示。

验证：WSL 中上下文设置／恢复测试 19 项通过，相关会话与 Provider 接口测试 113 项通过，变更文件 Ruff 与 git diff --check 通过。回归覆盖 Auto 默认值、较小和较大运行时窗口、会话恢复及手动设置清除后的预算重算。
