### PR TITLE
feat(files): modification sorting and named uploads with 1 GiB limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,9 +126,9 @@ MUSELAB_ROOT=/home/you/notes
 # Also editable via Settings UI.
 # MUSELAB_BUDGET_USD=20
 
-# Max single upload size (MiB). Default 100. Bump for big PDFs / xlsx,
+# Max single upload size (MiB). Default 1024 (1 GiB). Raise for larger files,
 # lower to enforce a stricter ceiling.
-# MUSELAB_MAX_UPLOAD_MB=100
+# MUSELAB_MAX_UPLOAD_MB=1024
 
 # Max conversation turns per chat session before the SDK auto-cuts.
 # Default unset = no muselab-imposed limit (SDK's own default applies).

--- a/backend/files.py
+++ b/backend/files.py
@@ -17,6 +17,7 @@ import threading
 import time
 from collections import OrderedDict
 from pathlib import Path
+from typing import Literal
 from fastapi import (
     APIRouter, Depends, File, Form, HTTPException, Query, UploadFile,
 )
@@ -2667,6 +2668,7 @@ MAX_LIST_ENTRIES = 500  # safety cap so huge dirs (.git/objects) don't freeze th
 def list_dir(
     path: str = "",
     show_hidden: bool = False,
+    sort: Literal["name", "mtime_desc", "mtime_asc"] = "name",
     root: Path = Depends(_workspace_root),
 ) -> dict:
     target = safe_resolve(path, root=root)
@@ -2714,8 +2716,16 @@ def list_dir(
                         is_dir = child.is_dir()
                     except OSError:
                         continue
+                    if sort != "name":
+                        try:
+                            modified = child.stat().st_mtime_ns
+                        except OSError:
+                            continue
+                        order = modified if sort == "mtime_asc" else -modified
+                    else:
+                        order = 0
                     yield (
-                        (not is_dir, child.name.lower(), child.name),
+                        (not is_dir, order, child.name.lower(), child.name),
                         child,
                         is_dir,
                     )
@@ -3403,8 +3413,8 @@ def write_file(req: WriteReq, root: Path = Depends(_workspace_root)) -> dict:
         return {"ok": True, "size": target.stat().st_size}
 
 
-# Default 100 MB cap per uploaded file. Override via MUSELAB_MAX_UPLOAD_MB.
-MAX_UPLOAD_BYTES = env_int("MUSELAB_MAX_UPLOAD_MB", 100, min_value=1) * 1024 * 1024
+# Default 1 GiB cap per uploaded file. Override via MUSELAB_MAX_UPLOAD_MB.
+MAX_UPLOAD_BYTES = env_int("MUSELAB_MAX_UPLOAD_MB", 1024, min_value=1) * 1024 * 1024
 # Filename extensions that are likely to be hostile or pointless to host in
 # a local workspace. Block at upload (cleaner than after-the-fact cleanup).
 UPLOAD_BLOCKED_SUFFIX = {
@@ -3412,6 +3422,12 @@ UPLOAD_BLOCKED_SUFFIX = {
     ".ps1",  # PowerShell scripts — block by default; allow via .env override later
     ".msi", ".app",
 }
+
+
+@router.get("/upload-limits", dependencies=[Depends(require_token)])
+def upload_limits() -> dict:
+    """Expose the configured cap so oversized files fail before transfer."""
+    return {"max_file_bytes": MAX_UPLOAD_BYTES}
 
 
 @router.post("/upload", dependencies=[Depends(require_token)])

--- a/backend/files.py
+++ b/backend/files.py
@@ -3430,10 +3430,108 @@ def upload_limits() -> dict:
     return {"max_file_bytes": MAX_UPLOAD_BYTES}
 
 
+# Two-phase browser uploads keep an aborted HTTP request from committing a
+# file whose body the server already received. Legacy uploads remain immediate.
+_PENDING_UPLOADS: dict[tuple[str, str, str], dict] = {}
+_PENDING_UPLOAD_LOCK = threading.RLock()
+_PENDING_UPLOAD_TTL = 600
+_PENDING_UPLOAD_CAP = 1024
+
+
+class UploadControlReq(BaseModel):
+    upload_id: str
+    path: str = ""
+
+
+def _upload_key(upload_id: str, path: str, root: Path) -> tuple[str, str, str]:
+    if not re.fullmatch(r"[0-9a-f]{32}", upload_id):
+        raise HTTPException(400, "invalid upload id")
+    directory = safe_resolve(path, root=root)
+    _guard_not_trash(directory, root)
+    return str(root), str(directory), upload_id
+
+
+def _expire_pending_upload(key, record):
+    with _PENDING_UPLOAD_LOCK:
+        if _PENDING_UPLOADS.get(key) is not record:
+            return
+        _PENDING_UPLOADS.pop(key)
+        if record.get("tmp"):
+            record["tmp"].unlink(missing_ok=True)
+
+
+def _new_pending_upload(key, **fields):
+    # Called on the request event loop while holding the registry lock.
+    if len(_PENDING_UPLOADS) >= _PENDING_UPLOAD_CAP:
+        raise HTTPException(503, "too many pending uploads")
+    record = dict(fields)
+    _PENDING_UPLOADS[key] = record
+    loop = asyncio.get_running_loop()
+    record["expiry"] = loop.call_later(
+        _PENDING_UPLOAD_TTL,
+        lambda: loop.run_in_executor(None, _expire_pending_upload, key, record),
+    )
+    return record
+
+
+
+async def cleanup_pending_uploads():
+    with _PENDING_UPLOAD_LOCK:
+        records = list(_PENDING_UPLOADS.values())
+        _PENDING_UPLOADS.clear()
+        for record in records:
+            record["cancelled"] = True
+            record["expiry"].cancel()
+    def cleanup():
+        for record in records:
+            if record.get("tmp"):
+                record["tmp"].unlink(missing_ok=True)
+    await asyncio.to_thread(cleanup)
+
+
+@router.post("/upload/cancel", dependencies=[Depends(require_token)])
+async def cancel_upload(req: UploadControlReq, root: Path = Depends(_workspace_root)) -> dict:
+    key = _upload_key(req.upload_id, req.path, root)
+    with _PENDING_UPLOAD_LOCK:
+        record = _PENDING_UPLOADS.get(key)
+        if record is None:
+            # A cancel may beat multipart parsing. Keep a tombstone so a
+            # later upload with the same id cannot stage or commit its body.
+            record = _new_pending_upload(key, cancelled=True)
+        record["cancelled"] = True
+        tmp = record.get("tmp")
+    if tmp:
+        await asyncio.to_thread(tmp.unlink, missing_ok=True)
+    return {"ok": True}
+
+
+@router.post("/upload/commit", dependencies=[Depends(require_token)])
+async def commit_upload(req: UploadControlReq, root: Path = Depends(_workspace_root)) -> dict:
+    key = _upload_key(req.upload_id, req.path, root)
+
+    def commit():
+        with _PENDING_UPLOAD_LOCK:
+            record = _PENDING_UPLOADS.get(key)
+            if not record or record.get("cancelled") or not record.get("ready"):
+                raise HTTPException(409, "upload is cancelled, expired, or not ready")
+            # Revalidate after staging; a directory may have been moved meanwhile.
+            if safe_resolve(record["path"], root=root) != record["dest"]:
+                raise HTTPException(409, "upload destination changed")
+            try:
+                trashed = record["finalize"]()
+                return {"ok": True, "path": record["path"], "size": record["size"],
+                        "replaced_trash_id": (trashed or {}).get("trash_id")}
+            finally:
+                _PENDING_UPLOADS.pop(key, None)
+                record["tmp"].unlink(missing_ok=True)
+    return await asyncio.to_thread(commit)
+
+
 @router.post("/upload", dependencies=[Depends(require_token)])
 async def upload(
     path: str = Form(""),
     file: UploadFile = File(...),
+    upload_id: str = Form(""),
     root: Path = Depends(_workspace_root),
 ) -> dict:
     target_dir = safe_resolve(path, root=root)
@@ -3461,11 +3559,20 @@ async def upload(
     # leaves a partial file at the intended path.
     import uuid as _uuid
     tmp_path = dest.parent / f".~{dest.name}.{_uuid.uuid4().hex[:8]}.uploading"
+    pending = None
+    if upload_id:
+        key = _upload_key(upload_id, path, root)
+        with _PENDING_UPLOAD_LOCK:
+            if key in _PENDING_UPLOADS:
+                raise HTTPException(409, "upload id already used or cancelled")
+            pending = _new_pending_upload(key, tmp=tmp_path, cancelled=False)
     written = 0
     try:
         with tmp_path.open("wb") as f:
             while chunk := await file.read(1024 * 1024):
                 written += len(chunk)
+                if pending and pending.get("cancelled"):
+                    raise HTTPException(409, "upload cancelled")
                 if written > MAX_UPLOAD_BYTES:
                     f.close()
                     tmp_path.unlink(missing_ok=True)
@@ -3508,11 +3615,21 @@ async def upload(
                 _rename_noreplace(tmp_path, dest)
                 _fsync_rename(tmp_path.parent, dest.parent)
                 return trashed
+        if pending is not None:
+            with _PENDING_UPLOAD_LOCK:
+                if pending.get("cancelled") or _PENDING_UPLOADS.get(key) is not pending:
+                    raise HTTPException(409, "upload cancelled or expired")
+                pending.update(ready=True, finalize=_finalize, dest=dest, size=written,
+                               path=(_logical_relative_path(path) / safe_name).as_posix())
+            return {"ok": True, "pending": True, "path": pending["path"], "size": written}
         trashed = await asyncio.to_thread(_finalize)
-    except HTTPException:
-        tmp_path.unlink(missing_ok=True)
-        raise
-    except Exception:
+    except BaseException:
+        if pending:
+            with _PENDING_UPLOAD_LOCK:
+                pending["cancelled"] = True
+                if _PENDING_UPLOADS.get(key) is pending:
+                    _PENDING_UPLOADS.pop(key)
+                    pending["expiry"].cancel()
         tmp_path.unlink(missing_ok=True)
         raise
     return {

--- a/backend/main.py
+++ b/backend/main.py
@@ -595,6 +595,8 @@ async def _lifespan(app: FastAPI):
             terminal=_terminal_manager,
             file_watcher=_file_watch_manager,
         )
+        from .files import cleanup_pending_uploads
+        await cleanup_pending_uploads()
         await asyncio.to_thread(stop_diagnostics)
 
 

--- a/docs/backend-files.md
+++ b/docs/backend-files.md
@@ -16,7 +16,7 @@ Unregistered, removed, or disallowed directories are rejected. Returned paths ar
 
 ## Endpoints
 
-There are currently 21 Files endpoints. Normal calls use token authentication;
+There are currently 22 Files endpoints. Normal calls use token authentication;
 browser downloads use a short-lived, scope-bound capability ticket minted by
 an authenticated call.
 
@@ -24,7 +24,7 @@ an authenticated call.
 
 | Method and path | Purpose |
 |---|---|
-| `GET /api/files/list` | List a directory, up to 500 entries |
+| `GET /api/files/list` | List a directory, up to 500 entries; sort by name or modification time |
 | `GET /api/files/stat` | Read type, size, and modification time for one path |
 | `GET /api/files/read` | Read text, up to 2 MiB |
 | `GET /api/files/raw` | Inline supported image, media, PDF, HTML, and SVG; force-download other types |
@@ -41,6 +41,8 @@ first mints a 60-second, one-use ticket bound to the exact resolved file and
 workspace. HTML and SVG previews use a sandbox CSP. The HTML preview bridge for
 scroll and image interaction is injected only for files up to 12 MiB.
 
+`list` accepts `sort=name` (default), `mtime_desc`, or `mtime_asc`. Directories stay first, and sorting is applied before the 500-entry cap. The file panel remembers this choice and updates modification-time ordering after file changes.
+
 Preview limits:
 
 - XLSX: 20 sheets, 500 rows and 50 columns per sheet, 500 characters per cell.
@@ -52,7 +54,8 @@ Preview limits:
 | Method and path | Purpose |
 |---|---|
 | `PUT /api/files/write` | Atomically create or replace text, up to 10 MiB |
-| `POST /api/files/upload` | Multipart upload, 100 MiB per file by default |
+| `GET /api/files/upload-limits` | Read the configured per-file cap in bytes for upload preflight |
+| `POST /api/files/upload` | Multipart upload, 1 GiB (1024 MiB) per file by default |
 | `POST /api/files/mkdir` | Create a directory |
 | `POST /api/files/rename` | Move or rename |
 | `POST /api/files/copy-bak` | Create `.bak`, `.bak.2`, and later backup copies |

--- a/docs/backend-files.md
+++ b/docs/backend-files.md
@@ -16,7 +16,7 @@ Unregistered, removed, or disallowed directories are rejected. Returned paths ar
 
 ## Endpoints
 
-There are currently 22 Files endpoints. Normal calls use token authentication;
+There are currently 24 Files endpoints. Normal calls use token authentication;
 browser downloads use a short-lived, scope-bound capability ticket minted by
 an authenticated call.
 
@@ -56,10 +56,14 @@ Preview limits:
 | `PUT /api/files/write` | Atomically create or replace text, up to 10 MiB |
 | `GET /api/files/upload-limits` | Read the configured per-file cap in bytes for upload preflight |
 | `POST /api/files/upload` | Multipart upload, 1 GiB (1024 MiB) per file by default |
+| `POST /api/files/upload/commit` | Atomically save a staged upload to its destination |
+| `POST /api/files/upload/cancel` | Cancel a staged upload and clean its temporary file |
 | `POST /api/files/mkdir` | Create a directory |
 | `POST /api/files/rename` | Move or rename |
 | `POST /api/files/copy-bak` | Create `.bak`, `.bak.2`, and later backup copies |
 | `DELETE /api/files/delete` | Soft-delete by default; `permanent=true` deletes permanently |
+
+Browser uploads use a random `upload_id` to stage bytes before explicitly committing them. Individual transfers can be cancelled without replacing an existing same-name file. Cancellation is disabled during the final save. Uncommitted staging expires after 10 minutes while the service runs and is cleaned on graceful shutdown. Legacy API calls without `upload_id` still save immediately.
 
 A same-name upload first moves the old file into the dustbin and then atomically replaces it, preserving recovery. Dangerous executable extensions and sensitive filenames are rejected by default.
 

--- a/docs/backend-files_zh.md
+++ b/docs/backend-files_zh.md
@@ -16,13 +16,13 @@
 
 ## 端点
 
-当前共 21 个文件端点。普通请求使用 token 鉴权；浏览器下载先通过已鉴权请求签发一个短时、限定作用域的能力票据。
+当前共 22 个文件端点。普通请求使用 token 鉴权；浏览器下载先通过已鉴权请求签发一个短时、限定作用域的能力票据。
 
 ### 读取与预览
 
 | 方法与路径 | 用途 |
 |---|---|
-| `GET /api/files/list` | 列目录，最多 500 项 |
+| `GET /api/files/list` | 列目录，最多 500 项；支持名称或修改时间排序 |
 | `GET /api/files/stat` | 获取单个路径的类型、大小和修改时间 |
 | `GET /api/files/read` | 读取文本，最大 2 MiB |
 | `GET /api/files/raw` | 内联预览受支持的图片、媒体、PDF、HTML 与 SVG，其余强制下载 |
@@ -35,6 +35,8 @@
 
 `raw` 用于 iframe 和图片，仍接受查询参数 token。`download` 不再把可复用的应用 token 放入 URL：前端会先签发一个有效期 60 秒、只能使用一次，并绑定到具体文件和工作目录的票据。HTML/SVG 预览使用 sandbox CSP；HTML 预览桥仅对不超过 12 MiB 的文件注入滚动和图片交互支持。
 
+`list` 接受 `sort=name`（默认）、`mtime_desc` 或 `mtime_asc`。目录始终在前，排序发生在截取 500 项之前。文件面板会记住选择，并在文件修改后更新按时间排序的顺序。
+
 预览限制：
 
 - XLSX：最多 20 个 sheet、每个 500 行、50 列，单元格最多 500 字符。
@@ -46,7 +48,8 @@
 | 方法与路径 | 用途 |
 |---|---|
 | `PUT /api/files/write` | 原子覆盖或创建文本文件，最大 10 MiB |
-| `POST /api/files/upload` | Multipart 上传，默认每文件最大 100 MiB |
+| `GET /api/files/upload-limits` | 读取单文件上限（字节），供上传前检查 |
+| `POST /api/files/upload` | Multipart 上传，默认每文件最大 1 GiB（1024 MiB） |
 | `POST /api/files/mkdir` | 创建目录 |
 | `POST /api/files/rename` | 移动或重命名 |
 | `POST /api/files/copy-bak` | 创建 `.bak`、`.bak.2` 等备份副本 |

--- a/docs/backend-files_zh.md
+++ b/docs/backend-files_zh.md
@@ -16,7 +16,7 @@
 
 ## 端点
 
-当前共 22 个文件端点。普通请求使用 token 鉴权；浏览器下载先通过已鉴权请求签发一个短时、限定作用域的能力票据。
+当前共 24 个文件端点。普通请求使用 token 鉴权；浏览器下载先通过已鉴权请求签发一个短时、限定作用域的能力票据。
 
 ### 读取与预览
 
@@ -50,10 +50,14 @@
 | `PUT /api/files/write` | 原子覆盖或创建文本文件，最大 10 MiB |
 | `GET /api/files/upload-limits` | 读取单文件上限（字节），供上传前检查 |
 | `POST /api/files/upload` | Multipart 上传，默认每文件最大 1 GiB（1024 MiB） |
+| `POST /api/files/upload/commit` | 确认暂存文件，原子保存到目标路径 |
+| `POST /api/files/upload/cancel` | 取消暂存上传并清理临时文件 |
 | `POST /api/files/mkdir` | 创建目录 |
 | `POST /api/files/rename` | 移动或重命名 |
 | `POST /api/files/copy-bak` | 创建 `.bak`、`.bak.2` 等备份副本 |
 | `DELETE /api/files/delete` | 默认软删除；`permanent=true` 永久删除 |
+
+浏览器上传携带随机 `upload_id`，先暂存，再确认保存。传输中可逐文件取消；取消不会覆盖已有同名文件。进入保存阶段后取消按钮禁用。未确认的暂存文件在服务运行期间最多保留 10 分钟，正常停机时也会清理。不带 `upload_id` 的兼容 API 请求仍直接保存。
 
 同名上传会先把原文件移入回收站，再原子替换，因而可以恢复。危险可执行扩展名和敏感文件名默认禁止上传。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ muselab only acts as an Images API client; it does not launch a local image mode
 | `MUSELAB_BUDGET_USD` | Monthly UI soft budget; does not hard-stop turns | `0` |
 | `MUSELAB_PERF_LOG` | Emit privacy-bounded performance summaries for core paths; set to `0` to disable | `1` |
 | `MUSELAB_SLOW_REQUEST_MS` | Duration threshold for slow HTTP and workspace-operation summaries, clamped to 25–60000 ms | `500` |
-| `MUSELAB_MAX_UPLOAD_MB` | Files API upload limit per file in MiB | `100` |
+| `MUSELAB_MAX_UPLOAD_MB` | Files API upload limit per file in MiB | `1024` |
 | `MUSELAB_MAX_TURNS` | Additional session turn cap; `0` means unlimited | `0` |
 | `MUSELAB_THINKING_BUDGET` | Extended-thinking token budget | `10000` |
 | `MUSELAB_RUNTIME_BUFFER_EVENTS` | Queued SDK messages per turn/background handoff, minimum 1 | `8192` |

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -94,7 +94,7 @@ muselab 只作为 Images API 客户端，不再启动本地生图模型或 Codex
 | `MUSELAB_BUDGET_USD` | 月度 UI 软预算，不会硬中断 | `0` |
 | `MUSELAB_PERF_LOG` | 输出核心链路的隐私受限性能摘要；设为 `0` 可关闭 | `1` |
 | `MUSELAB_SLOW_REQUEST_MS` | 慢 HTTP 请求和工作区操作的耗时阈值，限制在 25–60000 毫秒 | `500` |
-| `MUSELAB_MAX_UPLOAD_MB` | Files API 单文件上传上限 MiB | `100` |
+| `MUSELAB_MAX_UPLOAD_MB` | Files API 单文件上传上限 MiB | `1024` |
 | `MUSELAB_MAX_TURNS` | 每会话最大回合数，`0` 表示不额外限制 | `0` |
 | `MUSELAB_THINKING_BUDGET` | 扩展思考 token 预算 | `10000` |
 | `MUSELAB_RUNTIME_BUFFER_EVENTS` | 每个回合／后台 SDK 交接队列的消息数上限，最小 1 | `8192` |

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -22870,6 +22870,17 @@ function portal() {
           || String(a.path).localeCompare(String(b.path));
       });
     },
+    fileSortLabel() {
+      const labels = this.lang === "zh"
+        ? {name:"名称", mtime_desc:"修改时间：最新在前", mtime_asc:"修改时间：最早在前"}
+        : {name:"Name", mtime_desc:"Modified: newest first", mtime_asc:"Modified: oldest first"};
+      return (this.lang === "zh" ? "排序：" : "Sort: ") + labels[this.fileSort]
+        + (this.lang === "zh" ? "（点击切换）" : " (click to switch)");
+    },
+    cycleFileSort() {
+      const modes = ["name", "mtime_desc", "mtime_asc"];
+      return this.setFileSort(modes[(modes.indexOf(this.fileSort) + 1) % modes.length]);
+    },
     async setFileSort(value) {
       if (!["name", "mtime_desc", "mtime_asc"].includes(value)) return;
       this.fileSort = value;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -471,8 +471,9 @@ function portal() {
     // directory context uploads and OS-file drops all feed the same batch.
     fileUploadProgress: {
       visible: false, known: false, percent: 0,
-      totalFiles: 0, completedFiles: 0, failedFiles: 0, activeFiles: 0,
+      totalFiles: 0, completedFiles: 0, failedFiles: 0, activeFiles: 0, items: [],
     },
+    _fileUploadLimitPromise: null,
     _fileUploadBatch: null,
     _fileUploadTransferSeq: 0,
     _fileUploadHideTimer: null,
@@ -1159,6 +1160,7 @@ function portal() {
     leftWidth: 340,
     previewWidth: 440,
     showHidden: false,
+    fileSort: "name",
     // ===== Trash =====
     // Files /delete moves into <ROOT>/.muselab-dustbin/ instead of unlink
     // (see backend/files.py). The trash UI lives as a docked icon at the
@@ -7207,6 +7209,7 @@ function portal() {
         leftOpen: this.leftOpen, previewOpen: this.previewOpen,
         leftWidth: this.leftWidth, previewWidth: this.previewWidth,
         showHidden: this.showHidden,
+        fileSort: this.fileSort,
         openFilesCollapsed: this.openFilesCollapsed,
         openFilesHeight: this.openFilesHeight,
         // Mobile-only: remember which of the 3 tabs (files / preview / chat)
@@ -7283,6 +7286,7 @@ function portal() {
         if (typeof p.previewWidth === "number") this.previewWidth = p.previewWidth;
         else if (typeof p.rightWidth === "number") this.previewWidth = p.rightWidth;
         if (typeof p.showHidden === "boolean") this.showHidden = p.showHidden;
+        if (["name", "mtime_desc", "mtime_asc"].includes(p.fileSort)) this.fileSort = p.fileSort;
         if (p.currentId) this.currentId = p.currentId;
         // The standalone key is authoritative. p.openTabIds is accepted only as
         // a one-time migration source for users upgrading from schema <= 9.
@@ -17193,18 +17197,24 @@ function portal() {
       file,
       { reportError = false, ownerWorkspace = "" } = {},
     ) {
-      const transfer = this._beginFileUploadTransfer(file);
+      ownerWorkspace = ownerWorkspace || this.fileWorkspacePath();
+      const transfer = this._beginFileUploadTransfer(file, dirPath, ownerWorkspace);
       let succeeded = false;
+      let failure = "";
       try {
-        const r = await this._uploadWorkspaceFile(dirPath, file, transfer);
+        const limit = await this._workspaceUploadLimit();
+        if (limit && file.size > limit) {
+          failure = this.lang === "zh"
+            ? "文件 " + this.fmtSize(file.size) + " 超过单文件 " + this.fmtSize(limit) + " 上限"
+            : "File " + this.fmtSize(file.size) + " exceeds the " + this.fmtSize(limit) + " per-file limit";
+          return false;
+        }
+        const r = await this._uploadWorkspaceFile(dirPath, file, transfer, ownerWorkspace);
         if (!r.ok) {
-          console.warn("[upload]", file.name, "failed:", r.status);
-          if (
-            reportError
-            && (!ownerWorkspace || this._workspaceIsCurrent(ownerWorkspace))
-          ) {
-            const detail = await r.text().catch(() => "");
-            this.errToast("upload", detail || `HTTP ${r.status}`);
+          const raw = await r.text().catch(() => "");
+          failure = this._workspaceUploadError(r.status, raw);
+          if (reportError && this._workspaceIsCurrent(ownerWorkspace)) {
+            this.errToast("upload", failure);
           }
           return false;
         }
@@ -17215,7 +17225,7 @@ function portal() {
           replaced_trash_id: data.replaced_trash_id || null,
         };
       } catch (e) {
-        console.warn("[upload]", file.name, "error:", e);
+        failure = this._workspaceUploadError(0, "");
         if (
           reportError
           && (!ownerWorkspace || this._workspaceIsCurrent(ownerWorkspace))
@@ -17224,7 +17234,7 @@ function portal() {
         }
         return false;
       } finally {
-        this._finishFileUploadTransfer(transfer, succeeded);
+        this._finishFileUploadTransfer(transfer, succeeded, failure);
       }
     },
     _prepareUploadOverwrite(dirPath, files) {
@@ -17248,6 +17258,10 @@ function portal() {
         .filter(r => r.status === "fulfilled" && r.value && r.value.path)
         .map(r => r.value);
       if (!uploaded.length) return;
+      await this.revealInTree(uploaded[0].path, {
+        mode: "background", highlight: true, ownerWorkspace,
+      });
+      if (!this._workspaceIsCurrent(ownerWorkspace)) return;
       for (const item of uploaded) this._previewCacheDel(item.path);
       const replaced = uploaded.filter(item => item.replaced_trash_id).length;
       if (replaced) {
@@ -22723,6 +22737,8 @@ function portal() {
       this.childCache = Object.fromEntries(Object.entries(childCache).map(
         ([key, rows]) => [key, Array.isArray(rows) ? rows.map(row => ({ ...row })) : rows]));
       this.expanded = new Set(Array.isArray(cached.expanded) ? cached.expanded : []);
+      Object.assign(this, this._materializeFileSnapshot(
+        Object.values(this.childCache).flat().concat(this.visible), Array.from(this.expanded)));
       this._pendingExpanded = Array.from(this.expanded);
       if (cached.cursor != null) this._workspaceTreeCursors.set(ownerWorkspace, cached.cursor);
       this.treeError = "";
@@ -22823,6 +22839,28 @@ function portal() {
       }, this.WORKSPACE_TREE_PERSIST_DEBOUNCE_MS);
       this._workspaceTreeCacheTimers.set(ownerWorkspace, handle);
     },
+    _sortFileRows(rows) {
+      return rows.sort((a, b) => {
+        const directories = Number(!a.is_dir) - Number(!b.is_dir);
+        if (directories) return directories;
+        if (this.fileSort !== "name") {
+          const delta = (Number(a.mtime) || 0) - (Number(b.mtime) || 0);
+          if (delta) return this.fileSort === "mtime_asc" ? delta : -delta;
+        }
+        return String(a.name || a.path).localeCompare(String(b.name || b.path))
+          || String(a.path).localeCompare(String(b.path));
+      });
+    },
+    async setFileSort(value) {
+      if (!["name", "mtime_desc", "mtime_asc"].includes(value)) return;
+      this.fileSort = value;
+      this.savePrefs();
+      const entries = Object.values(this.childCache).flat().concat(this.visible);
+      Object.assign(this, this._materializeFileSnapshot(entries, Array.from(this.expanded)));
+      this._scheduleFileTreeViewportSync(true);
+      // Re-fetch truncated directory listings using the selected order too.
+      await this.reloadTree();
+    },
     _materializeFileSnapshot(entries, expandedPaths = []) {
       const byParent = new Map();
       const showHidden = !!this.showHidden;
@@ -22834,9 +22872,7 @@ function portal() {
         if (!byParent.has(parent)) byParent.set(parent, []);
         byParent.get(parent).push({ ...raw, path });
       }
-      const sortRows = rows => rows.sort((a, b) =>
-        (Number(!a.is_dir) - Number(!b.is_dir))
-        || String(a.name || a.path).localeCompare(String(b.name || b.path)));
+      const sortRows = rows => this._sortFileRows(rows);
       const childCache = {};
       for (const [parent, rows] of byParent) {
         childCache[`${parent}:${showHidden}`] = sortRows(rows);
@@ -22941,10 +22977,9 @@ function portal() {
               : 0)
             : raw.mtime_ns,
         });
-        // Existing rows are already sorted. A content/mtime-only modification
-        // preserves that order; only additions or sort-key changes need the
-        // affected sibling group sorted again.
-        if (type === "added"
+        // Re-sort the affected siblings when a selected sort key changes;
+        // content edits also change ordering in modification-time mode.
+        if (type === "added" || this.fileSort !== "name"
             || (previous && (
               (typeof raw.name === "string" && raw.name !== previous.name)
               || (raw.is_dir != null && !!raw.is_dir !== !!previous.is_dir)
@@ -23005,10 +23040,7 @@ function portal() {
         // snapshot/cache. Unknown collapsed parents stay lazy and canonical.
         if (siblings) siblings.push(row);
       }
-      const sortRows = rows => rows.sort((a, b) =>
-        (Number(!a.is_dir) - Number(!b.is_dir))
-        || String(a.name || a.path).localeCompare(String(b.name || b.path))
-        || String(a.path).localeCompare(String(b.path)));
+      const sortRows = rows => this._sortFileRows(rows);
       for (const parent of affectedParents) {
         const rows = byParent.get(parent);
         if (rows) sortRows(rows);
@@ -24157,7 +24189,8 @@ function portal() {
       const pendingKey = `${ownerWorkspace}\0${workspaceGeneration}\0${cacheKey}:${opts.force ? "force" : "normal"}`;
       if (this._childFetches.has(pendingKey)) return this._childFetches.get(pendingKey);
       const url = "/api/files/list?path=" + encodeURIComponent(path)
-        + (showHidden ? "&show_hidden=true" : "");
+        + (showHidden ? "&show_hidden=true" : "")
+        + (this.fileSort !== "name" ? "&sort=" + this.fileSort : "");
       const requestHeaders = this.fileHdr();
       const promise = (async () => {
         let r;
@@ -24195,7 +24228,7 @@ function portal() {
           stale.staleWorkspace = true;
           throw stale;
         }
-        const entries = d.entries || [];
+        const entries = this._sortFileRows(d.entries || []);
         const treeOwner = isOwner();
         if (opts.cache !== false && treeOwner) {
           this.childCache[cacheKey] = entries;
@@ -27375,7 +27408,9 @@ function portal() {
       //   4. Non-active tab — when the user right-clicks a non-current
       //      preview tab, `selected !== path`, so the row has no `sel`
       //      class. The pulse class handles that too.
-      if (!path) return;
+      const ownerWorkspace = opts.ownerWorkspace || this.fileWorkspacePath();
+      const isOwner = () => this._workspaceIsCurrent(ownerWorkspace);
+      if (!path || !isOwner()) return;
       const interactive = opts.mode !== "background";
       if (interactive) {
         if (this.searchMode) this.clearSearch();
@@ -27385,16 +27420,19 @@ function portal() {
       parts.pop();   // drop the filename, keep only directory chain
       const dirPath = parts.join("/");
       if (dirPath) await this.expandPath(dirPath);
+      if (!isOwner()) return;
       // With a virtualized tree the target row may intentionally not exist in
       // DOM yet. Position the logical row first; updating the viewport window
       // mounts it on the following tick.
       this.$nextTick(() => this.$nextTick(() => {
+        if (!isOwner()) return;
         this._positionFileTreePath(path, interactive ? "center" : "nearest");
         this.$nextTick(() => {
+          if (!isOwner()) return;
           const sel = (window.CSS && CSS.escape) ? CSS.escape(path) : path;
           const el = document.querySelector(`.filelist li[data-path="${sel}"]`);
           if (!el) return;
-          if (!interactive) return;
+          if (!interactive && !opts.highlight) return;
           // Pulse highlight — independent of `sel` class so it fires even
           // when this isn't the active tab. Restart by removing+adding so
           // rapid re-reveals still trigger the animation.
@@ -29791,6 +29829,46 @@ function portal() {
       this.previewDragHover = false;
       this.dragHover = false;
     },
+    _workspaceUploadLimit() {
+      if (!this._fileUploadLimitPromise) {
+        this._fileUploadLimitPromise = this._fetchWithDeadline(
+          "/api/files/upload-limits", { headers: this.hdr() }, 5000,
+        ).then(r => r.ok ? r.json() : null)
+          .then(data => Math.max(0, Number(data?.max_file_bytes) || 0))
+          .catch(() => 0);
+      }
+      return this._fileUploadLimitPromise;
+    },
+    _workspaceUploadError(status, raw) {
+      let detail = "";
+      try {
+        const data = JSON.parse(raw);
+        if (typeof data?.detail === "string") detail = data.detail.slice(0, 200);
+      } catch (_) { /* proxies may return HTML; do not render their error page */ }
+      const zh = this.lang === "zh";
+      if (status === 413) return (zh ? "文件超过服务器或入口的上传大小限制" : "File exceeds the server or proxy upload limit")
+        + (detail ? ": " + detail : "");
+      if (!status) return zh ? "网络连接中断，请重试；文件尚未确认保存" : "Connection interrupted; file has not been confirmed saved. Retry.";
+      return detail || (zh ? "上传失败，HTTP " : "Upload failed, HTTP ") + status;
+    },
+    fileUploadItemStatus(item) {
+      if (item.failed) return item.error || (this.lang === "zh" ? "上传失败" : "Failed");
+      if (item.done) return this.lang === "zh" ? "已保存" : "Saved";
+      if (item.known && item.loaded >= item.total) return this.lang === "zh" ? "正在保存…" : "Saving…";
+      return this.lang === "zh" ? "正在上传" : "Uploading";
+    },
+    async revealUploadedFile(item) {
+      if (!item.done || item.failed || !this._workspaceIsCurrent(item.workspace)) return;
+      await this._refreshParentInTree(item.path, item.workspace);
+      if (this._workspaceIsCurrent(item.workspace)) {
+        await this.revealInTree(item.path, { ownerWorkspace: item.workspace });
+      }
+    },
+    dismissFileUploads() {
+      if (this.fileUploadProgress.activeFiles) return;
+      if (this._fileUploadHideTimer) clearTimeout(this._fileUploadHideTimer);
+      this.fileUploadProgress = { ...this.fileUploadProgress, visible: false };
+    },
     fileUploadProgressLabel() {
       const progress = this.fileUploadProgress || {};
       const total = Math.max(0, Number(progress.totalFiles) || 0);
@@ -29809,9 +29887,9 @@ function portal() {
       if (!batch || this._fileUploadBatch !== batch) return;
       const transfers = Object.values(batch.transfers || {});
       const totalFiles = transfers.length;
-      const completedFiles = transfers.filter(item => item.done).length;
+      const completedFiles = transfers.filter(item => item.done && !item.failed).length;
       const failedFiles = transfers.filter(item => item.failed).length;
-      const activeFiles = totalFiles - completedFiles;
+      const activeFiles = totalFiles - completedFiles - failedFiles;
       const known = totalFiles > 0 && transfers.every(item => item.known);
       const totalBytes = transfers.reduce(
         (sum, item) => sum + Math.max(1, Number(item.total) || 0), 0,
@@ -29830,9 +29908,14 @@ function portal() {
         completedFiles,
         failedFiles,
         activeFiles,
+        items: Object.entries(batch.transfers).map(([id, item]) => ({
+          ...item, id,
+          percent: item.known && item.total > 0
+            ? Math.min(100, Math.max(0, item.loaded / item.total * 100)) : 0,
+        })),
       };
     },
-    _beginFileUploadTransfer(file) {
+    _beginFileUploadTransfer(file, dirPath = "", workspace = this.fileWorkspacePath()) {
       if (this._fileUploadHideTimer) clearTimeout(this._fileUploadHideTimer);
       this._fileUploadHideTimer = null;
       let batch = this._fileUploadBatch;
@@ -29847,6 +29930,9 @@ function portal() {
       }
       const transferId = String(++this._fileUploadTransferSeq);
       batch.transfers[transferId] = {
+        name: String(file?.name || ""),
+        path: dirPath ? dirPath + "/" + file.name : file.name,
+        workspace, error: "",
         loaded: 0,
         total: Math.max(0, Number(file && file.size) || 0),
         known: false,
@@ -29876,17 +29962,19 @@ function portal() {
       );
       this._publishFileUploadProgress(current.batch);
     },
-    _finishFileUploadTransfer(token, succeeded) {
+    _finishFileUploadTransfer(token, succeeded, error = "") {
       const current = this._fileUploadTransfer(token);
       if (!current || current.transfer.done) return;
       const transfer = current.transfer;
       transfer.known = true;
       transfer.total = Math.max(1, Number(transfer.total) || 0);
-      transfer.loaded = transfer.total;
+      if (succeeded) transfer.loaded = transfer.total;
       transfer.done = true;
       transfer.failed = !succeeded;
+      transfer.error = error;
       this._publishFileUploadProgress(current.batch);
       if (Object.values(current.batch.transfers).some(item => !item.done)) return;
+      if (Object.values(current.batch.transfers).some(item => item.failed)) return;
       const batchId = current.batch.id;
       this._fileUploadHideTimer = setTimeout(() => {
         const latest = this._fileUploadBatch;
@@ -29898,13 +29986,13 @@ function portal() {
           visible: false,
         };
         this._fileUploadHideTimer = null;
-      }, 900);
+      }, 6000);
     },
-    _uploadWorkspaceFile(dirPath, file, transferToken) {
+    _uploadWorkspaceFile(dirPath, file, transferToken, ownerWorkspace = "") {
       const fd = new FormData();
       fd.append("path", dirPath);
       fd.append("file", file);
-      const headers = this.fileHdr();
+      const headers = this.fileHdr(ownerWorkspace);
       return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         let settled = false;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -474,6 +474,7 @@ function portal() {
       totalFiles: 0, completedFiles: 0, failedFiles: 0, activeFiles: 0, items: [],
     },
     _fileUploadLimitPromise: null,
+    _fileUploadAborters: new Map(),
     _fileUploadBatch: null,
     _fileUploadTransferSeq: 0,
     _fileUploadHideTimer: null,
@@ -17165,7 +17166,8 @@ function portal() {
       );
       if (!this._workspaceIsCurrent(ownerWorkspace)) return;
       const ok = results.filter(r => r.status === "fulfilled" && r.value).length;
-      const failed = results.length - ok;
+      const uploadedName = results.find(r => r.status === "fulfilled" && r.value)?.value.path?.split("/").pop() || "";
+      const failed = results.filter(r => r.status === "rejected" || r.value === false).length;
       await this.reloadTree();
       if (!this._workspaceIsCurrent(ownerWorkspace)) return;
       await this._syncUploadedFiles(results, uploadContext, ownerWorkspace);
@@ -17180,9 +17182,9 @@ function portal() {
           : `Uploaded ${ok}, ${failed} failed`, "warn", 3500);
       } else if (ok === 1) {
         this.toast(this.lang === "zh"
-          ? `已上传 ${files[0].name}`
-          : `Uploaded ${files[0].name}`, "success", 2200);
-      } else {
+          ? `已上传 ${uploadedName}`
+          : `Uploaded ${uploadedName}`, "success", 2200);
+      } else if (ok) {
         this.toast(this.lang === "zh"
           ? `已上传 ${ok} 个文件`
           : `Uploaded ${ok} files`, "success", 2200);
@@ -17199,10 +17201,13 @@ function portal() {
     ) {
       ownerWorkspace = ownerWorkspace || this.fileWorkspacePath();
       const transfer = this._beginFileUploadTransfer(file, dirPath, ownerWorkspace);
+      const uploadState = this._fileUploadTransfer(transfer).transfer;
       let succeeded = false;
       let failure = "";
       try {
         const limit = await this._workspaceUploadLimit();
+        const pending = this._fileUploadTransfer(transfer);
+        if (!pending || uploadState.cancelled) return null;
         if (limit && file.size > limit) {
           failure = this.lang === "zh"
             ? "文件 " + this.fmtSize(file.size) + " 超过单文件 " + this.fmtSize(limit) + " 上限"
@@ -17218,13 +17223,27 @@ function portal() {
           }
           return false;
         }
-        const data = (await r.json().catch(() => ({}))) || {};
+        let data = (await r.json().catch(() => ({}))) || {};
+        if (uploadState.cancelled) return null;
+        if (data.pending) {
+          uploadState.saving = true;
+          const committed = await fetch("/api/files/upload/commit", {
+            method: "POST", headers: {...this.fileHdr(ownerWorkspace), "Content-Type": "application/json"},
+            body: JSON.stringify({upload_id: transfer.uploadId, path: dirPath}),
+          });
+          if (!committed.ok) {
+            failure = this._workspaceUploadError(committed.status, await committed.text());
+            return false;
+          }
+          data = await committed.json();
+        }
         succeeded = true;
         return {
           path: data.path || (dirPath ? `${dirPath}/${file.name}` : file.name),
           replaced_trash_id: data.replaced_trash_id || null,
         };
       } catch (e) {
+        if (uploadState.cancelled) return null;
         failure = this._workspaceUploadError(0, "");
         if (
           reportError
@@ -29851,14 +29870,34 @@ function portal() {
       if (!status) return zh ? "网络连接中断，请重试；文件尚未确认保存" : "Connection interrupted; file has not been confirmed saved. Retry.";
       return detail || (zh ? "上传失败，HTTP " : "Upload failed, HTTP ") + status;
     },
+    canCancelFileUpload(item) {
+      return !item.done && !item.saving
+        && !(item.known && item.loaded >= item.total);
+    },
+    cancelFileUpload(item) {
+      const batch = this._fileUploadBatch;
+      const transfer = batch?.transfers[item.id];
+      if (!transfer || !this.canCancelFileUpload(transfer)) return;
+      const token = { batchId: batch.id, transferId: item.id };
+      transfer.cancelled = true;
+      this._fileUploadAborters.get(batch.id + "/" + item.id)?.();
+      this._finishFileUploadTransfer(token, false);
+      // Staged data cannot commit without the explicit success path above.
+      // If cleanup cannot reach the server, its staging lease expires.
+      fetch("/api/files/upload/cancel", {
+        method: "POST", headers: {...this.fileHdr(transfer.workspace), "Content-Type": "application/json"},
+        body: JSON.stringify({upload_id: transfer.uploadId, path: transfer.dirPath}),
+      }).catch(() => {});
+    },
     fileUploadItemStatus(item) {
+      if (item.cancelled) return this.lang === "zh" ? "已取消传输" : "Transfer cancelled";
       if (item.failed) return item.error || (this.lang === "zh" ? "上传失败" : "Failed");
       if (item.done) return this.lang === "zh" ? "已保存" : "Saved";
       if (item.known && item.loaded >= item.total) return this.lang === "zh" ? "正在保存…" : "Saving…";
       return this.lang === "zh" ? "正在上传" : "Uploading";
     },
     async revealUploadedFile(item) {
-      if (!item.done || item.failed || !this._workspaceIsCurrent(item.workspace)) return;
+      if (!item.done || item.failed || item.cancelled || !this._workspaceIsCurrent(item.workspace)) return;
       await this._refreshParentInTree(item.path, item.workspace);
       if (this._workspaceIsCurrent(item.workspace)) {
         await this.revealInTree(item.path, { ownerWorkspace: item.workspace });
@@ -29879,6 +29918,11 @@ function portal() {
           ? this.t("files.uploading_many", { done: completed, total })
           : this.t("files.uploading_one");
       }
+      if (Number(progress.cancelledFiles) > 0) {
+        return this.lang === "zh"
+          ? `已保存 ${completed}，已取消 ${progress.cancelledFiles}，失败 ${failed}`
+          : `Saved ${completed}, cancelled ${progress.cancelledFiles}, failed ${failed}`;
+      }
       return failed > 0
         ? this.t("files.upload_finished_errors", { failed })
         : this.t("files.upload_finished");
@@ -29887,9 +29931,10 @@ function portal() {
       if (!batch || this._fileUploadBatch !== batch) return;
       const transfers = Object.values(batch.transfers || {});
       const totalFiles = transfers.length;
-      const completedFiles = transfers.filter(item => item.done && !item.failed).length;
+      const completedFiles = transfers.filter(item => item.done && !item.failed && !item.cancelled).length;
       const failedFiles = transfers.filter(item => item.failed).length;
-      const activeFiles = totalFiles - completedFiles - failedFiles;
+      const cancelledFiles = transfers.filter(item => item.cancelled).length;
+      const activeFiles = transfers.filter(item => !item.done).length;
       const known = totalFiles > 0 && transfers.every(item => item.known);
       const totalBytes = transfers.reduce(
         (sum, item) => sum + Math.max(1, Number(item.total) || 0), 0,
@@ -29907,6 +29952,7 @@ function portal() {
         totalFiles,
         completedFiles,
         failedFiles,
+        cancelledFiles,
         activeFiles,
         items: Object.entries(batch.transfers).map(([id, item]) => ({
           ...item, id,
@@ -29932,15 +29978,17 @@ function portal() {
       batch.transfers[transferId] = {
         name: String(file?.name || ""),
         path: dirPath ? dirPath + "/" + file.name : file.name,
-        workspace, error: "",
+        workspace, dirPath, uploadId: crypto.randomUUID().replaceAll("-", ""),
+        error: "", cancelled: false, saving: false,
         loaded: 0,
         total: Math.max(0, Number(file && file.size) || 0),
         known: false,
         done: false,
         failed: false,
       };
-      this._publishFileUploadProgress(batch);
-      return { batchId: batch.id, transferId };
+      // Alpine wraps a newly assigned batch; publish its canonical reactive identity.
+      this._publishFileUploadProgress(this._fileUploadBatch);
+      return { batchId: batch.id, transferId, uploadId: batch.transfers[transferId].uploadId };
     },
     _fileUploadTransfer(token) {
       const batch = this._fileUploadBatch;
@@ -29970,11 +30018,11 @@ function portal() {
       transfer.total = Math.max(1, Number(transfer.total) || 0);
       if (succeeded) transfer.loaded = transfer.total;
       transfer.done = true;
-      transfer.failed = !succeeded;
+      transfer.failed = !succeeded && !transfer.cancelled;
       transfer.error = error;
       this._publishFileUploadProgress(current.batch);
       if (Object.values(current.batch.transfers).some(item => !item.done)) return;
-      if (Object.values(current.batch.transfers).some(item => item.failed)) return;
+      if (Object.values(current.batch.transfers).some(item => item.failed || item.cancelled)) return;
       const batchId = current.batch.id;
       this._fileUploadHideTimer = setTimeout(() => {
         const latest = this._fileUploadBatch;
@@ -29992,13 +30040,17 @@ function portal() {
       const fd = new FormData();
       fd.append("path", dirPath);
       fd.append("file", file);
+      fd.append("upload_id", transferToken.uploadId);
       const headers = this.fileHdr(ownerWorkspace);
       return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
+        const abortKey = transferToken.batchId + "/" + transferToken.transferId;
+        this._fileUploadAborters.set(abortKey, () => xhr.abort());
         let settled = false;
         const finish = (callback, value) => {
           if (settled) return;
           settled = true;
+          this._fileUploadAborters.delete(abortKey);
           callback(value);
         };
         xhr.open("POST", "/api/files/upload", true);
@@ -30012,6 +30064,14 @@ function portal() {
             event.total,
             event.lengthComputable && event.total > 0,
           );
+        });
+        xhr.upload.addEventListener("load", () => {
+          const current = this._fileUploadTransfer(transferToken);
+          if (!current || current.transfer.done) return;
+          // Once the body has left the browser, abort cannot undo a server
+          // commit. Let the save response settle instead of promising removal.
+          current.transfer.saving = true;
+          this._publishFileUploadProgress(current.batch);
         });
         xhr.addEventListener("load", () => {
           const responseText = xhr.responseText || "";
@@ -30059,7 +30119,8 @@ function portal() {
         return;
       }
       const ok = results.filter(r => r.status === "fulfilled" && r.value).length;
-      const failed = results.length - ok;
+      const uploadedName = results.find(r => r.status === "fulfilled" && r.value)?.value.path?.split("/").pop() || "";
+      const failed = results.filter(r => r.status === "rejected" || r.value === false).length;
       await this.reloadTree();
       if (!this._workspaceIsCurrent(ownerWorkspace)) {
         ev.target.value = "";
@@ -30080,9 +30141,9 @@ function portal() {
           : `Uploaded ${ok}, ${failed} failed`, "warn", 3500);
       } else if (ok === 1) {
         this.toast(this.lang === "zh"
-          ? `已上传 ${files[0].name}`
-          : `Uploaded ${files[0].name}`, "success", 2200);
-      } else {
+          ? `已上传 ${uploadedName}`
+          : `Uploaded ${uploadedName}`, "success", 2200);
+      } else if (ok) {
         this.toast(this.lang === "zh"
           ? `已上传 ${ok} 个文件`
           : `Uploaded ${ok} files`, "success", 2200);
@@ -30296,7 +30357,8 @@ function portal() {
       );
       if (!this._workspaceIsCurrent(ownerWorkspace)) return;
       const ok = results.filter(r => r.status === "fulfilled" && r.value).length;
-      const failed = results.length - ok;
+      const uploadedName = results.find(r => r.status === "fulfilled" && r.value)?.value.path?.split("/").pop() || "";
+      const failed = results.filter(r => r.status === "rejected" || r.value === false).length;
       const firstUploaded = results.find(r =>
         r.status === "fulfilled" && r.value && r.value.path);
       if (firstUploaded) {
@@ -30316,9 +30378,9 @@ function portal() {
           : `Uploaded ${ok} to ${intoLabel}, ${failed} failed`, "warn", 3500);
       } else if (ok === 1) {
         this.toast(this.lang === "zh"
-          ? `已上传 ${files[0].name} 到 ${intoLabel}`
-          : `Uploaded ${files[0].name} to ${intoLabel}`, "success", 2200);
-      } else {
+          ? `已上传 ${uploadedName} 到 ${intoLabel}`
+          : `Uploaded ${uploadedName} to ${intoLabel}`, "success", 2200);
+      } else if (ok) {
         this.toast(this.lang === "zh"
           ? `已上传 ${ok} 个文件到 ${intoLabel}`
           : `Uploaded ${ok} files to ${intoLabel}`, "success", 2200);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -407,8 +407,12 @@
             <li class="file-upload-item" :class="{failed:transfer.failed}" :data-upload-name="transfer.name">
               <div class="file-upload-item-heading">
                 <span :title="transfer.path" x-text="transfer.name"></span>
+                <button type="button" class="btn-text sm" x-show="!transfer.done"
+                        :disabled="!canCancelFileUpload(transfer)"
+                        :title="transfer.saving ? (lang==='zh' ? '正在保存，请等待结果' : 'Saving; wait for the result') : ''"
+                        @click="cancelFileUpload(transfer)" x-text="lang==='zh' ? '取消' : 'Cancel'"></button>
                 <button type="button" class="btn-text sm"
-                        x-show="transfer.done && !transfer.failed && _workspaceIsCurrent(transfer.workspace)"
+                        x-show="transfer.done && !transfer.failed && !transfer.cancelled && _workspaceIsCurrent(transfer.workspace)"
                         @click="revealUploadedFile(transfer)" x-text="lang==='zh' ? '定位' : 'Locate'"></button>
               </div>
               <div class="file-upload-item-state">
@@ -417,7 +421,7 @@
               </div>
               <progress x-show="!transfer.done" max="100" :value="transfer.known ? transfer.percent : null"
                         :aria-label="transfer.name"></progress>
-              <small x-show="transfer.done && !transfer.failed" x-text="transfer.path"></small>
+              <small x-show="transfer.done && !transfer.failed && !transfer.cancelled" x-text="transfer.path"></small>
             </li>
           </template>
         </ul>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -530,17 +530,16 @@
                     aria-label="Refresh file tree">
               <svg :class="{ spinning: treeLoading }" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><use href="#i-refresh"/></svg>
             </button>
+            <button id="file-sort" class="root-action" type="button"
+                    @click.stop="cycleFileSort()" :data-sort="fileSort"
+                    :title="fileSortLabel()" :aria-label="fileSortLabel()">
+              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 5h10M4 10h7M4 15h4"/>
+                <path :d="fileSort==='mtime_asc' ? 'M18 20V4m-3 3 3-3 3 3' : 'M18 4v16m-3-3 3 3 3-3'"/>
+              </svg>
+            </button>
           </span>
         </div>
-      <div class="file-sort-bar">
-        <label for="file-sort" x-text="lang==='zh' ? '排序' : 'Sort'"></label>
-        <select id="file-sort" :value="fileSort" @change="setFileSort($event.target.value)"
-                :aria-label="lang==='zh' ? '文件排序' : 'File sort order'">
-          <option value="name" x-text="lang==='zh' ? '名称' : 'Name'"></option>
-          <option value="mtime_desc" x-text="lang==='zh' ? '修改时间：最新在前' : 'Modified: newest first'"></option>
-          <option value="mtime_asc" x-text="lang==='zh' ? '修改时间：最早在前' : 'Modified: oldest first'"></option>
-        </select>
-      </div>
       <ul class="filelist" x-ref="fileList"
           role="tree"
           :aria-label="lang==='zh' ? '工作区文件树' : 'Workspace file tree'"
@@ -582,12 +581,7 @@
               <svg x-show="n.is_dir && !expanded.has(n.path)"><use href="#i-chevron-right"/></svg>
             </span>
             <span class="icon"><svg><use :href="iconRef(n)"/></svg></span>
-            <span class="file-row-label">
-              <span class="name" x-text="n.name" :title="n.name"></span>
-              <time class="file-modified" :datetime="n.mtime ? new Date(n.mtime * 1000).toISOString() : null"
-                    :title="(lang==='zh' ? '修改时间：' : 'Modified: ') + fmtMtime(n.mtime)"
-                    x-text="n.mtime ? fmtMtime(n.mtime).slice(0, 16) : '—'"></time>
-            </span>
+            <span class="name" x-text="n.name" :title="n.name"></span>
             <!-- VSCode-style inline actions. Hidden by default; revealed on
                  hover (desktop) or always faded (touch — no hover). The "⋯"
                  more-menu renders for BOTH files and dirs — plain files used
@@ -596,9 +590,13 @@
                  rename / delete / copy a file. The "+" (new file here) stays
                  dir-only. @click.stop so the action doesn't also toggle the row. -->
             <span class="tree-trailing">
-              <span class="size" x-show="!n.is_dir"
-                    :title="fileSizeTitle(n.size)"
-                    x-text="fmtSize(n.size)"></span>
+              <span class="tree-metadata">
+                <span class="size" x-show="!n.is_dir"
+                      :title="fileSizeTitle(n.size)" x-text="fmtSize(n.size)"></span>
+                <time class="file-modified" :datetime="n.mtime ? new Date(n.mtime * 1000).toISOString() : null"
+                      :title="(lang==='zh' ? '修改时间：' : 'Modified: ') + fmtMtime(n.mtime)"
+                      x-text="n.mtime ? fmtMtime(n.mtime).slice(0, 16) : '—'"></time>
+              </span>
               <span class="tree-actions">
                 <button class="tree-action" type="button"
                         x-show="n.is_dir"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -390,16 +390,37 @@
            x-transition.opacity.duration.150ms x-cloak aria-live="polite">
         <div class="file-upload-progress-meta">
           <span x-text="fileUploadProgressLabel()"></span>
-          <strong x-show="fileUploadProgress.known"
+          <strong x-show="fileUploadProgress.known && fileUploadProgress.activeFiles"
                   x-text="Math.round(fileUploadProgress.percent || 0) + '%'">0%</strong>
+          <button type="button" class="btn-text sm" x-show="!fileUploadProgress.activeFiles"
+                  @click="dismissFileUploads()" :aria-label="lang==='zh' ? '关闭上传记录' : 'Dismiss uploads'">×</button>
         </div>
-        <div class="file-upload-progress-track"
+        <div class="file-upload-progress-track" x-show="fileUploadProgress.activeFiles"
              :class="{ indeterminate: !fileUploadProgress.known }"
              role="progressbar" aria-valuemin="0" aria-valuemax="100"
              :aria-valuenow="fileUploadProgress.known ? Math.round(fileUploadProgress.percent || 0) : null"
              :aria-valuetext="fileUploadProgressLabel()">
           <span :style="{ width: (fileUploadProgress.known ? fileUploadProgress.percent : 34) + '%' }"></span>
         </div>
+        <ul class="file-upload-items">
+          <template x-for="transfer in (fileUploadProgress.items || [])" :key="transfer.id">
+            <li class="file-upload-item" :class="{failed:transfer.failed}" :data-upload-name="transfer.name">
+              <div class="file-upload-item-heading">
+                <span :title="transfer.path" x-text="transfer.name"></span>
+                <button type="button" class="btn-text sm"
+                        x-show="transfer.done && !transfer.failed && _workspaceIsCurrent(transfer.workspace)"
+                        @click="revealUploadedFile(transfer)" x-text="lang==='zh' ? '定位' : 'Locate'"></button>
+              </div>
+              <div class="file-upload-item-state">
+                <span x-text="fileUploadItemStatus(transfer)"></span>
+                <span x-show="!transfer.done" x-text="transfer.known ? Math.round(transfer.percent) + '%' : fmtSize(transfer.total)"></span>
+              </div>
+              <progress x-show="!transfer.done" max="100" :value="transfer.known ? transfer.percent : null"
+                        :aria-label="transfer.name"></progress>
+              <small x-show="transfer.done && !transfer.failed" x-text="transfer.path"></small>
+            </li>
+          </template>
+        </ul>
       </div>
       <div class="searchbar">
         <div class="searchbar-wrap">
@@ -507,6 +528,15 @@
             </button>
           </span>
         </div>
+      <div class="file-sort-bar">
+        <label for="file-sort" x-text="lang==='zh' ? '排序' : 'Sort'"></label>
+        <select id="file-sort" :value="fileSort" @change="setFileSort($event.target.value)"
+                :aria-label="lang==='zh' ? '文件排序' : 'File sort order'">
+          <option value="name" x-text="lang==='zh' ? '名称' : 'Name'"></option>
+          <option value="mtime_desc" x-text="lang==='zh' ? '修改时间：最新在前' : 'Modified: newest first'"></option>
+          <option value="mtime_asc" x-text="lang==='zh' ? '修改时间：最早在前' : 'Modified: oldest first'"></option>
+        </select>
+      </div>
       <ul class="filelist" x-ref="fileList"
           role="tree"
           :aria-label="lang==='zh' ? '工作区文件树' : 'Workspace file tree'"
@@ -548,7 +578,12 @@
               <svg x-show="n.is_dir && !expanded.has(n.path)"><use href="#i-chevron-right"/></svg>
             </span>
             <span class="icon"><svg><use :href="iconRef(n)"/></svg></span>
-            <span class="name" x-text="n.name" :title="n.name"></span>
+            <span class="file-row-label">
+              <span class="name" x-text="n.name" :title="n.name"></span>
+              <time class="file-modified" :datetime="n.mtime ? new Date(n.mtime * 1000).toISOString() : null"
+                    :title="(lang==='zh' ? '修改时间：' : 'Modified: ') + fmtMtime(n.mtime)"
+                    x-text="n.mtime ? fmtMtime(n.mtime).slice(0, 16) : '—'"></time>
+            </span>
             <!-- VSCode-style inline actions. Hidden by default; revealed on
                  hover (desktop) or always faded (touch — no hover). The "⋯"
                  more-menu renders for BOTH files and dirs — plain files used

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -12555,36 +12555,39 @@ html[data-theme="light"] .hljs-symbol,
 html[data-theme="eyecare"] .hljs-built_in,
 html[data-theme="eyecare"] .hljs-symbol { color: #9a3e00; }
 
-/* Keep file rows compact; metadata gives way to names in narrow panes. */
-.filelist li .tree-trailing { flex-basis: 164px; }
+/* Size queries use each row's remaining width, including nested indentation.
+   Match touch selectors' specificity so metadata never overflows a 36px slot. */
+.filelist li[role="treeitem"] { container: file-row / inline-size; }
+.filelist li:is(.file, .dir) .tree-trailing { flex-basis: 164px; }
 .filelist .tree-metadata {
   display: flex; align-items: center; justify-content: flex-end; gap: 8px;
-  width: 100%; min-width: 0; white-space: nowrap;
+  width: 100%; min-width: 0; overflow: hidden; white-space: nowrap;
   color: var(--c-fg-3); font-size: var(--fs-2xs);
   font-variant-numeric: tabular-nums; transition: opacity var(--t-fast);
 }
 .filelist .tree-metadata .size { width: auto; flex: 0 0 auto; }
 .file-modified { flex: 0 0 auto; }
 .filelist li:hover .tree-metadata { opacity: 0; }
-@container (max-width: 320px) {
-  .filelist li .tree-trailing { flex-basis: 64px; }
+@container file-row (max-width: 300px) {
+  .filelist li:is(.file, .dir) .tree-trailing { flex-basis: 64px; }
   .file-modified { display: none; }
 }
-@container (max-width: 250px) {
-  .filelist li.file .tree-trailing { flex-basis: 22px; }
+@container file-row (max-width: 230px) {
+  .filelist li:is(.file, .dir) .tree-trailing { flex-basis: 44px; }
   .tree-metadata { display: none !important; }
 }
-@media (hover: none) {
-  .filelist li .tree-trailing { flex-basis: 208px; gap: 4px; }
-  .filelist li .tree-actions { position: static; flex: 0 0 40px; }
+@media (pointer: coarse), (hover: none) {
+  .filelist li:is(.file, .dir) .tree-trailing { flex-basis: 244px; gap: 4px; }
+  .filelist li .tree-actions { position: static; flex: 0 0 76px; }
   .filelist li .tree-metadata { opacity: 1; }
   .filelist li .tree-metadata .size { opacity: 1; }
-  @container (max-width: 360px) {
-    .filelist li .tree-trailing { flex-basis: 108px; }
+  @container file-row (max-width: 480px) {
+    .filelist li:is(.file, .dir) .tree-trailing { flex-basis: 144px; }
     .file-modified { display: none; }
   }
-  @container (max-width: 250px) {
-    .filelist li.file .tree-trailing { flex-basis: 40px; }
+  @container file-row (max-width: 230px) {
+    .filelist li:is(.file, .dir) .tree-trailing { flex-basis: 76px; }
+    .tree-metadata { display: none !important; }
   }
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -12555,3 +12555,20 @@ html[data-theme="light"] .hljs-built_in,
 html[data-theme="light"] .hljs-symbol,
 html[data-theme="eyecare"] .hljs-built_in,
 html[data-theme="eyecare"] .hljs-symbol { color: #9a3e00; }
+
+/* File metadata stays readable without squeezing long names into a date column. */
+.file-sort-bar { display:flex; align-items:center; gap:8px; padding:5px 10px; font-size:11px; color:var(--c-fg-3); }
+.file-sort-bar select { flex:1; min-width:0; color:var(--c-fg-1); background:var(--c-bg-1); border:1px solid var(--c-border); border-radius:4px; padding:4px; }
+.filelist li[role="treeitem"] { height:40px; min-height:40px; }
+.file-row-label { display:flex; flex:1; min-width:0; flex-direction:column; justify-content:center; gap:2px; }
+.filelist li .file-row-label .name { flex:none; line-height:16px; }
+.file-modified { font-size:10px; line-height:12px; color:var(--c-fg-3); font-variant-numeric:tabular-nums; white-space:nowrap; }
+
+.file-upload-items { list-style:none; padding:0; margin:6px 0 0; max-height:200px; overflow:auto; }
+.file-upload-item { padding:5px 0; border-top:1px solid var(--c-border); font-size:11px; }
+.file-upload-item-heading, .file-upload-item-state { display:flex; justify-content:space-between; gap:6px; }
+.file-upload-item-heading > span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; }
+.file-upload-item-state { color:var(--c-fg-3); font-size:10px; }
+.file-upload-item.failed .file-upload-item-state { color:var(--c-danger, #b34d3f); }
+.file-upload-item progress { display:block; width:100%; height:3px; margin-top:4px; }
+.file-upload-item small { display:block; color:var(--c-fg-3); overflow-wrap:anywhere; font-size:10px; }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2081,7 +2081,6 @@ body.kb-open .layout:focus-within .mobile-tab-bar { display: none; }
   .filelist li .tree-actions { opacity: 0.55; }
   .filelist li .tree-actions:active,
   .filelist li.sel .tree-actions { opacity: 1; }
-  .filelist li .size { display: none !important; }
 }
 .filelist li.sel {
   background: var(--c-accent-soft); color: var(--c-fg-0);
@@ -12556,13 +12555,38 @@ html[data-theme="light"] .hljs-symbol,
 html[data-theme="eyecare"] .hljs-built_in,
 html[data-theme="eyecare"] .hljs-symbol { color: #9a3e00; }
 
-/* File metadata stays readable without squeezing long names into a date column. */
-.file-sort-bar { display:flex; align-items:center; gap:8px; padding:5px 10px; font-size:11px; color:var(--c-fg-3); }
-.file-sort-bar select { flex:1; min-width:0; color:var(--c-fg-1); background:var(--c-bg-1); border:1px solid var(--c-border); border-radius:4px; padding:4px; }
-.filelist li[role="treeitem"] { height:40px; min-height:40px; }
-.file-row-label { display:flex; flex:1; min-width:0; flex-direction:column; justify-content:center; gap:2px; }
-.filelist li .file-row-label .name { flex:none; line-height:16px; }
-.file-modified { font-size:10px; line-height:12px; color:var(--c-fg-3); font-variant-numeric:tabular-nums; white-space:nowrap; }
+/* Keep file rows compact; metadata gives way to names in narrow panes. */
+.filelist li .tree-trailing { flex-basis: 164px; }
+.filelist .tree-metadata {
+  display: flex; align-items: center; justify-content: flex-end; gap: 8px;
+  width: 100%; min-width: 0; white-space: nowrap;
+  color: var(--c-fg-3); font-size: var(--fs-2xs);
+  font-variant-numeric: tabular-nums; transition: opacity var(--t-fast);
+}
+.filelist .tree-metadata .size { width: auto; flex: 0 0 auto; }
+.file-modified { flex: 0 0 auto; }
+.filelist li:hover .tree-metadata { opacity: 0; }
+@container (max-width: 320px) {
+  .filelist li .tree-trailing { flex-basis: 64px; }
+  .file-modified { display: none; }
+}
+@container (max-width: 250px) {
+  .filelist li.file .tree-trailing { flex-basis: 22px; }
+  .tree-metadata { display: none !important; }
+}
+@media (hover: none) {
+  .filelist li .tree-trailing { flex-basis: 208px; gap: 4px; }
+  .filelist li .tree-actions { position: static; flex: 0 0 40px; }
+  .filelist li .tree-metadata { opacity: 1; }
+  .filelist li .tree-metadata .size { opacity: 1; }
+  @container (max-width: 360px) {
+    .filelist li .tree-trailing { flex-basis: 108px; }
+    .file-modified { display: none; }
+  }
+  @container (max-width: 250px) {
+    .filelist li.file .tree-trailing { flex-basis: 40px; }
+  }
+}
 
 .file-upload-items { list-style:none; padding:0; margin:6px 0 0; max-height:200px; overflow:auto; }
 .file-upload-item { padding:5px 0; border-top:1px solid var(--c-border); font-size:11px; }

--- a/tests/e2e/test_file_upload_visibility.py
+++ b/tests/e2e/test_file_upload_visibility.py
@@ -31,10 +31,10 @@ def test_named_upload_results_preflight_and_locate(page, backend_url, auth_token
     expect(row).to_be_visible()
     expect(row.locator("time")).to_have_attribute("datetime", re.compile(r"^\d{4}-"))
     page.screenshot(path=str(tmp_path / "upload-results.png"))
-    page.select_option("#file-sort", "mtime_desc")
+    page.locator("#file-sort").click()
     page.wait_for_function("""() => document.querySelector('#app')._x_dataStack[0].fileSort === 'mtime_desc'""")
     page.reload()
-    expect(page.locator("#file-sort")).to_have_value("mtime_desc")
+    expect(page.locator("#file-sort")).to_have_attribute("data-sort", "mtime_desc")
 
 
 def test_sort_updates_existing_file_on_mtime_event(page, backend_url, auth_token):

--- a/tests/e2e/test_file_upload_visibility.py
+++ b/tests/e2e/test_file_upload_visibility.py
@@ -54,3 +54,76 @@ def test_sort_updates_existing_file_on_mtime_event(page, backend_url, auth_token
     """)
     assert result == {"before":["folder","z.txt","a.txt"],
                       "after":["folder","a.txt","z.txt"], "stamp":300}
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+def test_cancel_inflight_upload_keeps_other_file(page, backend_url, auth_token, width, tmp_path_factory):
+    page.set_viewport_size({"width": width, "height": 900})
+    _login(page, backend_url, auth_token)
+    _app_eval(page, "app.setMobileTab('files');")
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Network.enable")
+    cdp.send("Network.emulateNetworkConditions", {
+        "offline": False, "latency": 20,
+        "downloadThroughput": 1024 * 1024, "uploadThroughput": 64 * 1024,
+    })
+    failed = []
+    page.on("requestfailed", lambda req: failed.append(req.failure)
+            if req.method == "POST" and req.url.endswith("/api/files/upload") else None)
+    cancelled_name = f"cancel-mid-transfer-{width}.bin"
+    kept_name = f"keep-transfer-{width}.txt"
+    try:
+        page.locator('.pane.files input[x-ref="upload"]').set_input_files([
+            {"name": cancelled_name, "mimeType": "application/octet-stream", "buffer": b"x" * (2 * 1024 * 1024)},
+            {"name": kept_name, "mimeType": "text/plain", "buffer": b"keep this"},
+        ])
+        page.wait_for_function("""name => {
+            const app = document.querySelector('#app')._x_dataStack[0];
+            const item = app.fileUploadProgress.items.find(x => x.name === name);
+            return item && item.loaded > 0 && !item.done && app.canCancelFileUpload(item);
+        }""", arg=cancelled_name)
+        row = page.locator(f'[data-upload-name="{cancelled_name}"]')
+        row.get_by_role("button", name="Cancel", exact=True).click()
+        expect(row).to_contain_text("Transfer cancelled")
+        expect(row.get_by_role("button", name="Locate")).to_be_hidden()
+        cdp.send("Network.emulateNetworkConditions", {
+            "offline": False, "latency": 0,
+            "downloadThroughput": -1, "uploadThroughput": -1,
+        })
+        expect(page.locator(f'[data-upload-name="{kept_name}"]')).to_contain_text("Saved")
+        page.wait_for_timeout(300)
+        assert failed and any("ERR_ABORTED" in reason for reason in failed)
+        root = next(tmp_path_factory.getbasetemp().glob("e2e-root[0-9]*"))
+        assert not (root / cancelled_name).exists()
+        assert not list(root.glob(f".~{cancelled_name}.*.uploading"))
+        assert (root / kept_name).read_text() == "keep this"
+        assert _app_eval(page, "return app.fileUploadProgress.failedFiles;") == 0
+    finally:
+        cdp.detach()
+
+
+def test_cancel_preflight_never_starts_post_and_saving_cannot_cancel(page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    _app_eval(page, "app.setMobileTab('files');")
+    posts = []
+    page.on("request", lambda req: posts.append(req.url)
+            if req.method == "POST" and req.url.endswith("/api/files/upload") else None)
+    _app_eval(page, """
+        app._workspaceUploadLimit = () => new Promise(resolve => { window.releaseUploadLimit = resolve; });
+        window.preflightResult = app._uploadFileQuiet("", new File(["stop"], "cancel-preflight.txt"));
+    """)
+    row = page.locator('[data-upload-name="cancel-preflight.txt"]')
+    row.get_by_role("button", name="Cancel", exact=True).click()
+    expect(row).to_contain_text("Transfer cancelled")
+    _app_eval(page, "window.releaseUploadLimit(1024);")
+    page.wait_for_timeout(300)
+    assert posts == []
+    assert page.evaluate("window.preflightResult") is None
+    result = _app_eval(page, """
+        const token = app._beginFileUploadTransfer({name:'saving.txt',size:4});
+        const current = app._fileUploadTransfer(token);
+        current.transfer.saving = true;
+        app.cancelFileUpload({id:token.transferId});
+        return {cancelled:current.transfer.cancelled, done:current.transfer.done};
+    """)
+    assert result == {"cancelled": False, "done": False}

--- a/tests/e2e/test_file_upload_visibility.py
+++ b/tests/e2e/test_file_upload_visibility.py
@@ -1,0 +1,56 @@
+"""Uploads remain identifiable, and file dates/order survive refresh and live updates."""
+import re
+import pytest
+from playwright.sync_api import expect
+from tests.e2e.test_files_preview import _login
+from tests.e2e.test_chat_render_perf import _app_eval
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+def test_named_upload_results_preflight_and_locate(page, backend_url, auth_token, width, tmp_path):
+    page.set_viewport_size({"width":width, "height":900})
+    page.route("**/api/files/upload-limits", lambda route: route.fulfill(json={"max_file_bytes":1024}))
+    _login(page, backend_url, auth_token)
+    _app_eval(page, "app.setMobileTab('files');")
+    posts = []
+    page.on("request", lambda request: posts.append(request.url)
+            if request.method == "POST" and request.url.endswith("/api/files/upload") else None)
+    page.locator('.pane.files input[x-ref="upload"]').set_input_files([
+        {"name":"recent-upload.txt", "mimeType":"text/plain", "buffer":b"hello"},
+        {"name":"too-large.bin", "mimeType":"application/octet-stream", "buffer":b"x"*2048},
+    ])
+    good = page.locator('[data-upload-name="recent-upload.txt"]')
+    bad = page.locator('[data-upload-name="too-large.bin"]')
+    expect(good).to_contain_text("Saved")
+    expect(bad).to_contain_text("exceeds")
+    assert len(posts) == 1
+    page.wait_for_timeout(1000)
+    expect(bad).to_be_visible()
+    good.get_by_role("button", name="Locate").click()
+    row = page.locator('.filelist [data-path="recent-upload.txt"]')
+    expect(row).to_be_visible()
+    expect(row.locator("time")).to_have_attribute("datetime", re.compile(r"^\d{4}-"))
+    page.screenshot(path=str(tmp_path / "upload-results.png"))
+    page.select_option("#file-sort", "mtime_desc")
+    page.wait_for_function("""() => document.querySelector('#app')._x_dataStack[0].fileSort === 'mtime_desc'""")
+    page.reload()
+    expect(page.locator("#file-sort")).to_have_value("mtime_desc")
+
+
+def test_sort_updates_existing_file_on_mtime_event(page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = _app_eval(page, """
+        app.showHidden = false;
+        app.fileSort = 'mtime_desc';
+        const entries = [
+          {path:'folder', name:'folder', is_dir:true, mtime:1, size:0},
+          {path:'a.txt', name:'a.txt', is_dir:false, mtime:100, size:1},
+          {path:'z.txt', name:'z.txt', is_dir:false, mtime:200, size:1},
+        ];
+        Object.assign(app, app._materializeFileSnapshot(entries, []));
+        const before = app.visible.map(n => n.path);
+        app._applyFileTreeDelta([{type:'modified', path:'a.txt', mtime:300, size:2}]);
+        return {before, after:app.visible.map(n=>n.path), stamp:app.visible[1].mtime};
+    """)
+    assert result == {"before":["folder","z.txt","a.txt"],
+                      "after":["folder","a.txt","z.txt"], "stamp":300}

--- a/tests/e2e/test_file_upload_visibility.py
+++ b/tests/e2e/test_file_upload_visibility.py
@@ -127,3 +127,36 @@ def test_cancel_preflight_never_starts_post_and_saving_cannot_cancel(page, backe
         return {cancelled:current.transfer.cancelled, done:current.transfer.done};
     """)
     assert result == {"cancelled": False, "done": False}
+
+
+@pytest.mark.parametrize("width", [320, 390, 430])
+def test_touch_file_metadata_hides_without_overlapping_names(browser, backend_url, auth_token, width):
+    context = browser.new_context(viewport={"width": width, "height": 900},
+                                  is_mobile=True, has_touch=True, device_scale_factor=2)
+    page = context.new_page()
+    try:
+        _login(page, backend_url, auth_token)
+        _app_eval(page, """
+            app.setMobileTab('files');
+            app._stopFileEvents();
+            app.visible = [
+              {path:'report.md', name:'long-report-name.md', is_dir:false, depth:0, size:1024, mtime:1700000000},
+              {path:'nested/report.md', name:'nested-long-report.md', is_dir:false, depth:6, size:1024, mtime:1700000000},
+              {path:'folder', name:'long-folder-name', is_dir:true, depth:0, mtime:1700000000},
+            ];
+            app.fileTreeViewport = {start:0,end:80};
+        """)
+        assert page.evaluate("matchMedia('(pointer: coarse)').matches")
+        rows = page.locator('.filelist li[role="treeitem"]')
+        expect(rows).to_have_count(3)
+        for row in rows.all():
+            expect(row.locator(".file-modified")).to_be_hidden()
+            metrics = row.evaluate("""el => {
+                const name = el.querySelector('.name').getBoundingClientRect();
+                const trailing = el.querySelector('.tree-trailing').getBoundingClientRect();
+                return {overlap: name.right > trailing.left + 1,
+                        overflow: el.scrollWidth > el.clientWidth + 1};
+            }""")
+            assert metrics == {"overlap": False, "overflow": False}
+    finally:
+        context.close()

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -1800,6 +1800,8 @@ def test_virtual_file_tree_supports_keyboard_navigation_and_mobile_handoff(
     refresh = page.locator(".filelist-sticky-root .root-action").last
     refresh.focus()
     page.keyboard.press("Tab")
+    expect(page.locator("#file-sort")).to_be_focused()
+    page.keyboard.press("Tab")
     page.wait_for_function(
         "() => document.activeElement?.getAttribute('role') === 'treeitem'"
     )

--- a/tests/e2e/test_files_preview.py
+++ b/tests/e2e/test_files_preview.py
@@ -1797,7 +1797,7 @@ def test_virtual_file_tree_supports_keyboard_navigation_and_mobile_handoff(
           await new Promise(resolve => app.$nextTick(resolve));
         }"""
     )
-    refresh = page.locator(".filelist-sticky-root .root-action").last
+    refresh = page.get_by_role("button", name="Refresh file tree", exact=True)
     refresh.focus()
     page.keyboard.press("Tab")
     expect(page.locator("#file-sort")).to_be_focused()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -940,3 +940,54 @@ def test_upload_limits_match_server_enforcement(client, auth, temp_root, monkeyp
     assert not (temp_root / "over-limit.bin").exists()
     assert not list(temp_root.glob(".*.uploading"))
     assert client.get("/api/files/upload-limits").status_code == 401
+
+
+def test_staged_upload_cancel_preserves_existing_file(client, auth, temp_root):
+    import uuid
+    upload_id = uuid.uuid4().hex
+    target = temp_root / "cancel-existing.txt"
+    target.write_text("original")
+    response = client.post("/api/files/upload", headers=auth,
+                           data={"path": "", "upload_id": upload_id},
+                           files={"file": (target.name, b"replacement")})
+    assert response.status_code == 200 and response.json()["pending"] is True
+    assert target.read_text() == "original"
+    control = {"path": "", "upload_id": upload_id}
+    assert client.post("/api/files/upload/cancel", headers=auth, json=control).status_code == 200
+    assert client.post("/api/files/upload/commit", headers=auth, json=control).status_code == 409
+    assert target.read_text() == "original"
+    assert not list(temp_root.glob(".*.uploading"))
+
+
+def test_cancel_before_upload_parsing_prevents_late_save(client, auth, temp_root):
+    import uuid
+    upload_id = uuid.uuid4().hex
+    control = {"path": "", "upload_id": upload_id}
+    assert client.post("/api/files/upload/cancel", headers=auth, json=control).status_code == 200
+    response = client.post("/api/files/upload", headers=auth,
+                           data=control, files={"file": ("cancelled-late.txt", b"late bytes")})
+    assert response.status_code == 409
+    assert not (temp_root / "cancelled-late.txt").exists()
+    assert not list(temp_root.glob(".*.uploading"))
+
+
+def test_staged_upload_commit_and_expiry(client, auth, temp_root):
+    import uuid
+    from backend import files
+    for name, commit in [("committed.txt", True), ("expired.txt", False)]:
+        upload_id = uuid.uuid4().hex
+        control = {"path": "", "upload_id": upload_id}
+        staged = client.post("/api/files/upload", headers=auth, data=control,
+                             files={"file": (name, b"saved bytes")})
+        assert staged.status_code == 200
+        assert not (temp_root / name).exists()
+        if commit:
+            assert client.post("/api/files/upload/commit", json=control).status_code == 401
+            response = client.post("/api/files/upload/commit", headers=auth, json=control)
+            assert response.status_code == 200
+            assert (temp_root / name).read_bytes() == b"saved bytes"
+        else:
+            key = files._upload_key(upload_id, "", temp_root)
+            files._expire_pending_upload(key, files._PENDING_UPLOADS[key])
+            assert client.post("/api/files/upload/commit", headers=auth, json=control).status_code == 409
+        assert not list(temp_root.glob(".*.uploading"))

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -905,3 +905,38 @@ def test_csv_total_cache_reuses_signature_and_invalidates_on_write(
     assert changed.json()["total_rows"] == first_total + 1
     with files_module._CSV_TOTAL_CACHE_LOCK:
         assert files_module._CSV_TOTAL_CACHE[cache_key][1] > cached[1]
+
+
+def test_list_modified_sort_selects_before_truncation(client, auth, temp_root, monkeypatch):
+    import os
+    from backend import files
+    directory = temp_root / "modified-sort"
+    directory.mkdir()
+    for name, stamp in [("a.txt", 100), ("b.txt", 200), ("z.txt", 300)]:
+        path = directory / name
+        path.write_text(name, encoding="utf-8")
+        os.utime(path, (stamp, stamp))
+    monkeypatch.setattr(files, "MAX_LIST_ENTRIES", 2)
+    for mode, expected in [
+        ("mtime_desc", ["z.txt", "b.txt"]), ("mtime_asc", ["a.txt", "b.txt"]),
+    ]:
+        response = client.get("/api/files/list", params={"path":"modified-sort", "sort":mode}, headers=auth)
+        assert response.status_code == 200
+        assert [entry["name"] for entry in response.json()["entries"]] == expected
+        assert response.json()["truncated"] is True
+
+
+def test_upload_limits_match_server_enforcement(client, auth, temp_root, monkeypatch):
+    from backend import files
+    monkeypatch.setattr(files, "MAX_UPLOAD_BYTES", 1024)
+    assert client.get("/api/files/upload-limits", headers=auth).json() == {"max_file_bytes":1024}
+    exact = client.post("/api/files/upload", headers=auth,
+                        data={"path":""}, files={"file":("at-limit.bin", b"x" * 1024)})
+    assert exact.status_code == 200
+    assert (temp_root / "at-limit.bin").read_bytes() == b"x" * 1024
+    response = client.post("/api/files/upload", headers=auth,
+                           data={"path":""}, files={"file":("over-limit.bin", b"x" * 1025)})
+    assert response.status_code == 413
+    assert not (temp_root / "over-limit.bin").exists()
+    assert not list(temp_root.glob(".*.uploading"))
+    assert client.get("/api/files/upload-limits").status_code == 401

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -3148,9 +3148,9 @@ def test_workspace_file_upload_uses_real_aggregate_byte_progress():
     quiet_start = app.index("async _uploadFileQuiet(")
     quiet_end = app.index("\n    _prepareUploadOverwrite", quiet_start)
     quiet = app[quiet_start:quiet_end]
-    assert "_beginFileUploadTransfer(file)" in quiet
-    assert "_uploadWorkspaceFile(dirPath, file, transfer)" in quiet
-    assert "_finishFileUploadTransfer(transfer, succeeded)" in quiet
+    assert "_beginFileUploadTransfer(file, dirPath, ownerWorkspace)" in quiet
+    assert "_uploadWorkspaceFile(dirPath, file, transfer, ownerWorkspace)" in quiet
+    assert "_finishFileUploadTransfer(transfer, succeeded, failure)" in quiet
 
     context_start = app.index("async uploadFileTo(dirPath, file)")
     context_end = app.index("\n    // Custom MIME", context_start)


### PR DESCRIPTION
Files were difficult to find after uploading, and the aggregate upload bar did not identify individual transfers or explain failures. The file tree now shows modification times and remembers name/newest/oldest sorting; directory listings apply the selected order before their result cap.

Each upload shows its filename, progress, saving/saved state, and failure reason. Successful uploads can be located in the tree, while failed results remain visible until dismissed. The default per-file limit is now 1 GiB (1024 MiB), remains configurable through `MUSELAB_MAX_UPLOAD_MB`, and is exposed through an authenticated endpoint for client-side preflight checks. Upload completion stays tied to the initiating workspace.

A compact button beside refresh cycles through name/newest/oldest sorting. File rows remain on one line, with size followed by modification time aligned on the right; narrow panes hide metadata to preserve filename space.

Individual transfers can be cancelled, including during size preflight. Browser uploads stage data and explicitly commit only after a successful transfer; cancellation stops the request and discards staging without replacing existing files. Cancellation is disabled during the final save. Staging expires after ten minutes while the service runs and is cleaned during graceful shutdown. Legacy API uploads without an upload ID remain compatible.

Validation: 280 unit/security/static/documentation tests and 55 desktop/mobile browser tests passed in separate runs. Browser tests cancelled throttled transfers, verified the destination was absent and another file still saved, and covered preflight cancellation and the save boundary. Backend tests covered cancel-before-parse, preservation of existing files, commit, and expiration. A real HTTP staged upload accepted exactly 1 GiB with matching SHA-256; an oversized upload returned HTTP 413 without a partial destination. JavaScript syntax, Ruff, and diff checks passed.

Touch-device coverage includes 320, 390, and 430 pixel viewports with coarse pointer input, nested files, and directory actions. Modification times hide based on the actual row width, including indentation, while reserving room for touch actions.
