### PR TITLE
fix(runtime): 消除状态轮询阻塞并隔离记忆界面查询

### DIFF
--- a/backend/api_memory.py
+++ b/backend/api_memory.py
@@ -1,6 +1,8 @@
 """Authenticated white-box API for memory configuration and governance."""
 from __future__ import annotations
 
+import sqlite3
+
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -30,6 +32,25 @@ _IMPORTABLE_AUTHORITIES = ("confirmed", "inferred", "legacy_import")
 
 def _failure_detail(exc: BaseException) -> dict[str, object]:
     return classify_memory_failure(exc)[1]
+
+
+async def _read_response(awaitable):
+    try:
+        return await awaitable
+    except (TimeoutError, sqlite3.OperationalError) as exc:
+        if isinstance(exc, sqlite3.OperationalError) and (
+            getattr(exc, "sqlite_errorcode", 0) & 0xff
+        ) not in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED, sqlite3.SQLITE_INTERRUPT):
+            raise
+        # Do not expose SQL, paths, or private content in an error response.
+        raise HTTPException(
+            503, "Memory read unavailable; retry shortly",
+            headers={"Retry-After": "1"},
+        ) from None
+
+
+async def _read_store(operation):
+    return await _read_response(engine._read_store_call(operation))
 
 
 class MemoryCreate(BaseModel):
@@ -139,7 +160,7 @@ def _resolve_config_input(raw: dict, current: MemoryConfig) -> MemoryConfig:
 
 @router.get("/status")
 async def get_status() -> dict:
-    return await engine.status()
+    return await _read_response(engine.status())
 
 
 @router.get("/items")
@@ -167,7 +188,7 @@ async def list_items(
         return {"items": rows, "count": len(rows), "total": total,
                 "offset": offset, "limit": limit, "has_more": offset + len(rows) < total}
 
-    return await engine._store_call(load)
+    return await _read_store(load)
 
 
 @router.post("/items")
@@ -190,21 +211,22 @@ async def create_item(body: MemoryCreate) -> dict:
 @router.get("/items/{memory_id}")
 async def get_item(memory_id: str) -> dict:
     cfg = load_config()
-    item = await engine._store_call(
-        lambda store: store.memory(memory_id))
-    if not item or item.get("owner_id") != cfg.owner_id:
-        raise HTTPException(404, "memory not found")
-    item["recall_stats"] = (await engine._store_call(
-        lambda store: store.memory_recall_stats(cfg.owner_id, [memory_id])
-    ))[memory_id]
-    return item
+    def load(store):
+        item = store.memory(memory_id)
+        if not item or item.get("owner_id") != cfg.owner_id:
+            raise HTTPException(404, "memory not found")
+        item["recall_stats"] = store.memory_recall_stats(
+            cfg.owner_id, [memory_id])[memory_id]
+        return item
+
+    return await _read_store(load)
 
 
 @router.get("/items/{memory_id}/traceback")
 async def get_item_traceback(memory_id: str) -> dict:
     cfg = load_config()
     try:
-        sites = await engine._store_call(
+        sites = await _read_store(
             lambda store: store.memory_traceback(cfg.owner_id, memory_id))
     except KeyError:
         raise HTTPException(404, "memory not found") from None
@@ -284,7 +306,7 @@ async def list_episodes(
     limit: int = Query(default=100, ge=1, le=500),
 ) -> dict:
     cfg = load_config()
-    rows = await engine._store_call(
+    rows = await _read_store(
         lambda store: store.list_episodes(
             cfg.owner_id, status=status, limit=limit))
     return {"items": rows, "count": len(rows)}
@@ -293,7 +315,7 @@ async def list_episodes(
 @router.get("/episodes/{episode_id}")
 async def get_episode(episode_id: str) -> dict:
     cfg = load_config()
-    item = await engine._store_call(
+    item = await _read_store(
         lambda store: store.episode(episode_id))
     if not item or item.get("owner_id") != cfg.owner_id:
         raise HTTPException(404, "episode not found")
@@ -307,7 +329,7 @@ async def list_artifacts(
     limit: int = Query(default=100, ge=1, le=500),
 ) -> dict:
     cfg = load_config()
-    rows = await engine._store_call(
+    rows = await _read_store(
         lambda store: store.list_artifacts(
             cfg.owner_id, kind=kind, status=status, limit=limit))
     return {"items": rows, "count": len(rows)}
@@ -343,7 +365,7 @@ async def disable_skill(artifact_id: str) -> dict:
 
 @router.get("/jobs")
 async def list_jobs(limit: int = Query(default=100, ge=1, le=500)) -> dict:
-    rows = await engine._store_call(
+    rows = await _read_store(
         lambda store: store.list_jobs(limit=limit))
     return {"items": rows, "count": len(rows)}
 
@@ -351,7 +373,7 @@ async def list_jobs(limit: int = Query(default=100, ge=1, le=500)) -> dict:
 @router.get("/recalls")
 async def list_recalls(limit: int = Query(default=100, ge=1, le=500)) -> dict:
     cfg = load_config()
-    rows = await engine._store_call(
+    rows = await _read_store(
         lambda store: store.recent_recalls(cfg.owner_id, limit=limit))
     return {"items": rows, "count": len(rows)}
 
@@ -359,7 +381,7 @@ async def list_recalls(limit: int = Query(default=100, ge=1, le=500)) -> dict:
 @router.get("/audit")
 async def list_audit(limit: int = Query(default=100, ge=1, le=500)) -> dict:
     cfg = load_config()
-    rows = await engine._store_call(
+    rows = await _read_store(
         lambda store: store.audits(cfg.owner_id, limit=limit))
     return {"items": rows, "count": len(rows)}
 
@@ -377,7 +399,7 @@ async def list_backups(
     limit: int = Query(default=100, ge=1, le=500),
 ) -> dict:
     cfg = load_config()
-    rows = await engine._store_call(lambda store: store.list_backups(
+    rows = await _read_store(lambda store: store.list_backups(
         cfg.owner_id, memory_dir() / "backups", limit=limit))
     return {"items": rows, "count": len(rows)}
 

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -7128,9 +7128,10 @@ async def recover_runtime_continuation_outboxes_at_startup() -> int:
 
 def _runtime_continuation_projection_state(
     sid: str, *, runtime_lineage: list[str] | None = None,
+    disk_state: tuple[frozenset[str], str] | None = None,
 ) -> tuple[bool, str]:
     return chat_overlays._runtime_continuation_projection_state(
-        sid, runtime_lineage=runtime_lineage,
+        sid, runtime_lineage=runtime_lineage, disk_state=disk_state,
     )
 
 def _delete_cancelled_turn_snapshots(sid: str) -> None:
@@ -19842,7 +19843,7 @@ def _mux_session_state_fingerprint(state: dict) -> str:
     stable = {}
     for key, value in state.items():
         if key in {
-            "events_so_far", "latest_event_seq", "runtime_ui_revision",
+            "events_so_far", "latest_event_seq",
         }:
             continue
         # Announcement states are intentionally memory-only and may omit
@@ -19866,6 +19867,18 @@ def _runtime_reconcile_projections(
         sess.runtime_lineages(ordered_ids),
         sess.running_runtime_task_ids(ordered_ids),
     )
+
+
+def _runtime_reconcile_snapshot(session_ids: Iterable[str]):
+    """Capture disk facts off-loop; live broadcasts/watchers stay on-loop."""
+    ordered_ids = tuple(session_ids)
+    lineages, task_ids = _runtime_reconcile_projections(ordered_ids)
+    continuations = {
+        sid: chat_overlays._runtime_continuation_disk_state(
+            sid, runtime_lineage=lineages.get(sid, []))
+        for sid in ordered_ids
+    }
+    return lineages, task_ids, continuations
 
 
 async def _subscribe_multiplex(
@@ -20072,17 +20085,18 @@ async def _subscribe_multiplex(
         # index nor a large sidecar may be read/decoded on the event-loop thread.
         # Runtime-task summaries retain only immutable task ids, so warm passes
         # are O(stat) even when full sidecars churn out of their small cache.
-        runtime_lineages, durable_runtime_task_ids = (
+        runtime_lineages, durable_runtime_task_ids, continuation_states = (
             await asyncio.to_thread(
-                _runtime_reconcile_projections, candidate_ids,
+                _runtime_reconcile_snapshot, candidate_ids,
             )
-            if candidate_ids else ({}, {})
+            if candidate_ids else ({}, {}, {})
         )
         active_ids: set[str] = set()
         for session_id in sorted(candidate_ids):
             state = _session_active_status(
                 session_id,
                 runtime_lineage=runtime_lineages.get(session_id, []),
+                continuation_disk_state=continuation_states[session_id],
                 durable_runtime_task_ids=durable_runtime_task_ids.get(
                     session_id, frozenset(),
                 ),
@@ -20354,6 +20368,7 @@ def _session_active_status(
     *,
     runtime_lineage: list[str] | None = None,
     durable_runtime_task_ids: Iterable[str] | None = None,
+    continuation_disk_state: tuple[frozenset[str], str] | None = None,
 ) -> dict:
     """Tell the frontend whether `sid` has an in-progress background
     turn. Used on session load to decide between "render JSONL history"
@@ -20369,7 +20384,7 @@ def _session_active_status(
     runtime_background_pending = len(runtime_task_ids)
     runtime_continuation_pending, runtime_ui_revision = (
         _runtime_continuation_projection_state(
-            sid, runtime_lineage=runtime_lineage,
+            sid, runtime_lineage=runtime_lineage, disk_state=continuation_disk_state,
         )
     )
     scheduled_state = _sdk_scheduled_snapshot(sid)

--- a/backend/chat_overlays.py
+++ b/backend/chat_overlays.py
@@ -803,29 +803,54 @@ async def recover_runtime_continuation_outboxes_at_startup() -> int:
     return scheduled
 
 
+def _runtime_continuation_disk_state(
+    sid: str, *, runtime_lineage: list[str],
+) -> tuple[frozenset[str], str]:
+    """Read notification metadata only; never heal snapshots or index JSONL.
+
+    Multiplex callers run this on a worker. History reads retain ownership of
+    snapshot validation/healing; polling a revision must not initiate writes.
+    """
+    lineage = runtime_lineage or [sid]
+    owners = frozenset(
+        owner for owner in lineage[:-1]
+        if _session_has_runtime_continuation_outbox(owner)
+    )
+    directory = _cancelled_turn_session_dir(lineage[-1])
+    digest = hashlib.blake2b(digest_size=12)
+    found = False
+    if directory is not None:
+        try:
+            paths = sorted(directory.glob("*.json"))
+        except OSError:
+            paths = []
+        for path in paths:
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            found = True
+            digest.update(path.name.encode("ascii", errors="ignore"))
+            digest.update(f":{stat.st_mtime_ns}:{stat.st_size};".encode("ascii"))
+    return owners, digest.hexdigest() if found else ""
+
+
 def _runtime_continuation_projection_state(
     sid: str, *, runtime_lineage: list[str] | None = None,
+    disk_state: tuple[frozenset[str], str] | None = None,
 ) -> tuple[bool, str]:
-    """Return lineage-wide pending state and the visible leaf's UI revision."""
+    """Combine durable metadata with live watcher state on the caller thread."""
     _hooks = _require_hooks()
-    lineage = (
-        sess.runtime_lineage(sid)
-        if runtime_lineage is None
-        else list(runtime_lineage)
-    ) or [sid]
-    leaf_sid = lineage[-1]
-    pending = False
-    for owner_sid in lineage[:-1]:
-        if (
-            _hooks.session_has_live_watcher(owner_sid)
-            or _session_has_runtime_continuation_outbox(owner_sid)
-        ):
-            pending = True
-            break
-    try:
-        _, revision = _hooks.load_cancelled_turn_snapshots(leaf_sid)
-    except Exception:
-        revision = ""
+    lineage = (sess.runtime_lineage(sid) if runtime_lineage is None
+               else list(runtime_lineage)) or [sid]
+    owners, revision = (
+        _runtime_continuation_disk_state(sid, runtime_lineage=lineage)
+        if disk_state is None else disk_state
+    )
+    pending = any(
+        owner in owners or _hooks.session_has_live_watcher(owner)
+        for owner in lineage[:-1]
+    )
     return pending, revision
 
 

--- a/backend/memory_engine.py
+++ b/backend/memory_engine.py
@@ -213,9 +213,9 @@ class _MemoryStoreActor:
 
     Each actor owns a FIFO database lane. Write operations are shielded from
     coroutine cancellation; the separate read actor can discard queued reads.
-    A running operation is allowed to finish: SQLite cannot cancel a
-    running statement safely, so the transaction is allowed to finish and the
-    next operation observes its committed state. close appends a barrier,
+    Running writes finish their transactions before the next operation.
+    Read-only callers may install a SQLite progress handler to interrupt
+    expensive queries when their budget expires. close appends a barrier,
     drains every accepted operation, then joins the owned thread.
     """
 
@@ -280,6 +280,10 @@ class _MemoryStoreActor:
         executor.shutdown(wait=True)
 
 
+class _RegistryNotInitialized(Exception):
+    """A read-only connection needs the writer to create the first schema."""
+
+
 class MemoryEngine:
     def __init__(self, store: MemoryStore | None = None):
         self._store: MemoryStore | None = store
@@ -288,6 +292,9 @@ class MemoryEngine:
         self._recall_store: MemoryStore | None = None
         self._recall_store_actor = _MemoryStoreActor(
             self._resolve_recall_store, cancel_pending=True)
+        self._ui_store: MemoryStore | None = None
+        self._ui_store_actor = _MemoryStoreActor(
+            self._resolve_ui_store, cancel_pending=True)
         self._workers: set[asyncio.Task] = set()
         self._telemetry_tasks: set[asyncio.Task] = set()
         self._closing = False
@@ -318,6 +325,35 @@ class MemoryEngine:
         if self._recall_store is None or self._recall_store.path != path:
             self._recall_store = MemoryStore(path, read_only=True)
         return self._recall_store
+
+    def _resolve_ui_store(self) -> MemoryStore:
+        path = self._store.path if self._store_pinned else database_path()
+        if (self._store is None or self._store.path != path
+                or not path.exists()):
+            raise _RegistryNotInitialized
+        if self._ui_store is None or self._ui_store.path != path:
+            self._ui_store = MemoryStore(path, read_only=True)
+        return self._ui_store
+
+    UI_READ_TIMEOUT_S = 5.0
+
+    async def _read_store_call(self, operation: Callable[[MemoryStore], _T]) -> _T:
+        """Bound UI reads independently of both background writes and recall."""
+        deadline = time.perf_counter() + self.UI_READ_TIMEOUT_S
+
+        def read(store: MemoryStore) -> _T:
+            with store.read_budget(deadline):
+                return operation(store)
+
+        async with asyncio.timeout(self.UI_READ_TIMEOUT_S):
+            try:
+                return await self._ui_store_actor.call(read)
+            except _RegistryNotInitialized:
+                # First use with Memory disabled still needs an empty registry.
+                # Only the writer initializes schema; normal reads never join
+                # it or the shared asyncio thread pool.
+                await self._store_call(lambda store: None)
+                return await self._ui_store_actor.call(read)
 
     async def _recall_store_call(self, operation: Callable[[MemoryStore], _T]) -> _T:
         return await self._recall_store_actor.call(operation)
@@ -360,6 +396,7 @@ class MemoryEngine:
         self._closing = False
         self._store_actor.reopen()
         self._recall_store_actor.reopen()
+        self._ui_store_actor.reopen()
         if (os.environ.get("MUSELAB_MEMORY_WORKER_DISABLED") == "1"
                 or not self.enabled() or self._workers):
             return
@@ -458,6 +495,7 @@ class MemoryEngine:
         if close_store:
             await self._store_actor.close()
             await self._recall_store_actor.close()
+            await self._ui_store_actor.close()
 
     async def record_turn(self, session_id: str, model: str, user_text: str,
                           assistant_text: str, *, outcome: str = "success",
@@ -1599,7 +1637,7 @@ class MemoryEngine:
                 **store.stats(cfg.owner_id),
             }
 
-        registry = await self._store_call(load_status)
+        registry = await self._read_store_call(load_status)
         return {
             "enabled": cfg.enabled, "mode": cfg.mode,
             "worker_running": bool(self._workers),

--- a/backend/memory_store.py
+++ b/backend/memory_store.py
@@ -272,7 +272,24 @@ class MemoryStore:
                      else "PRAGMA busy_timeout=10000")
         if self._read_only:
             conn.execute("PRAGMA query_only=ON")
+            deadline = getattr(self, "_query_deadline", None)
+            if deadline is not None:
+                conn.set_progress_handler(
+                    lambda: int(time.perf_counter() >= deadline), 1000)
         return conn
+
+    @contextmanager
+    def read_budget(self, deadline: float):
+        """Interrupt expensive SQL after the read actor's absolute deadline."""
+        if not self._read_only:
+            raise RuntimeError("read budgets require a read-only store")
+        self._query_deadline = deadline
+        try:
+            if time.perf_counter() >= deadline:
+                raise TimeoutError("memory read deadline exceeded")
+            yield
+        finally:
+            self._query_deadline = None
 
     @contextmanager
     def _write_tx(self) -> Iterator[sqlite3.Connection]:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -20538,15 +20538,10 @@ function portal() {
           if (!item?.id || (item.content && item._traceback)) return item;
           try {
             const base = "/api/memory/items/" + encodeURIComponent(item.id);
-            const [detailResponse, tracebackResponse] = await Promise.all([
-              fetch(base, { headers: this.hdr(), cache: "no-store" }),
-              fetch(base + "/traceback", {
-                headers: this.hdr(), cache: "no-store",
-              }),
+            const [detail, traceback] = await Promise.all([
+              this._settingsRead(base),
+              this._settingsRead(base + "/traceback"),
             ]);
-            const detail = detailResponse.ok ? await detailResponse.json() : {};
-            const traceback = tracebackResponse.ok
-              ? await tracebackResponse.json() : { sites: [] };
             return {
               ...item,
               kind: detail.kind || item.kind,
@@ -20877,20 +20872,15 @@ function portal() {
     },
 
     async _pollMemoryReview() {
+      if (this._memoryReviewLoading) return;
+      this._memoryReviewLoading = true;
       try {
         if (this._memoryMonitorEnabled == null) {
-          const cfgR = await fetch("/api/memory/config", {
-            headers: this.hdr(), cache: "no-store",
-          });
-          if (!cfgR.ok) return;
-          this._memoryMonitorEnabled = (await cfgR.json()).mode !== "off";
+          const cfg = await this._settingsRead("/api/memory/config");
+          this._memoryMonitorEnabled = cfg.mode !== "off";
         }
         if (!this._memoryMonitorEnabled) return;
-        const r = await fetch("/api/memory/status", {
-          headers: this.hdr(), cache: "no-store",
-        });
-        if (!r.ok) return;
-        const status = await r.json();
+        const status = await this._settingsRead("/api/memory/status");
         this.settings.memory.status = status;
         const ids = status.pending_artifact_ids || [];
         let seen = [];
@@ -20910,6 +20900,7 @@ function portal() {
           this._setLS("muselab_memory_artifacts_seen", JSON.stringify(merged));
         }
       } catch (_) { /* optional and fail-soft */ }
+      finally { this._memoryReviewLoading = false; }
     },
 
     SETTINGS_READ_TIMEOUT_MS: 8000,
@@ -20937,6 +20928,11 @@ function portal() {
         const response = await fetch(url, {
           headers: this.hdr(), cache: "no-store", signal: controller.signal,
         });
+        if (response.status === 503 && url.startsWith("/api/memory/")) {
+          throw new Error(this.lang === "zh"
+            ? "记忆查询暂时不可用，请重试"
+            : "Memory is temporarily unavailable. Please retry.");
+        }
         if (!response.ok) throw new Error("HTTP " + response.status);
         return await response.json();
       } catch (error) {

--- a/tests/e2e/test_ux_reliability.py
+++ b/tests/e2e/test_ux_reliability.py
@@ -286,3 +286,77 @@ def test_completed_history_recovers_without_status_waterfall(
     else:
         assert result["installs"] == 0 and result["retries"] == 1
         assert result["delay"] >= 5000
+
+
+def test_memory_list_timeout_clears_loading_and_retry_recovers(page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    result = _app_eval(page, """
+      await app.openMemoryCenter();
+      const original = window.fetch, timeout = app.SETTINGS_READ_TIMEOUT_MS;
+      app.SETTINGS_READ_TIMEOUT_MS = 80;
+      window.fetch = (url, options) => {
+        if (String(url).startsWith('/api/memory/items?')) {
+          return new Promise((resolve, reject) => {
+            options.signal.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')), {once:true});
+          });
+        }
+        return original(url, options);
+      };
+      try {
+        await app.refreshMemoryCenter();
+        return {loading:app.settings.memory.listLoading,
+                error:app.settings.memory.listError};
+      } finally {
+        window.fetch=original; app.SETTINGS_READ_TIMEOUT_MS=timeout;
+      }
+    """)
+    assert result["loading"] is False
+    assert result["error"]
+    expect(page.locator(".memory-center-section [role=status]").filter(
+        has_text="正在加载记忆")).to_be_hidden()
+    page.route("**/api/memory/items?*", lambda route: route.fulfill(
+        status=200, content_type="application/json", body=json.dumps({
+            "items": [{"id": "retry-fixture", "content": "Memory retry succeeded",
+                       "kind": "fact", "status": "active"}], "total": 1,
+        })))
+    page.locator(".memory-center-section .settings-inline-error button").click()
+    expect(page.locator(".memory-card-content").filter(
+        has_text="Memory retry succeeded")).to_be_visible()
+    assert not _app_eval(page, "return app.settings.memory.listError;")
+
+
+def test_memory_monitor_does_not_accumulate_slow_requests(page, backend_url, auth_token):
+    _login(page, backend_url, auth_token)
+    page.wait_for_function("""() =>
+      !document.querySelector('#app')._x_dataStack[0]._memoryReviewLoading""")
+    result = _app_eval(page, """
+      const original=window.fetch, timeout=app.SETTINGS_READ_TIMEOUT_MS;
+      if (app._memoryMonitorTimer) clearInterval(app._memoryMonitorTimer);
+      app._memoryMonitorEnabled=true;
+      app.SETTINGS_READ_TIMEOUT_MS=80;
+      let requests=0, aborted=0;
+      window.fetch=(url, options)=>{
+        if (String(url)==='/api/memory/status') {
+          requests++;
+          return new Promise((resolve,reject)=>{
+            options.signal.addEventListener('abort',()=>{
+              aborted++; reject(new DOMException('aborted','AbortError'));
+            },{once:true});
+          });
+        }
+        return original(url,options);
+      };
+      try {
+        await Promise.all(Array.from({length:5},()=>app._pollMemoryReview()));
+        const afterFirst={requests,aborted,loading:app._memoryReviewLoading};
+        await app._pollMemoryReview();
+        return {afterFirst,requests,aborted,loading:app._memoryReviewLoading};
+      } finally {
+        window.fetch=original; app.SETTINGS_READ_TIMEOUT_MS=timeout;
+      }
+    """)
+    assert result == {
+        "afterFirst": {"requests": 1, "aborted": 1, "loading": False},
+        "requests": 2, "aborted": 2, "loading": False,
+    }

--- a/tests/test_chat_multiplex_stream.py
+++ b/tests/test_chat_multiplex_stream.py
@@ -322,6 +322,7 @@ def test_mux_reconcile_batches_durable_projections_off_loop(
 
     def state(
         sid, *, runtime_lineage=None, durable_runtime_task_ids=None,
+        continuation_disk_state=None,
     ):
         status_calls.append((
             sid, runtime_lineage, durable_runtime_task_ids,
@@ -804,3 +805,123 @@ def test_mux_child_resync_does_not_close_other_sessions(
         await stream.aclose()
 
     asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("cause", ["slow_index", "held_session_lock", "sqlite_writer_lock"])
+def test_mux_revision_poll_never_indexes_or_blocks_loop(
+        chat_mod, monkeypatch, tmp_path, cause):
+    """A cancelled snapshot plus a changing transcript must remain read-only."""
+    import sqlite3
+    import time
+    import uuid
+    from backend import transcript_index_store
+
+    sid, turn = str(uuid.uuid4()), str(uuid.uuid4())
+    source = tmp_path / "fixture.jsonl"
+    source.write_text("")
+    folder = chat_mod.sess.SESS_DIR / "cancelled_turns" / sid
+    folder.mkdir(parents=True)
+    snapshot = folder / f"{turn}.json"
+    snapshot.write_text(json.dumps({
+        "schema": 1, "sid": sid, "turn_id": turn, "messages": [],
+        "transcript_boundary": {"record_count": 0}, "started_at_ms": 1,
+    }))
+    monkeypatch.setattr(chat_mod, "_find_session_jsonl",
+                        lambda value: source if value == sid else None)
+    chat_mod._sessions_with_inflight_tasks[sid] = {"fixture-background-task"}
+    if cause == "sqlite_writer_lock":
+        chat_mod._ensure_transcript_index(sid)
+    writes = []
+    original_write = transcript_index_store._write
+
+    def delayed_write(*args, **kwargs):
+        writes.append(threading.get_ident())
+        if cause == "slow_index":
+            time.sleep(0.3)
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(transcript_index_store, "_write", delayed_write)
+    entered, release = threading.Event(), threading.Event()
+
+    def hold_lock():
+        if cause == "sqlite_writer_lock":
+            with sqlite3.connect(chat_mod._transcript_index_path(sid)) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                entered.set()
+                release.wait(2)
+                conn.rollback()
+        else:
+            with chat_mod.sess.session_lifecycle_lock(sid):
+                entered.set()
+                release.wait(2)
+
+    async def scenario():
+        holder = None
+        if cause != "slow_index":
+            holder = threading.Thread(target=hold_lock)
+            holder.start()
+            assert await asyncio.to_thread(entered.wait, 1)
+        frames, gaps = [], []
+        running = True
+
+        async def consume():
+            async for event in chat_mod._subscribe_multiplex({}):
+                if event["event"] == "session_state":
+                    frames.append(json.loads(event["data"]))
+
+        async def heartbeat():
+            while running:
+                before = time.perf_counter()
+                await asyncio.sleep(0.01)
+                gaps.append(time.perf_counter() - before)
+
+        consumer = asyncio.create_task(consume())
+        beat = asyncio.create_task(heartbeat())
+        try:
+            # Keep the JSONL changing as the SDK would during a live turn.
+            for _ in range(6):
+                with source.open("a") as output:
+                    output.write(json.dumps({
+                        "uuid": str(uuid.uuid4()), "type": "user",
+                        "sessionId": sid, "message": {"content": "fixture"},
+                    }) + "\n")
+                await asyncio.sleep(0.05)
+            assert frames
+            first_revision = frames[-1]["runtime_ui_revision"]
+            assert first_revision
+            snapshot.unlink()
+            for _ in range(30):
+                if frames[-1]["runtime_ui_revision"] != first_revision:
+                    break
+                await asyncio.sleep(0.02)
+            assert frames[-1]["runtime_ui_revision"] == ""
+            assert writes == []
+            assert max(gaps) < 0.15
+        finally:
+            release.set()
+            consumer.cancel()
+            await asyncio.gather(consumer, return_exceptions=True)
+            running = False
+            await beat
+            if holder:
+                await asyncio.to_thread(holder.join)
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        release.set()
+        chat_mod._sessions_with_inflight_tasks.pop(sid, None)
+
+
+def test_runtime_revision_unreadable_directory_does_not_break_status(
+        chat_mod, monkeypatch):
+    from backend import chat_overlays
+
+    class UnreadableDirectory:
+        def glob(self, pattern):
+            raise PermissionError("fixture")
+
+    monkeypatch.setattr(chat_overlays, "_cancelled_turn_session_dir",
+                        lambda sid: UnreadableDirectory())
+    assert chat_mod._runtime_continuation_projection_state(
+        "fixture-session", runtime_lineage=["fixture-session"]) == (False, "")

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -277,7 +277,7 @@ def test_memory_traceback_stats_recalls_and_backup_ui_are_wired():
     assert "copyMemorySourceEvidence(item)" in app
     assert "await this._copySessionEvidence(site.session_id)" in app
     assert "this._jumpToMessage(site.session_id, site.message_id)" in app
-    assert 'fetch(base + "/traceback"' in app
+    assert 'this._settingsRead(base + "/traceback")' in app
     assert "memoryRecallStatsText(item)" in app
     assert "memoryRecallResultsText(item)" in app
     assert "memoryCreateBackup()" in app

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -207,3 +207,83 @@ def test_approve_and_correct_reject_retired_rows(client, auth):
     assert client.post(
         f"/api/memory/items/{item['id']}/correct", headers=auth,
         json={"content": "再更正一次"}).status_code == 409
+
+
+def test_memory_reads_bypass_busy_writer_and_recall(client, auth, app_module):
+    """A background write and slow recall cannot hold the Memory Center."""
+    import threading
+    import time
+    from backend.memory_engine import engine
+
+    created = client.post("/api/memory/items", headers=auth, json={
+        "kind": "fact", "content": "只读查询测试",
+    }).json()
+    entered = [threading.Event(), threading.Event()]
+    release = threading.Event()
+
+    def hold(index):
+        def operation(store):
+            entered[index].set()
+            assert release.wait(5)
+        return operation
+
+    jobs = [engine._store_actor._submit(hold(0)),
+            engine._recall_store_actor._submit(hold(1))]
+    try:
+        assert all(event.wait(1) for event in entered)
+        started = time.perf_counter()
+        for route in [
+            "/items", f"/items/{created['id']}",
+            f"/items/{created['id']}/traceback",
+            "/status", "/episodes", "/artifacts", "/jobs", "/recalls",
+            "/audit", "/backups",
+        ]:
+            response = client.get("/api/memory" + route, headers=auth)
+            assert response.status_code == 200, (route, response.text)
+        elapsed = time.perf_counter() - started
+        assert elapsed < 2
+        assert not any(job.done() for job in jobs)
+    finally:
+        release.set()
+        for job in jobs:
+            job.result(timeout=2)
+
+
+def test_memory_read_timeout_is_retryable_and_queue_is_cancelled(
+        client, auth, app_module, monkeypatch):
+    import threading
+    import time
+    from backend.memory_engine import engine
+
+    assert client.get("/api/memory/items", headers=auth).status_code == 200
+    monkeypatch.setattr(engine, "UI_READ_TIMEOUT_S", 0.05)
+    entered, release = threading.Event(), threading.Event()
+    executions = []
+    original = engine._ui_store.browse_memories
+
+    def browse(*args, **kwargs):
+        executions.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(engine._ui_store, "browse_memories", browse)
+
+    def hold(store):
+        entered.set()
+        release.wait(2)
+
+    blocker = engine._ui_store_actor._submit(hold)
+    try:
+        assert entered.wait(1)
+        started = time.perf_counter()
+        response = client.get("/api/memory/items", headers=auth)
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        assert time.perf_counter() - started < 0.5
+    finally:
+        release.set()
+        blocker.result(timeout=2)
+    engine._ui_store_actor._submit(lambda store: None).result(timeout=2)
+    assert executions == []
+    monkeypatch.setattr(engine, "UI_READ_TIMEOUT_S", 1)
+    assert client.get("/api/memory/items", headers=auth).status_code == 200
+    assert executions == [True]

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -1150,3 +1150,56 @@ def test_recall_budget_fits_facade_and_watchdog():
     cfg = _config()
     cfg.retrieval.soft_timeout_ms = 5000
     assert cfg.retrieval.soft_timeout_ms / 1000 < _RECALL_DEADLINE < RECALL_HOOK_TIMEOUT
+
+
+def test_ui_read_interrupts_expensive_sql_and_next_request_recovers(tmp_path):
+    from backend.memory_engine import MemoryEngine
+    from backend.memory_store import MemoryStore
+
+    instance = MemoryEngine(MemoryStore(tmp_path / "registry.sqlite3"))
+    instance.UI_READ_TIMEOUT_S = 0.08
+
+    def expensive(store):
+        with store._connect() as conn:
+            return conn.execute("""
+                WITH RECURSIVE numbers(x) AS (
+                  SELECT 1 UNION ALL SELECT x + 1 FROM numbers WHERE x < 100000000
+                ) SELECT sum(x) FROM numbers
+            """).fetchone()[0]
+
+    async def scenario():
+        started = time.perf_counter()
+        try:
+            with pytest.raises((TimeoutError, sqlite3.OperationalError)):
+                await instance._read_store_call(expensive)
+            instance.UI_READ_TIMEOUT_S = 1
+            result = await instance._read_store_call(
+                lambda store: store.browse_memories("default"))
+            assert result == ([], 0)
+            assert time.perf_counter() - started < 0.8
+        finally:
+            await instance.stop()
+
+    asyncio.run(scenario())
+
+
+def test_first_ui_read_initializes_existing_empty_registry(tmp_path, monkeypatch):
+    from backend import memory_engine as module
+
+    path = tmp_path / "registry.sqlite3"
+    # An existing file alone does not prove the current schema was initialized.
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA user_version=0")
+    monkeypatch.setattr(module, "database_path", lambda: path)
+    instance = module.MemoryEngine()
+
+    async def scenario():
+        try:
+            assert await instance._read_store_call(
+                lambda store: store.browse_memories("default")) == ([], 0)
+            assert instance._ui_store._read_only
+            assert instance._store is not instance._ui_store
+        finally:
+            await instance.stop()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What this changes

消除 multiplex SSE 状态轮询中的同步索引修复：在后台线程读取延续任务和快照变更元数据，在事件循环中合并实时 watcher/broadcast 状态。快照 revision 变化会触发状态通知，实际历史读取仍负责校验和修复。

为记忆列表、详情、状态等界面查询新增独立只读 SQLite actor，与后台写入及自动召回分别排队。查询总预算为 5 秒，覆盖排队；取消未开始的过期读取，并通过 SQLite progress handler 中断耗时 SQL。首次 schema 初始化仍由写入 actor 负责。超时或数据库繁忙返回可重试的 503，前端读取有截止时间，状态轮询防止重入。

## Why

存在中断快照且 transcript 持续变化时，页面每 200 ms 的状态轮询可能触发同步索引写入，在事件循环中等待会话锁或 SQLite 写锁，导致其他请求与 SSE 一起停顿。关闭页面会停止重复触发。记忆界面另有独立排队问题：此前只隔离了自动召回，界面查询仍可能等待后台写入；没有截止和防重入的监控请求还会累积。

## Testing

- [x] 非浏览器覆盖 1998 项：全量运行 1995 项通过，1 条旧 fetch 源码断言修正后所在模块 183 项通过；另外补充并通过 2 个边界用例。
- [x] 最终聊天 stream/multiplex 模块：214 项通过。
- [x] Chromium：设置与可靠性 26 项、聊天与 multiplex 73 项通过。
- [x] 实际会话锁和 SQLite 写锁占用时，轮询不写索引、事件循环保持响应、revision 变化仍送达。
- [x] 写入与召回 actor 同时占用时，10 个记忆读取接口仍及时返回；过期排队取消、耗时 SQL 截止、后续请求恢复、空库初始化与页面重试均覆盖。
- [x] Python AST、JavaScript 语法和 git diff --check 通过。

## Checklist

- [x] 无凭据、私有日志或用户数据；测试使用隔离数据和通用样例。
- [x] 未增加运行依赖。
- [x] 无新增配置或操作流程；行为与边界记录在代码注释及回归测试中。
