### PR TITLE
修复活动列表、召回数量与运行时阻塞

### DIFF
--- a/backend/activity.py
+++ b/backend/activity.py
@@ -1149,11 +1149,13 @@ class ActivityService:
         child_sid: str,
         *,
         successor: bool = False,
+        activity_hidden: bool = False,
     ) -> dict[str, Any]:
         """Inherit a fork's durable group placement and optional activity row.
 
-        Ordinary forks copy only the custom-group assignment: the source remains
-        an independent conversation and the child gets its own row on first use.
+        Ordinary visible forks get an independent, read row immediately. The
+        caller publishes it only after committing the child's session metadata.
+        Hidden side questions inherit placement without adding a visible row.
         A true successor (for example compact recovery) moves the existing row,
         preserving its id, ordering, pin/read state and turn lineage.  The shared
         group/event journal makes the mutation atomic, while the child-key checks
@@ -1164,7 +1166,7 @@ class ActivityService:
         child = str(child_sid or "").strip()
         if not source or not child or source == child:
             raise ValueError("distinct source and child sessions are required")
-        child_name, _, _ = self._metadata(child)
+        child_name, workspace, workspace_name = self._metadata(child)
         with self._lock:
             source_item = self._latest(source)
             child_item = self._latest(child)
@@ -1180,6 +1182,11 @@ class ActivityService:
             changed = False
             if source_group and not child_group:
                 self._group_assignments[child] = source_group
+                changed = True
+            if not successor and not activity_hidden and child_item is None:
+                child_item = self._fork_row(
+                    child, child_name, workspace, workspace_name, time.time())
+                self._events.append(child_item)
                 changed = True
             if successor:
                 if source_item is not None:
@@ -1213,6 +1220,72 @@ class ActivityService:
                 "group_id": self._group_assignments.get(child, ""),
                 "successor": successor,
             }
+
+    def _fork_row(
+        self, sid: str, name: str, workspace: str, workspace_name: str, at: float,
+    ) -> dict[str, Any]:
+        # Fork creation has finished, but the child has not run a turn. Never
+        # copy a predecessor's running owners, unread result, pin or turn count.
+        item = {
+            "id": uuid.uuid4().hex, "session_id": sid,
+            "kind": "fork", "activity_source": "fork",
+            "session_name": name, "workspace": workspace,
+            "workspace_name": workspace_name, "task_summary": name[:500],
+            "state": "completed", "read": True, "needs_attention": False,
+            "status_detail": "", "turn_count": 0,
+            "started_at": at, "finished_at": at, "updated_at": at,
+        }
+        self._apply_assignment_locked(item)
+        return item
+
+    def publish_session(self, sid: str) -> None:
+        """Notify clients after a fork becomes openable, without starting work."""
+        self.initialize_runtime_state()
+        with self._lock:
+            item = self._latest(sid)
+            if item is not None and self._filter_live([item]):
+                # The durable write already applies retention. Keep older rows
+                # in memory until publication so a failed fork can roll back
+                # without losing the row it would otherwise have evicted.
+                self._events = self._events[-_MAX_EVENTS:]
+                self._publish_locked(item=item)
+
+    def reconcile_fork_sessions(self) -> int:
+        """Backfill missing visible forks once at startup using cached metadata.
+
+        Fill only spare ledger capacity, newest forks first. Never evict task
+        history or resurrect old forks beyond the normal retention limit. This
+        repair stays off the event loop and out of snapshot/polling paths.
+        """
+        self.initialize_runtime_state()
+        candidates = [
+            meta for meta in sessions.list_sessions()
+            if meta.get("id") and meta.get("forked_from")
+            and not any(meta.get(key) for key in (
+                "activity_hidden", "runtime_shadow", "runtime_predecessor",
+                "runtime_successor"))
+        ]
+        with self._lock:
+            known = {row.get("session_id") for row in self._events}
+            missing = sorted(
+                (meta for meta in candidates if meta["id"] not in known),
+                key=lambda meta: float(meta.get("created_at") or 0),
+                reverse=True,
+            )[:max(0, _MAX_EVENTS - len(self._events))]
+            if not missing:
+                return 0
+            snapshot = self._group_event_snapshot_locked()
+            # Append in oldest-first order, matching ordinary ledger insertion.
+            for meta in reversed(missing):
+                sid = str(meta["id"])
+                name = str(meta.get("name") or "Muse task")
+                workspace = str(meta.get("cwd") or ROOT)
+                self._events.append(self._fork_row(
+                    sid, name, workspace, Path(workspace).name or "Workspace",
+                    float(meta.get("created_at") or 0)))
+            self._save_group_event_state_locked(snapshot)
+            self._publish_locked(resync=True)
+            return len(missing)
 
     def discard_session(self, sid: str) -> bool:
         """Remove a provisional child's Activity projection transactionally."""

--- a/backend/api_memory.py
+++ b/backend/api_memory.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from .auth import require_token
+from .observability import to_thread_io
 from .memory_config import (
     MemoryConfig,
     load_config,
@@ -110,15 +111,21 @@ def get_config() -> dict:
 
 @router.put("/config")
 async def put_config(config: dict, probe: bool = Query(default=True)) -> dict:
-    current = load_config(fresh=True)
+    current = await to_thread_io("memory.config_read", "", load_config, fresh=True)
     merged = _resolve_config_input(config, current)
-    if merged.enabled and probe:
+    retrieval_only = (
+        current.model_dump(exclude={"retrieval"})
+        == merged.model_dump(exclude={"retrieval"}))
+    if merged.enabled and probe and not retrieval_only:
         try:
             await engine.probe(merged)
         except Exception as exc:
             raise HTTPException(400, _failure_detail(exc)) from None
-    save_config(merged)
-    await engine.reconfigure()
+    await to_thread_io("memory.config_write", "", save_config, merged, owned=True)
+    # Recall reads these settings for each request. Changing its limit/budget
+    # does not invalidate provider connections or the current background job.
+    if not retrieval_only:
+        await engine.reconfigure()
     return {"config": public_config(merged), "status": await engine.status()}
 
 

--- a/backend/chat.py
+++ b/backend/chat.py
@@ -14088,8 +14088,19 @@ async def _run_submission_owned(sid, kind, request_id, payload, operation):
 async def submission_status(
     sid: str, request_id: str, kind: str = Query("turn", pattern="^(turn|queue)$"),
 ) -> dict:
+    import sqlite3
     from . import submissions
-    return await asyncio.to_thread(submissions.lookup, sid, kind, request_id)
+    try:
+        return await obs.to_thread_io(
+            "chat.submission_lookup", sid, submissions.lookup, sid, kind, request_id)
+    except sqlite3.OperationalError as exc:
+        if (getattr(exc, "sqlite_errorcode", 0) & 0xff) not in {
+            sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED,
+        }:
+            raise
+        raise HTTPException(
+            503, "Submission status unavailable; retry shortly",
+            headers={"Retry-After": "1"}) from None
 
 
 @router.post("/sessions/{sid}/submissions/{request_id}/cancel", dependencies=[Depends(require_token)])

--- a/backend/chat_successor.py
+++ b/backend/chat_successor.py
@@ -183,7 +183,8 @@ def commit_fork_lifecycle(
         activity.inherit_session(
             source_sid,
             child_sid,
-            **({"successor": True} if successor else {}),
+            **({"successor": True} if successor else (
+                {"activity_hidden": True} if child_meta.get("activity_hidden") else {})),
         )
         activity_projected = True
 
@@ -197,8 +198,10 @@ def commit_fork_lifecycle(
             if not _link_if_source_live():
                 raise ValueError("successor link changed")
             linked = True
-        elif not sess.publish_fork_child(child_sid):
-            raise ValueError("fork child disappeared before publication")
+        else:
+            if not sess.publish_fork_child(child_sid):
+                raise ValueError("fork child disappeared before publication")
+            activity.publish_session(child_sid)
 
         return {
             "child_sid": child_sid,

--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -50,6 +50,7 @@ _RECONCILE_RETRY_MAX_S = 30.0
 _MAX_WATCHED_ROOTS = 16
 _MAX_EVENT_SUBSCRIBERS = 64
 _MAX_CONCURRENT_RECONCILES = 4
+_RECONCILE_MAX_STALE_SCANS = 3
 _SCAN_CANCEL_GRACE_S = 0.25
 _SCAN_EXCHANGE_TIMEOUT_S = max(30.0, _SCAN_MAX_SECONDS * 3)
 _PARTIAL_RECONCILE_YIELD_S = 0.01
@@ -1566,6 +1567,7 @@ class FileWatchManager:
             "mutation_lock_wait_ms": 0,
             "scan_slot_wait_ms": 0,
             "scan_ms": 0,
+            "stale_scans": 0,
             "replay_ms": 0,
             "scanned_files": 0,
             "snapshot_files": 0,
@@ -1621,6 +1623,7 @@ class FileWatchManager:
                 scan_slot_wait_ms=metrics["scan_slot_wait_ms"],
                 mutation_lock_wait_ms=metrics["mutation_lock_wait_ms"],
                 scan_ms=metrics["scan_ms"],
+                stale_scans=metrics["stale_scans"],
                 replay_ms=metrics["replay_ms"],
                 scanned_files=metrics["scanned_files"],
                 snapshot_files=metrics["snapshot_files"],
@@ -1777,6 +1780,12 @@ class FileWatchManager:
                 # A token change invalidates accumulated resume state; a new
                 # applicability window must establish its own complete snapshot.
                 state.scan_progress.clear()
+                metrics["stale_scans"] = int(metrics["stale_scans"]) + 1
+                if metrics["stale_scans"] >= _RECONCILE_MAX_STALE_SCANS:
+                    # Busy workspaces can invalidate every snapshot. Retain
+                    # the last-good index and let the existing retry backoff
+                    # yield disk/CPU time instead of looping through full walks.
+                    raise WorkspaceScanIncomplete("workspace changed during repeated scans")
                 continue
             break
         state.initialized = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -449,6 +449,12 @@ async def _lifespan(app: FastAPI):
         _asyncio.to_thread(_activity.initialize_runtime_state),
         _asyncio.to_thread(_todos.initialize_runtime_state),
     )
+    repaired_fork_activity = await _asyncio.to_thread(
+        _activity.reconcile_fork_sessions)
+    if repaired_fork_activity:
+        sys.stderr.write(
+            f"[muselab] restored {repaired_fork_activity} fork activity row(s) on startup\n")
+        sys.stderr.flush()
     # Older releases allowed a successor CLI's synthetic ``stopped`` record to
     # overwrite the predecessor's real terminal state. Repair each runtime
     # chain from its oldest owner before applying restart recovery, so a true

--- a/backend/memory_client.py
+++ b/backend/memory_client.py
@@ -195,6 +195,7 @@ def _json_data(facts: list[str]) -> str:
 
 def _render_block_with_count(
     mems: list[str], max_chars: int = _MAX_BLOCK_CHARS,
+    *, max_items: int = _SEARCH_LIMIT,
 ) -> tuple[str, int]:
     """Render untrusted facts and return the number actually injected."""
     if not mems:
@@ -207,7 +208,7 @@ def _render_block_with_count(
     )
     suffix = "\n</recalled_memory_data>\n"
     accepted: list[str] = []
-    for memory in mems[:_SEARCH_LIMIT]:
+    for memory in mems[:max_items]:
         candidate = prefix + _json_data([*accepted, memory]) + suffix
         if len(candidate) > max_chars:
             break
@@ -321,10 +322,19 @@ async def search_context(query: str, session_id: str) -> str:
             rows = await engine.recall(query, session_id)
             clean_rows = [(row, clean) for row in rows
                           if (clean := _sanitize(str(row.get("content", ""))))]
+            retrieval = engine.config().retrieval
             block, count = _render_block_with_count(
                 [clean for row, clean in clean_rows],
-                max_chars=engine.config().retrieval.max_context_chars)
+                max_chars=retrieval.max_context_chars,
+                max_items=retrieval.final_limit)
             trace = engine.peek_recall_trace(session_id)
+            perf_event(
+                "memory.recall_context", session=short_id(session_id) or "none",
+                recall_id=(trace or {}).get("id", "none"),
+                matched_count=len(rows), sanitized_count=len(clean_rows), count=count,
+                final_limit=retrieval.final_limit,
+                max_context_chars=retrieval.max_context_chars, context_chars=len(block),
+                context_limited=count < min(len(clean_rows), retrieval.final_limit))
             if trace is not None:
                 trace["matched_count"] = trace["count"]
                 trace["count"] = count

--- a/backend/memory_config.py
+++ b/backend/memory_config.py
@@ -139,6 +139,11 @@ def load_config(*, fresh: bool = False) -> MemoryConfig:
         stamp = path.stat().st_mtime_ns
     except OSError:
         stamp = -1
+    # Saving holds the writer lock across fsync/replace. Readers can keep
+    # using the last committed immutable snapshot while that write is pending.
+    cached = _cached
+    if not fresh and cached and cached[0] == stamp:
+        return cached[1].model_copy(deep=True)
     with _LOCK:
         if not fresh and _cached and _cached[0] == stamp:
             return _cached[1].model_copy(deep=True)

--- a/backend/memory_engine.py
+++ b/backend/memory_engine.py
@@ -1452,7 +1452,7 @@ class MemoryEngine:
                     lambda store: store.recent_evidence(
                         cfg.owner_id, session_id, role="user", limit=2), deadline=deadline))
                 result = await self._recall_candidates(
-                    cfg, query, recent, deadline, stages, stage)
+                    cfg, query, recent, deadline, stages, stage, recall_id)
                 return result
         except asyncio.CancelledError:
             cancelled = True
@@ -1482,7 +1482,7 @@ class MemoryEngine:
                        duration_ms=round(latency, 1), count=len(result),
                        status=status, timeout_ms=timeout_ms, **fields)
 
-    async def _recall_candidates(self, cfg, query, recent, deadline, stages, stage):
+    async def _recall_candidates(self, cfg, query, recent, deadline, stages, stage, recall_id):
         prior = [str(item.get("content", ""))[:1000] for item in recent
                  if item.get("content")]
         # Bound what goes to the embedder. Local CPU BGE-M3 latency scales
@@ -1493,11 +1493,29 @@ class MemoryEngine:
         # lives there; earlier turns only disambiguate it.
         retrieval_query = "\n".join([*prior, query])[-_RECALL_QUERY_CHARS:]
 
+        async def dependency(name, operation):
+            started = time.perf_counter()
+            status = "ok"
+            try:
+                return await operation()
+            except asyncio.CancelledError:
+                status = ("timeout" if deadline is not None
+                          and time.perf_counter() >= deadline else "cancelled")
+                raise
+            except Exception:
+                status = "error"
+                raise
+            finally:
+                perf_event("memory.recall_dependency", recall_id=recall_id,
+                           dependency=name, status=status,
+                           duration_ms=round((time.perf_counter() - started) * 1000, 1))
+
         async def dense() -> list[dict]:
-            vector = (await EmbeddingProvider(cfg.embedding).embed([retrieval_query]))[0]
-            return await vector_store(cfg.vector).search(
-                vector, owner_id=cfg.owner_id,
-                limit=cfg.retrieval.dense_candidates)
+            vectors = await dependency("embedding", lambda: EmbeddingProvider(
+                cfg.embedding).embed([retrieval_query]))
+            return await dependency("vector", lambda: vector_store(cfg.vector).search(
+                vectors[0], owner_id=cfg.owner_id,
+                limit=cfg.retrieval.dense_candidates))
 
         async def lexical() -> list[dict]:
             return await self._recall_store_call(lambda store: store.lexical_search(

--- a/backend/memory_store.py
+++ b/backend/memory_store.py
@@ -260,25 +260,32 @@ class MemoryStore:
                 except OSError as exc:
                     log.debug("could not chmod %s: %s", sibling, exc)
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         # Recall must never run schema migration or wait ten seconds for a writer.
         target = self.path.absolute().as_uri() + "?mode=ro" if self._read_only else self.path
         conn = sqlite3.connect(target, uri=self._read_only,
                                timeout=0.05 if self._read_only else 10,
                                isolation_level=None)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys=ON")
-        conn.execute("PRAGMA busy_timeout=50" if self._read_only
-                     else "PRAGMA busy_timeout=10000")
-        if self._read_only:
-            conn.execute("PRAGMA query_only=ON")
-            deadline = getattr(self, "_query_deadline", None)
-            cancelled = getattr(self, "_read_cancelled", None)
-            if deadline is not None or cancelled is not None:
-                conn.set_progress_handler(
-                    lambda: int((deadline is not None and time.perf_counter() >= deadline)
-                                or (cancelled is not None and cancelled.is_set())), 1000)
-        return conn
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.execute("PRAGMA busy_timeout=50" if self._read_only
+                         else "PRAGMA busy_timeout=10000")
+            if self._read_only:
+                conn.execute("PRAGMA query_only=ON")
+                deadline = getattr(self, "_query_deadline", None)
+                cancelled = getattr(self, "_read_cancelled", None)
+                if deadline is not None or cancelled is not None:
+                    conn.set_progress_handler(
+                        lambda: int((deadline is not None and time.perf_counter() >= deadline)
+                                    or (cancelled is not None and cancelled.is_set())), 1000)
+            with conn:
+                yield conn
+        finally:
+            # Do not defer SQLite handles and WAL cleanup to cyclic GC, which
+            # may otherwise run on the application's event-loop thread.
+            conn.close()
 
     @contextmanager
     def read_budget(self, deadline: float | None, *, cancel_event=None):

--- a/backend/submissions.py
+++ b/backend/submissions.py
@@ -17,8 +17,23 @@ from .private_storage import ensure_private_directory, ensure_private_regular_fi
 
 
 @contextmanager
-def _connect():
+def _connect(*, read_only: bool = False):
     base = sessions.SESS_DIR / ".submissions"
+    path = base / "receipts.sqlite3"
+    if read_only:
+        if (not ensure_private_directory(base, create=False)
+                or not ensure_private_regular_file(path)):
+            yield None
+            return
+        conn = sqlite3.connect(path.absolute().as_uri() + "?mode=ro",
+                               uri=True, timeout=.2)
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA query_only=ON")
+            yield conn
+        finally:
+            conn.close()
+        return
     ensure_private_directory(base)
     path = base / "receipts.sqlite3"
     if not ensure_private_regular_file(path):
@@ -31,6 +46,9 @@ def _connect():
     conn = sqlite3.connect(path, timeout=10)
     conn.row_factory = sqlite3.Row
     try:
+        # Readers must stay available while admission/cancellation is writing.
+        # Keep FULL durability for the idempotency receipt's commit boundary.
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=FULL")
         conn.execute("""CREATE TABLE IF NOT EXISTS receipts (
           sid TEXT NOT NULL, kind TEXT NOT NULL, request_id TEXT NOT NULL,
@@ -83,7 +101,11 @@ def finish(sid: str, kind: str, request_id: str, state: str, result: dict) -> di
 
 
 def lookup(sid: str, kind: str, request_id: str) -> dict:
-    with _connect() as conn:
+    with _connect(read_only=True) as conn:
+        if conn is None or conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='receipts'"
+        ).fetchone() is None:
+            return {"state": "not_found"}
         return _public(conn.execute(
             "SELECT * FROM receipts WHERE sid=? AND kind=? AND request_id=?",
             (sid, kind, request_id)).fetchone())

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -36668,6 +36668,11 @@ function portal() {
             if (pinRank) return pinRank;
             return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
           }
+          // The built-in inbox always follows activity time, including rows
+          // that acquired manual positions while moving between custom lanes.
+          if (groupKey === "custom:__ungrouped__") {
+            return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
+          }
           if (custom) {
             const aManual = Number.isFinite(Number(a.group_order));
             const bManual = Number.isFinite(Number(b.group_order));
@@ -36677,9 +36682,6 @@ function portal() {
             if (aManual && bManual) {
               const order = Number(a.group_order) - Number(b.group_order);
               if (order) return order;
-            }
-            if (groupKey === "custom:__ungrouped__") {
-              return this.activityEventTimestamp(b) - this.activityEventTimestamp(a);
             }
             const pinRank = Number(!!b.pinned) - Number(!!a.pinned);
             if (pinRank) return pinRank;
@@ -37224,7 +37226,7 @@ function portal() {
       if (this._activityGroupPending[eventId]) return false;
       const target = String(groupId || "");
       const previous = String(item.group_id || "");
-      const hasPlacement = beforeEventId !== null;
+      const hasPlacement = !!target && beforeEventId !== null;
       this.closeActivityMoveMenu(true);
       if (!hasPlacement && target === previous) return true;
       const previousPlacement = new Map(this.activity.events.map(row => [

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -58,12 +58,17 @@ def backend_url(tmp_path_factory):
             encoding="utf-8",
         )
 
+    # Real fork tests write SDK transcripts. Keep vendor storage and legacy
+    # migration sources inside this fixture, away from developer state.
+    (root / "tmp").mkdir()
     port = _free_port()
     env = {
         **os.environ,
         "MUSELAB_TOKEN": TEST_TOKEN,
         "MUSELAB_ROOT": str(root),
         "MUSELAB_SESSIONS_DIR": str(root / "sessions"),
+        "XDG_STATE_HOME": str(root / "state"),
+        "TMPDIR": str(root / "tmp"),
         "MUSELAB_PORT": str(port),
         "MUSELAB_ENV_PATH": str(root / "e2e.env"),
         "MUSELAB_MODEL": "deepseek-v4-pro",

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -2268,7 +2268,7 @@ def test_activity_row_targeted_lookup_opens_mobile_session_and_workspace(
     assert target_history_requests, "target session history was never loaded"
 
 
-def test_real_fork_appears_in_ungrouped_without_a_new_turn(page, backend_url, auth_token):
+def test_real_fork_appears_in_ungrouped_without_a_new_turn(page, backend_url, auth_token, request):
     """Exercise the real SDK fork, API, Activity SSE and persisted snapshot."""
     from claude_agent_sdk._internal.sessions import _sanitize_path
 
@@ -2277,6 +2277,17 @@ def test_real_fork_appears_in_ungrouped_without_a_new_turn(page, backend_url, au
                                  data={"name": "Activity fork fixture"})
     assert response.ok, response.text()
     source = response.json()
+    created = [source["id"]]
+
+    def cleanup():
+        # The backend is shared across the suite. Later browser logins must
+        # not adopt this fixture's real transcript as their starting history.
+        page.goto("about:blank")
+        for sid in reversed(created):
+            deleted = page.request.delete(f"{backend_url}/api/chat/sessions/{sid}", headers=headers)
+            assert deleted.ok, deleted.text()
+
+    request.addfinalizer(cleanup)
     root = Path(source["cwd"])
     # The E2E backend puts SDK transcripts under its own disposable root.
     project = root / "state" / "muselab" / "vendor-cli" / "projects" / _sanitize_path(str(root))
@@ -2319,6 +2330,7 @@ def test_real_fork_appears_in_ungrouped_without_a_new_turn(page, backend_url, au
         }""", {"sid": source["id"], "boundary": assistant_id})
     assert fork_response.value.ok, fork_response.value.text()
     child = fork_response.value.json()
+    created.append(child["id"])
     page.wait_for_function("""sid => document.querySelector('#app')._x_dataStack[0]
         .activity.events.some(row => row.session_id === sid)""", arg=child["id"], timeout=5000)
     page.evaluate("""() => {

--- a/tests/e2e/test_activity_center.py
+++ b/tests/e2e/test_activity_center.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
+import uuid
 
 import pytest
 
@@ -2264,3 +2266,136 @@ def test_activity_row_targeted_lookup_opens_mobile_session_and_workspace(
     assert target_sid not in result["listRequests"][0]
     assert target_sid in result["listRequests"][1]
     assert target_history_requests, "target session history was never loaded"
+
+
+def test_real_fork_appears_in_ungrouped_without_a_new_turn(page, backend_url, auth_token):
+    """Exercise the real SDK fork, API, Activity SSE and persisted snapshot."""
+    from claude_agent_sdk._internal.sessions import _sanitize_path
+
+    headers = {"X-Auth-Token": auth_token}
+    response = page.request.post(f"{backend_url}/api/chat/sessions", headers=headers,
+                                 data={"name": "Activity fork fixture"})
+    assert response.ok, response.text()
+    source = response.json()
+    root = Path(source["cwd"])
+    # The E2E backend puts SDK transcripts under its own disposable root.
+    project = root / "state" / "muselab" / "vendor-cli" / "projects" / _sanitize_path(str(root))
+    project.mkdir(parents=True, exist_ok=True)
+    user_id, assistant_id = str(uuid.uuid4()), str(uuid.uuid4())
+    transcript = [
+        {"type": "user", "uuid": user_id, "parentUuid": None,
+         "sessionId": source["id"], "cwd": str(root),
+         "timestamp": "2026-01-01T00:00:00.000Z",
+         "message": {"role": "user", "content": "Synthetic fork question"}},
+        {"type": "assistant", "uuid": assistant_id, "parentUuid": user_id,
+         "sessionId": source["id"], "cwd": str(root),
+         "timestamp": "2026-01-01T00:00:01.000Z",
+         "message": {"role": "assistant", "stop_reason": "end_turn",
+                     "content": [{"type": "text", "text": "Synthetic fork answer"}]}},
+    ]
+    (project / f"{source['id']}.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in transcript), encoding="utf-8")
+    _login(page, backend_url, auth_token)
+    page.evaluate("""async () => {
+        const app = document.querySelector('#app')._x_dataStack[0];
+        await app.openActivityCenter();
+        app.setActivityView('groups');
+    }""")
+    page.wait_for_function("""() => document.querySelector('#app')._x_dataStack[0]
+        ._activityLiveSource?.readyState === EventSource.OPEN""")
+    # Suppress HTTP snapshots after the initial load: only SSE can deliver the
+    # new row, rather than a convenient poll hiding a broken publication.
+    def block_snapshot(route):
+        if '/api/activity/events' in route.request.url:
+            route.continue_()
+        else:
+            route.fulfill(status=304)
+
+    page.route("**/api/activity?*", block_snapshot)
+    with page.expect_response(f"**/api/chat/sessions/{source['id']}/fork") as fork_response:
+        page.evaluate("""async ({sid, boundary}) => {
+            const app = document.querySelector('#app')._x_dataStack[0];
+            await app.forkConversation(sid, boundary);
+        }""", {"sid": source["id"], "boundary": assistant_id})
+    assert fork_response.value.ok, fork_response.value.text()
+    child = fork_response.value.json()
+    page.wait_for_function("""sid => document.querySelector('#app')._x_dataStack[0]
+        .activity.events.some(row => row.session_id === sid)""", arg=child["id"], timeout=5000)
+    page.evaluate("""() => {
+        const app = document.querySelector('#app')._x_dataStack[0];
+        app.activity.show = true;
+        app.setActivityView('groups');
+    }""")
+    lane = page.locator('.activity-group.is-custom').filter(
+        has=page.locator('.activity-custom-group-head > strong', has_text=re.compile('未分组|Ungrouped')))
+    expect(lane.locator('.activity-row').filter(has_text=child['name'])).to_be_visible()
+    rows = page.request.get(f"{backend_url}/api/activity?limit=500", headers=headers).json()['events']
+    fork_row = next(row for row in rows if row['session_id'] == child['id'])
+    assert fork_row['turn_count'] == 0 and fork_row['read'] is True
+    assert not fork_row.get('group_id')
+
+    page.unroute("**/api/activity?*", block_snapshot)
+    page.reload(wait_until="domcontentloaded")
+    _login(page, backend_url, auth_token)
+    page.evaluate("""async () => {
+        const app = document.querySelector('#app')._x_dataStack[0];
+        await app.openActivityCenter();
+        app.setActivityView('groups');
+    }""")
+    expect(page.locator('.activity-row').filter(has_text=child['name'])).to_be_visible()
+
+
+def test_ungrouped_uses_latest_activity_despite_saved_manual_positions(page, backend_url, auth_token):
+    rows = [
+        {"id": "old", "session_id": "old", "session_name": "Old fixture",
+         "state": "completed", "read": True, "updated_at": 100, "group_order": 0, "pinned": True},
+        {"id": "new", "session_id": "new", "session_name": "Newest fixture",
+         "state": "completed", "read": True, "updated_at": 300, "group_order": 9},
+        {"id": "middle", "session_id": "middle", "session_name": "Middle fixture",
+         "state": "waiting_approval", "read": False, "updated_at": 200},
+        {"id": "manual-first", "session_id": "manual-first", "session_name": "Manual first",
+         "state": "completed", "read": True, "updated_at": 10, "group_order": 0, "group_id": "manual"},
+        {"id": "manual-last", "session_id": "manual-last", "session_name": "Manual last",
+         "state": "completed", "read": True, "updated_at": 400, "group_order": 1, "group_id": "manual"},
+    ]
+    revision = 1
+
+    def snapshot(route):
+        route.fulfill(json={
+            "events": rows, "generation": "newest-time-fixture", "revision": revision,
+            "summary": {"generation": "newest-time-fixture", "revision": revision,
+                        "running": 1, "unread": 0, "attention": 1, "workspaces": []},
+            "custom_groups": [{"id": "manual", "name": "Manual group", "color": "blue"}],
+            "group_order": ["manual", "__ungrouped__"],
+        })
+
+    page.route("**/api/activity?*", snapshot)
+
+    def open_groups():
+        _login(page, backend_url, auth_token)
+        page.evaluate("""async () => {
+            const app = document.querySelector('#app')._x_dataStack[0];
+            app._stopActivityEvents();
+            await app.openActivityCenter();
+            app.setActivityView('groups');
+        }""")
+
+    def lane(title):
+        return page.locator('.activity-group.is-custom').filter(
+            has=page.locator('.activity-custom-group-head > strong', has_text=title))
+
+    open_groups()
+    ungrouped = lane(re.compile('未分组|Ungrouped')).locator('.activity-session-name')
+    expect(ungrouped).to_have_text(['Newest fixture', 'Middle fixture', 'Old fixture'])
+    expect(lane('Manual group').locator('.activity-session-name')).to_have_text(
+        ['Manual first', 'Manual last'])
+    # A new task transition must invalidate cached ordering immediately.
+    rows[0]['updated_at'] = 500
+    revision = 2
+    page.evaluate("""item => document.querySelector('#app')._x_dataStack[0]
+        ._applyActivityUpdate({generation: 'newest-time-fixture', revision: 2, item})""", rows[0])
+    expect(ungrouped).to_have_text(['Old fixture', 'Newest fixture', 'Middle fixture'])
+    page.reload(wait_until='domcontentloaded')
+    open_groups()
+    expect(lane(re.compile('未分组|Ungrouped')).locator('.activity-session-name')).to_have_text(
+        ['Old fixture', 'Newest fixture', 'Middle fixture'])

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -9,6 +9,8 @@ from backend.activity import ActivityService
 
 
 def _service(tmp_path, monkeypatch):
+    # app_module reloads backend packages; use the matching module generation.
+    from backend.activity import ActivityService
     service = ActivityService(tmp_path)
     workspace = str(tmp_path / "ws")
     monkeypatch.setattr(
@@ -612,7 +614,9 @@ def test_ordinary_fork_inherits_group_without_stealing_source_lineage(
 
     inherited = service.inherit_session("source", "child")
 
-    assert inherited["item"] is None
+    assert inherited["item"]["session_id"] == "child"
+    assert inherited["item"]["turn_count"] == 0
+    assert inherited["item"]["read"] is True
     assert inherited["group_id"] == group["id"]
     assert next(row for row in service.list() if row["session_id"] == "source")
     child = service.start("child", summary="new branch")
@@ -1191,3 +1195,96 @@ def test_activity_group_endpoints_manage_and_assign_custom_groups(
     )
     assert deleted.status_code == 200
     assert "group_id" not in service.list()[0]
+
+
+@pytest.mark.parametrize("hidden", [False, True])
+def test_fork_gets_independent_read_row_before_first_turn(tmp_path, monkeypatch, hidden):
+    service = _service(tmp_path, monkeypatch)
+    source = service.start("source", summary="source turn", owner_id="source-owner")
+    service.set_pin(source["id"], True)
+    before = next(row for row in service.list() if row["session_id"] == "source")
+    revision = service.revision
+
+    result = service.inherit_session("source", "child", activity_hidden=hidden)
+    assert service.revision == revision  # No SSE before the child is public.
+    assert next(row for row in service.list() if row["session_id"] == "source") == before
+    if hidden:
+        assert result["item"] is None
+        assert service._latest("child") is None
+        return
+    child = result["item"]
+    assert child["id"] != source["id"]
+    assert child["state"] == "completed" and child["read"] is True
+    assert child["turn_count"] == 0
+    assert not child.get("group_id")
+    assert not child.get("pinned")
+    assert not child.get("owner_id") and not child.get("active_owner_ids")
+    assert service.summary()["running"] == 1
+    assert service.summary()["unread"] == 0
+    assert service.inherit_session("source", "child")["item"] == child
+    restarted = _service(tmp_path, monkeypatch)
+    assert restarted._latest("child") == child
+    first_turn = restarted.start("child", summary="first child turn")
+    assert first_turn["id"] == child["id"] and first_turn["turn_count"] == 1
+
+
+def test_startup_backfills_only_visible_forks_and_preserves_placement(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    activity_globals = service.reconcile_fork_sessions.__globals__
+    existing = service.start("existing", summary="keep existing")
+    group = service.create_group("Branches", "green")["group"]
+    service._group_assignments["missing"] = group["id"]
+    service._save_group_state()
+    metadata = [
+        {"id": "missing", "name": "Older fork", "forked_from": "source", "created_at": 123},
+        {"id": "existing", "forked_from": "source", "created_at": 124},
+        {"id": "ungrouped", "forked_from": "source", "created_at": 125},
+        {"id": "ordinary", "created_at": 126},
+        *({"id": key, "forked_from": "source", key: True, "created_at": 127}
+          for key in ("activity_hidden", "runtime_shadow", "runtime_predecessor", "runtime_successor")),
+    ]
+    monkeypatch.setattr(activity_globals["sessions"], "list_sessions", lambda: metadata)
+    assert service.reconcile_fork_sessions() == 2
+    child = service._latest("missing")
+    assert child["group_id"] == group["id"]
+    assert child["updated_at"] == 123 and child["turn_count"] == 0
+    assert child["read"] is True
+    assert not service._latest("ungrouped").get("group_id")
+    assert service._latest("existing") == existing
+    assert {row["session_id"] for row in service.list()} == {"missing", "existing", "ungrouped"}
+    revision = service.revision
+    saved = service.path.read_bytes()
+    assert service.reconcile_fork_sessions() == 0
+    assert service.revision == revision and service.path.read_bytes() == saved
+    restarted = ActivityService(tmp_path)
+    assert restarted._latest("missing") == child
+    assert restarted.reconcile_fork_sessions() == 0
+
+
+def test_startup_fork_repair_respects_retention_and_rolls_back_failed_write(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    activity_globals = service.reconcile_fork_sessions.__globals__
+    source = service.start("source")
+    monkeypatch.setitem(activity_globals, "_MAX_EVENTS", 2)
+    monkeypatch.setattr(activity_globals["sessions"], "list_sessions", lambda: [
+        {"id": "source"},
+        {"id": "old", "forked_from": "source", "created_at": 1},
+        {"id": "new", "forked_from": "source", "created_at": 2},
+    ])
+    real_save = service._save
+    calls = 0
+
+    def fail_once():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("fork repair disk failure")
+        real_save()
+
+    monkeypatch.setattr(service, "_save", fail_once)
+    with pytest.raises(OSError, match="fork repair disk failure"):
+        service.reconcile_fork_sessions()
+    assert service.list() == [source]
+    assert service.reconcile_fork_sessions() == 1
+    assert {row["session_id"] for row in service.list()} == {"source", "new"}
+    assert service.reconcile_fork_sessions() == 0

--- a/tests/test_chat_endpoints.py
+++ b/tests/test_chat_endpoints.py
@@ -1955,7 +1955,7 @@ def test_fork_inherits_session_settings_and_records_lineage(
     assert body["activity_hidden"] is True
     assert body["runtime_profile"] == "side_question"
     assert body["cwd"] == source.json()["cwd"]
-    assert activity_inherits == [(sid, new_sid, {})]
+    assert activity_inherits == [(sid, new_sid, {"activity_hidden": True})]
 
 
 def test_fork_activity_inheritance_failure_removes_provisional_child(
@@ -3196,3 +3196,74 @@ async def test_force_stop_finalizes_attachments_for_every_owner_state(
         with chat_mod._image_store_lock:
             chat_mod._image_store.pop(aid, None)
             chat_mod._staged_attachment_claims.pop(aid, None)
+
+
+@pytest.mark.parametrize("hidden,grouped", [(False, False), (False, True), (True, False)])
+def test_fork_activity_is_published_only_when_child_is_openable(
+    chat_mod, client, monkeypatch, hidden, grouped,
+):
+    from backend.activity import ActivityService, activity
+
+    headers = {"X-Auth-Token": TEST_TOKEN}
+    source = client.post("/api/chat/sessions", headers=headers,
+                         json={"name": "fork activity source"}).json()
+    source_row = activity.start(source["id"], summary="source background work", owner_id="source-owner")
+    if grouped:
+        group = activity.create_group("Fork fixtures", "green")["group"]
+        activity.set_group(source_row["id"], group["id"])
+    source_before = activity._latest(source["id"]).copy()
+    child_sid = "25252525-3636-4789-89ab-898989898989"
+    monkeypatch.setattr(chat_mod, "sdk_fork_session",
+                        lambda *args, **kwargs: SimpleNamespace(session_id=child_sid))
+    monkeypatch.setattr(chat_mod, "_runtime_fork_uuid_mapping", lambda sid: {})
+    updates = []
+    real_publish = activity._publish_locked
+
+    def inspect_publish(**kwargs):
+        item = kwargs.get("item")
+        if item and item.get("session_id") == child_sid:
+            assert child_sid in {row["id"] for row in chat_mod.sess.list_sessions()}
+            assert chat_mod.sess.get_session_meta(child_sid)["runtime_shadow"] is False
+            updates.append(dict(item))
+        return real_publish(**kwargs)
+
+    monkeypatch.setattr(activity, "_publish_locked", inspect_publish)
+    response = client.post(f"/api/chat/sessions/{source['id']}/fork", headers=headers,
+                           json={"activity_hidden": hidden})
+    assert response.status_code == 200, response.text
+    assert activity._latest(source["id"]) == source_before
+    events = client.get("/api/activity?limit=500", headers=headers).json()["events"]
+    children = [row for row in events if row["session_id"] == child_sid]
+    if hidden:
+        assert children == updates == []
+        return
+    assert len(children) == len(updates) == 1
+    child = children[0]
+    assert child["turn_count"] == 0 and child["read"] is True
+    assert child["group_id"] == group["id"] if grouped else not child.get("group_id")
+    restarted = ActivityService(activity.path.parent.parent)
+    assert restarted._latest(child_sid) == child
+
+
+def test_failed_fork_publication_removes_activity_without_evicting_source(
+    chat_mod, client, monkeypatch,
+):
+    from backend import activity as module
+
+    activity = module.activity
+    headers = {"X-Auth-Token": TEST_TOKEN}
+    source = client.post("/api/chat/sessions", headers=headers,
+                         json={"name": "retained source"}).json()
+    source_row = activity.start(source["id"], summary="retained activity")
+    monkeypatch.setattr(module, "_MAX_EVENTS", 1)
+    child_sid = "26262626-3737-489a-8abc-909090909090"
+    monkeypatch.setattr(chat_mod, "sdk_fork_session",
+                        lambda *args, **kwargs: SimpleNamespace(session_id=child_sid))
+    monkeypatch.setattr(chat_mod, "_runtime_fork_uuid_mapping", lambda sid: {})
+    monkeypatch.setattr(chat_mod.sess, "publish_fork_child", lambda sid: False)
+    monkeypatch.setattr(chat_mod, "sdk_delete_session", lambda *args, **kwargs: None)
+    response = client.post(f"/api/chat/sessions/{source['id']}/fork", headers=headers, json={})
+    assert response.status_code == 400
+    assert chat_mod.sess.get_session_meta(child_sid) is None
+    assert activity.list() == [source_row]
+    assert json.loads(activity.path.read_text()) == [source_row]

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -3396,3 +3396,44 @@ async def test_scan_exchange_deadline_releases_shared_worker(app_module, temp_ro
         guard.cancel()
         manager._scan_cancel.set()
         await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_continuous_watcher_mutations_back_off_instead_of_rescanning_forever(
+    app_module, temp_root, monkeypatch,
+):
+    import backend.file_events as module
+
+    class Store:
+        def current_cursor(self, workspace_id):
+            return 0
+
+        def apply_reconcile_snapshot(self, *args, **kwargs):
+            raise AssertionError("invalidated snapshot must not replace the index")
+
+        def close(self):
+            pass
+
+    manager = module.FileWatchManager(Store())
+    state = module._WatchState(root=temp_root, workspace_id="busy-fixture", initialized=True)
+    scans = 0
+
+    async def scan(current):
+        nonlocal scans
+        scans += 1
+        current.native_mutation_revision += 1
+        current.scan_progress["fixture"] = "must be discarded"
+        if scans > 3:
+            pytest.fail("reconcile kept scanning despite continuous invalidation")
+        return [], {}
+
+    monkeypatch.setattr(manager, "_scan_workspace", scan)
+    try:
+        with pytest.raises(module.WorkspaceScanIncomplete):
+            await manager._reconcile_and_broadcast(state)
+        assert scans == 3
+        assert not state.scan_progress
+        assert state.initialized and state.reconcile_retry_at > module.monotonic()
+        assert state.reconcile_failures == 1
+    finally:
+        await manager.shutdown()

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1922,7 +1922,11 @@ def test_activity_center_groups_by_attention_order_and_read_state():
     custom_sort = app.index("const aManual = Number.isFinite")
     assert "if (aManual !== bManual) return aManual ? 1 : -1" in app[custom_sort:]
     assert "Number(a.group_order) - Number(b.group_order)" in app[custom_sort:]
-    assert 'groupKey === "custom:__ungrouped__"' in app[custom_sort:]
+    # The built-in inbox must apply time ordering before saved manual positions.
+    ungrouped_sort = app.index('groupKey === "custom:__ungrouped__"')
+    assert ungrouped_sort < custom_sort
+    assert "return this.activityEventTimestamp(b) - this.activityEventTimestamp(a)" in (
+        app[ungrouped_sort:custom_sort])
     assert "this._activityAppliedSeq = ++this._activityRequestSeq" in app
     assert '"/api/activity/events-ticket"' in app
     assert "new EventSource(" in app

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -301,3 +301,102 @@ def test_recall_timeout_roundtrips_and_negative_is_rejected(client, auth, timeou
     assert client.get("/api/memory/config", headers=auth).json()["retrieval"]["soft_timeout_ms"] == timeout_ms
     config["retrieval"]["soft_timeout_ms"] = -1
     assert client.put("/api/memory/config?probe=false", headers=auth, json=config).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_slow_config_save_keeps_other_requests_and_cached_reads_responsive(app_module, monkeypatch):
+    import asyncio
+    import threading
+    import time
+    import httpx
+    from backend import api_memory, memory_config
+    from tests.conftest import TEST_TOKEN
+
+    current = memory_config.MemoryConfig()
+    memory_config.save_config(current)
+    real_fsync = memory_config.os.fsync
+    real_save = api_memory.save_config
+    saving = threading.local()
+    writing = threading.Event()
+    release = threading.Event()
+
+    def slow_fsync(fd):
+        if getattr(saving, "active", False):
+            writing.set()
+            release.wait(0.6)
+        real_fsync(fd)
+
+    def save(config):
+        saving.active = True
+        try:
+            return real_save(config)
+        finally:
+            saving.active = False
+
+    async def status():
+        return {"enabled": False}
+
+    async def reconfigure():
+        pass
+
+    monkeypatch.setattr(memory_config.os, "fsync", slow_fsync)
+    monkeypatch.setattr(api_memory, "save_config", save)
+    monkeypatch.setattr(api_memory.engine, "status", status)
+    monkeypatch.setattr(api_memory.engine, "reconfigure", reconfigure)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app_module.app),
+                                base_url="http://fixture") as client:
+        assert (await client.get("/api/meta", headers={"X-Auth-Token": TEST_TOKEN})).status_code == 200
+        started = time.perf_counter()
+        task = asyncio.create_task(client.put("/api/memory/config?probe=false",
+            headers={"X-Auth-Token": TEST_TOKEN}, json=current.model_dump()))
+        try:
+            for _ in range(100):
+                if writing.is_set():
+                    break
+                await asyncio.sleep(.005)
+            assert writing.is_set()
+            # This cache lookup is used by active chat/memory code on the loop.
+            assert memory_config.load_config().mode == "off"
+            response = await client.get("/api/meta", headers={"X-Auth-Token": TEST_TOKEN})
+            assert response.status_code == 200
+            assert time.perf_counter() - started < .3
+            assert not task.done()
+        finally:
+            release.set()
+            response = await task
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_retrieval_settings_save_does_not_probe_or_restart_running_worker(app_module, monkeypatch):
+    from backend import api_memory, memory_config
+
+    cfg = memory_config.MemoryConfig.model_validate({
+        "mode": "active", "generation_model": "fixture:model",
+        "embedding": {"base_url": "http://fixture", "model": "fixture"},
+        "vector": {"url": "http://fixture"},
+    })
+    memory_config.save_config(cfg)
+    calls = []
+
+    async def probe(*args):
+        calls.append("probe")
+
+    async def reconfigure():
+        calls.append("restart")
+
+    async def status():
+        return {"enabled": True}
+
+    monkeypatch.setattr(api_memory.engine, "probe", probe)
+    monkeypatch.setattr(api_memory.engine, "reconfigure", reconfigure)
+    monkeypatch.setattr(api_memory.engine, "status", status)
+    changed = cfg.model_copy(deep=True)
+    changed.retrieval.final_limit = 15
+    changed.retrieval.soft_timeout_ms = 0
+    result = await api_memory.put_config(changed.model_dump(), probe=True)
+    assert result["config"]["retrieval"]["final_limit"] == 15
+    assert calls == []
+    changed.embedding.model = "new-embedding-model"
+    await api_memory.put_config(changed.model_dump(), probe=True)
+    assert calls == ["probe", "restart"]

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -1,5 +1,6 @@
 """Episode consolidation, verification, hybrid recall and Skill approval."""
 import asyncio
+import json
 import sqlite3
 import threading
 import time
@@ -1367,13 +1368,13 @@ def test_recall_retries_lexical_lock_contention_instead_of_returning_empty(
     attempts = []
 
     class Connection:
-        def __init__(self): self.connection = original()
+        def __init__(self): self.context = original()
 
         def __enter__(self):
-            self.connection.__enter__()
+            self.connection = self.context.__enter__()
             return self
 
-        def __exit__(self, *args): return self.connection.__exit__(*args)
+        def __exit__(self, *args): return self.context.__exit__(*args)
 
         def execute(self, sql, *args):
             if 'memory_fts MATCH' in sql:
@@ -1394,5 +1395,61 @@ def test_recall_retries_lexical_lock_contention_instead_of_returning_empty(
             assert instance.pop_recall_trace('busy-read')['lexical_status'] == 'ok'
         finally:
             await instance.stop()
+
+    _run(scenario())
+
+
+@pytest.mark.parametrize("final_limit,max_chars", [(1, 3000), (6, 3000), (15, 3000), (20, 3000), (15, 500)])
+def test_prepared_recall_injects_configured_limit_and_reports_actual_count(
+    recall_case, monkeypatch, final_limit, max_chars,
+):
+    from backend import memory_client as client, memory_engine as module
+
+    instance, cfg, _, vector = recall_case
+    cfg.retrieval.final_limit = final_limit
+    cfg.retrieval.max_context_chars = max_chars
+    cfg.retrieval.soft_timeout_ms = 0
+    memories = [instance.store.create_memory(
+        "default", "fact", f"Synthetic project {index} uses workspace fixture-{index}.",
+        authority="confirmed", confidence=1.0,
+    ) for index in range(20)]
+
+    async def search(*args, **kwargs):
+        return [{"id": row["id"], "channel": "dense"} for row in memories]
+
+    monkeypatch.setattr(vector, "search", search)
+    monkeypatch.setattr(module, "engine", instance)
+    monkeypatch.setattr(client, "native_enabled", lambda: True)
+    events = []
+    monkeypatch.setattr(client, "perf_event", lambda event, **fields: events.append((event, fields)))
+
+    async def scenario():
+        sid = f"configured-limit-{final_limit}-{max_chars}"
+        prompt = "Retrieve the synthetic projects"
+        await client.prepare_recall(sid, "turn", prompt)
+        response = await client.build_recall_hook(sid, prepared_only=True)(
+            {"prompt": prompt}, None, None)
+        block = response["hookSpecificOutput"]["additionalContext"]
+        facts = json.loads(next(line for line in block.splitlines()
+                                if line.startswith('{"facts":')))['facts']
+        trace = client.pop_recall_trace(sid)
+        assert len(block) <= max_chars
+        if max_chars == 3000:
+            assert len(facts) == final_limit
+        else:
+            assert 0 < len(facts) < final_limit
+        assert trace["matched_count"] == final_limit
+        assert trace["count"] == len(trace["items"]) == len(facts)
+        assert trace["injected"] is True
+        rendering = next(fields for event, fields in events if event == "memory.recall_context")
+        assert rendering["count"] == len(facts)
+        assert rendering["final_limit"] == final_limit
+        assert rendering["context_limited"] is (max_chars == 500)
+        assert "Synthetic project" not in str(events)
+        expected_ids = {row["id"] for row in memories if row["content"] in facts}
+        assert {row["id"] for row in trace["items"]} == expected_ids
+        assert await client.build_recall_hook(sid, prepared_only=True)(
+            {"prompt": prompt}, None, None) == {}
+        await instance.stop()
 
     _run(scenario())

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -314,3 +314,36 @@ def test_imported_active_skill_requires_local_reapproval(tmp_path: Path):
     assert imported["status"] == "pending_review"
     assert "installed_path" not in imported["payload"]
     assert "approved_at" not in imported["payload"]
+
+
+def test_registry_operations_release_connections_without_waiting_for_gc(tmp_path, monkeypatch):
+    import sqlite3
+
+    # Retain the Python objects deliberately: database handles must close at
+    # operation completion, rather than via GC on an arbitrary application thread.
+    store = MemoryStore(tmp_path / "registry.sqlite3")
+    real_connect = sqlite3.connect
+    opened = []
+
+    def connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    try:
+        row = store.create_memory("owner", "fact", "Synthetic resource fixture")
+        reader = MemoryStore(store.path, read_only=True)
+        for _ in range(20):
+            assert reader.memories_with_stats_by_ids("owner", [row["id"]])[0]["id"] == row["id"]
+        live = 0
+        for conn in opened:
+            try:
+                conn.execute("SELECT 1")
+            except sqlite3.ProgrammingError:
+                continue
+            live += 1
+        assert live == 0, f"{live} SQLite connections retained after completed operations"
+    finally:
+        for conn in opened:
+            conn.close()

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -183,3 +183,56 @@ async def test_queue_commit_after_previous_turn_stop_remains_runnable(app_module
     finally:
         chat._active_turns.pop(sid, None)
         broadcast.close()
+
+
+def test_receipt_lookup_remains_readable_while_writer_holds_exclusive_transaction(app_module):
+    import sqlite3
+    import time
+    from backend import sessions, submissions
+
+    submissions.reserve("fixture", "turn", "request", {"prompt": "fixture"})
+    path = sessions.SESS_DIR / ".submissions" / "receipts.sqlite3"
+    with sqlite3.connect(path) as writer:
+        # In WAL, an exclusive writer does not block readers. The old rollback
+        # journal plus CREATE TABLE in lookup instead times out with SQLITE_BUSY.
+        writer.execute("BEGIN EXCLUSIVE")
+        writer.execute("UPDATE receipts SET state='accepted'")
+        started = time.perf_counter()
+        try:
+            assert submissions.lookup("fixture", "turn", "request")["state"] == "pending"
+            assert time.perf_counter() - started < .3
+        finally:
+            writer.rollback()
+    writer.close()
+
+
+
+@pytest.mark.asyncio
+async def test_receipt_status_busy_is_retryable_and_not_a_missing_receipt(app_module, monkeypatch):
+    import sqlite3
+    from backend import chat, submissions
+
+    def busy(*args):
+        error = sqlite3.OperationalError("synthetic busy fixture")
+        error.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        raise error
+
+    monkeypatch.setattr(submissions, "lookup", busy)
+    with pytest.raises(HTTPException) as caught:
+        await chat.submission_status("fixture", "request", kind="turn")
+    assert caught.value.status_code == 503
+    assert caught.value.headers == {"Retry-After": "1"}
+    assert "synthetic" not in caught.value.detail
+
+
+def test_unknown_receipt_does_not_initialize_storage_and_handles_pending_schema(app_module):
+    import sqlite3
+    from backend import sessions, submissions
+
+    base = sessions.SESS_DIR / ".submissions"
+    assert submissions.lookup("fixture", "turn", "unknown") == {"state": "not_found"}
+    assert not base.exists()
+    base.mkdir(mode=0o700)
+    path = base / "receipts.sqlite3"
+    sqlite3.connect(path).close()
+    assert submissions.lookup("fixture", "turn", "unknown") == {"state": "not_found"}


### PR DESCRIPTION
## What this changes

修复活动列表、记忆召回和运行时响应性：普通 fork 发布后立即显示独立活动行，启动时补齐缺失的可见 fork；“未分组”统一按最近活动时间倒序，自定义分组保持手动排序。记忆注入使用配置的最终召回条数，仍遵守字符容量限制，并保留超时为 0 时完整等待的行为。

## Why

此前 fork 要等首次运行才出现，旧手动位置会覆盖“未分组”的时间排序，召回得到 15 条后又被注入阶段的隐藏上限裁成 5 条。性能修复针对可复现的阻塞和资源滞留：配置持久化移到 I/O 线程，缓存读取避开慢写锁，仅修改召回参数时不探测供应商或重启 worker；SQLite 连接及时关闭，提交回执查询改为只读并支持锁忙重试；文件快照连续失效后采用有界重试及退避。补充召回依赖耗时、实际注入条数和扫描失效计数，日志不包含记忆正文。

## Testing

- [x] 后端相关测试两批通过，共 452 项（346 + 106）。
- [x] 浏览器相关测试 22 项通过，覆盖真实 SDK fork 到活动 SSE、隐藏侧问、“未分组”初始/实时/刷新排序、自定义分组手动排序及召回超时设置。
- [x] 失败复现覆盖慢配置保存时的并发响应、SQLite 连接滞留、独占写事务中的回执查询、连续失效扫描和历史手动位置干扰排序。
- [x] Ruff、JavaScript 语法、项目 lint 和 `git diff --check` 通过。
- [x] 前端静态契约测试 183 项通过；真实 fork 清理后与断线重放、消息大纲三个用例连续运行通过。
- [x] [完整 CI](https://github.com/hesorchen/muselab/actions/runs/34592737326) 的 9 项检查全部完成并通过：Linux Python 3.12/3.13 各 2056 项、macOS Python 3.12 共 2000 项；浏览器全量 320 项通过，无重跑；覆盖率、依赖安全、静态检查及 Docker 启动验证均通过。

## Checklist

- [x] No secrets committed；新增测试均使用合成数据，SDK 存储隔离在临时测试目录。
- [x] 本次恢复已有功能的预期行为，无需新增使用文档。
- [x] 无新增运行时依赖。

本 PR 的本地回归验证不代表所有部署环境的交互卡顿已消除；上游超时和实际磁盘响应仍需部署后结合新指标核验。
