### PR TITLE
fix: 修复会话尾部回退、任务归属与响应延迟

### DIFF
--- a/backend/chat.py
+++ b/backend/chat.py
@@ -2721,7 +2721,7 @@ async def _detect_gateway_context_capability(model: str) -> dict | None:
         return None
     canonical = _canonical_context_model(model)
     slug = endpoints.normalize_model_id(canonical)
-    env = endpoints.env_override(canonical) or {}
+    env = endpoints.routing_env(canonical) or {}
     base = (env.get("ANTHROPIC_BASE_URL") or "").rstrip("/")
     key = env.get("ANTHROPIC_API_KEY") or env.get("ANTHROPIC_AUTH_TOKEN") or ""
     if not base:
@@ -2802,7 +2802,7 @@ def _cached_gateway_context_capability(model: str) -> dict | None:
     if not _is_codex_gateway_model(model):
         return None
     canonical = _canonical_context_model(model)
-    env = endpoints.env_override(canonical) or {}
+    env = endpoints.routing_env(canonical) or {}
     base = (env.get("ANTHROPIC_BASE_URL") or "").rstrip("/")
     if not base:
         return None
@@ -2837,7 +2837,7 @@ async def _detect_gateway_context_capabilities(
             capabilities[model] = cached
             continue
         canonical = _canonical_context_model(model)
-        env = endpoints.env_override(canonical) or {}
+        env = endpoints.routing_env(canonical) or {}
         base = (env.get("ANTHROPIC_BASE_URL") or "").rstrip("/")
         if base:
             unresolved_by_base.setdefault(base, []).append(model)
@@ -17384,6 +17384,21 @@ async def _start_turn(
             stale Result until the current query reaches its own terminal.
             """
             async def _run_query() -> None:
+                # Complete recall and native context accounting are independent.
+                # Keep both outside the SDK hook watchdog, and cancel the recall
+                # producer before clearing its receipt on any failed preflight.
+                recall = asyncio.create_task(mem0.prepare_recall(
+                    session_id, broadcast.turn_id, prompt,
+                    is_cancelled=lambda: broadcast.cancelled,
+                ))
+                try:
+                    await _run_prepared_query(recall)
+                finally:
+                    if not recall.done():
+                        recall.cancel()
+                    await asyncio.gather(recall, return_exceptions=True)
+
+            async def _run_prepared_query(recall: asyncio.Task[bool]) -> None:
                 # `merge_q` lives in event_gen's scope, one level deeper than
                 # _preflight_compact_if_needed's — hence the injected emitter
                 # rather than a closure reference. Events ride the same "side"
@@ -17446,10 +17461,7 @@ async def _start_turn(
                     # Recall may wait indefinitely when configured as zero.
                     # Prepare outside the CLI hook timer; only the exact next
                     # prompt can consume it through additionalContext.
-                    if broadcast.cancelled or not await mem0.prepare_recall(
-                        session_id, broadcast.turn_id, prompt,
-                        is_cancelled=lambda: broadcast.cancelled,
-                    ):
+                    if broadcast.cancelled or not await recall:
                         raise _TurnCancelledBeforeQuery()
                     # Every preflight/transcript/sidecar await above is a Stop
                     # race. This is the last instruction before SDK transport.
@@ -20861,7 +20873,18 @@ async def recover_native_cron_at_startup() -> int:
             if sid in _sdk_cron_jobs:
                 continue
             _sdk_cron_jobs[sid] = jobs
-        count += len(jobs)
+    # Load every receipt before scheduling recovery: a legacy CronList-only
+    # copy in B must not race the later load of A's creation receipt.
+    with _sdk_cron_state_lock:
+        for sid in receipts:
+            jobs = _sdk_cron_jobs.get(sid)
+            if jobs is None:
+                continue
+            for job_id in list(jobs):
+                if _sdk_cron_owned_elsewhere(sid, job_id):
+                    jobs.pop(job_id)
+            count += len(jobs)
+    for sid in receipts:
         _schedule_native_cron_recovery(sid)
     return count
 
@@ -21192,6 +21215,22 @@ def _sdk_tool_result_text(block: ToolResultBlock) -> str:
     return "\n".join(part for part in parts if part)
 
 
+def _sdk_cron_owned_elsewhere(session_id: str, job_id: str) -> bool:
+    """Only creation receipts establish ownership; list text cannot transfer it.
+
+    The caller holds the cron state lock. Legacy creation receipts have a
+    creation timestamp, while rows previously imported from CronList do not.
+    Native origin remains authoritative for delivery; these receipts only
+    control MuseLab's task inventory and origin-less compatibility fallback.
+    """
+    for sid, jobs in _sdk_cron_jobs.items():
+        raw = jobs.get(job_id, {})
+        owner = raw.get("owner_session_id") or (sid if raw.get("created_at_ms") else "")
+        if owner and owner != session_id:
+            return True
+    return False
+
+
 def _observe_sdk_cron_message(
     key: chat_runtime.ClientKey,
     message: Any,
@@ -21226,7 +21265,7 @@ def _observe_sdk_cron_message(
             jobs = dict(before)
             if name == "CronCreate":
                 match = _SDK_CRON_CREATE_RESULT.search(text)
-                if match:
+                if match and not _sdk_cron_owned_elsewhere(key[0], match.group("job_id")):
                     job_id = match.group("job_id")
                     jobs[job_id] = {
                         field: call[field]
@@ -21245,7 +21284,7 @@ def _observe_sdk_cron_message(
                     jobs[job_id].update({
                         "model": key[1], "effort": key[2], "service_tier": key[3],
                         "runtime_state": "active", "created_at_ms": int(time.time() * 1000),
-                        "record_saved": True,
+                        "record_saved": True, "owner_session_id": key[0],
                     })
                     expiry = re.search(r"Auto-expires after (\d+) days", text, re.IGNORECASE)
                     if expiry:
@@ -21273,7 +21312,11 @@ def _observe_sdk_cron_message(
                         jobs.update({
                             job_id: {**before.get(job_id, {}), "runtime_state": "active", "last_error": ""}
                             for job_id in listed
+                            if not _sdk_cron_owned_elsewhere(key[0], job_id)
                         })
+            if name == "CronList":
+                jobs = {job_id: raw for job_id, raw in jobs.items()
+                        if not _sdk_cron_owned_elsewhere(key[0], job_id)}
             if jobs:
                 from . import native_cron
                 _sdk_cron_jobs[key[0]] = native_cron.bounded_jobs(jobs)
@@ -21311,8 +21354,10 @@ def _matching_sdk_cron_job(
         return ""
     digest = safe_prompt[1]
     with _sdk_cron_state_lock:
-        jobs = tuple(_sdk_cron_jobs.get(key[0], {}).items())
-    matches = [str(job_id) for job_id, job in jobs if job.get("prompt_sha256") == digest]
+        matches = [str(job_id) for job_id, job in _sdk_cron_jobs.get(key[0], {}).items()
+                   if job.get("prompt_sha256") == digest
+                   and job.get("runtime_state", "active") in _NATIVE_CRON_LIVE_STATES
+                   and not _sdk_cron_owned_elsewhere(key[0], job_id)]
     return matches[0] if len(matches) == 1 else ""
 
 
@@ -21324,6 +21369,9 @@ def _is_sdk_scheduled_trigger(
         return False
     origin = sdk_lifecycle.normalize_origin(getattr(message, "origin", None))
     if origin is not None:
+        # Native provenance is authoritative, including a resumed task whose
+        # creation this host never observed. senderTaskId describes peer agents
+        # in the SDK contract; it is NOT a scheduled job id.
         return bool(
             origin["kind"] == "task-notification"
             and origin.get("subkind") == "scheduled-trigger"

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -1277,6 +1277,22 @@ def normalize_model_id(model: str) -> str:
     return model
 
 
+def routing_env(model: str) -> dict[str, str] | None:
+    """Read endpoint identity without preparing a CLI filesystem or credentials.
+
+    Capability/usage probes run on the event loop, often on every assistant
+    message. Runtime preparation belongs exclusively to env_override().
+    """
+    provider = lookup(model)
+    if provider is None:
+        return None
+    key = os.environ.get(provider.env_key, "")
+    if not key:
+        return None
+    return {"ANTHROPIC_BASE_URL": _resolve_base_url(provider.env_key, provider),
+            "ANTHROPIC_API_KEY": key, "ANTHROPIC_AUTH_TOKEN": key}
+
+
 def env_override(model: str) -> dict[str, str] | None:
     """Build the env dict to pass to ClaudeAgentOptions(env=...) so the SDK
     routes to the vendor's Anthropic-compatible endpoint. Returns None if no

--- a/backend/file_events.py
+++ b/backend/file_events.py
@@ -57,8 +57,6 @@ _PARTIAL_RECONCILE_YIELD_S = 0.01
 _NATIVE_DIRECTORY_WATCH_HARD_CAP = 131_072
 _WATCH_LINGER_S = 30.0
 _MAX_IDLE_WATCHERS = 3
-_RECONCILE_BACKOFF_START_S = 0.25
-_RECONCILE_BACKOFF_CAP_S = 5.0
 _EVENT_TICKET_TTL_S = 45
 _DATABASE_MAINTENANCE_DELAY_S = 30.0
 _EXCLUDED_DIRS = frozenset({TRASH_DIR_NAME, INTERNAL_DIR_NAME})
@@ -454,15 +452,16 @@ class FileWatchManager:
         return True
 
     @staticmethod
-    def _record_reconcile_retry(state: _WatchState) -> None:
+    def _record_reconcile_retry(state: _WatchState, *, elapsed_s: float = 0.0) -> float:
         """Apply workspace-local exponential backoff after a failed/partial pass."""
         state.reconcile_failures += 1
         delay = min(
             _RECONCILE_RETRY_MAX_S,
-            _RECONCILE_RETRY_BASE_S
-            * (2 ** min(state.reconcile_failures - 1, 16)),
+            max(elapsed_s, _RECONCILE_RETRY_BASE_S
+                * (2 ** min(state.reconcile_failures - 1, 16))),
         )
         state.reconcile_retry_at = monotonic() + delay
+        return delay
 
     @staticmethod
     def _reset_reconcile_retry(state: _WatchState) -> None:
@@ -1605,12 +1604,11 @@ class FileWatchManager:
         except Exception as exc:
             error_type = type(exc).__name__
             state.reconcile_error = exc
-            self._record_reconcile_retry(state)
-            backoff_ms = round(min(
-                _RECONCILE_BACKOFF_START_S
-                * (2 ** min(state.reconcile_failures - 1, 20)),
-                _RECONCILE_BACKOFF_CAP_S,
-            ) * 1000)
+            # Expensive failed scans must not immediately consume another scan
+            # slot. Bound retry duty cycle as well as repeated-failure frequency.
+            delay = self._record_reconcile_retry(
+                state, elapsed_s=monotonic() - started)
+            backoff_ms = round(delay * 1000)
             raise
         finally:
             # Keep this true through replay, broadcast, and watcher-path

--- a/backend/memory_providers.py
+++ b/backend/memory_providers.py
@@ -628,7 +628,7 @@ class GenerationProvider:
                 if route is None:
                     route_kind = "ducc" if configured_model.startswith("ducc:") else "sdk"
                     phases["phase"] = "awaiting_sdk_event"
-                    result = await self._complete_with_sdk(system, prompt)
+                    result = await self._complete_with_sdk(system, prompt, max_tokens)
                     response_chars, outcome = len(result), "done"
                     return result
                 route_kind = "http"
@@ -744,7 +744,7 @@ class GenerationProvider:
             )
             _generation_phases.reset(phase_token)
 
-    async def _complete_with_sdk(self, system: str, prompt: str) -> str:
+    async def _complete_with_sdk(self, system: str, prompt: str, max_tokens: int = 3000) -> str:
         from claude_agent_sdk import ClaudeAgentOptions, query
         from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
 
@@ -770,6 +770,9 @@ class GenerationProvider:
             options_kwargs["env"] = _ducc_subprocess_env(ducc_executable)
             model = endpoints.ducc_cli_model(model)
 
+        # Apply the same output budget as the HTTP provider through the native
+        # CLI setting. Extraction is a bounded text transform, not an agent task.
+        options_kwargs.setdefault("env", {})["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(max_tokens)
         workdir = memory_dir() / "generator"
         workdir.mkdir(parents=True, exist_ok=True)
         options = ClaudeAgentOptions(
@@ -783,6 +786,8 @@ class GenerationProvider:
             setting_sources=[],
             skills=[],
             max_turns=1,
+            thinking={"type": "disabled"},
+            effort="low",
             permission_mode="default",
             cwd=workdir,
             include_partial_messages=False,

--- a/backend/native_cron.py
+++ b/backend/native_cron.py
@@ -26,7 +26,7 @@ _TEXT_FIELDS = {
     "cron": 128, "prompt": 4000, "prompt_sha256": 64,
     "model": 256, "effort": 32, "service_tier": 32,
     "runtime_state": 32, "last_status": 32, "last_error": 96, "last_execution_status": 32,
-    "last_run_id": 128,
+    "last_run_id": 128, "owner_session_id": 128,
 }
 _BOOL_FIELDS = {"recurring", "durable", "prompt_truncated", "record_saved"}
 _INT_FIELDS = {

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1322,16 +1322,31 @@ def prune_empty_sessions(keep_ids: tuple | list = ()) -> list[str]:
 
 
 def rename_session(sid: str, name: str) -> bool:
-    with _INDEX_LOCK:
-        idx = _load_index()
-        for s in idx:
-            if s["id"] == sid:
-                s["name"] = name
-                s["updated_at"] = time.time()
-                s["auto_named"] = False
-                _save_index(idx)
-                return True
-        return False
+    from . import observability as obs
+    started = time.monotonic()
+    phases = {"lock_wait_ms": 0, "read_ms": 0, "write_ms": 0}
+    try:
+        with _INDEX_LOCK:
+            phases["lock_wait_ms"] = obs.elapsed_ms(started)
+            reading = time.monotonic()
+            idx = _load_index()
+            phases["read_ms"] = obs.elapsed_ms(reading)
+            for s in idx:
+                if s["id"] == sid:
+                    if s.get("name") == name and s.get("auto_named") is False:
+                        return True
+                    s["name"] = name
+                    s["updated_at"] = time.time()
+                    s["auto_named"] = False
+                    writing = time.monotonic()
+                    try:
+                        _save_index(idx)
+                    finally:
+                        phases["write_ms"] = obs.elapsed_ms(writing)
+                    return True
+            return False
+    finally:
+        obs.perf_event("sessions.rename_index", duration_ms=obs.elapsed_ms(started), **phases)
 
 
 def set_runtime_background_boundary(sid: str, message_id: str) -> bool:
@@ -2198,6 +2213,14 @@ def set_runtime_task_overlay(
                     updated["state"]
                 )
             updated["task_id"] = task_id
+            # Replayed lifecycle observations often differ only in wall time.
+            # Preserve the last substantive update and avoid another atomic
+            # sidecar write for every identical heartbeat.
+            if isinstance(stored, dict) and all(
+                stored.get(key) == value for key, value in updated.items()
+                if key != "updated_at"
+            ) and set(stored) - {"updated_at"} == set(updated) - {"updated_at"}:
+                updated = dict(stored)
             target_changed = not isinstance(stored, dict) or stored != updated
             if not target_changed and not overlays_compacted:
                 return False

--- a/docs/engineering/session-integrity.md
+++ b/docs/engineering/session-integrity.md
@@ -1,0 +1,43 @@
+# Session integrity and latency checks
+
+A quiet history refresh is still a destructive UI replacement. Before installing
+it, check the server's completion stability, the last observed update time, and
+the committed final message boundary within the same history generation. Compare
+counts against installed canonical history, not provisional streaming bubbles.
+Compaction and explicit full-history navigation may legitimately change the window.
+A rejected response leaves the displayed messages intact and pending reconciliation.
+
+Native schedules follow the Claude Agent SDK contract. MuseLab stores observation
+receipts; it does not interpret cron expressions, recreate tasks, redirect fires,
+or change native persistence and expiration. Successful creation establishes the
+receipt owner. A later CronList result or replayed creation cannot transfer an
+existing job to another session. Startup loads all receipts before deciding which
+session to resume, removing legacy list-only copies before recovery starts.
+
+SDK `origin.kind=task-notification` with `subkind=scheduled-trigger` remains
+valid even when MuseLab missed the original creation. Do not reject a native fire
+merely because its local receipt is absent. `senderTaskId` identifies peer agents,
+not cron jobs. For older runtimes that omit origin, exact prompt matching is only
+a fallback for a live task in the receiving session outside a foreground turn.
+The public contract is described in [Claude Code scheduled tasks](https://code.claude.com/docs/en/scheduled-tasks)
+and the pinned Python SDK's `MessageOrigin` type documentation.
+
+For startup latency, prepare full memory recall concurrently with native context
+preflight. Both must finish before query commit; cancellation or early failure
+must join the recall producer before clearing its receipt. Keep the configured
+recall timeout, result limit, and native context/compaction behavior intact.
+Capability reads must not prepare CLI configuration directories. Bounded memory
+extraction uses the native output-token budget and disabled thinking.
+
+Repeated task observations that only change `updated_at` should not rewrite a
+sidecar. Failed expensive filesystem scans use a bounded retry delay at least as
+large as the preceding pass, capped at 30 seconds; healthy partial continuations
+keep their short yield. The logged retry duration is the actual retry deadline.
+`sessions.rename_index` separates index lock, read, and write time without logging
+session names, paths, or contents. These timings distinguish local filesystem
+latency from SDK/network latency in a deployment that cannot be inspected directly.
+
+Focused regressions are in `test_history_snapshot_integrity.py`,
+`test_completion_visibility.py`, `test_native_cron_reliability.py`, and
+`test_turn_startup_overlap.py`. Browser coverage requires `RUN_E2E=1`; always use a
+temporary `MUSELAB_ROOT` and a synthetic authentication token for local tests.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8712,6 +8712,7 @@ function portal() {
         // Post-result work may briefly leave /active or a mux state snapshot
         // stale; never re-attach that already-rendered turn as "running".
         _lastTerminalTurnId: "",
+        _lastTerminalAssistantUuid: "",
         parentTurnId: "",
         lastEventSeq: 0,
         es: null,
@@ -8775,6 +8776,7 @@ function portal() {
         // never advances for optimistic/live bubbles, so a non-empty pane can
         // still detect that the server has committed a newer missing suffix.
         _installedCanonicalCount: 0,
+        _installedHistoryTotal: 0,
         _seenUpdated: undefined,
         _reconcileTargetUpdated: 0,
         _reconcileRetryN: 0,
@@ -8907,6 +8909,7 @@ function portal() {
       }
       if (st.activeTurnId === undefined) st.activeTurnId = "";
       if (st._lastTerminalTurnId === undefined) st._lastTerminalTurnId = "";
+      if (st._lastTerminalAssistantUuid === undefined) st._lastTerminalAssistantUuid = "";
       if (st.parentTurnId === undefined) st.parentTurnId = "";
       if (st._streamOwnerToken === undefined) st._streamOwnerToken = "";
       if (!Number.isFinite(Number(st._lastSseTransportAt))) {
@@ -18618,6 +18621,37 @@ function portal() {
       return false;
     },
 
+    _historySnapshotRejection(st, snapshot, opts = {}) {
+      // All replacement paths share this gate, including revision/replay loads
+      // that never pass through the explicit done-frame reconciler.
+      if (snapshot.completion_state?.stable === false) return "unstable_snapshot";
+      const seen = Number(st._seenUpdated) || 0;
+      const updated = Number(snapshot.updated_at) || 0;
+      if (seen && updated && updated < seen) return "older_snapshot";
+      const generation = String(snapshot.history_generation || "");
+      const sameGeneration = generation && generation === st.messageRange.generation;
+      if (sameGeneration && !opts.full && st.messageRange.order !== "full"
+          && Number.isFinite(snapshot.total)
+          && snapshot.total < (Number(st._installedHistoryTotal) || 0)) {
+        return "shorter_snapshot";
+      }
+      const expected = st._pendingCompletedTurnSync;
+      const boundary = opts.completedBoundary?.uuid
+        || (expected && expected.completedTurnId === st._lastTerminalTurnId
+          ? expected.expectedAssistantUuid : "")
+        || st._lastTerminalAssistantUuid;
+      // A compact/delete/full-history navigation can legitimately change the
+      // window. Within the SAME normal generation and completed turn, however,
+      // an acknowledged final UUID cannot disappear from the latest snapshot.
+      if (boundary && sameGeneration && !opts.full && !snapshot.has_later
+          && st.messageRange.order !== "full"
+          && snapshot.completion_state?.completed_turn_id === st._lastTerminalTurnId
+          && !(snapshot.messages || []).some(message => message.uuid === boundary)) {
+        return "missing_terminal_boundary";
+      }
+      return "";
+    },
+
     async loadSession(sid, opts = {}) {
       if (!sid) return false;
       // full:true → fetch the raw-JSONL view (?full=1) so PRE-compaction
@@ -18808,6 +18842,12 @@ function portal() {
           return false;
         }
         const loadedUpdated = Number(s.updated_at) || 0;
+        const rejection = this._historySnapshotRejection(st, s, opts);
+        if (rejection) {
+          historyPerf.cancel_reason = rejection;
+          st._pendingExternalUpdate = true;
+          return false;
+        }
         const shapeStarted = perfNow();
         // Build a lookup of blob preview URLs from the current in-memory
         // messages so we can carry them over after the server rebuild.
@@ -19045,6 +19085,10 @@ function portal() {
         st._installedCanonicalCount = Math.max(
           0, Number(s.message_count) || Number(s.total) || incomingCount,
         );
+        // Session metadata can count pre-compaction/raw records. Keep this
+        // normal-window baseline separate, excluding provisional active turns.
+        st._installedHistoryTotal = s.completion_state?.stable === true
+          && s.completion_state?.active === false ? (Number(s.total) || 0) : 0;
         // (The session outline is sourced from the backend via
         // refreshOutlineFromBackend (GET …/outline), not built here.)
         const permissionExpected = st._permissionExpected;
@@ -31467,7 +31511,8 @@ function portal() {
     },
     _refreshSlashPalette(prefix = this.input) {
       const text = String(prefix || "");
-      if (!text.startsWith("/")) {
+      if (!this.SLASH_ENABLED || !text.startsWith("/")
+          || /^\/[^\s]*[\/\\]/.test(text)) {
         this.slashShow = false;
         return false;
       }
@@ -32907,7 +32952,7 @@ function portal() {
       if (this.SLASH_ENABLED && isComposerSubmission) {
         const slashDraft = String((sendState.draft && sendState.draft.input) || "");
         const slashText = slashDraft.trim();
-        if (slashText.startsWith("/")) {
+        if (slashText.startsWith("/") && !/^\/[^\s]*[\/\\]/.test(slashText)) {
           const match = slashText.match(/^\/([^\s]+)(?:\s+([\s\S]*))?$/);
           if (match) {
             return await this._dispatchSlash(match[1], match[2] || "", {
@@ -34728,6 +34773,7 @@ function portal() {
         const terminalTurnId = streamTurnId || String(streamState.activeTurnId || "");
         if (authoritativeTerminal && terminalTurnId) {
           streamState._lastTerminalTurnId = terminalTurnId;
+          streamState._lastTerminalAssistantUuid = String(completionMeta?.assistantUuid || "");
         }
         if (streamState._stoppingTurnId === terminalTurnId) {
           streamState._stoppingTurnId = "";

--- a/tests/e2e/test_history_snapshot_integrity.py
+++ b/tests/e2e/test_history_snapshot_integrity.py
@@ -1,0 +1,93 @@
+"""History replacement must not roll an already-visible final answer backward."""
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+
+@pytest.mark.parametrize("case,accepted", [
+    ("unstable", False), ("older", False), ("missing_boundary", False),
+    ("shorter_without_boundary", False),
+    ("compacted", True), ("current", True), ("live_count", True),
+])
+@pytest.mark.parametrize("quiet", [True, False])
+def test_history_replacement_preserves_committed_tail(page, case, accepted, quiet):
+    root = Path(__file__).resolve().parents[2]
+    page.route("**/*", lambda route: route.fulfill(
+        status=200, content_type="text/html", body="<html><body></body></html>"))
+    page.goto("http://history-fixture.invalid/")
+    for script in ("i18n/index.js", "data/constants.js", "modules/task-delivery.js", "app.js"):
+        page.add_script_tag(path=str(root / "frontend" / script))
+    result = page.evaluate("""async ({caseName, quiet}) => {
+      const app = portal();
+      app.$nextTick = callback => Promise.resolve().then(callback);
+      app.currentId = 'other-tab';
+      for (const name of ['_scheduleHistoryViewport', '_syncSessionMessageStore',
+          'hydrateSubagents', 'hydrateHookTraces', '_scheduleIdlePreload']) app[name] = () => {};
+      let reason = '';
+      app._reportHistoryLoadPerf = event => { reason = event.cancel_reason; };
+      const sid = 'history-fixture';
+      const st = app._ensureTabState(sid);
+      st.messages = ['u1', 'a1', 'u2', 'a2'].map(uuid => ({
+        uuid, role: uuid[0] === 'u' ? 'user' : 'assistant', text: uuid, _k: sid + ':' + uuid,
+      }));
+      st._loaded = true; st._seenUpdated = 200; st._installedCanonicalCount = 9; st._installedHistoryTotal = 4;
+      st._lastTerminalTurnId = 'turn2'; st._lastTerminalAssistantUuid = 'a2';
+      if (caseName === 'shorter_without_boundary') st._lastTerminalAssistantUuid = '';
+      st.activeTurnId = 'turn2'; st.atBottom = true; st.runtimeUiRevision = 'new';
+      Object.assign(st.messageRange, {visibleStart: 0, visibleEnd: 4, offset: 0,
+        total: 4, order: 'normal', generation: 'generation1'});
+      if (caseName === 'live_count') st.messageRange.total = 6;
+      const incoming = ['current', 'live_count'].includes(caseName) ? st.messages : st.messages.slice(0, 2);
+      const snapshot = {messages: incoming.map(message => ({...message})),
+        total: caseName === 'missing_boundary' ? 4 : incoming.length, offset: 0, has_more: false, has_later: false,
+        updated_at: caseName === 'older' ? 100 : 300, runtime_ui_revision: 'response',
+        history_generation: caseName === 'compacted' ? 'generation2' : 'generation1',
+        completion_state: {stable: caseName !== 'unstable', active: false,
+          completed_turn_id: 'turn2'}};
+      app._fetchWithDeadline = async (url, options, timeout, consume) => {
+        const response = new Response(JSON.stringify(snapshot), {status: 200});
+        if (consume) await consume(response);
+        return response;
+      };
+      const loaded = await app.loadSession(sid, {quiet, probeActive: false});
+      return {loaded, ids: st.messages.map(message => message.uuid), seen: st._seenUpdated,
+        reason, range: [st.messageRange.visibleStart, st.messageRange.visibleEnd]};
+    }""", {"caseName": case, "quiet": quiet})
+    assert result["loaded"] is accepted, json.dumps(result)
+    assert result["ids"] == (["u1", "a1"] if case == "compacted" else ["u1", "a1", "u2", "a2"])
+    assert result["seen"] == (300 if accepted else 200)
+    assert result["range"][1] > result["range"][0]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_absolute_path_input_and_send_do_not_dispatch_slash(page, backend_url, auth_token, enabled):
+    from tests.e2e.test_chat_render_perf import _app_eval, _login
+    _login(page, backend_url, auth_token)
+    _app_eval(page, """
+      app.SLASH_ENABLED = arg;
+      app._confirmSessionBusy = async () => false;
+      app._submissionReceipt = async () => ({state: 'cancelled'});
+      const gate = new Promise(resolve => window.releasePathSend = resolve);
+      app._ensureChatMux = async () => {await gate; return false;};
+      window.pathSlashCalls = 0;
+      app._dispatchSlash = async () => {window.pathSlashCalls++; return false;};
+    """, enabled)
+    path = "/tmp/fixture-status.log inspect this file"
+    page.locator('textarea[x-ref="chatInput"]').fill(path)
+    assert _app_eval(page, "return app.slashShow;") is False
+    result = _app_eval(page, """
+      const sending = app.send();
+      try {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        const st = app._ensureTabState(app.currentId);
+        return {slashCalls: window.pathSlashCalls,
+          text: st.messages.filter(row => row.role === 'user').at(-1)?.text};
+      } finally {
+        window.releasePathSend(); await sending;
+        app._disposeSessionSync(app._ensureTabState(app.currentId));
+      }
+    """)
+    assert result == {"slashCalls": 0, "text": path}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -572,3 +572,16 @@ def test_available_groups_claude_always_first(monkeypatch):
     })
     groups = ep.available_groups()
     assert groups[0]["group"] == "Claude"
+
+
+def test_routing_identity_never_prepares_cli_storage(monkeypatch):
+    ep = _reload_endpoints(monkeypatch, {"DEEPSEEK_API_KEY": "synthetic-route-key"})
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("routing lookup entered CLI filesystem preparation")
+
+    monkeypatch.setattr(ep, "_vendor_config_dir", forbidden)
+    assert ep.routing_env("deepseek-v4-pro")["ANTHROPIC_API_KEY"] == "synthetic-route-key"
+    assert not ep._VENDOR_CONFIG_DIR.exists()
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "synthetic-rotated-key")
+    assert ep.routing_env("deepseek-v4-pro")["ANTHROPIC_API_KEY"] == "synthetic-rotated-key"

--- a/tests/test_file_events.py
+++ b/tests/test_file_events.py
@@ -2274,8 +2274,8 @@ async def test_reconcile_failures_back_off_coalesce_and_reset(
         return await real_scan(state)
 
     monkeypatch.setattr(manager, "_scan_workspace", fail_twice)
-    monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_START_S", 0.02)
-    monkeypatch.setattr(file_events, "_RECONCILE_BACKOFF_CAP_S", 0.04)
+    monkeypatch.setattr(file_events, "_RECONCILE_RETRY_BASE_S", 0.02)
+    monkeypatch.setattr(file_events, "_RECONCILE_RETRY_MAX_S", 0.04)
     monkeypatch.setattr(
         file_events,
         "perf_event",
@@ -3482,3 +3482,16 @@ def test_workspace_connection_context_closes_handle(app_module, temp_root):
         assert connection.execute('SELECT 1').fetchone()[0] == 1
     with pytest.raises(sqlite3.ProgrammingError, match='closed'):
         connection.execute('SELECT 1')
+
+
+def test_expensive_failed_scan_has_cost_proportional_bounded_retry(temp_root, monkeypatch):
+    from backend import file_events as events
+    monkeypatch.setattr(events, "monotonic", lambda: 100.0)
+    state = events._WatchState(root=temp_root, workspace_id="retry-fixture")
+    delay = events.FileWatchManager._record_reconcile_retry(state, elapsed_s=20.0)
+    assert delay == 20.0
+    assert state.reconcile_retry_at == 120.0
+    delay = events.FileWatchManager._record_reconcile_retry(state, elapsed_s=100.0)
+    assert delay == events._RECONCILE_RETRY_MAX_S
+    events.FileWatchManager._reset_reconcile_retry(state)
+    assert state.reconcile_retry_at == 0

--- a/tests/test_memory_providers.py
+++ b/tests/test_memory_providers.py
@@ -774,3 +774,24 @@ def test_generation_repairs_non_object_once_and_preserves_schema(monkeypatch):
     assert len(calls) == 2
     assert calls[0][1] == calls[1][1]
     assert 'wrong format' in calls[1][0]
+
+
+def test_sdk_memory_applies_native_output_and_reasoning_budget(tmp_path, monkeypatch):
+    import claude_agent_sdk
+    from claude_agent_sdk.types import ResultMessage
+    from backend.memory_config import MemoryConfig
+    from backend.memory_providers import GenerationProvider
+
+    monkeypatch.setenv("MUSELAB_MEMORY_DIR", str(tmp_path / "memory"))
+    provider = GenerationProvider(MemoryConfig(generation_model="claude-sonnet-4-6"))
+    monkeypatch.setattr(provider, "_route", lambda: None)
+
+    async def fake_query(*, prompt, options):
+        assert options.env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "1500"
+        assert options.thinking == {"type": "disabled"}
+        assert options.effort == "low"
+        yield ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                            is_error=False, num_turns=1, session_id="fixture", result="bounded output")
+
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    assert _run(provider.complete("system", "prompt", max_tokens=1500)) == "bounded output"

--- a/tests/test_native_cron_reliability.py
+++ b/tests/test_native_cron_reliability.py
@@ -412,3 +412,84 @@ def test_receipt_write_failure_is_visible_and_recovers_on_a_later_write(stream_e
         assert job["record_saved"] is True
         assert native_cron.load_all()[sid]["fixture01"]["record_saved"] is True
     asyncio.run(run())
+
+
+def test_cron_list_cannot_import_another_sessions_creation(stream_env):
+    chat = stream_env
+    owner = ("cron-owner-a", "model", "auto", "")
+    other = ("cron-owner-b", "model", "auto", "")
+
+    async def run():
+        await create_job(chat, owner)
+        # Also repair a legacy list-only duplicate from an earlier runtime.
+        chat._sdk_cron_jobs[other[0]] = {"fixture01": {"runtime_state": "active"}}
+        await chat._observe_sdk_stream_message(other, AssistantMessage(
+            content=[ToolUseBlock(id="list-b", name="CronList", input={})], model="model"))
+        await chat._observe_sdk_stream_message(other, UserMessage(content=[ToolResultBlock(
+            tool_use_id="list-b", content="fixture01 — Every minute\nrestored-b — Every hour")]))
+        assert set(chat._sdk_cron_jobs[other[0]]) == {"restored-b"}
+        assert chat._sdk_cron_jobs[owner[0]]["fixture01"]["owner_session_id"] == owner[0]
+        assert not chat._matching_sdk_cron_job(other, "Check the fixture status")
+
+    asyncio.run(run())
+
+
+def test_native_origin_does_not_require_a_host_creation_receipt(stream_env):
+    chat = stream_env
+    key = ("native-resumed-session", "model", "auto", "")
+    assert chat._is_sdk_scheduled_trigger(key, UserMessage(content="Native resumed prompt", origin={
+        "kind": "task-notification", "subkind": "scheduled-trigger"}))
+    assert not chat._is_sdk_scheduled_trigger(key, UserMessage(content="Peer message", origin={
+        "kind": "task-notification", "subkind": "peer-send-message"}))
+
+
+def test_originless_cron_fallback_ignores_terminal_or_foreign_receipts(stream_env):
+    chat = stream_env
+    owner = ("cron-fingerprint-a", "model", "auto", "")
+    other = ("cron-fingerprint-b", "model", "auto", "")
+
+    async def run():
+        await create_job(chat, owner)
+        prompt = "Check the fixture status"
+        duplicate = dict(chat._sdk_cron_jobs[owner[0]]["fixture01"])
+        chat._sdk_cron_jobs[other[0]] = {"fixture01": duplicate}
+        assert not chat._is_sdk_scheduled_trigger(other, UserMessage(content=prompt))
+        # Two independently created tasks may have identical prompts.
+        await create_job(chat, other, result="Scheduled recurring job other02. Session-only.")
+        assert chat._matching_sdk_cron_job(other, prompt) == "other02"
+        chat._sdk_cron_jobs[other[0]]["other02"]["runtime_state"] = "finished"
+        assert not chat._is_sdk_scheduled_trigger(other, UserMessage(content=prompt))
+        assert chat._matching_sdk_cron_job(owner, prompt) == "fixture01"
+
+    asyncio.run(run())
+
+
+def test_startup_loads_creation_owners_before_recovering_legacy_list_copies(stream_env, monkeypatch):
+    chat = stream_env
+    from backend import native_cron
+    scheduled = []
+    # The wrong-session copy is deliberately loaded first.
+    monkeypatch.setattr(native_cron, "load_all", lambda: {
+        "copy-b": {"job-shared": {"runtime_state": "active"}},
+        "owner-a": {"job-shared": {"runtime_state": "active", "created_at_ms": 1}},
+    })
+    monkeypatch.setattr(chat.sess, "get_session_meta", lambda _sid: {"model": "model"})
+    monkeypatch.setattr(chat, "_schedule_native_cron_recovery", lambda sid:
+                        scheduled.append(sid) if chat._sdk_cron_jobs.get(sid) else None)
+    assert asyncio.run(chat.recover_native_cron_at_startup()) == 1
+    assert scheduled == ["owner-a"]
+    assert not chat._sdk_cron_jobs["copy-b"]
+
+
+def test_replayed_creation_cannot_move_an_existing_native_job(stream_env):
+    chat = stream_env
+    owner = ("create-owner-a", "model", "auto", "")
+    other = ("create-replay-b", "model", "auto", "")
+
+    async def run():
+        await create_job(chat, owner)
+        await create_job(chat, other)
+        assert "fixture01" in chat._sdk_cron_jobs[owner[0]]
+        assert "fixture01" not in chat._sdk_cron_jobs.get(other[0], {})
+
+    asyncio.run(run())

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2070,3 +2070,23 @@ def test_export_session_markdown_rejects_bad_token(client, auth, app_module):
         params={"token": "not-the-real-token-but-long-enough-to-pass-the-len-check"},
     )
     assert r.status_code == 401
+
+
+def test_repeated_task_observation_does_not_rewrite_timestamp(app_module, monkeypatch):
+    from backend import sessions as sess
+    sid = "overlay-repeat-session"
+    assert sess.set_runtime_task_overlay(sid, "task-repeat", state="running", updated_at=10)
+    original = sess._save_runtime_task_overlays
+    writes = []
+
+    def save(*args):
+        writes.append(args)
+        return original(*args)
+
+    monkeypatch.setattr(sess, "_save_runtime_task_overlays", save)
+    assert not sess.set_runtime_task_overlay(sid, "task-repeat", state="running", updated_at=20)
+    assert writes == []
+    assert sess.get_runtime_task_overlays(sid)["task-repeat"]["updated_at"] == 10
+    assert sess.set_runtime_task_overlay(sid, "task-repeat", state="completed", summary="Finished", updated_at=30)
+    assert len(writes) == 1
+    assert sess.get_runtime_task_overlays(sid)["task-repeat"]["state"] == "completed"

--- a/tests/test_turn_startup_overlap.py
+++ b/tests/test_turn_startup_overlap.py
@@ -1,0 +1,60 @@
+"""Independent startup work overlaps without weakening query commit barriers."""
+import asyncio
+
+import pytest
+from claude_agent_sdk import ResultMessage
+from tests import test_chat_stream
+
+stream_env = test_chat_stream.stream_env
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_preflight", [False, True])
+async def test_recall_overlaps_preflight_and_is_cancelled_on_early_failure(
+        stream_env, client, monkeypatch, fail_preflight):
+    chat = stream_env
+    sid = test_chat_stream._make_session(client)
+    recall_started, release_recall, recall_finished = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    preflight_started = asyncio.Event()
+    original_prepare = chat.mem0.prepare_recall
+
+    async def prepare(*args, **kwargs):
+        recall_started.set()
+        try:
+            await release_recall.wait()
+            return await original_prepare(*args, **kwargs)
+        finally:
+            recall_finished.set()
+
+    class Client(test_chat_stream._FakeStreamClient):
+        async def get_context_usage(self):
+            # This is a dependency test, not a timing microbenchmark: a serial
+            # implementation cannot reach this barrier while recall is pending.
+            await asyncio.wait_for(recall_started.wait(), 1)
+            preflight_started.set()
+            return {"maxTokens": 200_000, "totalTokens": 1}
+
+    fake = Client([ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                                is_error=False, num_turns=1, session_id=sid)])
+
+    async def get_client(*_args, **_kwargs):
+        return fake
+
+    monkeypatch.setattr(chat, "get_client", get_client)
+    monkeypatch.setattr(chat.mem0, "prepare_recall", prepare)
+    if fail_preflight:
+        original_write = chat._write_active_turn_sidecar
+        monkeypatch.setattr(chat, "_write_active_turn_sidecar", lambda *args:
+                            False if recall_started.is_set() else original_write(*args))
+    broadcast = await chat._start_turn(sid, "startup barrier fixture", model="claude-sonnet-4-6")
+    if not fail_preflight:
+        await asyncio.wait_for(preflight_started.wait(), 2)
+        assert not recall_finished.is_set()
+        assert fake.queried == []
+        release_recall.set()
+    async with asyncio.timeout(3):
+        while not broadcast.done:
+            await asyncio.sleep(.01)
+    assert recall_finished.is_set()
+    assert fake.queried == ([] if fail_preflight else ["startup barrier fixture"])
+    assert sid not in chat.mem0._prepared_recalls


### PR DESCRIPTION
普通历史刷新可能用旧快照覆盖已完成的尾部消息，原生 Cron 列表的观测记录也可能把同一任务认领到其他会话。本次修复这些状态回退，并减少发送前串行等待和重复文件写入。

- 历史替换统一验证快照稳定性、更新时间和最终消息边界；正常压缩及原始历史导航仍可更新。文件路径输入不会触发命令面板或命令分发，命令入口继续默认关闭。
- 创建回执保留任务归属，列表与重放不能转移已有任务；启动时读齐归属记录后再恢复所属会话，排除旧的重复认领。SDK 的原生通知、调度、持久化和恢复语义保持不变，未观察到创建过程也可接收合法原生触发。
- 完整记忆召回与原生上下文预检并行，保留取消及查询提交边界；能力探测不再准备 CLI 配置目录；后台记忆提取使用原生输出预算。
- 相同任务状态与重复重命名避免重复写入；昂贵扫描失败按实际耗时退避；索引重命名日志区分锁等待、读取和写入耗时。

验证：当前提交的 CI 后端测试 2102 项通过，完整浏览器测试 344 项通过；本地补测覆盖历史回退、原始统计与展示条数差异、跨会话任务归属、恢复顺序及取消边界。ruff、项目 lint、前端语法与 vendor 校验通过。另用真实 SDK 和本地模拟 API 验证路径文本原样进入请求。

本 PR 交付代码修复。外部实例未部署，实际网络与文件系统延迟的改善幅度需更新后复测。
